### PR TITLE
fix: use root-relative href in super-wolf.html back-link

### DIFF
--- a/sessions/super-wolf.html
+++ b/sessions/super-wolf.html
@@ -292,7 +292,7 @@
 <div class="page">
 
   <nav class="back-nav" aria-label="Return to archive">
-    <a href="https://fenrir-ledger.vercel.app/sessions/" class="back-link">← ᛏ Session Archive</a>
+    <a href="/sessions/" class="back-link">← ᛏ Session Archive</a>
   </nav>
 
   <header class="session-header">


### PR DESCRIPTION
## Summary
- Fixed absolute URL `https://fenrir-ledger.vercel.app/sessions/` → root-relative `/sessions/` in `sessions/super-wolf.html` back-link
- This was causing `test-navigation.spec.ts` test 26 to fail: Playwright selector `.back-link[href="/sessions/"]` couldn't match the absolute URL

## Root Cause
When `super-wolf.html` was exported, the back-link accidentally used an absolute URL. All other chronicle pages already used the correct root-relative form.

## Cherry-picked into
- `feat/s3-fix-valhalla-gaps` (PR #31)
- `feat/s3-fix-status-ring` (PR #32)

## Test plan
- [ ] Verify all 28 Playwright tests pass (especially test 26: chronicle navigation)
- [ ] Verify back-link works on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)