### PR TITLE
feat: Story 5.3 — Google Sheets import wizard UI

### DIFF
--- a/development/src/src/app/page.tsx
+++ b/development/src/src/app/page.tsx
@@ -20,11 +20,13 @@
  */
 
 import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { useAuth } from "@/hooks/useAuth";
 import Link from "next/link";
 import { Dashboard } from "@/components/dashboard/Dashboard";
 import { CardSkeletonGrid } from "@/components/dashboard/CardSkeletonGrid";
 import { AnimatedHowlPanel } from "@/components/layout/HowlPanel";
+import { ImportWizard } from "@/components/sheets/ImportWizard";
 import { initializeHousehold, getCards, migrateIfNeeded } from "@/lib/storage";
 import type { Card } from "@/lib/types";
 
@@ -34,6 +36,8 @@ export default function DashboardPage() {
   const [isLoading, setIsLoading] = useState(true);
   // Mobile HowlPanel bottom-sheet visibility
   const [mobileHowlOpen, setMobileHowlOpen] = useState(false);
+  // Import wizard visibility
+  const [importWizardOpen, setImportWizardOpen] = useState(false);
 
   useEffect(() => {
     // Wait for auth state to resolve before reading localStorage
@@ -46,13 +50,40 @@ export default function DashboardPage() {
     const loaded = getCards(householdId);
     setCards(loaded);
     setIsLoading(false);
+
+    // Pick up merge result from auth callback redirect
+    const mergeResult = sessionStorage.getItem("fenrir:merge-result");
+    if (mergeResult) {
+      sessionStorage.removeItem("fenrir:merge-result");
+      try {
+        const { merged } = JSON.parse(mergeResult) as { merged: number };
+        toast.success(`${merged} card${merged !== 1 ? "s" : ""} carried into your ledger.`);
+      } catch {
+        // Corrupt data — ignore silently
+      }
+    }
   }, [householdId, status]);
+
+  // Listen for custom event from EmptyState's "Import from Google Sheets" button
+  useEffect(() => {
+    function handleOpenWizard() {
+      setImportWizardOpen(true);
+    }
+    window.addEventListener("fenrir:open-import-wizard", handleOpenWizard);
+    return () => window.removeEventListener("fenrir:open-import-wizard", handleOpenWizard);
+  }, []);
 
   const urgentCount = cards.filter(
     (c) => c.status === "fee_approaching" || c.status === "promo_expiring"
   ).length;
 
   const loaded = !isLoading && status !== "loading";
+
+  // Placeholder — Story 5.4 implements real persistence + dedup
+  function handleConfirmImport(importedCards: Omit<Card, "householdId">[]) {
+    toast.success(`${importedCards.length} card${importedCards.length !== 1 ? "s" : ""} ready to import.`);
+    setImportWizardOpen(false);
+  }
 
   return (
     <div className="px-6 py-6">
@@ -88,6 +119,17 @@ export default function DashboardPage() {
               >
                 {urgentCount}
               </span>
+            </button>
+          )}
+
+          {/* Import button — shown in toolbar only when cards exist */}
+          {loaded && cards.length > 0 && (
+            <button
+              type="button"
+              onClick={() => setImportWizardOpen(true)}
+              className="inline-flex items-center justify-center rounded-sm text-sm font-heading tracking-wide ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 border border-border text-muted-foreground hover:border-gold/50 hover:text-gold h-9 px-4 py-2"
+            >
+              Import
             </button>
           )}
 
@@ -131,6 +173,13 @@ export default function DashboardPage() {
           />
         )}
       </div>
+
+      {/* Import Wizard modal */}
+      <ImportWizard
+        open={importWizardOpen}
+        onClose={() => setImportWizardOpen(false)}
+        onConfirmImport={handleConfirmImport}
+      />
     </div>
   );
 }

--- a/development/src/src/components/dashboard/EmptyState.tsx
+++ b/development/src/src/components/dashboard/EmptyState.tsx
@@ -52,6 +52,16 @@ export function EmptyState() {
       >
         Add Card
       </Link>
+
+      <button
+        type="button"
+        onClick={() => {
+          window.dispatchEvent(new CustomEvent("fenrir:open-import-wizard"));
+        }}
+        className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors border border-border text-muted-foreground hover:border-gold/50 hover:text-gold h-10 px-6 mt-3"
+      >
+        Import from Google Sheets
+      </button>
     </div>
   );
 }

--- a/development/src/src/components/sheets/ImportWizard.tsx
+++ b/development/src/src/components/sheets/ImportWizard.tsx
@@ -1,0 +1,319 @@
+"use client";
+
+/**
+ * ImportWizard — multi-step Google Sheets import modal.
+ *
+ * Steps: entry → loading → preview → error → success
+ *
+ * Uses shadcn Dialog with the project's standard modal sizing:
+ * w-[92vw] max-w-[680px] max-h-[90vh] (team norm for mobile-friendly modals).
+ *
+ * Accessibility: focus trap from Radix built-in, aria-live="polite" on step
+ * container, 44px minimum touch targets on all interactive elements.
+ */
+
+import { useEffect } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { KNOWN_ISSUERS } from "@/lib/constants";
+import { useSheetImport } from "@/hooks/useSheetImport";
+import type { Card } from "@/lib/types";
+import type { SheetImportErrorCode } from "@/lib/sheets/types";
+
+interface ImportWizardProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirmImport: (cards: Omit<Card, "householdId">[]) => void;
+}
+
+/** Human-readable error messages keyed by error code */
+const ERROR_MESSAGES: Record<SheetImportErrorCode, string> = {
+  INVALID_URL: "The URL doesn't look like a Google Sheets link.",
+  SHEET_NOT_PUBLIC:
+    "This spreadsheet isn't publicly accessible. Share it with 'Anyone with the link can view'.",
+  NO_CARDS_FOUND: "No credit card data was found in the spreadsheet.",
+  PARSE_ERROR: "The card data couldn't be parsed correctly.",
+  ANTHROPIC_ERROR: "Our card extraction service is temporarily unavailable.",
+  FETCH_ERROR: "Couldn't reach the spreadsheet. Check the URL and try again.",
+};
+
+/** Format cents as a dollar amount string */
+function formatFee(cents: number): string {
+  if (cents === 0) return "No annual fee";
+  return `$${(cents / 100).toFixed(0)}/yr`;
+}
+
+/** Format ISO date string to short locale date */
+function formatDate(iso: string): string {
+  try {
+    return new Date(iso).toLocaleDateString("en-US", {
+      month: "short",
+      year: "numeric",
+    });
+  } catch {
+    return iso;
+  }
+}
+
+export function ImportWizard({ open, onClose, onConfirmImport }: ImportWizardProps) {
+  const {
+    step,
+    url,
+    setUrl,
+    cards,
+    warning,
+    errorCode,
+    errorMessage,
+    submit,
+    cancel,
+    reset,
+  } = useSheetImport();
+
+  // URL validation: must contain Google Sheets domain
+  const isValidUrl = url.includes("docs.google.com/spreadsheets");
+  const showUrlError = url.length > 0 && !isValidUrl;
+
+  // Auto-close after 1.5s on success
+  useEffect(() => {
+    if (step !== "success") return;
+    const timer = setTimeout(() => {
+      onClose();
+    }, 1500);
+    return () => clearTimeout(timer);
+  }, [step, onClose]);
+
+  function handleConfirm() {
+    onConfirmImport(cards);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <DialogContent
+        className="w-[92vw] max-w-[680px] max-h-[90vh] overflow-hidden flex flex-col border-border bg-background"
+        aria-label="Google Sheets Import Wizard"
+      >
+        {/* aria-live region announces step changes to screen readers */}
+        <div aria-live="polite" className="sr-only">
+          {step === "entry" && "Step 1: Enter Google Sheets URL"}
+          {step === "loading" && "Loading: fetching cards from spreadsheet"}
+          {step === "preview" && `Preview: ${cards.length} cards ready to import`}
+          {step === "error" && "Error: import failed"}
+          {step === "success" && "Success: cards imported"}
+        </div>
+
+        {/* ── Entry step ─────────────────────────────────────────────── */}
+        {step === "entry" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-display text-gold tracking-wide text-lg">
+                Import from Google Sheets
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="flex flex-col gap-4 py-2">
+              <p className="font-body text-muted-foreground text-sm">
+                Paste the URL of a publicly shared Google Sheets document containing
+                your credit cards.
+              </p>
+
+              <div className="flex flex-col gap-1">
+                <input
+                  id="sheets-url"
+                  type="url"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
+                  placeholder="Paste your Google Sheets URL..."
+                  className="h-11 w-full rounded-sm border border-border bg-background px-3 font-mono text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-gold/50 focus:border-gold/50"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && isValidUrl) submit();
+                  }}
+                  autoFocus
+                />
+                {showUrlError && (
+                  <p className="text-xs text-red-400 font-body">
+                    Enter a valid Google Sheets URL
+                  </p>
+                )}
+              </div>
+
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={submit}
+                  disabled={!isValidUrl}
+                  className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors bg-primary text-primary-foreground hover:bg-gold-bright disabled:opacity-40 disabled:cursor-not-allowed h-11 px-6 min-w-[44px]"
+                >
+                  Import
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── Loading step ───────────────────────────────────────────── */}
+        {step === "loading" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-display text-gold tracking-wide text-lg">
+                Fetching cards...
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="flex flex-col items-center gap-6 py-8">
+              {/* Loading spinner */}
+              <div
+                className="h-12 w-12 rounded-full border-2 border-border border-t-gold animate-spin"
+                role="status"
+                aria-label="Loading"
+              />
+
+              <p className="font-body text-muted-foreground text-sm italic text-center">
+                Reading the runes from your spreadsheet...
+              </p>
+
+              <button
+                type="button"
+                onClick={cancel}
+                className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors border border-border text-muted-foreground hover:border-gold/50 hover:text-gold h-11 px-6 min-w-[44px]"
+              >
+                Cancel
+              </button>
+            </div>
+          </>
+        )}
+
+        {/* ── Preview step ───────────────────────────────────────────── */}
+        {step === "preview" && (
+          <>
+            <DialogHeader>
+              <div className="flex items-center gap-3">
+                <DialogTitle className="font-display text-gold tracking-wide text-lg">
+                  Preview Import
+                </DialogTitle>
+                <span className="inline-flex items-center justify-center rounded-full bg-gold/20 text-gold font-mono text-xs font-bold px-2 py-0.5 border border-gold/30">
+                  {cards.length} card{cards.length !== 1 ? "s" : ""}
+                </span>
+              </div>
+            </DialogHeader>
+
+            <div className="flex flex-col gap-3 overflow-hidden flex-1">
+              {/* Warning banner */}
+              {warning && (
+                <div className="rounded-sm border border-amber-500/40 bg-amber-500/10 px-3 py-2">
+                  <p className="text-xs font-body text-amber-400">{warning}</p>
+                </div>
+              )}
+
+              {/* Scrollable card list */}
+              <div className="overflow-y-auto flex-1 min-h-0 max-h-[45vh] flex flex-col gap-1.5 pr-1">
+                {cards.map((card) => {
+                  const issuer = KNOWN_ISSUERS.find((i) => i.id === card.issuerId);
+                  return (
+                    <div
+                      key={card.id}
+                      className="flex items-center justify-between rounded-sm border border-border bg-card px-4 py-3 gap-4"
+                    >
+                      <div className="flex flex-col gap-0.5 min-w-0">
+                        <span className="font-heading text-sm text-foreground tracking-wide truncate">
+                          {card.cardName}
+                        </span>
+                        <span className="font-body text-xs text-muted-foreground">
+                          {issuer?.name ?? card.issuerId}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-4 shrink-0">
+                        <span className="font-mono text-xs text-muted-foreground">
+                          {formatDate(card.openDate)}
+                        </span>
+                        <span className="font-mono text-xs text-gold">
+                          {formatFee(card.annualFee)}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Actions */}
+              <div className="flex justify-end gap-2 pt-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors border border-border text-muted-foreground hover:border-gold/50 hover:text-gold h-11 px-6 min-w-[44px]"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirm}
+                  className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors bg-primary text-primary-foreground hover:bg-gold-bright h-11 px-6 min-w-[44px]"
+                >
+                  Import {cards.length} card{cards.length !== 1 ? "s" : ""}
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── Error step ─────────────────────────────────────────────── */}
+        {step === "error" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-display text-red-400 tracking-wide text-lg">
+                Import Failed
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="flex flex-col gap-4 py-2">
+              <p className="font-body text-muted-foreground text-sm">
+                {errorCode ? ERROR_MESSAGES[errorCode] : errorMessage}
+              </p>
+
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors border border-border text-muted-foreground hover:border-gold/50 hover:text-gold h-11 px-6 min-w-[44px]"
+                >
+                  Close
+                </button>
+                <button
+                  type="button"
+                  onClick={reset}
+                  className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors bg-primary text-primary-foreground hover:bg-gold-bright h-11 px-6 min-w-[44px]"
+                >
+                  Try Again
+                </button>
+              </div>
+            </div>
+          </>
+        )}
+
+        {/* ── Success step ───────────────────────────────────────────── */}
+        {step === "success" && (
+          <>
+            <DialogHeader>
+              <DialogTitle className="font-display text-gold tracking-wide text-lg">
+                Cards imported!
+              </DialogTitle>
+            </DialogHeader>
+
+            <div className="flex flex-col items-center gap-4 py-6">
+              <div className="text-4xl" aria-hidden="true">
+                ᚠ
+              </div>
+              <p className="font-body text-muted-foreground text-sm text-center">
+                The runes have been inscribed in the ledger. Your cards have been
+                added to the household.
+              </p>
+            </div>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/development/src/src/hooks/useSheetImport.ts
+++ b/development/src/src/hooks/useSheetImport.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { useState, useCallback, useRef } from "react";
+import type { Card } from "@/lib/types";
+import type { SheetImportErrorCode } from "@/lib/sheets/types";
+
+export type ImportStep = "entry" | "loading" | "preview" | "error" | "success";
+
+export interface UseSheetImportReturn {
+  step: ImportStep;
+  url: string;
+  setUrl: (url: string) => void;
+  cards: Omit<Card, "householdId">[];
+  warning: string | undefined;
+  errorCode: SheetImportErrorCode | null;
+  errorMessage: string;
+  submit: () => void;
+  cancel: () => void;
+  reset: () => void;
+}
+
+export function useSheetImport(): UseSheetImportReturn {
+  const [step, setStep] = useState<ImportStep>("entry");
+  const [url, setUrl] = useState("");
+  const [cards, setCards] = useState<Omit<Card, "householdId">[]>([]);
+  const [warning, setWarning] = useState<string | undefined>(undefined);
+  const [errorCode, setErrorCode] = useState<SheetImportErrorCode | null>(null);
+  const [errorMessage, setErrorMessage] = useState("");
+  const abortRef = useRef<AbortController | null>(null);
+
+  const submit = useCallback(async () => {
+    // Validate URL contains Google Sheets domain
+    if (!url.includes("docs.google.com/spreadsheets")) {
+      setErrorCode("INVALID_URL");
+      setErrorMessage("Enter a valid Google Sheets URL");
+      return;
+    }
+
+    setStep("loading");
+
+    const controller = new AbortController();
+    abortRef.current = controller;
+
+    // 20-second timeout guard
+    const timeoutId = setTimeout(() => {
+      controller.abort();
+    }, 20_000);
+
+    try {
+      const response = await fetch("/api/sheets/import", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ url }),
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      const data = (await response.json()) as
+        | { cards: Omit<Card, "householdId">[]; warning?: string }
+        | { error: { code: SheetImportErrorCode; message: string } };
+
+      if ("error" in data) {
+        setErrorCode(data.error.code);
+        setErrorMessage(data.error.message);
+        setStep("error");
+      } else {
+        setCards(data.cards);
+        setWarning(data.warning);
+        setStep("preview");
+      }
+    } catch (err) {
+      clearTimeout(timeoutId);
+
+      if ((err as { name?: string }).name === "AbortError") {
+        // User cancelled or timeout — go back to entry
+        setStep("entry");
+      } else {
+        setErrorCode("FETCH_ERROR");
+        setErrorMessage("Couldn't reach the spreadsheet. Check the URL and try again.");
+        setStep("error");
+      }
+    } finally {
+      abortRef.current = null;
+    }
+  }, [url]);
+
+  const cancel = useCallback(() => {
+    if (abortRef.current) {
+      abortRef.current.abort();
+    }
+    setStep("entry");
+  }, []);
+
+  const reset = useCallback(() => {
+    // Go back to entry with URL pre-filled
+    setStep("entry");
+    setErrorCode(null);
+    setErrorMessage("");
+  }, []);
+
+  return {
+    step,
+    url,
+    setUrl,
+    cards,
+    warning,
+    errorCode,
+    errorMessage,
+    submit,
+    cancel,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary
- Multi-step Google Sheets import wizard modal (entry → loading → preview → error → success)
- `useSheetImport` hook implements the state machine with 20s timeout guard and AbortController cancel
- `ImportWizard` component uses shadcn Dialog; all steps in one file; aria-live announcements; 44px touch targets; `w-[92vw] max-w-[680px] max-h-[90vh]` sizing (team norm)
- `EmptyState` gets an "Import from Google Sheets" secondary button dispatching a custom event
- `page.tsx` wires up wizard state, toolbar "Import" button (cards-only), placeholder `handleConfirmImport` (toast — Story 5.4 handles persistence), and merge-result sessionStorage pickup

## Test plan
- [ ] Dashboard with no cards: EmptyState shows "Import from Google Sheets" button → clicking opens wizard
- [ ] Dashboard with cards: toolbar shows "Import" button → clicking opens wizard
- [ ] Entry step: invalid URL shows red error text; valid Google Sheets URL enables Import button
- [ ] Loading step: spinner + Norse flavor text + Cancel button (aborts fetch, returns to entry)
- [ ] Preview step: card list with issuer name, card name, fee, open date; warning banner if present; "Import N cards" button calls toast placeholder; Cancel closes modal
- [ ] Error step: human-readable message per error code; "Try Again" returns to entry with URL pre-filled
- [ ] Success step: auto-closes after 1.5 seconds
- [ ] `npm run build` passes with zero TypeScript errors ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)