### PR TITLE
feat: Story 5.2 — Google Sheets import API route

### DIFF
--- a/development/src/src/app/api/sheets/import/route.ts
+++ b/development/src/src/app/api/sheets/import/route.ts
@@ -1,0 +1,195 @@
+import { NextRequest, NextResponse } from "next/server";
+import Anthropic from "@anthropic-ai/sdk";
+import { z } from "zod";
+import { extractSheetId, buildCsvExportUrl } from "@/lib/sheets/parse-url";
+import { buildExtractionPrompt, CSV_TRUNCATION_LIMIT } from "@/lib/sheets/prompt";
+import type { SheetImportError, SheetImportSuccess } from "@/lib/sheets/types";
+
+export const maxDuration = 60;
+
+const CardSchema = z.object({
+  issuerId: z.string(),
+  cardName: z.string(),
+  openDate: z.string(),
+  creditLimit: z.number().int().min(0),
+  annualFee: z.number().int().min(0),
+  annualFeeDate: z.string(),
+  promoPeriodMonths: z.number().int().min(0),
+  signUpBonus: z
+    .object({
+      type: z.enum(["points", "miles", "cashback"]),
+      amount: z.number(),
+      spendRequirement: z.number().int().min(0),
+      deadline: z.string(),
+      met: z.boolean(),
+    })
+    .nullable(),
+  notes: z.string(),
+});
+
+const CardsArraySchema = z.array(CardSchema);
+
+function errorResponse(
+  code: SheetImportError["code"],
+  message: string,
+  status: number = 400,
+): NextResponse {
+  return NextResponse.json(
+    { error: { code, message } satisfies SheetImportError },
+    { status },
+  );
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  // 1. Parse + validate body
+  let url: string;
+  try {
+    const body = await request.json();
+    url = body?.url;
+    if (!url || typeof url !== "string") {
+      return errorResponse(
+        "INVALID_URL",
+        "Request body must include a 'url' string.",
+      );
+    }
+  } catch {
+    return errorResponse("INVALID_URL", "Invalid JSON body.");
+  }
+
+  // 2. Extract sheet ID
+  const sheetId = extractSheetId(url);
+  if (!sheetId) {
+    return errorResponse(
+      "INVALID_URL",
+      "URL does not appear to be a Google Sheets link.",
+    );
+  }
+
+  // 3. Fetch CSV
+  let csv: string;
+  let warning: string | undefined;
+  try {
+    const csvUrl = buildCsvExportUrl(sheetId);
+    const csvResponse = await fetch(csvUrl, { redirect: "follow" });
+
+    if (csvResponse.status === 403 || csvResponse.status === 404) {
+      return errorResponse(
+        "SHEET_NOT_PUBLIC",
+        "The spreadsheet is not publicly accessible. Make sure it's shared as 'Anyone with the link can view'.",
+      );
+    }
+
+    if (!csvResponse.ok) {
+      return errorResponse(
+        "FETCH_ERROR",
+        `Failed to fetch spreadsheet (HTTP ${csvResponse.status}).`,
+      );
+    }
+
+    csv = await csvResponse.text();
+
+    if (!csv.trim()) {
+      return errorResponse(
+        "NO_CARDS_FOUND",
+        "The spreadsheet appears to be empty.",
+      );
+    }
+
+    // Truncate if needed
+    if (csv.length > CSV_TRUNCATION_LIMIT) {
+      csv = csv.slice(0, CSV_TRUNCATION_LIMIT);
+      warning = `CSV was truncated at ${CSV_TRUNCATION_LIMIT.toLocaleString()} characters. Some rows may be missing.`;
+    }
+  } catch (err) {
+    return errorResponse(
+      "FETCH_ERROR",
+      `Failed to fetch spreadsheet: ${err instanceof Error ? err.message : "Unknown error"}`,
+    );
+  }
+
+  // 4. Anthropic API call
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return errorResponse(
+      "ANTHROPIC_ERROR",
+      "Server configuration error: missing API key.",
+      500,
+    );
+  }
+
+  const client = new Anthropic({ apiKey });
+  const prompt = buildExtractionPrompt(csv);
+
+  let responseText: string = "";
+
+  // Single retry on transient errors
+  for (let attempt = 0; attempt < 2; attempt++) {
+    try {
+      const message = await client.messages.create({
+        model: "claude-haiku-4-5-20251001",
+        max_tokens: 4096,
+        messages: [{ role: "user", content: prompt }],
+      });
+
+      const textBlock = message.content.find((b) => b.type === "text");
+      responseText = textBlock?.text ?? "";
+      break;
+    } catch (err) {
+      if (attempt === 1) {
+        return errorResponse(
+          "ANTHROPIC_ERROR",
+          `AI extraction failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+          500,
+        );
+      }
+      // First attempt failed — retry
+    }
+  }
+
+  // 5. Parse and validate response
+  try {
+    // Extract JSON from response (handle markdown code blocks)
+    let jsonStr = responseText.trim();
+    if (jsonStr.startsWith("```")) {
+      jsonStr = jsonStr
+        .replace(/^```(?:json)?\n?/, "")
+        .replace(/\n?```$/, "");
+    }
+
+    const parsed = JSON.parse(jsonStr);
+    const validated = CardsArraySchema.parse(parsed);
+
+    if (validated.length === 0) {
+      return errorResponse(
+        "NO_CARDS_FOUND",
+        "No credit card data could be extracted from the spreadsheet.",
+      );
+    }
+
+    // 6. Assign fresh IDs and timestamps
+    const now = new Date().toISOString();
+    const cards = validated.map((card) => ({
+      ...card,
+      id: crypto.randomUUID(),
+      status: "active" as const,
+      createdAt: now,
+      updatedAt: now,
+    }));
+
+    const result: SheetImportSuccess = { cards };
+    if (warning) result.warning = warning;
+
+    return NextResponse.json(result);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      return errorResponse(
+        "PARSE_ERROR",
+        `Extracted data validation failed: ${err.errors.map((e) => e.message).join(", ")}`,
+      );
+    }
+    return errorResponse(
+      "PARSE_ERROR",
+      "Failed to parse AI response as valid card data.",
+    );
+  }
+}

--- a/development/src/src/lib/sheets/parse-url.ts
+++ b/development/src/src/lib/sheets/parse-url.ts
@@ -1,0 +1,21 @@
+/**
+ * Extracts the Google Sheets spreadsheet ID from a URL.
+ * Handles URLs like:
+ *   https://docs.google.com/spreadsheets/d/SHEET_ID/edit
+ *   https://docs.google.com/spreadsheets/d/SHEET_ID/edit#gid=0
+ *   https://docs.google.com/spreadsheets/d/SHEET_ID
+ */
+export function extractSheetId(url: string): string | null {
+  try {
+    const parsed = new URL(url);
+    if (!parsed.hostname.endsWith("google.com")) return null;
+    const match = parsed.pathname.match(/\/spreadsheets\/d\/([a-zA-Z0-9_-]+)/);
+    return match?.[1] ?? null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildCsvExportUrl(sheetId: string): string {
+  return `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv`;
+}

--- a/development/src/src/lib/sheets/prompt.ts
+++ b/development/src/src/lib/sheets/prompt.ts
@@ -1,0 +1,33 @@
+import { KNOWN_ISSUERS } from "@/lib/constants";
+
+const CSV_TRUNCATION_LIMIT = 100_000;
+
+export { CSV_TRUNCATION_LIMIT };
+
+export function buildExtractionPrompt(csv: string): string {
+  const issuerList = KNOWN_ISSUERS.map(i => `${i.id}: ${i.name}`).join(", ");
+
+  return `You are a data extraction assistant. Parse the following CSV data from a credit card spreadsheet and extract card information.
+
+Return ONLY a valid JSON array of objects. No markdown, no explanation, just the JSON array.
+
+Each object must have these exact fields:
+- issuerId: string — match to one of these known issuers: ${issuerList}. Use "other" if no match.
+- cardName: string — the card product name (e.g., "Sapphire Preferred", "Gold Card")
+- openDate: string — ISO 8601 date when the card was opened (e.g., "2024-01-15T00:00:00.000Z"). Use "" if unknown.
+- creditLimit: number — credit limit in cents (multiply dollars by 100). Use 0 if unknown.
+- annualFee: number — annual fee in cents (multiply dollars by 100). Use 0 if no fee or unknown.
+- annualFeeDate: string — ISO 8601 date when the next annual fee is due. Use "" if unknown or no fee.
+- promoPeriodMonths: number — promotional period in months. Use 0 if none.
+- signUpBonus: object or null — if sign-up bonus info exists: { type: "points"|"miles"|"cashback", amount: number, spendRequirement: number (in cents), deadline: string (ISO 8601), met: boolean }. Use null if no bonus info.
+- notes: string — any additional notes or info from the spreadsheet. Use "" if none.
+
+Important:
+- All money values must be in CENTS (integer). If the CSV shows "$95", that's 9500 cents.
+- Dates must be full ISO 8601 UTC timestamps ending in "T00:00:00.000Z"
+- If a row clearly isn't a credit card (headers, totals, notes), skip it.
+- Return an empty array [] if no cards can be extracted.
+
+CSV data:
+${csv}`;
+}

--- a/development/src/src/lib/sheets/types.ts
+++ b/development/src/src/lib/sheets/types.ts
@@ -1,0 +1,21 @@
+import type { Card } from "@/lib/types";
+
+export type SheetImportErrorCode =
+  | "INVALID_URL"
+  | "SHEET_NOT_PUBLIC"
+  | "NO_CARDS_FOUND"
+  | "PARSE_ERROR"
+  | "ANTHROPIC_ERROR"
+  | "FETCH_ERROR";
+
+export interface SheetImportError {
+  code: SheetImportErrorCode;
+  message: string;
+}
+
+export interface SheetImportSuccess {
+  cards: Array<Omit<Card, "householdId">>;
+  warning?: string;
+}
+
+export type SheetImportResponse = SheetImportSuccess | { error: SheetImportError };


### PR DESCRIPTION
## Summary

- **POST /api/sheets/import** — accepts a Google Sheets URL, fetches CSV, uses Anthropic claude-haiku-4-5 for structured extraction, returns validated Card objects
- New `lib/sheets/` module: URL parsing (`extractSheetId`, `buildCsvExportUrl`), prompt builder (`buildExtractionPrompt`), and TypeScript types (`SheetImportErrorCode`, `SheetImportSuccess`, `SheetImportResponse`)
- Zod validation of extracted card data, fresh UUID/timestamp assignment, single retry on transient Anthropic errors, CSV truncation at 100k chars

## Error Codes

| Code | HTTP | When |
|------|------|------|
| `INVALID_URL` | 400 | Bad JSON, missing URL, or not a Google Sheets link |
| `SHEET_NOT_PUBLIC` | 400 | Sheet returns 403/404 |
| `NO_CARDS_FOUND` | 400 | Empty sheet or no cards extracted |
| `PARSE_ERROR` | 400 | AI response fails Zod validation |
| `ANTHROPIC_ERROR` | 500 | Missing API key or AI call fails after retry |
| `FETCH_ERROR` | 400 | Network error fetching CSV |

## Test plan

- [ ] Verify TypeScript compilation passes (`npm run build` type-check step)
- [ ] Test with a public Google Sheet URL containing credit card data
- [ ] Test error cases: invalid URL, private sheet, empty sheet
- [ ] Verify extracted cards have correct field types (cents for money, ISO dates)
- [ ] Verify fresh UUIDs and timestamps are assigned
- [ ] Verify `householdId` is NOT set (Story 5.4 responsibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)