### PR TITLE
feat(s4): Wolf's Hunger Meter

### DIFF
--- a/development/src/src/components/layout/AboutModal.tsx
+++ b/development/src/src/components/layout/AboutModal.tsx
@@ -20,6 +20,7 @@ import {
   GleipnirWomansBeard,
   useGleipnirFragment2,
 } from "@/components/cards/GleipnirWomansBeard";
+import { WolfHungerMeter } from "@/components/shared/WolfHungerMeter";
 
 const ROMAN = ["I", "II", "III", "IV", "V", "VI"] as const;
 
@@ -178,6 +179,12 @@ export function AboutModal({ open, onOpenChange }: AboutModalProps) {
                 </li>
               ))}
             </ol>
+
+            {/* Separator */}
+            <div className="border-t border-border mt-5 mb-5" aria-hidden="true" />
+
+            {/* Wolf's Hunger — aggregate bonus summary */}
+            <WolfHungerMeter />
 
           </div>
         </div>

--- a/development/src/src/components/layout/ForgeMasterEgg.tsx
+++ b/development/src/src/components/layout/ForgeMasterEgg.tsx
@@ -23,6 +23,7 @@
 
 import { useEffect, useState } from "react";
 import { EasterEggModal } from "@/components/easter-eggs/EasterEggModal";
+import { WolfHungerMeter } from "@/components/shared/WolfHungerMeter";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -132,6 +133,11 @@ export function ForgeMasterEgg() {
             Six impossible things wait to be found.
           </p>
         )}
+      </div>
+
+      {/* Wolf's Hunger — aggregate bonus summary */}
+      <div className="border-t border-[#1e2235] pt-3 mt-1">
+        <WolfHungerMeter />
       </div>
     </EasterEggModal>
   );

--- a/development/src/src/components/shared/WolfHungerMeter.tsx
+++ b/development/src/src/components/shared/WolfHungerMeter.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+/**
+ * WolfHungerMeter — aggregate sign-up bonus summary.
+ *
+ * Shows total rewards earned (bonuses where met === true) across all
+ * non-deleted cards, grouped by type: points, miles, cashback.
+ * Fallback: "The wolf has not yet fed." when no bonuses are met.
+ */
+
+import { useEffect, useState } from "react";
+import { useAuth } from "@/hooks/useAuth";
+import { getCards, getClosedCards } from "@/lib/storage";
+import type { Card, BonusType } from "@/lib/types";
+
+interface BonusTotals {
+  points: number;
+  miles: number;
+  cashback: number; // in cents
+}
+
+function aggregateBonuses(cards: Card[]): BonusTotals {
+  const totals: BonusTotals = { points: 0, miles: 0, cashback: 0 };
+  for (const card of cards) {
+    if (card.signUpBonus && card.signUpBonus.met) {
+      const { type, amount } = card.signUpBonus;
+      totals[type] += amount;
+    }
+  }
+  return totals;
+}
+
+function formatBonusLine(type: BonusType, amount: number): string {
+  if (type === "cashback") {
+    // amount is in cents
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0,
+    }).format(amount / 100) + " cashback";
+  }
+  const label = type === "miles" ? "miles" : "points";
+  return new Intl.NumberFormat("en-US").format(amount) + " " + label;
+}
+
+export function WolfHungerMeter() {
+  const { householdId, status } = useAuth();
+  const [totals, setTotals] = useState<BonusTotals>({ points: 0, miles: 0, cashback: 0 });
+  const [loaded, setLoaded] = useState(false);
+
+  useEffect(() => {
+    if (status === "loading" || !householdId) return;
+
+    const active = getCards(householdId);
+    const closed = getClosedCards(householdId);
+    const all = [...active, ...closed];
+    setTotals(aggregateBonuses(all));
+    setLoaded(true);
+  }, [householdId, status]);
+
+  if (!loaded) return null;
+
+  const hasAny = totals.points > 0 || totals.miles > 0 || totals.cashback > 0;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <p className="font-mono text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-[#8a8578]">
+        Fenrir&apos;s Plunder
+      </p>
+      {hasAny ? (
+        <div className="flex flex-col gap-1">
+          {totals.points > 0 && (
+            <p className="font-mono text-xs text-[#c9920a]">
+              {formatBonusLine("points", totals.points)}
+            </p>
+          )}
+          {totals.miles > 0 && (
+            <p className="font-mono text-xs text-[#c9920a]">
+              {formatBonusLine("miles", totals.miles)}
+            </p>
+          )}
+          {totals.cashback > 0 && (
+            <p className="font-mono text-xs text-[#c9920a]">
+              {formatBonusLine("cashback", totals.cashback)}
+            </p>
+          )}
+        </div>
+      ) : (
+        <p className="font-body text-xs italic text-[#3d3d52]">
+          The wolf has not yet fed.
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Add \`WolfHungerMeter\` component in \`components/shared/\` that aggregates sign-up bonuses earned (where \`met === true\`) across all active and closed cards, grouped by type: points, miles, cashback
- Integrate into \`AboutModal\` after the Gleipnir ingredients list with a separator
- Integrate into \`ForgeMasterEgg\` after the Gleipnir fragment count section

## Test plan

- [ ] Open the About modal (click Fenrir logo in TopBar) — verify "Fenrir's Plunder" section appears below the Gleipnir ingredients
- [ ] With no earned bonuses, verify fallback text "The wolf has not yet fed." appears in muted style
- [ ] With earned point/mile bonuses, verify the correct formatted count appears in gold
- [ ] With earned cashback bonuses, verify amount shows as currency (e.g. "$500 cashback")
- [ ] Press \`?\` to trigger the ForgeMasterEgg modal — verify "Fenrir's Plunder" appears after the fragment count
- [ ] TypeScript: \`npx tsc --noEmit\` passes
- [ ] Build: \`npm run build\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)