### PR TITLE
fix(docs): replace broken Vercel badge with production + preview badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # ᛟ Fenrir Ledger
 
-[![Deploy to Vercel](https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/vercel.yml/badge.svg)](https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/vercel.yml)
+[![Deploy to Vercel — Production](https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/vercel-production.yml/badge.svg)](https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/vercel-production.yml)
+[![Deploy to Vercel — Preview](https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/vercel-preview.yml/badge.svg)](https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/vercel-preview.yml)
 [![Last Commit](https://img.shields.io/github/last-commit/declanshanaghy/fenrir-ledger?color=c9920a&logo=git&logoColor=white)](https://github.com/declanshanaghy/fenrir-ledger/commits/main)
 [![License: ELv2](https://img.shields.io/badge/license-ELv2-brightgreen)](LICENSE.md)
 [![Next.js](https://img.shields.io/badge/Next.js-15-black?logo=next.js&logoColor=white)](https://nextjs.org)


### PR DESCRIPTION
## Bug

The README had a broken GitHub Actions badge pointing to a workflow file that does not exist:

\`\`\`
.github/workflows/vercel.yml  ← does not exist
\`\`\`

## Fix

Replaced the single broken badge with two correct badges that point to the actual workflow files:

- `.github/workflows/vercel-production.yml` — Deploy to Vercel (Production)
- `.github/workflows/vercel-preview.yml` — Deploy to Vercel (Preview)

## Changes

- `README.md` line 3: removed broken badge, added two working badges

## Test plan

- [ ] Confirm both badge images resolve on the merged README (GitHub renders them from the workflow names)
- [ ] Confirm neither badge points to a non-existent workflow file