### PR TITLE
fix: allow preview-branch origins in token proxy whitelist

### DIFF
--- a/development/src/src/app/api/auth/token/route.ts
+++ b/development/src/src/app/api/auth/token/route.ts
@@ -23,10 +23,16 @@
 
 import { NextRequest, NextResponse } from "next/server";
 
-/** Whitelisted origins that may call this endpoint. */
+/**
+ * Whitelisted origins that may call this endpoint.
+ * VERCEL_URL is injected automatically by Vercel on every deployment
+ * (production and preview), enabling preview-branch sign-in when the
+ * redirect URI for that branch is also registered in Google Cloud Console.
+ */
 const ALLOWED_ORIGINS = new Set([
   "http://localhost:9653",
   "https://fenrir-ledger.vercel.app",
+  ...(process.env.VERCEL_URL ? [`https://${process.env.VERCEL_URL}`] : []),
 ]);
 
 /** Google token endpoint. */


### PR DESCRIPTION
## Summary

- Adds `VERCEL_URL` (auto-injected by Vercel on every deployment) to `ALLOWED_ORIGINS` in the `/api/auth/token` proxy
- Preview-branch sign-in now works when the preview URL is also registered as an authorized redirect URI in Google Cloud Console
- No-op when `VERCEL_URL` is unset (local development unchanged)

## Context

On Vercel preview deployments the origin is e.g. `https://fenrir-ledger-abc123.vercel.app`, which was not in the static `ALLOWED_ORIGINS` set. The token proxy returned `400 redirect_uri origin is not whitelisted`, causing sign-in to fail silently.

## Test plan

- [ ] Verify preview deployment accepts its own origin in `/api/auth/token`
- [ ] Verify production sign-in still works (regression check)
- [ ] Verify local dev (`localhost:9653`) still works (VERCEL_URL unset → no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)