### PR TITLE
fix static site logo: use square icon-192.png

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -712,7 +712,7 @@
   <nav class="site-nav">
     <div class="container nav-inner">
       <a href="#" class="nav-logo">
-        <img src="/static/icon.png" alt="Fenrir Ledger" width="40" height="40" />
+        <img src="/static/icon-192.png" alt="Fenrir Ledger" width="40" height="40" />
         <span class="nav-wordmark">FENRIR LEDGER</span>
       </a>
       <a href="#" data-app-link target="_blank" rel="noopener" class="btn btn-gold btn-sm">
@@ -727,7 +727,7 @@
     <section class="hero-section">
       <div class="hero-inner saga-reveal">
         <!-- Wolf icon: centered, large, ice-blue glow -->
-        <img src="/static/icon.png" alt="" aria-hidden="true" class="hero-icon" />
+        <img src="/static/icon-192.png" alt="" aria-hidden="true" class="hero-icon" />
 
         <!-- Title block: centered column -->
         <span class="hero-eyebrow">ᚠ · ᛟ · ᛏ</span>


### PR DESCRIPTION
## Problem

`icon.png` is `1536×1024` (non-square, 2.6 MB). With `object-fit: contain` at `40×40`, the entire canvas is scaled down and the wolf emblem becomes tiny/unrecognisable.

## Fix

Swap both display `<img>` tags to `icon-192.png` — a `192×192` square RGBA PNG where the wolf medallion fills the frame cleanly.

- Nav logo (40×40): renders correctly at intended size
- Hero icon (160–200px): still within resolution, no upscaling artefacts
- OG `<meta>` tag left on `icon.png` (larger images are better for social sharing previews)

🤖 Generated with [Claude Code](https://claude.com/claude-code)