### PR TITLE
update sprint 5 backlog stories with pre-sprint decisions

### DIFF
--- a/product/backlog/story-5.1-silent-auto-merge.md
+++ b/product/backlog/story-5.1-silent-auto-merge.md
@@ -32,7 +32,7 @@ After this ships:
 3. If yes: merge all non-duplicate cards into the Google household automatically. No dialog. No user decision required.
 4. If no: proceed directly to the signed-in dashboard. No change in behavior.
 5. A brief non-blocking toast confirms the merge ("N cards carried into your ledger.") — informational only, not a decision gate.
-6. The anonymous `fenrir:household` key is cleared (or tombstoned) after a successful merge to prevent re-merging the same cards on next sign-in.
+6. The anonymous `fenrir:household` key is cleared completely after a successful merge to prevent re-merging the same cards on next sign-in.
 
 ---
 
@@ -73,7 +73,7 @@ Does fenrir:household exist with card count > 0?
         │       into your ledger."    │
         │               │             │
         │               ▼             ▼
-        │       Clear fenrir:household (tombstone or remove)
+        │       Clear fenrir:household completely (remove key)
         │               │
         └───────────────┤
                         ▼
@@ -111,7 +111,7 @@ The existing migration prompt dialog (`MigrationPrompt` component, if it exists)
 - [ ] Each imported card has its `householdId` field updated to the Google `sub` before being saved
 - [ ] After a successful merge, a non-blocking toast displays: "N card(s) carried into your ledger." where N is the count of merged cards
 - [ ] If no mergeable cards are found (anonymous household is empty or all cards already exist in Google household), no toast is shown and the user proceeds directly to the signed-in dashboard
-- [ ] After merge, the anonymous `fenrir:household` localStorage key is cleared (or tombstoned with a `mergedAt` timestamp) so the same cards are not re-imported on the next sign-in
+- [ ] After merge, the anonymous `fenrir:household` localStorage key is removed completely so the same cards are not re-imported on the next sign-in
 - [ ] The migration is idempotent: signing out and signing back in does not re-import already-merged cards
 - [ ] If the merge operation fails (e.g., localStorage write error), the sign-in still completes and an error toast is shown; cards are not lost from the anonymous household
 - [ ] The signed-in dashboard renders correctly after a merge with the full portfolio visible
@@ -122,7 +122,7 @@ The existing migration prompt dialog (`MigrationPrompt` component, if it exists)
 
 ## Technical Notes for FiremanDecko
 
-**Where to trigger the merge**: The OAuth callback handler (the function that establishes `FenrirSession` in localStorage after the Google token exchange) is the right place. After writing `fenrir:auth`, before redirecting to the dashboard, run the merge logic.
+**Where to trigger the merge**: The `/auth/callback` page — confirmed as the location where `FenrirSession` is written to localStorage after the Google token exchange completes. After writing `fenrir:auth`, before redirecting to the dashboard, run the merge logic.
 
 **Anonymous householdId source**: Read `fenrir:household` from localStorage to get the anonymous UUID. This is the source household for the merge.
 
@@ -132,7 +132,9 @@ The existing migration prompt dialog (`MigrationPrompt` component, if it exists)
 
 **householdId rewrite**: Each imported card must have `householdId` set to the Google `sub` before `saveCard()` is called. Do not write the anonymous card to the Google namespace without this field update.
 
-**Tombstone vs. clear**: After merge, set `fenrir:household` to a tombstone value (e.g. `{ mergedAt: ISO_TIMESTAMP, mergedInto: googleSub }`) rather than deleting the key outright. This provides an audit trail and prevents re-merge logic from failing silently if the key is recreated by some other code path. Check for a `mergedAt` field in `fenrir:household` at OAuth callback time — if present, skip the merge.
+**Clearing anonymous storage**: After a successful merge, remove the `fenrir:household` key from localStorage completely (`localStorage.removeItem("fenrir:household")`). Do not use a tombstone — a clean removal is the correct behavior. Since all anonymous data has UUID primary keys and is bulk-copied into the Google household, there is no risk of re-merge: the anonymous household is simply empty after sign-in. The merge is idempotent because re-running it on an empty anonymous household is a no-op.
+
+**Merge utility module**: Implement all merge logic in a standalone utility module in the storage layer — e.g. `development/src/src/lib/merge-anonymous.ts`. This module must be the single source of truth for merging anonymous data into a signed-in household. Exporting it as a discrete module makes it testable and ensures future data types (not just cards) can be merged by adding to this one file. The `/auth/callback` page imports and calls this module — it does not inline the merge logic.
 
 **Toast pattern**: Reuse the existing toast infrastructure (Sprint 4.2 milestone toasts established the pattern). This toast is informational, auto-dismisses, does not require user action.
 
@@ -144,7 +146,7 @@ The existing migration prompt dialog (`MigrationPrompt` component, if it exists)
 
 ## Open Questions for FiremanDecko
 
-1. **OAuth callback location**: Where is the current Google OIDC callback handler implemented? Is it a Next.js route handler (`/api/auth/callback`) or client-side PKCE completion logic? The merge logic needs to be inserted at the point where the `FenrirSession` is committed to localStorage — confirm the exact location.
+1. ~~**OAuth callback location**~~ — **Resolved**: The merge fires in the `/auth/callback` page, which is the confirmed location where `FenrirSession` is written to localStorage after the Google OIDC token exchange.
 
 2. **Toast infrastructure**: Sprint 4.2 introduced milestone toasts. Is there a reusable `showToast()` utility or does this story need to integrate with a toast library (e.g. sonner, react-hot-toast)? The merge toast must use the same system.
 

--- a/product/backlog/story-5.2-sheets-import-api-route.md
+++ b/product/backlog/story-5.2-sheets-import-api-route.md
@@ -57,7 +57,7 @@ The route must:
 
 The API route calls the Anthropic API (server-side only — API key never exposed to client) with:
 
-- **Model**: `claude-haiku-3-5` (fast and cost-effective for structured extraction)
+- **Model**: `claude-haiku-4-5-20251001` (fast and cost-effective for structured extraction)
 - **Prompt strategy**: A system prompt that explains the `Card` schema in detail and instructs the model to extract all credit card records from the provided CSV, returning a JSON array.
 
 ### System Prompt (product-specified):
@@ -99,7 +99,7 @@ Rules:
 
 ```json
 {
-  "model": "claude-haiku-3-5",
+  "model": "claude-haiku-4-5-20251001",
   "max_tokens": 4096,
   "messages": [
     {
@@ -218,13 +218,13 @@ GID (tab ID) is optional in the URL hash: `#gid=0`. Default to GID `0` if absent
 
 ## Open Questions for FiremanDecko
 
-1. **Anthropic model selection**: `claude-haiku-3-5` is the product preference for cost/speed. If the model has been superseded or has a different model ID in the current SDK version, use the equivalent fast/cheap model and document the choice in the route file.
+1. ~~**Anthropic model selection**~~ — **Resolved**: Use `claude-haiku-4-5-20251001`. This is the confirmed model ID for Sprint 5.
 
 2. **CSV encoding**: Google Sheets CSV exports may use UTF-8 with BOM. Confirm whether the fetch response needs BOM stripping before passing to Anthropic.
 
 3. **Rate limiting**: Anthropic has per-minute token limits. If a user submits a very large sheet, the request may be rate-limited. Should the route return a retryable `429` response, or silently truncate the input first? Product preference: truncate first (at 100k characters), then surface a warning.
 
-4. **Vercel timeout**: Default Vercel serverless function timeout is 10 seconds. A large sheet fetch + Anthropic call may exceed this. Does the Vercel project have an extended timeout configured, or does this route need to be declared as an edge function or streaming response?
+4. ~~**Vercel timeout**~~ — **Resolved**: Extend the function timeout using `export const maxDuration = 60` at the top of the route file (Vercel Pro, serverless runtime). Do not use streaming or edge runtime for this route.
 
 ---
 

--- a/product/backlog/story-5.3-sheets-import-wizard.md
+++ b/product/backlog/story-5.3-sheets-import-wizard.md
@@ -74,7 +74,7 @@ Validation (client-side, before submitting to the API):
 
 UI elements:
 - Animated loading indicator (existing app loading pattern — not a spinner, see interactions.md for the rune-pulse pattern if available, otherwise a simple text pulse).
-- No cancel button during this step — the request is in flight. If the user closes the modal (ESC or ×), show a confirmation: "Cancel the import? Your sheet will not be saved." Accept/dismiss.
+- No cancel button during this step — the request is in flight. If the user presses ESC or clicks ×, replace the loading view inline (within the same modal — no nested dialog) with a two-button cancellation screen: heading "Cancel the import?" + body "Your sheet will not be saved." + buttons "Yes, cancel" (closes wizard) / "Keep waiting" (returns to loading view).
 - The loading step times out at 20 seconds. If the API has not responded, surface Step 4 (error state) with message: "The Norns took too long. Try again."
 
 ### Step 3 — Preview
@@ -131,7 +131,7 @@ Then: modal closes, dashboard refreshes with new cards visible, toast from Story
 - Focus is trapped inside the wizard at all steps.
 - On step advance, focus moves to the new step's heading.
 - The loading step announces its status to screen readers: `aria-live="polite"` region with the loading message.
-- ESC dismisses the wizard at Steps 1, 3, and 4 (with confirmation at Step 2 if loading).
+- ESC dismisses the wizard at Steps 1, 3, and 4. At Step 2 (loading), ESC switches the modal to the inline cancellation screen (not a second dialog).
 - All buttons meet the 44px minimum touch target.
 - Error messages are announced immediately via `aria-live="assertive"`.
 
@@ -171,7 +171,7 @@ Then: modal closes, dashboard refreshes with new cards visible, toast from Story
 
 **Annual fee formatting**: Divide cents by 100. Show `$X` format. Use `$0` vs "No annual fee" based on `annualFee === 0`.
 
-**Cancel during loading**: A simple `useRef` to track whether the component is still mounted is sufficient. If the user cancels, set an `aborted` ref to `true` — when the fetch resolves, check the ref before advancing to Step 3.
+**Cancel during loading**: When the user presses ESC or × at Step 2, transition the wizard's `step` state to `"cancel_confirm"` — a new inline step rendered within the same modal (no `<dialog>` nested inside the wizard dialog). The cancel confirmation screen shows heading "Cancel the import?", body "Your sheet will not be saved.", and two buttons: "Yes, cancel" (closes the wizard entirely) and "Keep waiting" (reverts step back to `"loading"`). Use a `useRef` `aborted` flag: if the fetch resolves after the user has chosen "Keep waiting", check the flag before advancing to Step 3.
 
 **Import trigger**: The "Import N cards" button in Step 3 should call a prop/callback function supplied by the parent component (not navigate or dispatch directly). This decouples the wizard from the storage logic in Story 5.4.
 

--- a/product/backlog/story-5.5-lcars-mode.md
+++ b/product/backlog/story-5.5-lcars-mode.md
@@ -23,7 +23,7 @@ This is a pure delight feature. It adds no functional value. It is the product's
 
 After this ships:
 
-1. Pressing `Cmd+Shift+W` (Mac) / `Ctrl+Shift+W` (Windows/Linux) on any page triggers LCARS mode.
+1. Pressing `Cmd+Shift+L` (Mac) / `Ctrl+Shift+L` (Windows/Linux) on any page triggers LCARS mode.
 2. A full-viewport amber overlay fades in over the current page, styled in the LCARS aesthetic (Star Trek: TNG computer panels).
 3. The overlay displays:
    - A "STARDATE" reading (derived from today's date in stardate format)
@@ -97,10 +97,10 @@ RAGNAROK THREAT LEVEL: {NONE / ELEVATED / CRITICAL}
 
 ## Trigger
 
-- **Key combo**: `Cmd+Shift+W` (Mac) / `Ctrl+Shift+W` (Windows/Linux)
+- **Key combo**: `Cmd+Shift+L` (Mac) / `Ctrl+Shift+L` (Windows/Linux)
 - **Scope**: global keyboard listener, active on all pages
 - **Guard**: if LCARS mode is already visible, the key combo is a no-op
-- **Conflict check**: `Ctrl+W` is the browser's "close tab" shortcut; `Ctrl+Shift+W` closes all tabs in some browsers. FiremanDecko must verify `e.preventDefault()` is called on the keydown event to suppress the browser's default behavior. If suppression is not possible across all target browsers, propose an alternative key combo at implementation time.
+- **Conflict check**: `Ctrl+Shift+L` has no known browser default action across Chrome, Firefox, or Safari. FiremanDecko must still call `e.preventDefault()` on the keydown event as a precaution and verify no conflict exists before shipping.
 
 ---
 
@@ -114,7 +114,7 @@ RAGNAROK THREAT LEVEL: {NONE / ELEVATED / CRITICAL}
 
 ## Acceptance Criteria
 
-- [ ] Pressing `Cmd+Shift+W` (Mac) or `Ctrl+Shift+W` (Windows/Linux) on any page triggers the LCARS overlay
+- [ ] Pressing `Cmd+Shift+L` (Mac) or `Ctrl+Shift+L` (Windows/Linux) on any page triggers the LCARS overlay
 - [ ] The overlay covers the full viewport with a fixed-position panel in LCARS amber/black aesthetic
 - [ ] The overlay displays the stardate (derived from today's date using the simplified formula)
 - [ ] The overlay displays card counts by status (active, fee_approaching, promo_expiring, closed) read live from the current household
@@ -136,7 +136,7 @@ RAGNAROK THREAT LEVEL: {NONE / ELEVATED / CRITICAL}
 
 **Component**: `LcarsOverlay.tsx` — a new client component rendered in `AppShell` alongside `KonamiHowl` and the Ragnarök overlay. It holds its own `visible` state.
 
-**Keyboard listener**: `useEffect` on mount, `window.addEventListener("keydown", handler)`. Check `e.metaKey` (Mac Cmd) or `e.ctrlKey` plus `e.shiftKey` and `e.key === "W"`. Call `e.preventDefault()` to suppress browser defaults.
+**Keyboard listener**: `useEffect` on mount, `window.addEventListener("keydown", handler)`. Check `e.metaKey` (Mac Cmd) or `e.ctrlKey` plus `e.shiftKey` and `e.key === "L"`. Call `e.preventDefault()` to suppress any browser defaults.
 
 **Card data**: Read from the current household using `getAllCardsGlobal(householdId)`. Count by status. The `householdId` is available from whatever auth context the app uses. Use `getClosedCards(householdId)` for the "Honored Dead" count.
 
@@ -156,7 +156,7 @@ RAGNAROK THREAT LEVEL: {NONE / ELEVATED / CRITICAL}
 
 ## Open Questions for FiremanDecko
 
-1. **`Ctrl+Shift+W` browser conflict**: In Chrome and Firefox on Windows/Linux, `Ctrl+Shift+W` closes all windows in the browser. `e.preventDefault()` may or may not prevent this depending on the browser. If it cannot be prevented reliably, the fallback key combo is `Ctrl+Shift+L` (L for "LCARS"). Product preference: try `Ctrl+Shift+W` first; if it cannot be safely suppressed, use `Ctrl+Shift+L`. Document the actual key combo used in a comment in the component.
+1. ~~**Key combo browser conflict**~~ — **Resolved**: The trigger is `Cmd+Shift+L` (Mac) / `Ctrl+Shift+L` (Windows/Linux). `Ctrl+Shift+L` has no known browser default action. FiremanDecko must verify this holds across Chrome, Firefox, and Safari before shipping and document the confirmation in a code comment in `LcarsOverlay.tsx`.
 
 2. **Mobile trigger**: There is no physical keyboard on most mobile devices. The LCARS easter egg is effectively desktop-only. Confirm this is acceptable — product preference is yes, desktop-only is fine for this easter egg.
 


### PR DESCRIPTION
## Summary

- Story 5.1: confirm merge fires in `/auth/callback`, remove tombstone in favour of full wipe, add standalone `merge-anonymous.ts` utility module requirement
- Story 5.2: update model ID to `claude-haiku-4-5-20251001`, resolve Vercel timeout via `maxDuration` config
- Story 5.3: update Step 2 cancel UX to inline cancellation screen (no nested dialog)
- Story 5.5: change LCARS trigger from `Cmd+Shift+L` to `Cmd+Shift+L`, resolve open question on key combo browser conflict

## Test plan

- [ ] Verify all four story files render correctly in GitHub markdown
- [ ] Confirm no secrets or env values in any changed file
- [ ] Confirm story cross-references remain accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)