### PR TITLE
feat: Sprint 5 Phase 0 — toast + Anthropic SDK + setAllCards export

### DIFF
--- a/development/src/.env.example
+++ b/development/src/.env.example
@@ -35,3 +35,11 @@ NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
 #
 # No NEXT_PUBLIC_ prefix — Next.js will NOT include this in the client bundle.
 GOOGLE_CLIENT_SECRET=your-google-client-secret
+
+# ─── Anthropic API Key ──────────────────────────────────────────────────────
+# Required for the Google Sheets import feature (Story 5.2).
+# Used server-side only by /api/sheets/import to extract card data from CSV.
+#
+# Obtain from: https://console.anthropic.com/
+# No NEXT_PUBLIC_ prefix — Next.js will NOT include this in the client bundle.
+ANTHROPIC_API_KEY=

--- a/development/src/package-lock.json
+++ b/development/src/package-lock.json
@@ -8,6 +8,7 @@
       "name": "fenrir-ledger",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.78.0",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-checkbox": "^1.1.3",
         "@radix-ui/react-dialog": "^1.1.4",
@@ -22,6 +23,7 @@
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.54.2",
+        "sonner": "^2.0.7",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.24.1"
@@ -49,6 +51,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.78.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.78.0.tgz",
+      "integrity": "sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -4842,6 +4873,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -6347,6 +6391,16 @@
         "is-arrayish": "^0.3.1"
       }
     },
+    "node_modules/sonner": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
+      "integrity": "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
+        "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6772,6 +6826,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/development/src/package.json
+++ b/development/src/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.78.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.4",
@@ -23,6 +24,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.54.2",
+    "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.24.1"

--- a/development/src/src/components/layout/AppShell.tsx
+++ b/development/src/src/components/layout/AppShell.tsx
@@ -23,6 +23,7 @@ import { SideNav } from "./SideNav";
 import { SyncIndicator } from "./SyncIndicator";
 import { KonamiHowl } from "./KonamiHowl";
 import { ForgeMasterEgg } from "./ForgeMasterEgg";
+import { Toaster } from "sonner";
 import { Footer } from "./Footer";
 import { UpsellBanner } from "./UpsellBanner";
 import {
@@ -98,6 +99,17 @@ export function AppShell({ children }: AppShellProps) {
       <ForgeMasterEgg />
       {/* Easter egg #3 — The Roots of a Mountain (first sidebar collapse, one-time) */}
       <GleipnirMountainRoots open={rootsOpen} onClose={dismissRoots} />
+      <Toaster
+        position="bottom-right"
+        toastOptions={{
+          className: "font-body",
+          style: {
+            background: "hsl(var(--card))",
+            border: "1px solid hsl(var(--border))",
+            color: "hsl(var(--foreground))",
+          },
+        }}
+      />
     </div>
   );
 }

--- a/development/src/src/lib/storage.ts
+++ b/development/src/src/lib/storage.ts
@@ -264,7 +264,7 @@ function getAllCards(householdId: string): Card[] {
  * @param cards - Complete array of Card objects to persist (all records,
  *   including soft-deleted ones)
  */
-function setAllCards(householdId: string, cards: Card[]): void {
+export function setAllCards(householdId: string, cards: Card[]): void {
   if (!isBrowser()) return;
 
   try {


### PR DESCRIPTION
## Summary
- Install `sonner` (toast library) and `@anthropic-ai/sdk` dependencies
- Wire `<Toaster />` in AppShell with dark Nordic theme styling
- Export `setAllCards` from `storage.ts` for merge/import flows
- Add `ANTHROPIC_API_KEY` placeholder to `.env.example`

## Test plan
- [x] `npm run build` succeeds
- [ ] Toast renders with correct dark theme styling in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)