### PR TITLE
fix hook observability for worktree subagents

### DIFF
--- a/.claude/commands/plan_w_team.md
+++ b/.claude/commands/plan_w_team.md
@@ -8,12 +8,12 @@ hooks:
     - hooks:
         - type: command
           command: >-
-            uv run $CLAUDE_PROJECT_DIR/.claude/hooks/validators/validate_new_file.py
+            uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/validators/validate_new_file.py
             --directory specs
             --extension .md
         - type: command
           command: >-
-            uv run $CLAUDE_PROJECT_DIR/.claude/hooks/validators/validate_file_contains.py
+            uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/validators/validate_file_contains.py
             --directory specs
             --extension .md
             --contains '## Task Description'

--- a/.claude/hooks/send_event.py
+++ b/.claude/hooks/send_event.py
@@ -63,7 +63,8 @@ def main():
     parser.add_argument('--server-url', default='http://localhost:4000/events', help='Server URL')
     parser.add_argument('--add-chat', action='store_true', help='Include chat transcript if available')
     parser.add_argument('--summarize', action='store_true', help='Generate AI summary of the event')
-    
+    parser.add_argument('--agent-name', default=None, help='Agent name for identity tagging (e.g. fireman-decko, loki)')
+
     args = parser.parse_args()
     
     try:
@@ -80,11 +81,20 @@ def main():
     if transcript_path:
         model_name = get_model_from_transcript(session_id, transcript_path)
 
+    # Resolve agent identity: CLI arg > env var > input payload > default
+    agent_name = (
+        args.agent_name
+        or os.environ.get('CLAUDE_AGENT_NAME')
+        or input_data.get('agent_type')
+        or 'orchestrator'
+    )
+
     # Prepare event data for server
     event_data = {
         'source_app': args.source_app,
         'session_id': session_id,
         'hook_event_type': args.event_type,
+        'agent_name': agent_name,
         'payload': input_data,
         'timestamp': int(datetime.now().timestamp() * 1000),
         'model_name': model_name

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -14,11 +14,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/pre_tool_use.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/pre_tool_use.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PreToolUse --summarize"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PreToolUse --summarize"
           }
         ]
       }
@@ -29,11 +29,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/post_tool_use.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/post_tool_use.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PostToolUse --summarize"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PostToolUse --summarize"
           }
         ]
       }
@@ -43,11 +43,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/notification.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/notification.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type Notification --summarize"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type Notification --summarize"
           }
         ]
       }
@@ -57,11 +57,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/stop.py --chat"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/stop.py --chat"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type Stop --add-chat"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type Stop --add-chat"
           }
         ]
       }
@@ -71,11 +71,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/subagent_stop.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/subagent_stop.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SubagentStop"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SubagentStop"
           }
         ]
       }
@@ -85,11 +85,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/pre_compact.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/pre_compact.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PreCompact"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PreCompact"
           }
         ]
       }
@@ -99,11 +99,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/user_prompt_submit.py --log-only --store-last-prompt --name-agent"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/user_prompt_submit.py --log-only --store-last-prompt --name-agent"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type UserPromptSubmit --summarize"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type UserPromptSubmit --summarize"
           }
         ]
       }
@@ -113,11 +113,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/session_start.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/session_start.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SessionStart"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SessionStart"
           }
         ]
       }
@@ -127,11 +127,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/session_end.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/session_end.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SessionEnd"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SessionEnd"
           }
         ]
       }
@@ -142,11 +142,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/permission_request.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/permission_request.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PermissionRequest --summarize"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PermissionRequest --summarize"
           }
         ]
       }
@@ -157,11 +157,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/post_tool_use_failure.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/post_tool_use_failure.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PostToolUseFailure --summarize"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PostToolUseFailure --summarize"
           }
         ]
       }
@@ -172,11 +172,11 @@
         "hooks": [
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/subagent_start.py"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/subagent_start.py"
           },
           {
             "type": "command",
-            "command": "uv run $CLAUDE_PROJECT_DIR/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SubagentStart"
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SubagentStart"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Replace all `$CLAUDE_PROJECT_DIR` with absolute path in hook commands (26 substitutions across `settings.json` and `plan_w_team.md`) so hooks resolve correctly in worktree subagents where the env var is empty
- Add `--agent-name` CLI arg and `CLAUDE_AGENT_NAME` env var fallback to `send_event.py` so observability events carry agent identity
- Include `agent_name` as a top-level field in every event payload sent to the observability server

## Context

`$CLAUDE_PROJECT_DIR` resolves to empty string in subagent environments ([claude-code#26429](https://github.com/anthropics/claude-code/issues/26429)), causing all hook scripts to silently fail. This replaces it with a hardcoded absolute path — the only reliable workaround until the upstream issue is fixed.

## Test plan

- [x] Verified zero `$CLAUDE_PROJECT_DIR` references remain in tracked files
- [x] Ran `send_event.py` from `/tmp` with `CLAUDE_PROJECT_DIR` unset — exits 0, script resolves correctly
- [x] Tested `--agent-name` flag produces correct identity in event payload
- [ ] Integration: launch a worktree subagent and verify events appear at `localhost:4000`

🤖 Generated with [Claude Code](https://claude.com/claude-code)