### PR TITLE
groom sprint 4 backlog: 5 stories Ready

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 Track every fee-wyrm in your portfolio. Every chain forged, every promo deadline, every fee-serpent's strike date — Fenrir watches and howls before the trap snaps shut. Add your cards, name your thresholds, and the wolf does the rest: reminding you to spend, transfer, downgrade, or close before you lose a single dollar to a fee you didn't choose to pay.
 
-*Sprint 3 in progress — Stories 3.2 (Norse copy pass), 3.3 (Framer Motion card animations), 3.4 (HowlPanel urgent sidebar), and 3.5 (Valhalla archive + Close Card action) shipped. StatusRing next.*
+*Sprint 3 complete. Sprint 4 groomed and Ready: Ragnarök threshold mode, card count milestones, Gleipnir Hunt completion (resolves DEF-001), accessibility polish, and the Wolf's Hunger meter. All 5 stories carry code-audit notes from Freya's 2026-02-28 groom.*
 
 ---
 
@@ -116,7 +116,13 @@ Kanban · Max 5 chains per sprint · The forge-script runs every sprint
 
 - [product/README.md](product/README.md) — Product domain index: mythology map, copywriting guide, backlog
 - [product/product-design-brief.md](product/product-design-brief.md) — Design philosophy, anonymous-first identity model, header states
-- [product/backlog/README.md](product/backlog/README.md) — Groomed backlog index
+- [product/backlog/README.md](product/backlog/README.md) — Groomed backlog index (Sprint 4 stories: 4.1–4.5)
+- [product/backlog/story-4.1-ragnarok-threshold.md](product/backlog/story-4.1-ragnarok-threshold.md) — P1: Ragnarök Threshold Mode (visual alarm ≥3 urgent cards)
+- [product/backlog/story-4.2-card-count-milestones.md](product/backlog/story-4.2-card-count-milestones.md) — P2: Card Count Milestone Toasts (5 thresholds, one-time)
+- [product/backlog/story-4.3-gleipnir-hunt-complete.md](product/backlog/story-4.3-gleipnir-hunt-complete.md) — P2: Gleipnir Hunt — wire fragments 4 and 6, complete the unlock
+- [product/backlog/story-4.4-accessibility-and-ux-polish.md](product/backlog/story-4.4-accessibility-and-ux-polish.md) — P2: Accessibility and UX polish pass (keyboard, mobile, reduced motion)
+- [product/backlog/story-4.5-wolves-hunger-and-about-modal.md](product/backlog/story-4.5-wolves-hunger-and-about-modal.md) — P3: Wolf's Hunger Meter in About modal
+- [product/backlog/future-deferred.md](product/backlog/future-deferred.md) — Deferred items with rationale (LCARS, migration wizard, reminders)
 - [product/backlog/story-auth-oidc-google.md](product/backlog/story-auth-oidc-google.md) — P3 (GA-deferred): Optional Login — Google OIDC + Cloud Sync Upsell
 - [product/handoff-to-luna-anon-auth.md](product/handoff-to-luna-anon-auth.md) — Handoff to Luna: anonymous-first auth + cloud sync upsell UX brief
 

--- a/product/README.md
+++ b/product/README.md
@@ -10,6 +10,12 @@ Freya shapes the vision before the forge ever heats. Nothing moves downstream un
 - [product-design-brief.md](product-design-brief.md) — The Saga Ledger product design brief: design philosophy, aesthetic direction, information architecture, target audience, tone rules, and key design decisions.
 - [mythology-map.md](mythology-map.md) — Norse cosmology mapped to every card state, team role, and UI feature in Fenrir Ledger.
 - [copywriting.md](copywriting.md) — The two-voice rule, kenning vocabulary, status badge copy, action labels, empty states, and Edda quotes.
-- [backlog/README.md](backlog/README.md) — Freya's groomed backlog index: all stories written, prioritized, and cleared for engineering.
+- [backlog/README.md](backlog/README.md) — Freya's groomed backlog index: Sprint 4 stories 4.1–4.5 all marked Ready; groom notes from 2026-02-28 included.
+- [backlog/story-4.1-ragnarok-threshold.md](backlog/story-4.1-ragnarok-threshold.md) — P1-Critical: Ragnarök Threshold Mode (visual alarm when 3+ cards urgent)
+- [backlog/story-4.2-card-count-milestones.md](backlog/story-4.2-card-count-milestones.md) — P2-High: Card Count Milestone Toasts (5 thresholds, one-time each)
+- [backlog/story-4.3-gleipnir-hunt-complete.md](backlog/story-4.3-gleipnir-hunt-complete.md) — P2-High: Gleipnir Hunt — wire fragments 4 and 6, complete the unlock; resolves DEF-001
+- [backlog/story-4.4-accessibility-and-ux-polish.md](backlog/story-4.4-accessibility-and-ux-polish.md) — P2-High: Accessibility and UX polish pass (keyboard, mobile, reduced motion)
+- [backlog/story-4.5-wolves-hunger-and-about-modal.md](backlog/story-4.5-wolves-hunger-and-about-modal.md) — P3-Medium: Wolf's Hunger Meter in About modal and ForgeMasterEgg overlay
+- [backlog/future-deferred.md](backlog/future-deferred.md) — Items explicitly parked out of Sprint 4 with rationale
 - [backlog/story-auth-oidc-google.md](backlog/story-auth-oidc-google.md) — P3-Medium (GA-deferred): Optional Login — Google OIDC + Cloud Sync Upsell; anonymous users need no login; householdId is a locally-generated UUID.
 - [handoff-to-luna-anon-auth.md](handoff-to-luna-anon-auth.md) — Handoff to Luna: anonymous-first auth + cloud sync upsell wireframe requirements.

--- a/product/backlog/README.md
+++ b/product/backlog/README.md
@@ -6,5 +6,53 @@ Groomed stories ready for sprint planning. All stories follow the format defined
 
 | Story | Priority | Status | Sprint Target |
 |-------|----------|--------|---------------|
-| [Branch-Based CI/CD + Vercel Preview Deployments](story-branch-based-ci-cd.md) | P2-High | ✅ Shipped | PR #9 |
-| [Optional Login — Google OIDC + Cloud Sync Upsell (Iteration 1)](story-auth-oidc-google.md) | P3-Medium | ✅ Shipped | commit 60d8f64, QA 24/24 |
+| [Branch-Based CI/CD + Vercel Preview Deployments](story-branch-based-ci-cd.md) | P2-High | Shipped | PR #9 |
+| [Optional Login — Google OIDC + Cloud Sync Upsell (Iteration 1)](story-auth-oidc-google.md) | P3-Medium | Shipped | commit 60d8f64, QA 24/24 |
+| [4.1 — Ragnarök Threshold Mode](story-4.1-ragnarok-threshold.md) | P1-Critical | Ready | Sprint 4 |
+| [4.2 — Card Count Milestone Toasts](story-4.2-card-count-milestones.md) | P2-High | Ready | Sprint 4 |
+| [4.3 — Gleipnir Hunt: Wire Fragments 4 and 6 + Unlock](story-4.3-gleipnir-hunt-complete.md) | P2-High | Ready | Sprint 4 |
+| [4.4 — Accessibility and UX Polish Pass](story-4.4-accessibility-and-ux-polish.md) | P2-High | Ready | Sprint 4 |
+| [4.5 — Wolf's Hunger Meter + About Modal Completeness](story-4.5-wolves-hunger-and-about-modal.md) | P3-Medium | Ready | Sprint 4 |
+
+## Deferred / Future
+
+See [future-deferred.md](future-deferred.md) for items explicitly parked out of Sprint 4 with rationale.
+
+| Item | Why Deferred |
+|------|-------------|
+| LCARS Mode (Star Trek Easter Egg #6) | Sprint cap reached; pure delight, no user-value dependency |
+| localStorage Migration Wizard | Product brief constraint — deferred to GA, no exceptions |
+| Smart Reminders / Notification Engine | Requires backend; out of MVP scope |
+| Reward Value Tracking + Net ROI | Significant feature, needs its own design brief |
+| Timeline View | No UX wireframe; needs Luna's design sprint first |
+| Action Recommendations (Valkyrie Engine) | Complex business logic; needs dedicated design brief |
+| Wolf Paw Cursor | Browser support inconsistency; Luna must champion |
+| Data Export CSV/JSON | Pre-GA only; localStorage DevTools access sufficient |
+
+## Sprint 4 Priority Rationale
+
+**Why this order:**
+
+1. **4.1 Ragnarök (P1)**: Core product promise — "never be surprised by a fee." Ragnarök is the app's most dramatic alarm surface. Ships first because it is the only P1 item and has no dependencies on other Sprint 4 stories.
+
+2. **4.2 Milestones (P2)**: Low complexity, high emotional payoff. Hooks into the card-add flow that FiremanDecko already knows cold. Ships second because it is a quick win that builds momentum.
+
+3. **4.3 Gleipnir Hunt (P2)**: Completes the signature easter egg system. Fragments 4 and 6 are the only missing pieces in an otherwise complete set. The unlock mechanic (shimmer + Valhalla entry) is what makes the whole system pay off. Also resolves Loki's Sprint 3 QA hold (DEF-001: wrong `aria-description` on `ValhallaEmptyState`). Ships third.
+
+4. **4.4 Accessibility Polish (P2)**: Required before real users see this. The team has shipped fast; technical debt in focus management and mobile layout must be addressed before the product enters any broader user testing. Ships fourth — it touches many components, so better to land after other Sprint 4 changes are merged.
+
+5. **4.5 Wolf's Hunger Meter (P3)**: Purely additive to the About modal and ForgeMasterEgg overlay. No risk to core flows. Ships last because if the sprint runs short, this is the safest story to defer to Sprint 5.
+
+## Sprint 4 Groom Notes (2026-02-28)
+
+These observations were made during the Sprint 4 groom. They refine the stories but do not change their scope or priority.
+
+**4.1 Ragnarök**: `KonamiHowl.tsx` already performs a card-data read to check for urgent cards (for the existing pulse flash). The new `RagnarokContext` must be the single source of truth — `KonamiHowl` should consume the context rather than doing its own card read. The audio volume escalation note has been updated: as of Sprint 3, the wolf animation is visual-only (no audio node). The Konami volume criterion may be marked N/A in the QA handoff if no audio is wired.
+
+**4.3 Gleipnir Hunt**: Both fragment components (`GleipnirBearSinews`, `GleipnirBirdSpittle`) and their hooks are fully built — only the trigger wiring is missing. The Sprint 3 DEF-001 bug (wrong `aria-description` on `ValhallaEmptyState`) is explicitly in scope for this story's delivery.
+
+**4.5 Wolf's Hunger Meter**: The `SignUpBonus` interface uses `met: boolean` — not `bonusMet`. All acceptance criteria and technical notes have been corrected. This was a grooming error in the original story; it would have caused a type error on first compile.
+
+## Sprint Cap
+
+Max 5 stories per sprint (per product brief technical constraints). Sprint 4 is at cap.

--- a/product/backlog/future-deferred.md
+++ b/product/backlog/future-deferred.md
@@ -1,0 +1,63 @@
+# Future / Deferred Items
+
+Stories explicitly parked by Freya as post-Sprint 4 work. These are not forgotten — they are in the queue for the right sprint.
+
+---
+
+## LCARS Mode (Star Trek Easter Egg #6) — Deferred to Sprint 5+
+
+**Why deferred**: The Gleipnir Hunt completion, Ragnarök mode, milestone toasts, and the accessibility pass are all higher-value and more tightly integrated with existing features. LCARS mode is a standalone easter egg that requires building a temporary UI overlay with no dependencies on other Sprint 4 work. It has no user-value justification beyond delight. Sprint 4 has 5 stories already (at the team's sprint cap).
+
+**When to revisit**: Sprint 5, as the opening story if the team has capacity for pure delight work after core functionality gaps are addressed.
+
+**Spec**: See `ux/easter-eggs.md` #6. `Cmd+Shift+W` trigger, 5-second LCARS amber overlay with stardate, card counts, and a scan-line wipe exit. The full spec is written and ready — this is purely an implementation deferral.
+
+---
+
+## localStorage Migration Wizard — Explicitly and Permanently Deferred to GA
+
+**Why deferred**: The product brief is unambiguous: "Remote storage and data migration are explicitly deferred until the team has received multiple rounds of real user feedback and declared the product ready for GA." This is a product constraint, not a technical one. localStorage is sufficient for the entire validation cycle.
+
+**This cannot be moved up** regardless of sprint capacity. If FiremanDecko wants to do preparatory architectural work, he can open an ADR for review — but no user-visible migration UI will ship before GA planning is triggered.
+
+---
+
+## Smart Reminders / Notification Engine — Deferred to Sprint 5+
+
+**Why deferred**: The product brief lists this as a "Future" item. It requires either push notifications (requires a backend service) or in-browser notifications (requires the Notifications API + user permission). Neither is in scope for the localStorage-only phase. The Howl panel is the current reminder surface and is sufficient for MVP validation.
+
+---
+
+## Reward Value Tracking + Net ROI — Deferred to Sprint 5+
+
+**Why deferred**: The Wolf's Hunger meter (Story 4.5) surfaces existing bonus data. True reward tracking — logging ongoing spend per category, calculating net value after fees paid — requires new data model fields (`feePaid`, `rewardsEarned` log, etc.) and likely a new UI surface. This is a significant feature that deserves its own sprint, not a bolt-on to the easter egg system.
+
+---
+
+## Timeline View — Deferred
+
+**Why deferred**: The product brief describes a timeline view showing card opening dates, promo expiration, and fee dates on a visual axis. This is a meaningful feature but has no UX wireframe and no architecture plan. It belongs in a dedicated sprint with Luna designing it first.
+
+---
+
+## Action Recommendations (Valkyrie Engine) — Deferred
+
+**Why deferred**: The mythology-map describes a "Valkyrie" recommendation engine (keep, close, downgrade, transfer). This requires business logic that touches card ROI, issuer rules, and user preferences. It's a product feature that warrants its own design brief. Not Sprint 4.
+
+---
+
+## Optional Login / Google OIDC (Iteration 2) — Deferred to GA
+
+**Status**: Story `story-auth-oidc-google.md` exists in the backlog and is marked P3-Medium. The anonymous-first auth + cloud sync upsell banner shipped in Sprint 3. Actual OIDC authentication and backend storage are deferred to GA per the product brief. Nothing changes here.
+
+---
+
+## Wolf Paw Cursor — Deferred
+
+**Spec**: `public/cursors/wolf-paw.svg` is mentioned in the architecture brief as a Sprint 4 item. However, custom SVG cursors have inconsistent browser support (especially on mobile, where cursors don't apply) and add non-trivial asset work for minimal user impact. Deferred indefinitely unless Luna champions it with a specific UX rationale.
+
+---
+
+## Data Export (CSV/JSON) — Deferred
+
+**Why deferred**: Useful for power users who want a backup or want to switch tools. But this is pre-GA work only — during the validation cycle, localStorage data is visible via DevTools and the upsell banner will eventually prompt users toward cloud sync. No sprint target yet.

--- a/product/backlog/story-4.1-ragnarok-threshold.md
+++ b/product/backlog/story-4.1-ragnarok-threshold.md
@@ -1,0 +1,124 @@
+# Story 4.1: Ragnarök Threshold Mode
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: The app to visually escalate when I have multiple cards in critical status simultaneously
+- **So that**: I feel the urgency of multiple approaching deadlines — not just one card's badge turning orange, but the entire war room going to red
+- **Priority**: P1-Critical
+- **Sprint Target**: 4
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+The Saga Ledger's mythology is built around the idea that annual fees are wolves chasing you across the sky. When multiple wolves catch up at once — that is Ragnarök. Right now, a user with 4 cards all going fee-critical at the same time sees the same UI as a user with zero urgent cards. There is no escalation. The emotional design contract is broken.
+
+Ragnarök threshold mode is the app's single most important visual alarm: when ≥ 3 cards are simultaneously `fee_approaching` or `promo_expiring`, the entire UI shifts register. This is not a toast. This is an atmosphere change.
+
+This story is P1 because it directly serves the core product promise: never let a fee surprise you. Visual escalation is the last line of defense before a missed deadline.
+
+---
+
+## Desired Outcome
+
+When a user reaches ≥ 3 cards with `fee_approaching` or `promo_expiring` status simultaneously:
+
+1. The background gains a deep red radial overlay (CSS-only, no JS layout thrash)
+2. Gold accents shift toward blood orange (`#c94a0a`)
+3. The browser `<title>` becomes `Ragnarök — Fenrir Ledger`
+4. The Howl panel header glows red and reads: *"Ragnarök approaches. Multiple chains tighten."*
+5. Konami code during Ragnarök plays the wolf howl at maximum intensity (existing `KonamiHowl` component reads a context flag)
+6. When cards drop below threshold, the mode resolves automatically — no manual dismiss needed
+
+---
+
+## Interactions and User Flow
+
+1. User has 0-2 urgent cards: normal UI. No change.
+2. User reaches 3rd urgent card (by adding a card, editing a date, or time passing): Ragnarök mode activates within one render cycle.
+3. Ragnarök mode active: red overlay visible across all pages (not just dashboard). Title updates.
+4. User closes/resolves a card so urgent count drops to 2: Ragnarök resolves. UI returns to normal. Transition must be graceful (CSS transition, not a flash).
+5. During Ragnarök: if user triggers Konami code, the howl plays at `volume = 1.0` instead of `0.25`.
+
+---
+
+## Look and Feel Direction
+
+- **Red overlay**: `radial-gradient(ellipse at 50% 0%, rgba(150, 30, 10, 0.18) 0%, transparent 65%)` applied as a pseudo-element on `<body>` or a fixed full-viewport `<div>` with `pointer-events: none`. Do NOT use `filter` on the root — it will break stacking contexts for all the modals.
+- **Accent shift**: CSS custom property `--ragnarok` toggled on `<html>` (e.g. `class="ragnarok"`) so all downstream gold-colored elements can optionally shift via the class. Keep shifts subtle — only Howl panel header and key accents, not every element on screen.
+- **No layout shift**: The overlay must be `position: fixed`, `inset: 0`, `pointer-events: none`, and `z-index` below modals/toasts.
+- **Transition**: 1.2s ease-in on activation; 0.8s ease-out on deactivation.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When ≥ 3 cards have `fee_approaching` or `promo_expiring` status, the app enters Ragnarök mode within one render cycle of the threshold being crossed
+- [ ] Ragnarök mode: a red radial overlay is visible on the dashboard — does not obstruct readability or interaction
+- [ ] Ragnarök mode: the browser `<title>` on the dashboard page reads `Ragnarök — Fenrir Ledger`
+- [ ] Ragnarök mode: the HowlPanel header reads *"Ragnarök approaches. Multiple chains tighten."* (overrides normal empty-state copy)
+- [ ] When the urgent card count drops below 3, Ragnarök mode deactivates within one render cycle
+- [ ] Transitions in and out are CSS-animated (no jarring flash)
+- [ ] Ragnarök overlay does not block clicks, form inputs, or keyboard navigation
+- [ ] Konami code during Ragnarök triggers the wolf howl at maximum volume (`1.0`)
+- [ ] Konami code outside Ragnarök continues to use normal volume (`0.25`)
+- [ ] Ragnarök mode does not affect the Valhalla page (closed cards are beyond the storm)
+- [ ] No WCAG AA contrast violations introduced by the red overlay on foreground text
+- [ ] Ragnarök state is computed from live card data — does not require a page refresh to activate/deactivate
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Code audit completed (Sprint 4 groom)**: `KonamiHowl.tsx` already reads card data from `getAllCardsGlobal()` and checks for `fee_approaching || promo_expiring` cards to decide whether to show the Ragnarök pulse flash. However, it does not read a shared `RagnarokContext` — it reads cards independently. This story must add the shared context so `HowlPanel` and the volume escalation are coordinated. The existing pulse check in `KonamiHowl` is complementary, not conflicting.
+
+**State computation**: `computeCardStatus()` in `card-utils.ts` already determines `fee_approaching` and `promo_expiring`. Count urgentCards where `status === 'fee_approaching' || status === 'promo_expiring'`. If `urgentCards.length >= 3`, Ragnarök.
+
+**React context pattern** (recommended): Create a `RagnarokContext` (or add a `ragnarok: boolean` field to an existing dashboard state) and provide it from the `AppShell` or a dedicated `RagnarokProvider` wrapping the layout. Components that need to read the state (HowlPanel, KonamiHowl) consume this context.
+
+**KonamiHowl volume escalation**: The component currently hardcodes no volume variable — the wolf silhouette SVG plays via `AudioContext`. Inspect `KonamiHowl.tsx` to find the audio trigger path. If it uses a static amplitude, add a `useRagnarok()` context consumer that adjusts gain on the audio node. If no audio node is currently wired (the howl is visual-only), this criterion is trivially met and may be annotated as "audio not yet implemented" in the QA handoff.
+
+**Overlay approach**: A `<div>` in AppShell with:
+```tsx
+<div
+  aria-hidden="true"
+  className={`fixed inset-0 pointer-events-none transition-opacity duration-[1200ms]
+              ${ragnarok ? 'opacity-100' : 'opacity-0'}`}
+  style={{
+    background: 'radial-gradient(ellipse at 50% 0%, rgba(150,30,10,0.18) 0%, transparent 65%)',
+    zIndex: 1, // above background, below all content
+  }}
+/>
+```
+
+**KonamiHowl integration**: `KonamiHowl.tsx` currently hardcodes `HOWL_TARGET_VOLUME = 0.25`. It needs to read the `ragnarok` context flag and use `1.0` when active. The component is already in AppShell — wiring context is straightforward.
+
+**Title update**: Use Next.js `<title>` metadata — but since metadata is per-route, the simplest approach is a `useEffect` on the dashboard page that sets `document.title` when `ragnarok` is true and resets it on cleanup. Not ideal for SEO but acceptable for an easter egg state.
+
+**HowlPanel header copy**: HowlPanel currently renders a fixed header. It needs to accept a `ragnarok` prop (or consume context) and conditionally render the Ragnarök copy.
+
+**Do NOT**: use CSS `filter` on any layout-level element. It will create a stacking context and break all portal-rendered modals (Dialog, Sheet, etc.).
+
+**Valhalla exclusion**: Ragnarök mode should not activate on `/valhalla`. The overlay div can read `pathname` from `usePathname()` and render `null` on that route.
+
+---
+
+## Open Questions Resolved
+
+- **Threshold**: ≥ 3 urgent cards. This matches the easter eggs doc and mythology-map. Not configurable in Sprint 4 — hard-coded.
+- **Which statuses count**: `fee_approaching` and `promo_expiring` both count. `active` and `closed` do not. Overdue (future status) would count.
+- **Konami volume behavior**: Double intensity = `volume: 1.0`, not literally double the normal value. Capped at max.
+- **localStorage migration wizard**: Explicitly deferred — see future section.
+
+---
+
+## UX Notes
+
+See `ux/easter-eggs.md` #8 and `ux/interactions.md` for the saga-shake animation spec (reused during Konami in Ragnarök state). The wolf-rise animation is unchanged — only volume increases.
+
+---
+
+## Future (Not Sprint 4)
+
+- Configurable Ragnarök threshold in settings
+- Ragnarök-specific sound effect distinct from the normal howl

--- a/product/backlog/story-4.2-card-count-milestones.md
+++ b/product/backlog/story-4.2-card-count-milestones.md
@@ -1,0 +1,111 @@
+# Story 4.2: Card Count Milestone Toasts
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: The app to acknowledge when I hit significant portfolio milestones
+- **So that**: I feel the satisfying weight of building a serious rewards portfolio — not just adding cards silently into a list
+- **Priority**: P2-High
+- **Sprint Target**: 4
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+Adding a card right now is purely transactional. Form filled, card appears in the grid. Done. There is no ceremony. This wastes a perfect emotional hook: the moment when a power user's portfolio reaches a meaningful size is a real milestone, and the mythology gives us exactly the right voice for it.
+
+The easter eggs doc defines 5 milestone thresholds with copy already written. The copy is great. This story is the implementation.
+
+---
+
+## Desired Outcome
+
+When the user's count of **active** cards (not counting Valhalla/closed) crosses specific thresholds for the first time, a toast fires. Each threshold is one-time-only — it never fires again for that user.
+
+| Active card count | Toast copy |
+|---|---|
+| 1 | *"The first chain is forged. Fenrir stirs."* |
+| 5 | *"Five chains. The Pack grows."* |
+| 9 | *"Nine chains — one for each realm. Odin watches."* |
+| 13 | *"Thirteen chains. Even Loki is impressed."* |
+| 20 | *"Twenty chains. The great wolf is bound no longer — it is the gods who should fear you."* |
+
+---
+
+## Interactions and User Flow
+
+1. User adds a card. After the form saves and the dashboard re-renders:
+2. The new active card count is computed.
+3. If the count matches a threshold AND the user has not seen this milestone toast before, fire the toast.
+4. Toast appears in the standard shadcn `Toaster` position (top-right or bottom-right — match existing toast placement).
+5. Toast uses atmospheric Voice 2 copy. No emoji. No action buttons.
+6. Toast auto-dismisses after 5 seconds. Not sticky.
+7. `localStorage` key `egg:milestone-N` (where N = the count) is set on first fire — never fires again.
+
+**Edge case**: User adds 3 cards at once via some future bulk import. Each threshold that was crossed fires its toast. Toasts stack. This is correct behavior — don't suppress earlier thresholds just because a later one fired.
+
+---
+
+## Look and Feel Direction
+
+- Toast background: `#0f1018` (slightly elevated from void-black — same as Gleipnir modals)
+- Border: `1px solid #2a2d45` (rune-border)
+- Text: `#e8e4d4` body copy, gold accent rune prefix
+- A rune character as a visual prefix: use ᚠ (Fehu — cattle/wealth) for milestones 1-5, ᛊ (Sowilo — sun/glory) for 9+
+- Duration: 5 seconds, then auto-dismiss with a fade-out
+- No close button required — these are celebratory, not actionable
+
+---
+
+## Acceptance Criteria
+
+- [ ] Adding a card that brings the active count to 1 fires the milestone-1 toast exactly once
+- [ ] Adding a card that brings the active count to 5 fires the milestone-5 toast exactly once
+- [ ] Adding a card that brings the active count to 9 fires the milestone-9 toast exactly once
+- [ ] Adding a card that brings the active count to 13 fires the milestone-13 toast exactly once
+- [ ] Adding a card that brings the active count to 20 fires the milestone-20 toast exactly once
+- [ ] No toast fires if that threshold has already been seen (checked against `localStorage`)
+- [ ] Toasts use the exact copy from the easter eggs doc (see above table) — no paraphrasing
+- [ ] Toast auto-dismisses after 5 seconds
+- [ ] Closing a card (sending to Valhalla) that drops the count below a threshold does NOT re-fire the toast when the threshold is re-crossed later (milestones are one-time)
+- [ ] Milestone tracking uses localStorage keys `egg:milestone-1`, `egg:milestone-5`, `egg:milestone-9`, `egg:milestone-13`, `egg:milestone-20`
+- [ ] Milestone count is based on active cards only — `closed` cards are not counted
+- [ ] No milestone toast fires during page load/hydration — only on explicit user action (card add/edit)
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Where to fire**: The best location is in the `onSubmit` success handler of `CardForm.tsx` (after `storage.ts` write completes). Alternatively, a `useEffect` watching the card count in `Dashboard.tsx` will also work — but be careful to suppress the effect on initial page load (use a `mounted` ref or compare previous count).
+
+**Count computation**: Filter cards from `getCards(householdId)` where `status !== 'closed'`. Length = active count.
+
+**Storage keys**: `egg:milestone-1`, `egg:milestone-5`, `egg:milestone-9`, `egg:milestone-13`, `egg:milestone-20`. Check before firing; set on fire.
+
+**Toast system**: shadcn/ui's `useToast` (or `sonner` if that's what's installed — check `package.json`). The toast needs custom styling (dark background, gold accent). Use the `className` prop on the toast call or a custom toast variant.
+
+**Multiple thresholds in one action**: If a user has 4 cards and adds 5 at once (future bulk import), both the 5-card and 9-card toasts may fire. Handle this by iterating all thresholds and queueing multiple toasts with a short delay between them (200ms stagger). This is unlikely to occur in Sprint 4 but the implementation should not assume a single threshold per save.
+
+**The 20-card toast**: The copy is long. Ensure the toast container has `max-w-sm` or wider — don't clip it.
+
+---
+
+## Open Questions Resolved
+
+- **Which count**: Active cards only. Closed cards in Valhalla do not count.
+- **Re-fire behavior**: Never. Once seen, never again. localStorage is the gate.
+- **Milestone at app load**: Suppress. Milestones celebrate adding a card, not page load.
+- **Toast duration**: 5 seconds. Not configurable in Sprint 4.
+
+---
+
+## UX Notes
+
+See `product/copywriting.md` and `ux/easter-eggs.md` #11 for the full milestone table and copy. Voice 2 (atmospheric) throughout — no functional copy mixed in.
+
+---
+
+## Future (Not Sprint 4)
+
+- Additional milestones beyond 20
+- Milestone for total lifetime rewards value extracted (Wolf's Hunger meter integration)
+- Milestone animation: brief card-grid flash on threshold crossing

--- a/product/backlog/story-4.3-gleipnir-hunt-complete.md
+++ b/product/backlog/story-4.3-gleipnir-hunt-complete.md
@@ -1,0 +1,163 @@
+# Story 4.3: Gleipnir Hunt — Wire the Two Missing Triggers (Fragments 4 and 6)
+
+- **As a**: Credit card churner and rewards optimizer who has been exploring the app
+- **I want**: All six Gleipnir fragments to be discoverable through natural app use
+- **So that**: Finding all six and watching the app shimmer is a real, achievable reward for curious exploration — not a half-finished promise
+- **Priority**: P2-High
+- **Sprint Target**: 4
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+The Gleipnir Hunt is the signature easter egg of Fenrir Ledger — six hidden phrases scattered across the UI that, when all found, unlock a special Valhalla entry. It is the most ambitious hidden system in the product.
+
+After Sprint 3, the status is:
+
+| Fragment | Ingredient | Trigger | Status |
+|----------|-----------|---------|--------|
+| 1 | *The sound of a cat's footfall* | Click/hover the SyncIndicator dot (bottom-right) | **Wired and shipped** |
+| 2 | *The beard of a woman* | Click the ingredient text in the About modal | **Wired and shipped** |
+| 3 | *The roots of a mountain* | First sidebar collapse | **Wired and shipped** |
+| 4 | *The sinews of a bear* | TBD — trigger undefined | **Modal exists; trigger missing** |
+| 5 | *The breath of a fish* | Hover the © in the Footer | **Wired and shipped** |
+| 6 | *The spittle of a bird* | TBD — trigger undefined | **Modal exists; trigger missing** |
+
+Fragments 4 and 6 have modals (`GleipnirBearSinews.tsx` and `GleipnirBirdSpittle.tsx`) fully implemented but no trigger is wired. The hunt is uncompletable. This story fixes that.
+
+Additionally, when all 6 fragments are found, the Valhalla page should gain a special "Gleipnir" entry and the page should play the `gleipnir-shimmer` CSS animation. This unlock mechanic is also not yet implemented.
+
+---
+
+## Fragment 4: The Sinews of a Bear — Trigger Decision
+
+**Placement**: The card detail view / edit form (`/cards/[id]` or the edit dialog). When the user saves a card for the **seventh time** — the number 7 is already a magic number in Fenrir Ledger (Loki's children). On the seventh save of any card, the ingredient *"The sinews of a bear"* briefly appears as a flash over the forge-success animation, and the modal fires.
+
+**Rationale**: Bears are associated with strength and endurance. Editing a card 7 times means you've been maintaining it — persistent, methodical. This rewards the dedicated optimizer who keeps their ledger updated.
+
+**Alternative placement considered and rejected**: A tooltip on the credit limit field — too discoverable, breaks the "impossible things" theme (the sinews of a bear are invisible, not something you'd hover over a number field to find).
+
+**Implementation approach**: Count saves per card in localStorage under `fenrir:card-saves:{cardId}`. On reaching 7, trigger the fragment. The count only needs to track "has this threshold been hit for this card" — it does not need to count across cards.
+
+**Simpler alternative** (if 7-save tracking adds complexity FiremanDecko wants to defer): The trigger can be the card-delete confirm button — a long press (600ms) on the "Delete" button in the confirmation dialog. Long-press is unexpected, rewarding, and thematically appropriate (the sinews of a bear require force to break). This is a valid fallback.
+
+---
+
+## Fragment 6: The Spittle of a Bird — Trigger Decision
+
+**Placement**: The Valhalla page empty state. When a user visits Valhalla with zero closed cards and waits on the page for **15 seconds without interaction**, the `GleipnirBirdSpittle` modal fires.
+
+**Rationale**: The Valhalla empty state already has an `aria-description="the beard of a woman"` placeholder comment from Sprint 3 — but that was a mistake in the naming (beard = fragment 2, already taken). The intended fragment here is 6 (bird spittle). Birds are the carriers of messages — waiting in an empty hall, listening. The 15-second idle trigger rewards patience.
+
+**Implementation**: In the Valhalla page empty state component (`ValhallaEmptyState`), add a `setTimeout` that fires after 15 seconds of the component being mounted. If the user navigates away, the `useEffect` cleanup cancels the timer. One-time: check `localStorage` before firing.
+
+**Fallback note**: If the product team finds the 15-second wait too long in testing, reduce to 10 seconds. FiremanDecko can tune this without a story update.
+
+---
+
+## The Gleipnir Complete Unlock
+
+When all 6 fragments are found (detected via all 6 `egg:gleipnir-N` localStorage keys being set), the following happens:
+
+1. **Page shimmer**: The `gleipnir-shimmer` CSS animation fires on `<html>` (already defined in `interactions.md`). Duration: 2 seconds.
+2. **Valhalla special entry**: The `/valhalla` page adds a special card at the top of the list:
+   > **Gleipnir** — *The chain that bound the great wolf. Made of impossible things. No chain is stronger.*
+   > Opened: [user's first card open date] · Closed: [today's date] · Rewards extracted: *Freedom itself*
+3. **localStorage key**: `egg:gleipnir-complete` is set to `"1"` to mark the achievement.
+
+The Valhalla special entry persists across page refreshes (read from the `egg:gleipnir-complete` key + the fragment completion check).
+
+---
+
+## Acceptance Criteria
+
+**Fragment 4 — Sinews of a Bear:**
+- [ ] Saving a card for the 7th time (any card, cumulative per-card) triggers the `GleipnirBearSinews` modal
+- [ ] The trigger fires only once per user (`egg:gleipnir-4` localStorage key gates it)
+- [ ] The per-card save count is stored in localStorage and does not reset on page reload
+
+**Fragment 6 — Spittle of a Bird:**
+- [ ] Visiting the Valhalla page empty state and remaining idle for 15 seconds triggers the `GleipnirBirdSpittle` modal
+- [ ] The trigger fires only if the empty state is visible (no closed cards) AND the user is on the Valhalla route
+- [ ] Navigating away before 15 seconds cancels the timer (no modal fires after navigation)
+- [ ] The trigger fires only once per user (`egg:gleipnir-6` localStorage key gates it)
+
+**Gleipnir Complete Unlock:**
+- [ ] When all 6 `egg:gleipnir-N` keys are set, the `gleipnir-shimmer` animation fires on `<html>` for 2 seconds
+- [ ] The Valhalla page shows the Gleipnir special entry at the top when `egg:gleipnir-complete` is set
+- [ ] The Gleipnir entry displays: name "Gleipnir", atmospheric subtext, first card open date, today's date, and "Freedom itself" as rewards
+- [ ] If the user has no active or closed cards, the first card open date field shows "Before memory" (fallback)
+- [ ] The Gleipnir entry is visually distinct from normal Valhalla tombstone cards (gold border, no issuer badge, italicized rewards field)
+- [ ] `ForgeMasterEgg` (`?` shortcut) shows "6 of 6 Gleipnir fragments found" when complete
+
+**General:**
+- [ ] All 6 fragment triggers are independently discoverable without documentation
+- [ ] Fragment modals show the correct "N of 6 found" count when opened
+- [ ] The fragment-found modal for the completing fragment (whichever is 6th) shows "6 of 6 found" and displays the shimmer unlock message
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Code audit completed (Sprint 4 groom)**: Both `GleipnirBearSinews.tsx` and `GleipnirBirdSpittle.tsx` exist in `src/components/cards/` and are fully implemented — modal, accessibility description, fragment counter display, and `useGleipnirFragment4()` / `useGleipnirFragment6()` hooks with localStorage gating. The `trigger()` and `dismiss()` functions are ready to consume. This story is purely about wiring the triggers — no new component work is needed. Similarly, `GleipnirWomansBeard.tsx` (fragment 2) and `GleipnirMountainRoots.tsx` (fragment 3) demonstrate the established wiring pattern to follow.
+
+**Fragment 4 (save count)**:
+- localStorage key pattern: `fenrir:card-saves:{cardId}` — store as a stringified integer
+- Increment in the `onSubmit` success path of `CardForm.tsx` (same place as milestone toasts)
+- Check `!localStorage.getItem('egg:gleipnir-4')` before triggering
+- The `GleipnirBearSinews` component and `useGleipnirBearSinews` hook are already built in `components/cards/GleipnirBearSinews.tsx`
+
+**Fragment 6 (idle timer)**:
+- `useEffect` in `ValhallaEmptyState` (or the parent `ValhallaPage`):
+  ```tsx
+  useEffect(() => {
+    if (localStorage.getItem('egg:gleipnir-6')) return; // already found
+    const id = setTimeout(() => triggerBirdSpittle(), 15_000);
+    return () => clearTimeout(id);
+  }, []); // run once on mount; cleanup on unmount cancels timer
+  ```
+- Wire `triggerBirdSpittle` from `useGleipnirFragment6()` hook (already exists in `GleipnirBirdSpittle.tsx`)
+- The `ValhallaEmptyState` only renders when there are zero closed cards — the mount condition is correct by construction
+
+**Gleipnir complete check** (shared utility — recommend adding to `lib/storage.ts` or a new `lib/gleipnir-utils.ts`):
+```ts
+export function getGleipnirFoundCount(): number {
+  return Array.from({ length: 6 }, (_, i) =>
+    localStorage.getItem(`egg:gleipnir-${i + 1}`)
+  ).filter(Boolean).length;
+}
+
+export function isGleipnirComplete(): boolean {
+  return getGleipnirFoundCount() === 6;
+}
+```
+
+**Shimmer animation**: Already defined in `ux/interactions.md` as `@keyframes gleipnir-shimmer` on `html.gleipnir-complete`. Add the class to `<html>` via `document.documentElement.classList.add('gleipnir-complete')`, then remove it after 2 seconds.
+
+**Valhalla special entry**: The Gleipnir entry should render at the top of the card list in `ValhallaPage`, before the normal tombstone cards. It is not a real `Card` object — render it as a separate JSX element conditional on `isGleipnirComplete()`. First card open date: `Math.min` of all card `openedDate` values across active + closed cards, formatted as a date string.
+
+**`aria-description` cleanup (DEF-001 from Loki's Sprint 3 QA verdict)**: The `ValhallaEmptyState` in `valhalla/page.tsx` has `aria-description="the beard of a woman"` — this was a Sprint 3 bug identified by Loki (QA hold: `quality/story-3.5-verdict.md`). The beard is fragment 2, already wired in `AboutModal.tsx`. The Valhalla empty state's `aria-description` must be removed as part of this story. The idle timer (15-second mount delay) is the correct fragment 6 trigger — no DOM aria annotation is needed or wanted.
+
+---
+
+## Open Questions Resolved
+
+- **Fragment 4 trigger**: 7th card save. Fallback: long-press on Delete button. FiremanDecko chooses based on implementation complexity.
+- **Fragment 6 trigger**: 15-second idle on Valhalla empty state.
+- **localStorage migration wizard**: Explicitly out of scope — see product brief. This story does NOT introduce any migration tooling.
+- **Gleipnir entry data**: First card open date sourced from all cards in localStorage (active + closed combined).
+
+---
+
+## UX Notes
+
+See `ux/easter-eggs.md` #1 for the full Gleipnir Hunt specification, including the `@keyframes gleipnir-shimmer` animation and the Valhalla unlock card copy. See `ux/interactions.md` for the shimmer animation definition.
+
+---
+
+## Future (Not Sprint 4)
+
+- LCARS mode (Star Trek easter egg, `Cmd+Shift+W`) — deferred; see story-4.x-future-deferred.md
+- Wolf's Hunger meter in the About modal — deferred (requires reward tracking feature first)
+- Sound effect on Gleipnir complete (distinct from the growl)

--- a/product/backlog/story-4.4-accessibility-and-ux-polish.md
+++ b/product/backlog/story-4.4-accessibility-and-ux-polish.md
@@ -1,0 +1,130 @@
+# Story 4.4: Accessibility and UX Polish Pass
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: The app to work correctly at every breakpoint, with keyboard-only navigation, and without jarring rough edges
+- **So that**: I can use Fenrir Ledger efficiently on any device, in any context, without fighting the UI
+- **Priority**: P2-High
+- **Sprint Target**: 4
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+Sprint 1 through 3 prioritized feature velocity. The design system is in, the mythology is wired, the easter eggs are landing. But this sprint creates an opportunity to address the accumulated roughness that fast-moving sprints always leave behind.
+
+This is not a "nice to have" polish sprint. Accessibility is a minimum bar for any product that will reach real users. Several concrete issues have been identified or are likely based on the component inventory:
+
+1. **Keyboard navigation through easter eggs**: The Gleipnir fragment modals, the About modal, and the ForgeMasterEgg dialog all need verified keyboard trap behavior (focus does not escape modal; Escape closes; Tab cycles within).
+2. **Mobile layout at 375px**: The HowlPanel sidebar has not been verified on 375px width. At narrow widths it could overlap card content or push the main column.
+3. **Focus management on card add/edit**: After a successful card save, focus should return to a sensible location (the "Add Card" button or the card tile that was just created). Right now focus likely falls off into the void.
+4. **Toast positioning**: Toasts added in Story 4.2 need positioning verified on mobile so they do not overlap the sticky TopBar.
+5. **StatusRing and StatusBadge aria labels**: Screen reader users need to understand the card status without relying on color or rune glyphs.
+6. **The HowlPanel on mobile**: The spec calls for it to be a drawer on mobile. Verify it renders as a drawer (from the bottom or side) at <768px, not a fixed sidebar that overlaps content.
+7. **Animation reduced-motion support**: `prefers-reduced-motion` should suppress or reduce all `framer-motion` and CSS keyframe animations. The `globals.css` likely does not have these media query overrides yet.
+
+---
+
+## Desired Outcome
+
+After this story ships:
+- A keyboard-only user can add a card, navigate to Valhalla, open and close the About modal, and dismiss the HowlPanel without using a mouse
+- A user on a 375px mobile device sees no horizontal overflow on any page
+- Screen readers announce card status in plain English (not just rune glyphs)
+- All animations respect `prefers-reduced-motion: reduce`
+- Focus is managed correctly on modal open and close throughout the app
+
+---
+
+## Acceptance Criteria
+
+**Keyboard Navigation:**
+- [ ] The About modal traps focus when open: Tab cycles through interactive elements inside the modal; Escape closes it; focus returns to the trigger element (Fenrir logo button) on close
+- [ ] The ForgeMasterEgg (`?` shortcut) modal traps focus and closes on Escape; focus returns to the previously focused element
+- [ ] All 6 Gleipnir fragment modals trap focus and close on Escape
+- [ ] The HowlPanel is keyboard-reachable (a skip link or Tab order includes it)
+- [ ] The SyncIndicator dot is keyboard-accessible (Tab-focusable, Enter/Space triggers the fragment)
+
+**Mobile Layout (375px minimum):**
+- [ ] Dashboard card grid renders without horizontal overflow at 375px
+- [ ] HowlPanel renders as a bottom drawer or dismissible overlay on mobile (<768px) — not as a sidebar that narrows the content column
+- [ ] The TopBar, SideNav (collapsed), and main content column are all visible at 375px with no content clipped
+- [ ] Toast notifications render within the viewport at 375px without overlapping the TopBar
+
+**Focus Management:**
+- [ ] After a successful card save (add or edit), focus moves to the newly created/updated card tile OR to the "Add Card" button — not lost
+- [ ] After closing a card (sending to Valhalla), focus moves to the next card tile or the empty state if no cards remain
+- [ ] After dismissing any modal, focus returns to the element that triggered it
+
+**Screen Reader Accessibility:**
+- [ ] `StatusBadge` includes an `aria-label` that reads the status in plain English (e.g. "Card status: Fee Due Soon — 14 days remaining")
+- [ ] `StatusRing` SVG includes a `<title>` or `aria-label` with the days-remaining value
+- [ ] Rune characters used as decorative elements carry `aria-hidden="true"` throughout
+- [ ] Gleipnir fragment modals have accessible `DialogDescription` text (already partially implemented — verify all 6)
+
+**Reduced Motion:**
+- [ ] `@media (prefers-reduced-motion: reduce)` disables or reduces: `saga-enter`, `saga-shimmer`, `muspel-pulse`, `wolf-rise`, `raven-warn`, and `gleipnir-shimmer` animations
+- [ ] Framer Motion's `useReducedMotion()` hook is applied in `AnimatedCardGrid.tsx` to suppress card enter/exit animations when the user prefers reduced motion
+
+**Contrast:**
+- [ ] No WCAG AA contrast failures on any foreground text against the Ragnarök red overlay (from Story 4.1)
+- [ ] No WCAG AA contrast failures introduced by milestone toasts (from Story 4.2)
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Focus trap**: shadcn/ui `Dialog` handles focus trap by default via Radix UI. Verify this is working correctly for all modals — it should be, but test explicitly. The `ForgeMasterEgg` modal likely uses `Dialog` as well.
+
+**HowlPanel mobile (code audit, Sprint 4 groom)**: `HowlPanel.tsx` exports both `HowlPanel` and `AnimatedHowlPanel`. The `AnimatedHowlPanel` already implements the mobile bottom-sheet pattern: when `mobileOpen` is true, it renders a backdrop + a `motion.div` anchored to `bottom-0` with `max-h-[70vh]`. The desktop panel slides in from the right using `AnimatePresence`. This is very close to the specified behaviour. FiremanDecko should verify the mobile sheet renders correctly at 375px and that the close button within the sheet is keyboard-accessible. No full rewrite should be necessary — just verification and any gap fixes.
+
+**Reduced motion CSS**:
+```css
+@media (prefers-reduced-motion: reduce) {
+  .saga-reveal > * {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+  .ring--urgent {
+    animation: none;
+  }
+  @keyframes saga-shimmer { /* no-op */ }
+  html.gleipnir-complete {
+    animation: none;
+  }
+}
+```
+
+**Framer Motion reduced motion**:
+```tsx
+import { useReducedMotion } from 'framer-motion';
+const shouldReduce = useReducedMotion();
+// Pass shouldReduce to AnimatePresence/motion.div to skip animations
+```
+
+**`aria-hidden` audit**: Search the codebase for all rune character renders. Each one should have `aria-hidden="true"`. Common patterns: `<span>ᚠ</span>` — add `aria-hidden="true"` to all.
+
+**StatusBadge aria-label**: The badge text already uses plain English ("Active", "Fee Due Soon") per the copywriting doc. Verify these read correctly with VoiceOver/NVDA. Add `role="status"` if the badge updates dynamically.
+
+---
+
+## Open Questions Resolved
+
+- **HowlPanel on mobile**: Drawer behavior at <768px. The spec always called for this; implementation was deferred.
+- **Reduced motion scope**: All CSS animations and all Framer Motion transitions. No exceptions.
+- **WCAG target**: AA (not AAA) for color contrast.
+
+---
+
+## UX Notes
+
+See team norms (`memory/team-norms.md`) for the touch target minimum (44x44px) and mobile width minimum (375px). All items in this story are enforcement of existing team norms, not new requirements.
+
+---
+
+## Future (Not Sprint 4)
+
+- Full WCAG AAA audit
+- Automated accessibility testing in the Playwright CI suite (Axe integration)
+- i18n / localization groundwork

--- a/product/backlog/story-4.5-wolves-hunger-and-about-modal.md
+++ b/product/backlog/story-4.5-wolves-hunger-and-about-modal.md
@@ -1,0 +1,131 @@
+# Story 4.5: Wolf's Hunger Meter + About Modal Completeness
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: The About modal to show how much total reward value I've extracted across my entire card history
+- **So that**: I feel the cumulative weight of what I've built — the wolf has been feeding, and the ledger remembers every meal
+- **Priority**: P3-Medium
+- **Sprint Target**: 4
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+The ForgeMasterEgg (`?` key shortcut) and the About modal (Fenrir logo click) are both wired and shipping since Sprint 3. They show the team, the Gleipnir ingredients, and the fragment progress count. But the Wolf's Hunger meter — the final piece of the About modal — is not yet implemented.
+
+The Wolf's Hunger meter reads the aggregate of all rewards logged across active and Valhalla cards and presents it as atmospheric flavor:
+
+> **Fenrir has consumed:** [total lifetime rewards value] pts / miles / $ cashback
+> *The chain grows heavier.*
+
+This is the easter egg that makes power users grin. They've been building a rewards portfolio for months. Seeing the total number — all of it, including closed cards in Valhalla — puts a number on their mastery.
+
+---
+
+## Desired Outcome
+
+The About modal (and the ForgeMasterEgg overlay that shares the same data) gains a new section: the Wolf's Hunger meter. It shows the total accumulated rewards value across all cards in the user's localStorage, both active and closed.
+
+The display is aggregated by reward type where possible, but falls back gracefully to a single total if the data is mixed.
+
+---
+
+## Interactions and User Flow
+
+1. User presses `?` or clicks the Fenrir logo in the TopBar.
+2. The modal opens. Existing sections (team, Gleipnir ingredients, fragment count) render as before.
+3. Below the Gleipnir section, a new divider and section appears: **Fenrir's Hunger**.
+4. The meter shows the aggregate total, computed from localStorage at render time.
+5. If no rewards have been logged on any card, show: *"The wolf has not yet fed. Add reward details to your cards."*
+6. The meter does not update in real time — it reads once on modal open. No live polling.
+
+---
+
+## Display Format
+
+Rewards are stored per card in the `Card` type. The relevant fields are `signUpBonus.type` and `signUpBonus.amount`. Aggregate by type:
+
+| Scenario | Display |
+|----------|---------|
+| All cards are cash back | `Fenrir has consumed: $1,240 cashback` |
+| All cards are points | `Fenrir has consumed: 847,000 pts` |
+| Mixed types (points + miles + cash) | `Fenrir has consumed: 412,000 pts · 95,000 miles · $320 cashback` |
+| No rewards data on any card | *"The wolf has not yet fed."* |
+
+Format numbers with locale-appropriate comma separators (`toLocaleString()`). Cash: `$` prefix, no decimals (integer). Points/miles: bare number with type label.
+
+Atmospheric subline beneath the meter: *"The chain grows heavier."* (always, when any rewards are shown)
+
+---
+
+## Acceptance Criteria
+
+- [ ] The About modal renders a Wolf's Hunger section below the Gleipnir ingredients list
+- [ ] The hunger meter sums `signUpBonus.amount` across all cards where `signUpBonus.met === true` (only count bonuses actually earned, not just promised)
+- [ ] Active cards and closed (Valhalla) cards are both included in the aggregate
+- [ ] Rewards are grouped and displayed by type (points, miles, cashback)
+- [ ] Cash values are formatted as `$N` with comma separators (no decimals)
+- [ ] Point/mile values are formatted with comma separators and type label
+- [ ] Mixed types render on one line separated by ` · `
+- [ ] When no bonuses have been marked as met on any card, the fallback copy renders
+- [ ] The `ForgeMasterEgg` (`?` shortcut) overlay also shows the hunger meter (same data, same component)
+- [ ] The meter reads data once on modal open — no live updates while the modal is open
+- [ ] The hunger section is below the Gleipnir fragment count line, separated by a divider
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Data source**: `getCards(householdId)` returns all non-deleted cards. For Valhalla cards, they are status `"closed"` — include them. Filter: `card.signUpBonus?.met === true`. Sum by `card.signUpBonus.type` (values: `"points"`, `"miles"`, `"cashback"` — see `types.ts`).
+
+**IMPORTANT — field name correction (Sprint 4 groom)**: The `SignUpBonus` interface in `src/lib/types.ts` uses `met: boolean` (not `bonusMet`). All references in this story have been corrected. FiremanDecko must use `signUpBonus.met`, not `signUpBonus.bonusMet`.
+
+**Aggregation example**:
+```ts
+const totals: Record<string, number> = {};
+cards.forEach(card => {
+  if (card.signUpBonus?.met && card.signUpBonus.amount) {
+    const type = card.signUpBonus.type ?? 'points';
+    totals[type] = (totals[type] ?? 0) + card.signUpBonus.amount;
+  }
+});
+```
+
+**Formatting**:
+```ts
+function formatReward(type: string, amount: number): string {
+  if (type === 'cashback') return `$${amount.toLocaleString()}`;
+  return `${amount.toLocaleString()} ${type}`;
+}
+```
+
+**Code audit completed (Sprint 4 groom)**: `AboutModal.tsx` currently shows: team members, a divider, and the Gleipnir ingredients list. There is no Wolf's Hunger section. `ForgeMasterEgg.tsx` shows the team list, a lore line, and the Gleipnir fragment count — also no hunger meter. Both components are well-structured and the hunger section can be appended after the existing content with a divider. Extract a shared `<WolfHungerMeter householdId={...} />` component — both `AboutModal` and `ForgeMasterEgg` already import from `@/hooks/useAuth` and have access to `householdId`. The `getCards(householdId)` call in `storage.ts` returns active cards only; `getClosedCards(householdId)` returns Valhalla cards. Both are needed here.
+
+**Where to add**: The hunger section is new JSX inside `AboutModal.tsx` (for the Fenrir logo click trigger) and `ForgeMasterEgg.tsx` (for the `?` key trigger). Consider extracting a shared `<WolfHungerMeter householdId={...} />` component to avoid duplication.
+
+**Household ID**: Read from `useAuth()` hook (already imported in both components).
+
+**Type check**: The `SignUpBonus` interface in `types.ts` uses `met: boolean` (confirmed during Sprint 4 groom). The `amount`, `type`, `spendRequirement`, `deadline`, and `met` fields are all present. No gap exists — the data model is complete for this feature.
+
+---
+
+## Open Questions Resolved
+
+- **Which bonuses count**: Only `met === true` (the `SignUpBonus.met` field in `types.ts`). A card with a sign-up bonus that hasn't been earned yet contributes $0 to the hunger meter.
+- **Valhalla cards included**: Yes. The wolf remembers every meal, not just the current chains.
+- **Real-time update**: No. Static read on open.
+- **localStorage migration wizard**: Not in this story, not in Sprint 4 at all. See product brief — deferred to GA.
+
+---
+
+## UX Notes
+
+See `ux/easter-eggs.md` #10 for the full Wolf's Hunger meter specification and the exact atmospheric copy. See `ux/easter-eggs.md` #9 for the About modal specification.
+
+---
+
+## Future (Not Sprint 4)
+
+- Wolf's Hunger meter on the dashboard stats bar (always visible, not just in modal)
+- Lifetime rewards vs. fees paid net ROI calculation (requires fee-paid tracking feature)
+- Animated hunger meter that "fills" when a new bonus is marked met


### PR DESCRIPTION
Freya's Sprint 4 backlog groom. All 5 stories sharpened against the actual codebase and marked Ready.

## Stories

| # | Story | Priority |
|---|-------|----------|
| 4.1 | Ragnarök Threshold Mode | P1 |
| 4.2 | Card Count Milestone Toasts | P2 |
| 4.3 | Full Gleipnir Hunt | P2 |
| 4.4 | Accessibility + UX Polish | P2 |
| 4.5 | Wolf's Hunger Meter + About Modal | P3 |

## Key groom findings

- Story 4.3: `GleipnirBearSinews` and `GleipnirBirdSpittle` components already exist — only trigger wiring needed
- Story 4.5: Fixed `signUpBonus.bonusMet` → `signUpBonus.met` throughout (matches actual `SignUpBonus` interface)
- Story 4.1: `KonamiHowl` already reads cards independently; must consume `RagnarökContext` instead

🤖 Generated with [Claude Code](https://claude.com/claude-code)