### PR TITLE
feat: Story 5.4 — import dedup and persistence

### DIFF
--- a/development/src/src/app/page.tsx
+++ b/development/src/src/app/page.tsx
@@ -27,7 +27,7 @@ import { Dashboard } from "@/components/dashboard/Dashboard";
 import { CardSkeletonGrid } from "@/components/dashboard/CardSkeletonGrid";
 import { AnimatedHowlPanel } from "@/components/layout/HowlPanel";
 import { ImportWizard } from "@/components/sheets/ImportWizard";
-import { initializeHousehold, getCards, migrateIfNeeded } from "@/lib/storage";
+import { initializeHousehold, getCards, saveCard, migrateIfNeeded } from "@/lib/storage";
 import type { Card } from "@/lib/types";
 
 export default function DashboardPage() {
@@ -79,10 +79,24 @@ export default function DashboardPage() {
 
   const loaded = !isLoading && status !== "loading";
 
-  // Placeholder — Story 5.4 implements real persistence + dedup
   function handleConfirmImport(importedCards: Omit<Card, "householdId">[]) {
-    toast.success(`${importedCards.length} card${importedCards.length !== 1 ? "s" : ""} ready to import.`);
+    if (!householdId) return;
+
+    for (const c of importedCards) {
+      const card: Card = {
+        ...c,
+        householdId,
+        status: "active",
+      };
+      saveCard(card);
+    }
+
+    const refreshed = getCards(householdId);
+    setCards(refreshed);
     setImportWizardOpen(false);
+
+    const count = importedCards.length;
+    toast.success(`${count} card${count !== 1 ? "s" : ""} added to your ledger.`);
   }
 
   return (
@@ -179,6 +193,7 @@ export default function DashboardPage() {
         open={importWizardOpen}
         onClose={() => setImportWizardOpen(false)}
         onConfirmImport={handleConfirmImport}
+        existingCards={cards}
       />
     </div>
   );

--- a/development/src/src/components/sheets/ImportDedupStep.tsx
+++ b/development/src/src/components/sheets/ImportDedupStep.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { KNOWN_ISSUERS } from "@/lib/constants";
+import type { DuplicateMatch } from "@/lib/sheets/dedup";
+
+interface ImportDedupStepProps {
+  duplicates: DuplicateMatch[];
+  uniqueCount: number;
+  onSkipDuplicates: () => void;
+  onImportAll: () => void;
+  onCancel: () => void;
+}
+
+export function ImportDedupStep({
+  duplicates,
+  uniqueCount,
+  onSkipDuplicates,
+  onImportAll,
+  onCancel,
+}: ImportDedupStepProps) {
+  const dupCount = duplicates.length;
+
+  function issuerName(issuerId: string): string {
+    return KNOWN_ISSUERS.find((i) => i.id === issuerId)?.name ?? issuerId;
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-3">
+        <h2 className="font-display text-gold tracking-wide text-lg">
+          Duplicates Found
+        </h2>
+        <span className="inline-flex items-center justify-center rounded-full bg-amber-500/20 text-amber-400 font-mono text-xs font-bold px-2 py-0.5 border border-amber-500/30">
+          {dupCount} duplicate{dupCount !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div className="flex flex-col gap-3 overflow-hidden flex-1">
+        <p className="font-body text-muted-foreground text-sm">
+          {dupCount} card{dupCount !== 1 ? "s" : ""} already exist in your ledger.
+          Choose how to proceed.
+        </p>
+
+        {/* Duplicate pairs list */}
+        <div className="overflow-y-auto flex-1 min-h-0 max-h-[40vh] flex flex-col gap-2 pr-1">
+          {duplicates.map((match, i) => (
+            <div
+              key={i}
+              className="rounded-sm border border-amber-500/40 bg-amber-500/5 px-4 py-3 flex flex-col gap-2"
+            >
+              {/* Imported card */}
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex flex-col gap-0.5 min-w-0">
+                  <span className="font-heading text-xs text-amber-400 tracking-wide uppercase">
+                    Importing
+                  </span>
+                  <span className="font-heading text-sm text-foreground tracking-wide truncate">
+                    {match.imported.cardName}
+                  </span>
+                  <span className="font-body text-xs text-muted-foreground">
+                    {issuerName(match.imported.issuerId)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Divider */}
+              <div className="flex items-center gap-2">
+                <div className="flex-1 border-t border-border" />
+                <span className="font-mono text-[10px] text-muted-foreground">
+                  matches existing
+                </span>
+                <div className="flex-1 border-t border-border" />
+              </div>
+
+              {/* Existing card */}
+              <div className="flex flex-col gap-0.5 min-w-0">
+                <span className="font-heading text-xs text-muted-foreground tracking-wide uppercase">
+                  In Ledger
+                </span>
+                <span className="font-heading text-sm text-foreground tracking-wide truncate">
+                  {match.existing.cardName}
+                </span>
+                <span className="font-body text-xs text-muted-foreground">
+                  {issuerName(match.existing.issuerId)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-col gap-2 pt-2">
+          {/* Primary: skip duplicates, import unique only */}
+          {uniqueCount > 0 && (
+            <button
+              type="button"
+              onClick={onSkipDuplicates}
+              className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors bg-primary text-primary-foreground hover:bg-gold-bright h-11 px-6 min-w-[44px] w-full"
+            >
+              Skip {dupCount} duplicate{dupCount !== 1 ? "s" : ""} and import {uniqueCount} new
+            </button>
+          )}
+
+          {/* Secondary: import all anyway */}
+          <button
+            type="button"
+            onClick={onImportAll}
+            className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors border border-amber-500/40 text-amber-400 hover:border-amber-500 hover:text-amber-300 h-11 px-6 min-w-[44px] w-full"
+          >
+            Import all anyway ({dupCount + uniqueCount} card{dupCount + uniqueCount !== 1 ? "s" : ""})
+          </button>
+
+          {/* Cancel */}
+          <button
+            type="button"
+            onClick={onCancel}
+            className="inline-flex items-center justify-center rounded-sm font-heading tracking-wide text-sm transition-colors border border-border text-muted-foreground hover:border-gold/50 hover:text-gold h-11 px-6 min-w-[44px] w-full"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/development/src/src/components/sheets/ImportWizard.tsx
+++ b/development/src/src/components/sheets/ImportWizard.tsx
@@ -12,7 +12,7 @@
  * container, 44px minimum touch targets on all interactive elements.
  */
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -21,6 +21,9 @@ import {
 } from "@/components/ui/dialog";
 import { KNOWN_ISSUERS } from "@/lib/constants";
 import { useSheetImport } from "@/hooks/useSheetImport";
+import { findDuplicates } from "@/lib/sheets/dedup";
+import type { DedupResult } from "@/lib/sheets/dedup";
+import { ImportDedupStep } from "@/components/sheets/ImportDedupStep";
 import type { Card } from "@/lib/types";
 import type { SheetImportErrorCode } from "@/lib/sheets/types";
 
@@ -28,6 +31,7 @@ interface ImportWizardProps {
   open: boolean;
   onClose: () => void;
   onConfirmImport: (cards: Omit<Card, "householdId">[]) => void;
+  existingCards: Card[];
 }
 
 /** Human-readable error messages keyed by error code */
@@ -59,9 +63,10 @@ function formatDate(iso: string): string {
   }
 }
 
-export function ImportWizard({ open, onClose, onConfirmImport }: ImportWizardProps) {
+export function ImportWizard({ open, onClose, onConfirmImport, existingCards }: ImportWizardProps) {
   const {
     step,
+    setStep,
     url,
     setUrl,
     cards,
@@ -72,6 +77,8 @@ export function ImportWizard({ open, onClose, onConfirmImport }: ImportWizardPro
     cancel,
     reset,
   } = useSheetImport();
+
+  const [dedupResult, setDedupResult] = useState<DedupResult | null>(null);
 
   // URL validation: must contain Google Sheets domain
   const isValidUrl = url.includes("docs.google.com/spreadsheets");
@@ -87,6 +94,21 @@ export function ImportWizard({ open, onClose, onConfirmImport }: ImportWizardPro
   }, [step, onClose]);
 
   function handleConfirm() {
+    const result = findDuplicates(cards, existingCards);
+    if (result.duplicates.length > 0) {
+      setDedupResult(result);
+      setStep("dedup");
+    } else {
+      onConfirmImport(cards);
+    }
+  }
+
+  function handleSkipDuplicates() {
+    if (!dedupResult) return;
+    onConfirmImport(dedupResult.unique);
+  }
+
+  function handleImportAll() {
     onConfirmImport(cards);
   }
 
@@ -101,6 +123,7 @@ export function ImportWizard({ open, onClose, onConfirmImport }: ImportWizardPro
           {step === "entry" && "Step 1: Enter Google Sheets URL"}
           {step === "loading" && "Loading: fetching cards from spreadsheet"}
           {step === "preview" && `Preview: ${cards.length} cards ready to import`}
+          {step === "dedup" && `Duplicates found: ${dedupResult?.duplicates.length ?? 0} duplicate cards detected`}
           {step === "error" && "Error: import failed"}
           {step === "success" && "Success: cards imported"}
         </div>
@@ -257,6 +280,17 @@ export function ImportWizard({ open, onClose, onConfirmImport }: ImportWizardPro
               </div>
             </div>
           </>
+        )}
+
+        {/* ── Dedup step ─────────────────────────────────────────────── */}
+        {step === "dedup" && dedupResult && (
+          <ImportDedupStep
+            duplicates={dedupResult.duplicates}
+            uniqueCount={dedupResult.unique.length}
+            onSkipDuplicates={handleSkipDuplicates}
+            onImportAll={handleImportAll}
+            onCancel={onClose}
+          />
         )}
 
         {/* ── Error step ─────────────────────────────────────────────── */}

--- a/development/src/src/hooks/useSheetImport.ts
+++ b/development/src/src/hooks/useSheetImport.ts
@@ -4,10 +4,11 @@ import { useState, useCallback, useRef } from "react";
 import type { Card } from "@/lib/types";
 import type { SheetImportErrorCode } from "@/lib/sheets/types";
 
-export type ImportStep = "entry" | "loading" | "preview" | "error" | "success";
+export type ImportStep = "entry" | "loading" | "preview" | "dedup" | "error" | "success";
 
 export interface UseSheetImportReturn {
   step: ImportStep;
+  setStep: (step: ImportStep) => void;
   url: string;
   setUrl: (url: string) => void;
   cards: Omit<Card, "householdId">[];
@@ -101,6 +102,7 @@ export function useSheetImport(): UseSheetImportReturn {
 
   return {
     step,
+    setStep,
     url,
     setUrl,
     cards,

--- a/development/src/src/lib/sheets/dedup.ts
+++ b/development/src/src/lib/sheets/dedup.ts
@@ -1,0 +1,41 @@
+import type { Card } from "@/lib/types";
+
+export interface DuplicateMatch {
+  imported: Omit<Card, "householdId">;
+  existing: Card;
+}
+
+export interface DedupResult {
+  duplicates: DuplicateMatch[];
+  unique: Omit<Card, "householdId">[];
+}
+
+/**
+ * Splits imported cards into duplicates and unique based on
+ * issuerId + cardName (case-insensitive, trimmed).
+ */
+export function findDuplicates(
+  imported: Omit<Card, "householdId">[],
+  existing: Card[]
+): DedupResult {
+  const existingKeys = new Map<string, Card>();
+  for (const card of existing) {
+    const key = `${card.issuerId}::${card.cardName.trim().toLowerCase()}`;
+    existingKeys.set(key, card);
+  }
+
+  const duplicates: DuplicateMatch[] = [];
+  const unique: Omit<Card, "householdId">[] = [];
+
+  for (const card of imported) {
+    const key = `${card.issuerId}::${card.cardName.trim().toLowerCase()}`;
+    const match = existingKeys.get(key);
+    if (match) {
+      duplicates.push({ imported: card, existing: match });
+    } else {
+      unique.push(card);
+    }
+  }
+
+  return { duplicates, unique };
+}


### PR DESCRIPTION
## Summary

- Add `lib/sheets/dedup.ts` — pure `findDuplicates()` function matching on issuerId + cardName (case-insensitive, trimmed)
- Add `ImportDedupStep.tsx` — Step 3B UI showing duplicate pairs with amber warning styling; two actions: skip duplicates or import all
- Extend `useSheetImport` with `"dedup"` step in `ImportStep` type; export `setStep` for external step transitions
- Update `ImportWizard` to accept `existingCards` prop, run dedup check on confirm, and render the dedup step when duplicates exist
- Replace placeholder `handleConfirmImport` in `page.tsx` with real persistence via `saveCard()`, dashboard refresh, and success toast

## Test plan

- [ ] Import a sheet with no duplicates → cards saved directly, toast: "N card(s) added to your ledger."
- [ ] Import a sheet where all cards already exist → dedup step shown, "Skip N duplicate(s) and import 0 new" button (only "Import all anyway" visible since uniqueCount === 0)
- [ ] Import a sheet with mixed new + duplicate cards → dedup step shown, "Skip N duplicate(s) and import M new" primary button visible
- [ ] Click "Skip duplicates" → only unique cards saved, toast fires, wizard closes
- [ ] Click "Import all anyway" → all cards saved (including duplicates as new records), wizard closes
- [ ] Click "Cancel" in dedup step → wizard closes, nothing saved
- [ ] Verify dashboard card list refreshes after import
- [ ] Build passes: `cd development/src && npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)