### PR TITLE
add Sprint 5 groomed backlog stories

### DIFF
--- a/product/backlog/README.md
+++ b/product/backlog/README.md
@@ -13,6 +13,11 @@ Groomed stories ready for sprint planning. All stories follow the format defined
 | [4.3 — Gleipnir Hunt: Wire Fragments 4 and 6 + Unlock](story-4.3-gleipnir-hunt-complete.md) | P2-High | Ready | Sprint 4 |
 | [4.4 — Accessibility and UX Polish Pass](story-4.4-accessibility-and-ux-polish.md) | P2-High | Ready | Sprint 4 |
 | [4.5 — Wolf's Hunger Meter + About Modal Completeness](story-4.5-wolves-hunger-and-about-modal.md) | P3-Medium | Ready | Sprint 4 |
+| [5.1 — Silent Auto-Merge on Google Sign-In](story-5.1-silent-auto-merge.md) | P1-Critical | Ready | Sprint 5 |
+| [5.2 — Google Sheets Import: Anthropic Conversion API Route](story-5.2-sheets-import-api-route.md) | P1-Critical | Ready | Sprint 5 |
+| [5.3 — Google Sheets Import: Import Wizard UI](story-5.3-sheets-import-wizard.md) | P1-Critical | Ready | Sprint 5 |
+| [5.4 — Google Sheets Import: Deduplication and Persistence](story-5.4-sheets-import-confirm.md) | P2-High | Ready | Sprint 5 |
+| [5.5 — LCARS Mode: Star Trek Easter Egg](story-5.5-lcars-mode.md) | P3-Medium | Ready | Sprint 5 |
 
 ## Deferred / Future
 
@@ -20,7 +25,6 @@ See [future-deferred.md](future-deferred.md) for items explicitly parked out of 
 
 | Item | Why Deferred |
 |------|-------------|
-| LCARS Mode (Star Trek Easter Egg #6) | Sprint cap reached; pure delight, no user-value dependency |
 | localStorage Migration Wizard | Product brief constraint — deferred to GA, no exceptions |
 | Smart Reminders / Notification Engine | Requires backend; out of MVP scope |
 | Reward Value Tracking + Net ROI | Significant feature, needs its own design brief |
@@ -53,6 +57,32 @@ These observations were made during the Sprint 4 groom. They refine the stories 
 
 **4.5 Wolf's Hunger Meter**: The `SignUpBonus` interface uses `met: boolean` — not `bonusMet`. All acceptance criteria and technical notes have been corrected. This was a grooming error in the original story; it would have caused a type error on first compile.
 
+## Sprint 5 Priority Rationale
+
+**Why this order:**
+
+1. **5.1 Silent Auto-Merge (P1)**: Corrects a product decision flaw in the existing auth flow. The current migration dialog introduces a "Start fresh" footgun — a user who taps it accidentally loses the connection between their local data and their cloud account. Removing the choice and always merging is the unambiguously correct behavior. Ships first because it is a behavioral correction with no new dependencies.
+
+2. **5.2 Sheets Import API Route (P1)**: The server-side Anthropic conversion route is the technical foundation for the entire Google Sheets import feature. FiremanDecko can build and test it in isolation (Stories 5.3 and 5.4 depend on it). Ships second so the API exists before the wizard UI is integrated.
+
+3. **5.3 Sheets Import Wizard (P1)**: The user-facing entry point for the import feature. Depends on 5.2 for integration testing. Ships third because Luna needs Story 5.2's response schema to design the preview step accurately.
+
+4. **5.4 Sheets Import Deduplication (P2)**: Completes the import feature by adding safe merge behavior against the existing portfolio. Ships fourth because it is the last leg of the import pipeline — Stories 5.2 and 5.3 must be done first.
+
+5. **5.5 LCARS Mode (P3)**: The highest-value deferred delight item from Sprint 4. The spec is fully written. No new design work required. Ships last — it is the one story that can be safely deferred to Sprint 6 if the sprint runs short.
+
+## Sprint 5 Groom Notes (2026-02-28)
+
+**5.1 Auto-Merge**: The existing migration prompt dialog (`ux/wireframes/auth/migration-prompt.html`) is now superseded. Luna must produce an updated wireframe for the auto-merge toast surface. The "Start fresh" path is eliminated by product decision — if any code implements this path, it must be removed. Key risk: the tombstone strategy for `fenrir:household` must be carefully implemented to prevent re-merge on subsequent sign-ins. FiremanDecko to confirm the OAuth callback hook location before starting.
+
+**5.2 Sheets Import API Route**: `ANTHROPIC_API_KEY` is a new server-side dependency. It must be provisioned in Vercel before the route can be tested in preview deployments. The model ID `claude-haiku-3-5` should be confirmed against the current Anthropic SDK — if it has been updated, use the equivalent. CSV truncation at 100k characters is a product-specified limit; do not change without Freya's approval.
+
+**5.3 Sheets Import Wizard**: Story 5.3 and 5.4 are split at the "Import N cards" confirm button. Story 5.3 owns the wizard UI up to and including that button. Story 5.4 owns the callback that fires when the button is pressed. The interface between them is `onConfirmImport(cards: Card[])` — a callback prop. This boundary must be respected to keep both stories independently reviewable by Loki.
+
+**5.4 Sheets Import Deduplication**: The issuer alias normalization question (e.g. `"american_express"` vs `"amex"`) must be resolved before FiremanDecko begins the deduplication function. Product preference: normalize using a lookup table; FiremanDecko proposes the table for Freya's approval.
+
+**5.5 LCARS Mode**: `Ctrl+Shift+W` browser conflict is a known risk. If `e.preventDefault()` cannot reliably suppress the browser's "close all tabs" behavior in all target browsers, the fallback is `Ctrl+Shift+L`. FiremanDecko must test this before committing to the key combo. The stardate formula is intentionally simplified — canonical accuracy is not required.
+
 ## Sprint Cap
 
-Max 5 stories per sprint (per product brief technical constraints). Sprint 4 is at cap.
+Max 5 stories per sprint (per product brief technical constraints). Sprint 5 is at cap.

--- a/product/backlog/future-deferred.md
+++ b/product/backlog/future-deferred.md
@@ -4,13 +4,9 @@ Stories explicitly parked by Freya as post-Sprint 4 work. These are not forgotte
 
 ---
 
-## LCARS Mode (Star Trek Easter Egg #6) — Deferred to Sprint 5+
+## LCARS Mode (Star Trek Easter Egg #6) — Pulled into Sprint 5
 
-**Why deferred**: The Gleipnir Hunt completion, Ragnarök mode, milestone toasts, and the accessibility pass are all higher-value and more tightly integrated with existing features. LCARS mode is a standalone easter egg that requires building a temporary UI overlay with no dependencies on other Sprint 4 work. It has no user-value justification beyond delight. Sprint 4 has 5 stories already (at the team's sprint cap).
-
-**When to revisit**: Sprint 5, as the opening story if the team has capacity for pure delight work after core functionality gaps are addressed.
-
-**Spec**: See `ux/easter-eggs.md` #6. `Cmd+Shift+W` trigger, 5-second LCARS amber overlay with stardate, card counts, and a scan-line wipe exit. The full spec is written and ready — this is purely an implementation deferral.
+**Status**: Scheduled as Story 5.5. No longer deferred.
 
 ---
 

--- a/product/backlog/story-5.1-silent-auto-merge.md
+++ b/product/backlog/story-5.1-silent-auto-merge.md
@@ -1,0 +1,172 @@
+# Story 5.1: Silent Auto-Merge on Google Sign-In
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: My locally-tracked cards to automatically merge into my Google account whenever I sign in — whether for the first time or returning after using the app offline
+- **So that**: I never lose card data and never have to make a decision about whether to import or start fresh; the app always does the right thing
+- **Priority**: P1-Critical
+- **Sprint Target**: 5
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+The current migration prompt (wireframe `ux/wireframes/auth/migration-prompt.html`) presents two choices after Google OAuth completes: "Import N cards" or "Start fresh." This two-choice dialog was designed to give users control, but it creates a friction point and a footgun — a user who accidentally taps "Start fresh" loses the connection between their local data and their cloud account.
+
+The product direction for Sprint 5 is: **always merge, never ask.** The merge is the only correct behavior in both scenarios:
+
+**Scenario A — First sign-in (new Google household):** The user has been using the app anonymously. They now sign in with Google. Their anonymous localStorage cards must be merged into the new Google-scoped household automatically. No dialog. No choice.
+
+**Scenario B — Returning sign-in (existing Google household has cards, AND localStorage also has cards):** The user has signed in before. They signed out or used a different device, and new cards were added to localStorage under the anonymous householdId. When they sign back in, those localStorage cards must be merged into the existing Google household — again, automatically.
+
+Both scenarios use the same merge function. The trigger differs (new vs. existing household), but the merge logic is identical.
+
+---
+
+## Desired Outcome
+
+After this ships:
+
+1. User completes Google OAuth (first time or returning).
+2. App silently checks: does `fenrir:household` in localStorage contain cards not already in the Google household?
+3. If yes: merge all non-duplicate cards into the Google household automatically. No dialog. No user decision required.
+4. If no: proceed directly to the signed-in dashboard. No change in behavior.
+5. A brief non-blocking toast confirms the merge ("N cards carried into your ledger.") — informational only, not a decision gate.
+6. The anonymous `fenrir:household` key is cleared (or tombstoned) after a successful merge to prevent re-merging the same cards on next sign-in.
+
+---
+
+## Interactions and User Flow
+
+```
+OAuth callback received
+        │
+        ▼
+Establish FenrirSession (existing behavior)
+        │
+        ▼
+Does fenrir:household exist with card count > 0?
+        │
+    NO  │                       │ YES
+        │                       ▼
+        │           Load anonymous cards (getAllCards(anonHouseholdId))
+        │                       │
+        │                       ▼
+        │           Load Google household cards (getAllCards(googleSub))
+        │                       │
+        │                       ▼
+        │           Deduplicate: filter anonymous cards not already present
+        │           in Google household (match on card ID first; if new ID,
+        │           treat as a new card to import)
+        │                       │
+        │           merged cards > 0?
+        │               │             │
+        │           YES │             │ NO (all were duplicates or list was empty)
+        │               ▼             │
+        │       Bulk-save merged      │
+        │       cards under           │
+        │       Google householdId    │
+        │               │             │
+        │               ▼             │
+        │       Show toast:           │
+        │       "N cards carried      │
+        │       into your ledger."    │
+        │               │             │
+        │               ▼             ▼
+        │       Clear fenrir:household (tombstone or remove)
+        │               │
+        └───────────────┤
+                        ▼
+               Dashboard (signed-in state)
+               Avatar transition fires
+```
+
+---
+
+## Deduplication Rules
+
+When merging anonymous cards into the Google household, the following rules apply:
+
+1. **Same card ID**: If a card in the anonymous household shares a UUID with a card already in the Google household, the Google household version wins. The anonymous version is dropped — not merged, not overwritten. This prevents accidental data overwrites.
+2. **Different card ID**: The anonymous card is treated as a new card and copied into the Google household with its `householdId` updated to the Google `sub`.
+3. **Deleted anonymous cards**: Cards with `deletedAt` set in the anonymous household are not imported. Soft-deleted cards stay soft-deleted in their source household and do not cross over.
+4. **Closed anonymous cards**: Closed cards (`status === "closed"`, `closedAt` set) ARE imported. They belong in Valhalla under the signed-in household.
+
+---
+
+## Behavior Change: Removing the Migration Dialog
+
+The existing migration prompt dialog (`MigrationPrompt` component, if it exists) must be removed or disabled. The "Start fresh" path is eliminated by product decision. There is no migration dialog in Sprint 5 onward.
+
+**Impact on Luna's wireframe**: The `ux/wireframes/auth/migration-prompt.html` file documents the old two-choice dialog. Luna will need to produce a new wireframe for the auto-merge toast/confirmation surface. The old wireframe is not deleted — it is superseded.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When a user completes Google OAuth and `fenrir:household` contains ≥ 1 non-deleted card not in the Google household, all such cards are automatically merged into the Google household without presenting any dialog or choice to the user
+- [ ] Cards with `deletedAt` set in the anonymous household are NOT imported into the Google household
+- [ ] Cards with `status === "closed"` in the anonymous household ARE imported into the Google household
+- [ ] If a card in the anonymous household shares an ID with a card already in the Google household, the Google household version is preserved; the anonymous version is discarded
+- [ ] Each imported card has its `householdId` field updated to the Google `sub` before being saved
+- [ ] After a successful merge, a non-blocking toast displays: "N card(s) carried into your ledger." where N is the count of merged cards
+- [ ] If no mergeable cards are found (anonymous household is empty or all cards already exist in Google household), no toast is shown and the user proceeds directly to the signed-in dashboard
+- [ ] After merge, the anonymous `fenrir:household` localStorage key is cleared (or tombstoned with a `mergedAt` timestamp) so the same cards are not re-imported on the next sign-in
+- [ ] The migration is idempotent: signing out and signing back in does not re-import already-merged cards
+- [ ] If the merge operation fails (e.g., localStorage write error), the sign-in still completes and an error toast is shown; cards are not lost from the anonymous household
+- [ ] The signed-in dashboard renders correctly after a merge with the full portfolio visible
+- [ ] `npm run build` passes with zero errors
+- [ ] TypeScript strict mode: zero new type errors introduced
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Where to trigger the merge**: The OAuth callback handler (the function that establishes `FenrirSession` in localStorage after the Google token exchange) is the right place. After writing `fenrir:auth`, before redirecting to the dashboard, run the merge logic.
+
+**Anonymous householdId source**: Read `fenrir:household` from localStorage to get the anonymous UUID. This is the source household for the merge.
+
+**Google householdId source**: `FenrirSession.user.sub` — the immutable Google account ID used as the Google household's ID.
+
+**Deduplication key**: `Card.id` (UUID). Use a `Set<string>` of existing Google household card IDs to do an O(n) membership check.
+
+**householdId rewrite**: Each imported card must have `householdId` set to the Google `sub` before `saveCard()` is called. Do not write the anonymous card to the Google namespace without this field update.
+
+**Tombstone vs. clear**: After merge, set `fenrir:household` to a tombstone value (e.g. `{ mergedAt: ISO_TIMESTAMP, mergedInto: googleSub }`) rather than deleting the key outright. This provides an audit trail and prevents re-merge logic from failing silently if the key is recreated by some other code path. Check for a `mergedAt` field in `fenrir:household` at OAuth callback time — if present, skip the merge.
+
+**Toast pattern**: Reuse the existing toast infrastructure (Sprint 4.2 milestone toasts established the pattern). This toast is informational, auto-dismisses, does not require user action.
+
+**Bulk save strategy**: Do not call `saveCard()` in a loop — each call dispatches `fenrir:sync`. Instead, load all Google household cards, append the merged cards, and call `setAllCards()` once. Then dispatch `fenrir:sync` once.
+
+**Race condition guard**: If the user somehow triggers the OAuth callback while the dashboard is open in another tab and already writing to the Google household, the merge operation should load the freshest state from localStorage immediately before writing, not from a cached copy loaded at callback init.
+
+---
+
+## Open Questions for FiremanDecko
+
+1. **OAuth callback location**: Where is the current Google OIDC callback handler implemented? Is it a Next.js route handler (`/api/auth/callback`) or client-side PKCE completion logic? The merge logic needs to be inserted at the point where the `FenrirSession` is committed to localStorage — confirm the exact location.
+
+2. **Toast infrastructure**: Sprint 4.2 introduced milestone toasts. Is there a reusable `showToast()` utility or does this story need to integrate with a toast library (e.g. sonner, react-hot-toast)? The merge toast must use the same system.
+
+3. **Anonymous householdId stability**: If the user clears their browser between sign-ins, `fenrir:household` will be a new UUID on re-visit (no anonymous cards). Confirm the merge logic handles this gracefully — a fresh anonymous household with zero cards should result in a no-op, not an error.
+
+---
+
+## Mythology Frame
+
+The wolf does not scatter its prey across two lairs. What the wolf has hunted belongs to the wolf's hall — always. Signing in is not abandonment; it is homecoming. The chains are carried with you.
+
+*"Before you named yourself, the wolf's chains were already counted here."* — migration prompt copy, repurposed as toast footnote if desired.
+
+---
+
+## UX Notes
+
+Luna to produce:
+1. Updated `ux/wireframes/auth/migration-prompt.html` (or a new `auto-merge-toast.html`) showing the auto-merge toast surface — positioning, copy, timing, dismiss behavior.
+2. The old two-choice dialog wireframe is now superseded. Luna should annotate or archive it.
+
+Toast copy direction (Voice 1 with atmospheric tail):
+- Main: "N card(s) carried into your ledger."
+- Optional sub-line (Voice 2, smaller): *"The pack is whole."*
+- No action required. Auto-dismiss at 4 seconds.

--- a/product/backlog/story-5.2-sheets-import-api-route.md
+++ b/product/backlog/story-5.2-sheets-import-api-route.md
@@ -1,0 +1,240 @@
+# Story 5.2: Google Sheets Import — Anthropic Conversion API Route
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: The app to be able to read my Google Sheets credit card data and convert it to the app's format using AI
+- **So that**: I can get started quickly without manually re-entering every card I already track in a spreadsheet
+- **Priority**: P1-Critical
+- **Sprint Target**: 5
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+A meaningful segment of our target users are already tracking their credit cards in Google Sheets. These users have invested time in their own tracking system and will not abandon that investment to manually re-enter 5–20+ cards into a new app. The friction of manual entry is the single largest barrier to adoption for this cohort.
+
+The Anthropic API can solve this: given the raw contents of a Google Sheets document (in any user-defined format), the API can identify credit card data and map it to Fenrir Ledger's `Card` schema. The user provides a URL; the app fetches, converts, and previews.
+
+This story covers the **server-side API route** that performs the actual conversion. It is the technical foundation that Stories 5.3 and 5.4 (the wizard UI and import confirmation) depend on. It is written as a separate story because FiremanDecko can build and test this route independently while Luna designs the wizard UI.
+
+---
+
+## Desired Outcome
+
+After this ships, a Next.js API route exists at `/api/sheets/import` that:
+
+1. Accepts a Google Sheets URL.
+2. Fetches the sheet's public CSV export.
+3. Sends the raw CSV content to the Anthropic API with a structured prompt.
+4. Receives a JSON array of `Card`-shaped objects from Anthropic.
+5. Validates the output against the `Card` schema.
+6. Returns the validated cards (and any validation errors) to the client.
+
+This route does not save any cards. It only converts. Persistence is the responsibility of Story 5.4.
+
+---
+
+## Google Sheets URL Fetching
+
+The app will only support **publicly shared** Google Sheets. The import workflow will make this requirement explicit to the user. Private sheets (requiring OAuth with the Google Sheets API) are out of scope for Sprint 5.
+
+A publicly shared Google Sheet can be fetched as CSV via a deterministic URL transform:
+
+```
+Input:  https://docs.google.com/spreadsheets/d/{SHEET_ID}/edit#gid={GID}
+Output: https://docs.google.com/spreadsheets/d/{SHEET_ID}/export?format=csv&gid={GID}
+```
+
+The route must:
+1. Extract `SHEET_ID` and optionally `GID` from the user-supplied URL.
+2. Construct the CSV export URL.
+3. `fetch()` the CSV export from the Google Sheets CDN (server-side — no CORS issues).
+4. If the fetch returns a non-200 response or a redirect to a login page, return a structured error: `{ error: "SHEET_NOT_PUBLIC", message: "..." }`.
+
+---
+
+## Anthropic API Conversion
+
+The API route calls the Anthropic API (server-side only — API key never exposed to client) with:
+
+- **Model**: `claude-haiku-3-5` (fast and cost-effective for structured extraction)
+- **Prompt strategy**: A system prompt that explains the `Card` schema in detail and instructs the model to extract all credit card records from the provided CSV, returning a JSON array.
+
+### System Prompt (product-specified):
+
+```
+You are a data extraction assistant for a credit card tracking application.
+Your task: read the provided CSV content and extract all credit card records.
+
+Return ONLY a valid JSON array. No prose, no markdown, no code blocks.
+Each element must conform to this schema:
+
+{
+  "issuerId": string,       // lowercase snake_case issuer name, e.g. "chase", "amex", "citi", "capital_one", "barclays", "wells_fargo", "bank_of_america", "us_bank", "discover"
+  "cardName": string,       // human-readable card name, e.g. "Sapphire Preferred"
+  "openDate": string,       // ISO 8601 date, e.g. "2023-06-15T00:00:00.000Z". If unknown, use today's date.
+  "creditLimit": number,    // integer cents. If unknown, use 0.
+  "annualFee": number,      // integer cents. If unknown, use 0.
+  "annualFeeDate": string,  // ISO 8601 date of next annual fee due. Empty string if no annual fee.
+  "promoPeriodMonths": number, // integer months of intro APR or bonus period. 0 if none.
+  "signUpBonus": {          // null if no sign-up bonus
+    "type": "points" | "miles" | "cashback",
+    "amount": number,       // points/miles count or cashback in cents
+    "spendRequirement": number, // integer cents
+    "deadline": string,     // ISO 8601 deadline. If unknown, use one year from today.
+    "met": false
+  } | null,
+  "notes": string           // any notes from the spreadsheet not captured above. Empty string if none.
+}
+
+Rules:
+- Dollar amounts → integer cents (multiply by 100). E.g. $500 → 50000.
+- If a value is ambiguous or missing, use the default specified above.
+- Do not invent data. If a field cannot be reasonably inferred, use the default.
+- If the CSV contains no credit card data, return an empty array [].
+- If the sheet contains multiple tabs merged into CSV, process all rows.
+```
+
+### Request structure:
+
+```json
+{
+  "model": "claude-haiku-3-5",
+  "max_tokens": 4096,
+  "messages": [
+    {
+      "role": "user",
+      "content": "Extract credit card records from this CSV:\n\n{CSV_CONTENT}"
+    }
+  ],
+  "system": "{SYSTEM_PROMPT_ABOVE}"
+}
+```
+
+### Response handling:
+
+- Parse Anthropic's `content[0].text` as JSON.
+- If parsing fails, return `{ error: "PARSE_ERROR", rawResponse: string }`.
+- If the array is empty, return `{ cards: [], warning: "NO_CARDS_FOUND" }`.
+- Assign each card a fresh UUID (`crypto.randomUUID()`) for `id`.
+- Set `createdAt` and `updatedAt` to the current timestamp.
+- Set `status` to `"active"` (will be recomputed by `computeCardStatus()` on save).
+- Do NOT set `householdId` — that is supplied by the client at import time (Story 5.4).
+
+---
+
+## API Route Specification
+
+**Route**: `POST /api/sheets/import`
+
+**Request body**:
+```json
+{
+  "url": "https://docs.google.com/spreadsheets/d/..."
+}
+```
+
+**Success response** (`200`):
+```json
+{
+  "cards": [Card, Card, ...],
+  "sheetTitle": "My Credit Cards",
+  "rowCount": 12,
+  "cardCount": 8
+}
+```
+
+**Error responses**:
+
+| HTTP status | Error code | Meaning |
+|-------------|------------|---------|
+| `400` | `INVALID_URL` | URL is not a recognizable Google Sheets URL |
+| `422` | `SHEET_NOT_PUBLIC` | Sheet fetch returned a non-CSV response (login page or 403) |
+| `422` | `NO_CARDS_FOUND` | Anthropic returned an empty array — sheet has no credit card data |
+| `422` | `PARSE_ERROR` | Anthropic response could not be parsed as JSON |
+| `500` | `ANTHROPIC_ERROR` | Anthropic API returned a non-200 status |
+| `500` | `FETCH_ERROR` | Network error fetching the Google Sheet |
+
+---
+
+## Environment Variables
+
+This story requires a new server-side environment variable:
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+- Must be added to `.env.example` (with placeholder value, not a real key).
+- Must be documented in the project README or architecture docs.
+- Must NOT be prefixed with `NEXT_PUBLIC_` — this key must never be exposed to the client bundle.
+- Vercel preview deployments must have this variable set to run the import feature; if unset, the route returns `500 ANTHROPIC_NOT_CONFIGURED`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `POST /api/sheets/import` exists and is reachable in the Next.js app
+- [ ] A valid public Google Sheets URL results in a `200` response containing a `cards` array
+- [ ] Each card in the response has a unique UUID `id`, `createdAt`, `updatedAt`, and `status: "active"`
+- [ ] Dollar amounts in the source sheet are correctly converted to integer cents in the response
+- [ ] Dates in the source sheet are correctly normalized to ISO 8601 UTC timestamps
+- [ ] A Google Sheets URL pointing to a private/non-public sheet returns `422 SHEET_NOT_PUBLIC`
+- [ ] An invalid (non-Sheets) URL returns `400 INVALID_URL`
+- [ ] A sheet with no recognizable credit card data returns `422 NO_CARDS_FOUND`
+- [ ] `ANTHROPIC_API_KEY` is documented in `.env.example` and never appears in client-side bundles
+- [ ] The route returns `500 ANTHROPIC_NOT_CONFIGURED` if `ANTHROPIC_API_KEY` is not set
+- [ ] The Anthropic API key does not appear in any response body, error message, or server log at `info` level or below
+- [ ] The route handles sheets with non-standard column names (e.g. "Bank" instead of "Issuer") and still extracts recognizable card data
+- [ ] A sheet containing 20 cards is processed in under 15 seconds end-to-end (URL fetch + Anthropic call)
+- [ ] `npm run build` passes with zero errors
+- [ ] TypeScript strict mode: zero new type errors introduced
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Next.js route location**: `development/src/src/app/api/sheets/import/route.ts` — a standard App Router route handler using `export async function POST(request: Request)`.
+
+**CSV fetch**: Use the native `fetch()` API (available in Node 18+ and Next.js App Router edge/Node runtime). Set a `User-Agent` header to avoid being blocked by Google's CDN.
+
+**Sheet ID extraction regex**: Google Sheets URLs follow this pattern:
+```
+/spreadsheets\/d\/([a-zA-Z0-9_-]+)/
+```
+GID (tab ID) is optional in the URL hash: `#gid=0`. Default to GID `0` if absent.
+
+**CSV size limit**: Truncate CSV content at 100,000 characters before sending to Anthropic. Large sheets are unlikely to be fully parseable by the model anyway, and this prevents token overflows. Return a `warning: "CSV_TRUNCATED"` in the response if truncation occurs.
+
+**Anthropic SDK**: Use the official `@anthropic-ai/sdk` npm package. This is a server-side call — do not use the SDK in any client component. Do not add the SDK to the client bundle.
+
+**Response validation**: After parsing Anthropic's JSON output, validate each card object minimally — confirm `issuerId` is a non-empty string, `cardName` is non-empty, `annualFee` is a non-negative integer. Drop any record that fails validation rather than returning garbage to the client. Return `droppedCount` in the response so the user knows how many records were unusable.
+
+**Error isolation**: Wrap the entire route handler in try/catch. Never let an unhandled exception return a 500 with a stack trace — map all exceptions to the structured error response format above.
+
+**No authentication required on this route in Sprint 5**: The route does not check for a signed-in session. Any client (signed-in or anonymous) can call it. This is acceptable because the route reads a public URL and calls the Anthropic API — there is no user data at risk. Rate limiting can be added post-GA if abuse is observed.
+
+---
+
+## Open Questions for FiremanDecko
+
+1. **Anthropic model selection**: `claude-haiku-3-5` is the product preference for cost/speed. If the model has been superseded or has a different model ID in the current SDK version, use the equivalent fast/cheap model and document the choice in the route file.
+
+2. **CSV encoding**: Google Sheets CSV exports may use UTF-8 with BOM. Confirm whether the fetch response needs BOM stripping before passing to Anthropic.
+
+3. **Rate limiting**: Anthropic has per-minute token limits. If a user submits a very large sheet, the request may be rate-limited. Should the route return a retryable `429` response, or silently truncate the input first? Product preference: truncate first (at 100k characters), then surface a warning.
+
+4. **Vercel timeout**: Default Vercel serverless function timeout is 10 seconds. A large sheet fetch + Anthropic call may exceed this. Does the Vercel project have an extended timeout configured, or does this route need to be declared as an edge function or streaming response?
+
+---
+
+## Dependencies
+
+- **Depends on**: Nothing (this story is the foundation; no upstream dependency)
+- **Blocks**: Story 5.3 (wizard UI), Story 5.4 (import confirmation)
+
+---
+
+## Mythology Frame
+
+The Norns read the threads of fate across every loom — in any format, in any language. Anthropic is the Norn. The spreadsheet is the loom. The ledger is where the threads find their final record.

--- a/product/backlog/story-5.3-sheets-import-wizard.md
+++ b/product/backlog/story-5.3-sheets-import-wizard.md
@@ -1,0 +1,195 @@
+# Story 5.3: Google Sheets Import — Import Wizard UI
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: A step-by-step interface where I can paste my Google Sheets URL and see my cards previewed before they are imported
+- **So that**: I can validate the AI-converted data looks correct before it lands in my ledger, without committing to anything blindly
+- **Priority**: P1-Critical
+- **Sprint Target**: 5
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+Story 5.2 builds the Anthropic conversion route. This story builds the user-facing wizard that drives it. The wizard must handle the full interaction arc: URL entry, loading state, preview of parsed cards, and the confirm/import action (which triggers Story 5.4's deduplication and persistence).
+
+The wizard is a multi-step modal dialog, not a dedicated page. It appears over the dashboard when the user initiates an import. This is consistent with the app's existing modal-first UX pattern (card form, Gleipnir fragments, Ragnarök alerts all use modals).
+
+The import entry point should be accessible from the dashboard — both the empty state (when zero cards exist, this is the primary onboarding path for Sheets users) and from a persistent "Import" action in the dashboard toolbar or card grid header.
+
+---
+
+## Desired Outcome
+
+After this ships, a user with zero or more cards can:
+
+1. Open the import wizard from the dashboard.
+2. Paste a Google Sheets URL and submit.
+3. See a loading state while the server fetches and converts the sheet.
+4. See a preview of all parsed cards — card name, issuer, annual fee, open date — in a scannable list.
+5. Review the count of cards found.
+6. Confirm the import (or cancel and discard).
+7. See the cards appear in their dashboard after confirmation.
+
+---
+
+## Entry Points
+
+Two entry points must exist. Both open the same wizard modal.
+
+**Entry Point A — Empty state CTA**: On the dashboard empty state ("Before Gleipnir was forged..."), add a secondary CTA below the "Add your first card" button:
+- Label: "Import from Google Sheets"
+- This is a secondary action — visually subordinate to the primary "Add card" button.
+
+**Entry Point B — Dashboard toolbar**: A persistent "Import" button or icon in the dashboard header/toolbar area, visible when the card grid has ≥ 1 card. This serves returning users who want to bulk-import additional cards.
+- Label: "Import cards"
+- Placement: in the dashboard action area near the existing "Add card" button.
+- Luna to determine exact placement in the wireframe.
+
+---
+
+## Wizard Steps
+
+### Step 1 — URL Entry
+
+**Heading (Voice 2)**: *"Read the loom."*
+**Sub-heading (Voice 1)**: "Paste your Google Sheets URL to import your credit cards."
+
+UI elements:
+- Text input: full URL from the user's clipboard. Placeholder: "https://docs.google.com/spreadsheets/d/..."
+- Helper text (Voice 1): "Your sheet must be set to 'Anyone with the link can view.'"
+- A link-styled hint: "How to share a Google Sheet" — opens Google's help page in a new tab.
+- Submit button: "Fetch my cards"
+- Cancel button (or × close): "Cancel"
+
+Validation (client-side, before submitting to the API):
+- URL must be non-empty.
+- URL must contain `docs.google.com/spreadsheets` — surface inline error if not: "That doesn't look like a Google Sheets URL."
+- No other client-side validation — let the server decide if the sheet is public.
+
+### Step 2 — Loading
+
+**Heading (Voice 2)**: *"The Norns are reading the threads..."*
+**Sub-heading (Voice 1)**: "Fetching your sheet and converting it — this may take a few seconds."
+
+UI elements:
+- Animated loading indicator (existing app loading pattern — not a spinner, see interactions.md for the rune-pulse pattern if available, otherwise a simple text pulse).
+- No cancel button during this step — the request is in flight. If the user closes the modal (ESC or ×), show a confirmation: "Cancel the import? Your sheet will not be saved." Accept/dismiss.
+- The loading step times out at 20 seconds. If the API has not responded, surface Step 4 (error state) with message: "The Norns took too long. Try again."
+
+### Step 3 — Preview
+
+**Heading (Voice 2)**: *"The chains are counted."*
+**Sub-heading (Voice 1)**: "{N} cards found in your sheet. Review them before importing."
+
+UI elements:
+- Card count badge: "N cards found"
+- A scrollable list of parsed card previews. Each preview row shows:
+  - Issuer name (formatted from `issuerId`, e.g. "Chase")
+  - Card name (`cardName`)
+  - Annual fee (formatted as "$X" or "No annual fee" if 0)
+  - Open date (formatted as "Opened [Month YYYY]")
+  - A warning icon if any field has a default value applied (i.e., data was missing from the sheet)
+- If `droppedCount > 0`: a warning banner below the list: "N row(s) could not be parsed and were skipped."
+- If `warning: "CSV_TRUNCATED"` in the API response: a warning banner: "Your sheet was very large — only the first portion was processed."
+- Primary button: "Import {N} cards" (count is dynamic)
+- Secondary button: "Cancel"
+- Tertiary action (text link): "Back" — returns to Step 1 to try a different URL.
+
+### Step 4 — Error State
+
+**Heading (Voice 2)**: *"The threads are knotted."*
+**Sub-heading (Voice 1)**: "[Human-readable error message]"
+
+Error messages by error code:
+- `SHEET_NOT_PUBLIC`: "We couldn't read that sheet. Make sure it's shared as 'Anyone with the link can view.'"
+- `NO_CARDS_FOUND`: "No credit card data was found in that sheet. Make sure your cards are listed with columns like name, issuer, or annual fee."
+- `PARSE_ERROR`: "Something went wrong reading the response. Try again."
+- `ANTHROPIC_ERROR`, `FETCH_ERROR`: "Something went wrong on our end. Try again in a moment."
+- `INVALID_URL`: "That doesn't look like a Google Sheets URL. Check the link and try again."
+- Timeout: "The conversion took too long. Try again."
+
+UI elements:
+- Error message
+- "Try again" button — returns to Step 1 with the URL pre-filled
+- "Cancel" button — closes the wizard
+
+### Step 5 — Success
+
+Displayed briefly (1.5s) before the modal closes and the toast fires.
+
+**Heading (Voice 2)**: *"The pack grows."*
+**Sub-heading (Voice 1)**: "{N} cards added to your ledger."
+
+Then: modal closes, dashboard refreshes with new cards visible, toast from Story 5.4 fires.
+
+---
+
+## Accessibility Requirements
+
+- The wizard is a modal dialog: `role="dialog"`, `aria-modal="true"`, `aria-labelledby` bound to the step heading.
+- Focus is trapped inside the wizard at all steps.
+- On step advance, focus moves to the new step's heading.
+- The loading step announces its status to screen readers: `aria-live="polite"` region with the loading message.
+- ESC dismisses the wizard at Steps 1, 3, and 4 (with confirmation at Step 2 if loading).
+- All buttons meet the 44px minimum touch target.
+- Error messages are announced immediately via `aria-live="assertive"`.
+
+---
+
+## Acceptance Criteria
+
+- [ ] "Import from Google Sheets" CTA is visible on the dashboard empty state below the "Add your first card" button
+- [ ] "Import cards" button is visible in the dashboard toolbar when ≥ 1 card exists
+- [ ] Both entry points open the same import wizard modal
+- [ ] Step 1 accepts a Google Sheets URL and shows an inline error if the URL does not contain `docs.google.com/spreadsheets`
+- [ ] Step 2 (loading) displays while the API call is in flight
+- [ ] Step 3 (preview) displays the card count and a scrollable list of parsed cards with issuer, name, annual fee, and open date
+- [ ] The "Import N cards" button label is dynamic and matches the card count from the API response
+- [ ] Step 4 (error) displays a human-readable error for each error code returned by the API
+- [ ] Step 4 pre-fills the URL from Step 1 when the user taps "Try again"
+- [ ] Step 5 (success) displays briefly before the modal closes
+- [ ] If `droppedCount > 0` in the API response, a warning is shown in Step 3
+- [ ] If `warning: "CSV_TRUNCATED"` in the API response, a warning is shown in Step 3
+- [ ] The wizard is accessible: focus trap active, ESC dismisses, `aria-live` for loading and errors
+- [ ] All buttons and touch targets are ≥ 44px
+- [ ] The wizard renders correctly on mobile (375px min width) and desktop
+- [ ] `npm run build` passes with zero errors
+- [ ] TypeScript strict mode: zero new type errors introduced
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Wizard state machine**: Use a local `step` state variable (not a router navigation) with values: `"entry" | "loading" | "preview" | "error" | "success"`. All steps render inside the same dialog element — swap content based on step.
+
+**API call**: `POST /api/sheets/import` with `{ url }` in the body. This is a standard `fetch()` from a client component. No authentication header required (per Story 5.2's decision).
+
+**Preview list performance**: If the API returns 20+ cards, the preview list should use a fixed-height scrollable container (`max-height: 320px; overflow-y: auto`) to avoid a modal that extends beyond the viewport.
+
+**Issuer display name**: The API returns `issuerId` in snake_case. Map to human-readable names using the existing `Issuer` list from `development/src/src/lib/` (or a simple lookup map). For any unknown `issuerId`, display it as-is with title case applied.
+
+**Annual fee formatting**: Divide cents by 100. Show `$X` format. Use `$0` vs "No annual fee" based on `annualFee === 0`.
+
+**Cancel during loading**: A simple `useRef` to track whether the component is still mounted is sufficient. If the user cancels, set an `aborted` ref to `true` — when the fetch resolves, check the ref before advancing to Step 3.
+
+**Import trigger**: The "Import N cards" button in Step 3 should call a prop/callback function supplied by the parent component (not navigate or dispatch directly). This decouples the wizard from the storage logic in Story 5.4.
+
+---
+
+## Dependencies
+
+- **Depends on**: Story 5.2 (API route must be implemented first for integration testing)
+- **Blocks**: Story 5.4 (deduplication and persistence need the wizard's "confirm" event)
+
+---
+
+## UX Notes
+
+Luna to produce a wireframe for the full wizard: `ux/wireframes/sheets-import/import-wizard.html`. The wizard must feel consistent with the app's existing modal patterns:
+- Same `modal-rise` animation as all other modals
+- Same `w-[92vw] max-h-[90vh]` sizing on mobile
+- Void-black background, gold accents on the primary action button
+- The loading state rune-pulse or equivalent from `interactions.md`
+
+The step headings are Voice 2 (atmospheric) and the body copy is Voice 1 (functional). This is the Fenrir Ledger dual-register convention and must be respected in every step.

--- a/product/backlog/story-5.4-sheets-import-confirm.md
+++ b/product/backlog/story-5.4-sheets-import-confirm.md
@@ -1,0 +1,153 @@
+# Story 5.4: Google Sheets Import — Deduplication and Persistence
+
+- **As a**: Credit card churner and rewards optimizer
+- **I want**: Cards imported from Google Sheets to be safely merged into my existing ledger without creating duplicates
+- **So that**: I can import confidently even if I have already manually added some of my cards, knowing the app will not create duplicate entries
+- **Priority**: P2-High
+- **Sprint Target**: 5
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+Story 5.3 builds the wizard UI through to the "Import N cards" confirmation button. This story covers what happens when the user taps that button: deduplication against the existing household portfolio, the actual persistence of new cards, and the post-import feedback.
+
+Deduplication is non-trivial for this feature. Because the Anthropic API assigns new UUIDs to every imported card (they have no `id` in the source sheet), ID-based deduplication (used in Story 5.1's sign-in merge) does not apply here. Instead, deduplication must be based on **content similarity**: same issuer + same card name is treated as a potential duplicate, and the user is informed rather than silently skipped.
+
+This story also owns the `householdId` assignment: imported cards must be scoped to the current user's household (Google `sub` if signed in, anonymous `householdId` if not).
+
+---
+
+## Desired Outcome
+
+After this ships, when a user confirms an import:
+
+1. Each imported card is checked against the current household's existing cards for potential duplicates.
+2. Cards that are likely duplicates (same `issuerId` + same `cardName`, case-insensitive) are flagged — not silently dropped.
+3. The user is shown a clear summary: "X new cards will be added. Y cards look like duplicates — skip them?"
+4. The user can choose to skip duplicates or import everything (including duplicates).
+5. Confirmed cards are saved to localStorage under the current household.
+6. The dashboard refreshes and the new cards are immediately visible.
+7. A success toast fires: "N card(s) added to your ledger."
+
+---
+
+## Deduplication Rules
+
+### Primary match (skip by default)
+
+If an imported card has **the same `issuerId` AND the same `cardName`** (case-insensitive, trimmed) as any existing non-deleted card in the household, it is considered a likely duplicate and is excluded from the default import set.
+
+Examples:
+- Existing: `issuerId: "chase"`, `cardName: "Sapphire Preferred"` → skip imported "Chase Sapphire Preferred"
+- Existing: `issuerId: "amex"`, `cardName: "Platinum Card"` → skip imported "Amex Platinum"
+
+### Fuzzy edge cases (import by default, annotate)
+
+If the issuer matches but the card name is different (likely a different product from the same issuer), import it without flagging. The user's sheet may contain multiple Chase cards.
+
+### User override
+
+The duplicate summary screen (Step 3B in the wizard, inserted between Step 3 and Step 5) must let the user choose to import duplicates anyway. This handles cases where the user legitimately has the same card twice (e.g., a personal and a business version).
+
+---
+
+## Wizard Step 3B — Duplicate Summary
+
+This step is only shown if ≥ 1 likely duplicate is found. If no duplicates, skip directly from Step 3 to the import action (no additional step).
+
+**Heading (Voice 2)**: *"Some chains are already forged."*
+**Sub-heading (Voice 1)**: "We found {Y} card(s) that look like ones you already have."
+
+UI elements:
+- A list of flagged duplicates: issuer + card name, paired with the existing card it matched.
+- Two choices:
+  - "Skip {Y} duplicate(s) and import {X} new cards" — primary action (recommended)
+  - "Import all {N} cards anyway" — secondary action (for users who want duplicates)
+- "Cancel" (close wizard without importing anything)
+
+If the user chooses "Skip duplicates": only the X non-duplicate cards are imported.
+If the user chooses "Import all": all N cards are imported regardless of duplicates.
+
+---
+
+## householdId Assignment
+
+Every imported card must have its `householdId` set to the **current user's active household ID** before being saved. The current household ID is determined as follows:
+
+- If signed in: `FenrirSession.user.sub` (Google sub claim, from `fenrir:auth` in localStorage)
+- If anonymous: the UUID from `fenrir:household` in localStorage
+
+The wizard must read the active `householdId` at the time the user confirms the import — not at the time the URL was submitted. This ensures correctness if the user somehow signs in between the URL submission and the import confirmation (unlikely but defensive).
+
+---
+
+## Post-Import State
+
+After cards are saved:
+
+1. The import wizard closes (Step 5 success flash, then modal closes).
+2. The dashboard card grid re-renders with the new cards visible.
+3. A non-blocking toast fires: "N card(s) added to your ledger." (4-second auto-dismiss)
+4. If skipped duplicates > 0, the toast includes a secondary line: "Y duplicate(s) were skipped."
+5. The new cards enter the normal card lifecycle: `computeCardStatus()` is called on each before save, so their status badges are immediately correct.
+
+---
+
+## Acceptance Criteria
+
+- [ ] When the user confirms an import, each imported card is checked against the current household for `issuerId` + `cardName` duplicates (case-insensitive)
+- [ ] If ≥ 1 duplicate is found, Step 3B (duplicate summary) is shown before any cards are saved
+- [ ] The duplicate summary accurately lists each flagged card and the existing card it matched
+- [ ] "Skip duplicates and import new cards" imports only the non-duplicate cards
+- [ ] "Import all cards anyway" imports all cards regardless of duplicate flags
+- [ ] All imported cards have `householdId` set to the current active household ID at the time of confirmation
+- [ ] All imported cards have `status` computed via `computeCardStatus()` before saving
+- [ ] All imported cards have valid `createdAt` and `updatedAt` timestamps set to the import time
+- [ ] After confirmation, the dashboard card grid reflects all newly imported cards without requiring a page refresh
+- [ ] After confirmation, a success toast fires: "N card(s) added to your ledger."
+- [ ] If duplicates were skipped, the toast includes: "Y duplicate(s) were skipped."
+- [ ] If the import results in zero new cards (all were duplicates and the user chose to skip), the toast reads: "No new cards were imported — all matched existing entries."
+- [ ] The import works correctly for both anonymous users (anonymous householdId) and signed-in users (Google sub)
+- [ ] `saveCard()` is called for each imported card (or the batch equivalent per the technical notes)
+- [ ] `npm run build` passes with zero errors
+- [ ] TypeScript strict mode: zero new type errors introduced
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Deduplication function**: Write a pure function `findDuplicates(imported: Card[], existing: Card[]): { duplicates: Card[], newCards: Card[] }`. The function compares `issuerId.toLowerCase()` and `cardName.toLowerCase().trim()` across all pairs. Return both sets so the wizard UI can render the duplicate summary accurately.
+
+**Batch save strategy**: Mirror the approach from Story 5.1 — do not call `saveCard()` in a loop. Load all existing cards once, append the new cards, call `setAllCards()` once. This dispatches `fenrir:sync` once instead of once-per-card.
+
+**householdId resolution timing**: The wizard component should resolve the active `householdId` immediately before the save operation (not when the wizard opens). Read `fenrir:auth` for signed-in state; read `fenrir:household` for anonymous state. Use whatever auth context / hook is already established in the app.
+
+**computeCardStatus timing**: Run `computeCardStatus(card)` on each card in the import array before the batch save, not after. Cards should enter the store with correct status already set.
+
+**No UI for editing individual cards pre-import**: Sprint 5 does not include the ability to edit card fields in the wizard preview. If the AI got a field wrong (e.g., wrong annual fee), the user imports and then edits via the normal card edit flow. A future sprint could add inline editing to the preview — but that is out of scope here to keep the story bounded.
+
+**Concurrency with Story 5.3**: The "Import N cards" button in Story 5.3's Step 3 should call a callback (`onConfirmImport(cards: Card[])`) that is provided by the parent component. That parent component implements the deduplication + save logic from this story. This keeps the wizard UI (5.3) decoupled from the persistence logic (5.4) and makes both easier to test.
+
+---
+
+## Dependencies
+
+- **Depends on**: Story 5.3 (wizard UI supplies the cards array to be imported)
+- **Depends on**: Story 5.2 (API route must be functional for end-to-end testing)
+- **Blocks**: Nothing
+
+---
+
+## Open Questions for FiremanDecko
+
+1. **Duplicate detection edge case — same card, different issuerId format**: The Anthropic API may return `"american_express"` for a card that the app's issuer list stores as `"amex"`. Should deduplication normalize these? Product preference: use a lookup table of known issuer aliases (e.g. `"american_express" → "amex"`) when comparing. FiremanDecko to propose the normalization table.
+
+2. **What happens to the duplicate check if the existing household has zero cards?** Deduplication should short-circuit to "no duplicates" in that case — no comparison needed. Confirm this is handled in the function.
+
+---
+
+## Mythology Frame
+
+The Norns do not weave the same thread twice. When a chain already binds, the new strand finds another link — it does not replace. The ledger grows; it does not repeat.

--- a/product/backlog/story-5.5-lcars-mode.md
+++ b/product/backlog/story-5.5-lcars-mode.md
@@ -1,0 +1,177 @@
+# Story 5.5: LCARS Mode — Star Trek Easter Egg
+
+- **As a**: Credit card churner and rewards optimizer (and builder / nerd culture enthusiast)
+- **I want**: A hidden keyboard trigger that briefly transforms the app's UI into a Star Trek LCARS-style overlay
+- **So that**: Developers, power users, and nerd culture explorers who discover it feel the product rewards their curiosity
+- **Priority**: P3-Medium
+- **Sprint Target**: 5
+- **Status**: Ready
+
+---
+
+## Context / Problem
+
+This story was deferred from Sprint 4 due to the sprint cap (5 stories, all higher priority). It is the first item in the deferred backlog (`product/backlog/future-deferred.md`) marked "Sprint 5, if capacity allows."
+
+The full spec exists in `ux/easter-eggs.md` Easter Egg #6. This story is an implementation story — the design is already written. No new UX design work is required beyond Luna confirming the spec still matches the current state of the app.
+
+This is a pure delight feature. It adds no functional value. It is the product's way of saying to FiremanDecko, to Loki, and to any developer who discovers it: "We see you. The wolf howls at stardate now."
+
+---
+
+## Desired Outcome
+
+After this ships:
+
+1. Pressing `Cmd+Shift+W` (Mac) / `Ctrl+Shift+W` (Windows/Linux) on any page triggers LCARS mode.
+2. A full-viewport amber overlay fades in over the current page, styled in the LCARS aesthetic (Star Trek: TNG computer panels).
+3. The overlay displays:
+   - A "STARDATE" reading (derived from today's date in stardate format)
+   - Current card counts by status (Active, Fee Approaching, Promo Expiring, Honored Dead)
+   - A scan-line animation effect
+4. After 5 seconds, the overlay performs a scan-line wipe exit and disappears.
+5. The user can also dismiss early by pressing `Escape` or clicking anywhere on the overlay.
+
+---
+
+## LCARS Aesthetic Specification
+
+Per `ux/easter-eggs.md` #6:
+
+- **Background**: deep black (`#0a0a0f`)
+- **Primary accent**: LCARS amber (`#ff9900`)
+- **Secondary accent**: LCARS dusty orange (`#cc6600`)
+- **Tertiary accent**: LCARS lavender (`#cc88ff`)
+- **Typography**: `JetBrains Mono` (already in the design system) — monospace data readout feel
+- **Layout**: a full-viewport `position: fixed` overlay with `z-index` above all other elements (above modals, above toasts)
+- **LCARS panel shapes**: rectangular blocks with rounded corners on one side only — the classic asymmetric LCARS panel geometry. Implemented as simple CSS border-radius applied asymmetrically (e.g. `border-radius: 24px 4px 4px 24px`).
+- **Scan-line entry animation**: a horizontal scan line sweeps top-to-bottom across the overlay as it fades in (0.4s)
+- **Scan-line exit animation**: the same scan line sweeps bottom-to-top as the overlay fades out (0.4s), then the overlay is removed from the DOM
+
+---
+
+## Stardate Calculation
+
+Classic TNG stardate format: `YYMM.DD` where `YY` is the two-digit year (offset from 2323 to the current year in the show's timeline). For the purposes of this easter egg, use a simplified stardate derived directly from today's date:
+
+```
+stardate = (currentYear - 1987) * 1000 + (dayOfYear / 365 * 1000)
+```
+
+Display format: `STARDATE [value].{fractional}`
+
+Example: 2026-02-28 → approximately `STARDATE 39154.4`
+
+This does not need to match any canonical formula precisely — the vibe is what matters.
+
+---
+
+## Data Display
+
+The LCARS overlay displays the following card data (read live from the current household at trigger time):
+
+```
+FENRIR LEDGER TACTICAL REPORT
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+STARDATE {value}
+
+CARD STATUS SUMMARY
+  ACTIVE              {n}
+  FEE APPROACHING     {n}
+  PROMO EXPIRING      {n}
+  HONORED DEAD        {n}
+  ──────────────────
+  TOTAL               {n}
+
+SYSTEM STATUS: NOMINAL
+RAGNAROK THREAT LEVEL: {NONE / ELEVATED / CRITICAL}
+```
+
+`RAGNAROK THREAT LEVEL` maps from the `RagnarokContext` introduced in Story 4.1:
+- `NONE` — fewer than 3 urgent cards
+- `ELEVATED` — 3–4 urgent cards (Ragnarök active)
+- `CRITICAL` — 5+ urgent cards
+
+---
+
+## Trigger
+
+- **Key combo**: `Cmd+Shift+W` (Mac) / `Ctrl+Shift+W` (Windows/Linux)
+- **Scope**: global keyboard listener, active on all pages
+- **Guard**: if LCARS mode is already visible, the key combo is a no-op
+- **Conflict check**: `Ctrl+W` is the browser's "close tab" shortcut; `Ctrl+Shift+W` closes all tabs in some browsers. FiremanDecko must verify `e.preventDefault()` is called on the keydown event to suppress the browser's default behavior. If suppression is not possible across all target browsers, propose an alternative key combo at implementation time.
+
+---
+
+## Interaction with Existing Easter Eggs
+
+- LCARS mode does not conflict with the Konami code howl.
+- LCARS mode does not conflict with Ragnarök mode — if both are active simultaneously, the LCARS overlay renders above the Ragnarök red overlay. The LCARS overlay's `z-index` must be above all other layers.
+- LCARS mode does not contribute to or subtract from the Gleipnir Hunt fragment collection.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Pressing `Cmd+Shift+W` (Mac) or `Ctrl+Shift+W` (Windows/Linux) on any page triggers the LCARS overlay
+- [ ] The overlay covers the full viewport with a fixed-position panel in LCARS amber/black aesthetic
+- [ ] The overlay displays the stardate (derived from today's date using the simplified formula)
+- [ ] The overlay displays card counts by status (active, fee_approaching, promo_expiring, closed) read live from the current household
+- [ ] The overlay displays the Ragnarök threat level derived from the current urgent card count
+- [ ] The overlay auto-dismisses after 5 seconds with a scan-line wipe exit animation
+- [ ] Pressing `Escape` or clicking anywhere on the overlay dismisses it immediately
+- [ ] Triggering the key combo while LCARS mode is already visible is a no-op
+- [ ] The overlay's z-index is above all other app elements (modals, toasts, Ragnarök overlay)
+- [ ] The entry animation is a downward scan-line sweep (0.4s); the exit animation is an upward scan-line wipe (0.4s)
+- [ ] The trigger key combo does not allow the browser's default action (tab close) to fire
+- [ ] The overlay is `aria-hidden="true"` — it must not be reachable by keyboard navigation or screen readers
+- [ ] After dismissal, keyboard focus returns to whatever element was focused before the overlay appeared
+- [ ] `npm run build` passes with zero errors
+- [ ] TypeScript strict mode: zero new type errors introduced
+
+---
+
+## Technical Notes for FiremanDecko
+
+**Component**: `LcarsOverlay.tsx` — a new client component rendered in `AppShell` alongside `KonamiHowl` and the Ragnarök overlay. It holds its own `visible` state.
+
+**Keyboard listener**: `useEffect` on mount, `window.addEventListener("keydown", handler)`. Check `e.metaKey` (Mac Cmd) or `e.ctrlKey` plus `e.shiftKey` and `e.key === "W"`. Call `e.preventDefault()` to suppress browser defaults.
+
+**Card data**: Read from the current household using `getAllCardsGlobal(householdId)`. Count by status. The `householdId` is available from whatever auth context the app uses. Use `getClosedCards(householdId)` for the "Honored Dead" count.
+
+**Ragnarök integration**: Consume `useRagnarok()` context (introduced in Story 4.1) to get the `ragnarok` boolean and the raw urgent count. Map count to the three threat levels.
+
+**z-index**: Use `z-index: 500` (above the modal layer at `z-index: 200`, above the Ragnarök overlay at `z-index: 1`). Document in the z-index table in `wireframes.md` or `architecture/`.
+
+**Scan-line animation**: A single `<div>` with `position: absolute`, `width: 100%`, `height: 2px`, `background: amber`, animated via CSS `@keyframes` to translate from `top: 0` to `top: 100%` over 0.4s on entry, reversed on exit.
+
+**Auto-dismiss timer**: Use `useEffect` with a `setTimeout` of 5000ms when `visible` becomes `true`. Clean up with `clearTimeout` on component unmount and on early dismiss to prevent state updates on unmounted components.
+
+**Stardate formula**: Implement as a pure utility function in a new file `development/src/src/lib/stardate.ts`. Keep it separate for testability. The formula is simple arithmetic — no dependencies.
+
+**LCARS font**: Use `JetBrains Mono` — already loaded in the design system. No new font imports needed.
+
+---
+
+## Open Questions for FiremanDecko
+
+1. **`Ctrl+Shift+W` browser conflict**: In Chrome and Firefox on Windows/Linux, `Ctrl+Shift+W` closes all windows in the browser. `e.preventDefault()` may or may not prevent this depending on the browser. If it cannot be prevented reliably, the fallback key combo is `Ctrl+Shift+L` (L for "LCARS"). Product preference: try `Ctrl+Shift+W` first; if it cannot be safely suppressed, use `Ctrl+Shift+L`. Document the actual key combo used in a comment in the component.
+
+2. **Mobile trigger**: There is no physical keyboard on most mobile devices. The LCARS easter egg is effectively desktop-only. Confirm this is acceptable — product preference is yes, desktop-only is fine for this easter egg.
+
+---
+
+## UX Notes
+
+Luna to review `ux/easter-eggs.md` #6 and confirm the LCARS spec is still accurate relative to the current app state. If any visual refinements are needed (color tweaks, layout adjustments), Luna should update the easter eggs doc before FiremanDecko begins implementation.
+
+No new wireframe is required — the easter-eggs.md spec is sufficient for this story.
+
+---
+
+## Mythology Frame
+
+In the halls of the Federation, a war room is a bridge. In the halls of Fenrir, a bridge is a war room. For five seconds, both are true. LCARS is the dream Odin had when he traded his eye for a glimpse of what lay beyond Yggdrasil.
+
+*"Computer: current stardate." — The wolf, briefly.*


### PR DESCRIPTION
## Summary

- 5.1 Silent Auto-Merge on Google Sign-In (P1-Critical) — always merges anon localStorage cards into Google household on sign-in; eliminates Import/Start-fresh dialog
- 5.2 Sheets Import: Anthropic Conversion API Route (P1-Critical) — server-side `POST /api/sheets/import`; fetches public Sheets CSV, calls `claude-haiku-3-5`, returns `Card[]`
- 5.3 Sheets Import: Wizard UI (P1-Critical) — multi-step modal: URL entry → loading → card preview → `onConfirmImport` callback
- 5.4 Sheets Import: Dedup + Persistence (P2-High) — content-based deduplication (issuerId + cardName), batch save via `setAllCards()`
- 5.5 LCARS Mode Easter Egg #6 (P3-Medium) — pulled from deferred backlog; safest story to cut if sprint runs short
- Update backlog README with Sprint 5 table
- Remove LCARS from future-deferred.md

## Test plan

- [ ] Review each story's acceptance criteria for completeness
- [ ] Verify backlog README table is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)