### PR TITLE
mark backlog stories as shipped

### DIFF
--- a/product/backlog/README.md
+++ b/product/backlog/README.md
@@ -6,5 +6,5 @@ Groomed stories ready for sprint planning. All stories follow the format defined
 
 | Story | Priority | Status | Sprint Target |
 |-------|----------|--------|---------------|
-| [Branch-Based CI/CD + Vercel Preview Deployments](story-branch-based-ci-cd.md) | P2-High | Backlog | Next infra sprint |
-| [Optional Login — Google OIDC + Cloud Sync Upsell (Iteration 1)](story-auth-oidc-google.md) | P3-Medium | Backlog | GA sprint (deferred) |
+| [Branch-Based CI/CD + Vercel Preview Deployments](story-branch-based-ci-cd.md) | P2-High | ✅ Shipped | PR #9 |
+| [Optional Login — Google OIDC + Cloud Sync Upsell (Iteration 1)](story-auth-oidc-google.md) | P3-Medium | ✅ Shipped | commit 60d8f64, QA 24/24 |


### PR DESCRIPTION
## Summary

- Mark Branch-Based CI/CD + Vercel Previews as ✅ Shipped (PR #9)
- Mark Optional Login / Google OIDC + Cloud Sync Upsell as ✅ Shipped (commit 60d8f64, QA 24/24)

Both were already in `main` — backlog README was stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)