### PR TITLE
feat: route ownership config and import proxy

### DIFF
--- a/designs/architecture/route-ownership.md
+++ b/designs/architecture/route-ownership.md
@@ -1,0 +1,32 @@
+# Route Ownership — Fenrir Ledger
+
+**Date:** 2026-03-01
+**Author:** FiremanDecko (Principal Engineer)
+**Related:** ADR: `adr-backend-server.md`
+
+## Route Placement
+
+| Route | Host | Method | Purpose | Rationale |
+|-------|------|--------|---------|-----------|
+| `/` (app routes) | Next.js (Vercel) | GET | All UI pages (dashboard, cards, valhalla, auth) | App Router serves the React SPA |
+| `POST /api/auth/token` | Next.js (Vercel) | POST | Google OAuth2 PKCE token exchange proxy | Fast (~200ms), stateless, keeps GOOGLE_CLIENT_SECRET server-side |
+| `POST /api/sheets/import` | Next.js → Backend proxy | POST | Thin HTTP proxy to backend /import | Fallback for non-WebSocket clients; delegates long-running work to backend |
+| `GET /health` | Backend (Fly.io) | GET | Liveness probe | Backend health check for monitoring and frontend availability detection |
+| `POST /import` | Backend (Fly.io) | POST | Full import pipeline (CSV fetch + Anthropic + Zod) | Long-running operation (~5-30s); freed from Vercel timeout limits |
+| `ws://` (WebSocket) | Backend (Fly.io) | WS | Real-time import progress streaming | Duplex: server streams phase events, client can cancel mid-import |
+
+## Environment Variables
+
+| Variable | Runtime | Scope | Description |
+|----------|---------|-------|-------------|
+| `BACKEND_URL` | Next.js (server) | Server-side only | HTTP URL of backend for proxy use (e.g., `http://localhost:9753`) |
+| `NEXT_PUBLIC_BACKEND_WS_URL` | Next.js (client) | Browser-exposed | WebSocket URL for client-side connection (e.g., `ws://localhost:9753`) |
+| `GOOGLE_CLIENT_SECRET` | Next.js (server) | Server-side only | Stays in Next.js — used by auth token proxy |
+| `ANTHROPIC_API_KEY` | Backend | Server-side only | Moved to backend — used by import pipeline |
+
+## Design Principles
+
+1. **Fast + stateless -> Next.js**: Routes that complete in <1s with no persistent state belong in Next.js/Vercel.
+2. **Long-running + stateful -> Backend**: Operations exceeding Vercel's timeout ceiling or requiring WebSocket belong on the backend.
+3. **Graceful degradation**: The frontend works without the backend for anonymous users (localStorage-only mode). The backend is an optional enhancement.
+4. **Single secret per runtime**: Each secret lives in exactly one runtime. No secret is shared across both.

--- a/development/qa-handoff.md
+++ b/development/qa-handoff.md
@@ -1,201 +1,86 @@
-# QA Handoff: Backend Server with WebSocket Import Pipeline
+# QA Handoff — Story 5: Route Ownership + Env Config
 
 **Date:** 2026-03-01
-**Author:** FiremanDecko (Principal Engineer)
-**Branch:** `feat/backend-ws-pipeline`
-**Stories:** Backend Stories 1-3 (Scaffold + WebSocket + Import Pipeline)
+**Engineer:** FiremanDecko
+**Branch:** `feat/route-ownership-config`
 
 ---
 
 ## What Was Built
 
-### Story 1 — Backend Scaffold (`development/backend/`)
-A new standalone Node.js + TypeScript backend server using Hono as the HTTP framework. Runs independently from the Next.js frontend on port 9753.
+This story converts the Next.js `/api/sheets/import` route from a full Anthropic import implementation into a thin HTTP proxy that delegates to the backend server. It also documents the route ownership split and adds the `BACKEND_URL` environment variable.
 
-- `package.json` — Project manifest with Hono, ws, @anthropic-ai/sdk, zod dependencies
-- `tsconfig.json` — ES2022 target, NodeNext module resolution, strict mode
-- `.env.example` — Template for ANTHROPIC_API_KEY, FENRIR_BACKEND_PORT, NODE_ENV
-- `.gitignore` — Excludes .env, node_modules/, dist/, logs/
-- `fly.toml` — Fly.io deployment configuration
-- `src/config.ts` — Environment variable resolution; assertConfig() for lazy API key validation
-- `src/routes/health.ts` — GET /health liveness probe
-- `src/index.ts` — Hono app entry point with logger, CORS, health route, import route, WebSocket
-
-### Story 2 — WebSocket Server + Types
-WebSocket server attached to the same HTTP server for duplex communication during imports.
-
-- `src/types/messages.ts` — ClientMessage, ServerMessage, ImportErrorCode, ImportedCard types
-- `src/ws/server.ts` — WebSocketServer creation and connection lifecycle management
-- `src/ws/handlers/import.ts` — WebSocket import handler with cancellation support
-
-### Story 3 — Backend Import Pipeline
-Full port of the Google Sheets import pipeline from Next.js to the backend.
-
-- `src/lib/sheets/parse-url.ts` — extractSheetId and buildCsvExportUrl (ported from frontend)
-- `src/lib/sheets/prompt.ts` — buildExtractionPrompt with inlined KNOWN_ISSUERS array
-- `src/lib/sheets/fetch-csv.ts` — CSV fetch with error handling (403/404, empty body, truncation)
-- `src/lib/anthropic/extract.ts` — Anthropic Claude Haiku call with single retry
-- `src/routes/import.ts` — HTTP POST /import endpoint for non-WebSocket clients
-
----
-
-## How to Test
-
-### Prerequisites
-- Node.js 20+
-- An `ANTHROPIC_API_KEY` in `development/backend/.env` (copy from `.env.example`)
-
-### Start the Server
-
-```bash
-# Option A: Use the backend-server.sh script
-.claude/scripts/backend-server.sh start
-
-# Option B: Direct npm run
-cd development/backend
-npm install
-npm run dev
-```
-
-### Test 1: Health Endpoint
-
-```bash
-curl http://localhost:9753/health
-```
-
-**Expected response:**
-```json
-{"status":"ok","service":"fenrir-ledger-backend","ts":"2026-03-01T...Z"}
-```
-
-### Test 2: HTTP Import (requires ANTHROPIC_API_KEY)
-
-```bash
-curl -X POST http://localhost:9753/import \
-  -H "Content-Type: application/json" \
-  -d '{"url":"https://docs.google.com/spreadsheets/d/YOUR_PUBLIC_SHEET_ID/edit"}'
-```
-
-**Expected:** JSON response with `{ cards: [...] }` or `{ error: { code, message } }`.
-
-### Test 3: HTTP Import Error Cases
-
-```bash
-# Invalid URL
-curl -X POST http://localhost:9753/import \
-  -H "Content-Type: application/json" \
-  -d '{"url":"not-a-url"}'
-# Expected: {"error":{"code":"INVALID_URL",...}}
-
-# Missing URL
-curl -X POST http://localhost:9753/import \
-  -H "Content-Type: application/json" \
-  -d '{}'
-# Expected: {"error":{"code":"INVALID_URL",...}}
-
-# Invalid JSON
-curl -X POST http://localhost:9753/import \
-  -H "Content-Type: application/json" \
-  -d 'not json'
-# Expected: {"error":{"code":"INVALID_URL","message":"Invalid JSON body."}}
-```
-
-### Test 4: WebSocket Import
-
-Use `wscat` or any WebSocket client:
-
-```bash
-npx wscat -c ws://localhost:9753
-```
-
-Then send:
-```json
-{"type":"import_start","payload":{"url":"https://docs.google.com/spreadsheets/d/YOUR_PUBLIC_SHEET_ID/edit"}}
-```
-
-**Expected messages (in order):**
-1. `{"type":"import_phase","phase":"fetching_sheet"}`
-2. `{"type":"import_phase","phase":"extracting"}`
-3. `{"type":"import_phase","phase":"validating"}`
-4. `{"type":"import_phase","phase":"done"}`
-5. `{"type":"import_complete","cards":[...]}`
-
-### Test 5: WebSocket Cancellation
-
-Send `import_start`, then immediately send:
-```json
-{"type":"import_cancel"}
-```
-
-**Expected:** The pipeline stops at the next checkpoint. No `import_complete` event is sent.
-
-### Test 6: TypeScript Type Check
-
-```bash
-cd development/backend && npm run typecheck
-```
-
-**Expected:** Exit code 0, no errors.
-
-### Test 7: Backend Server Script
-
-```bash
-.claude/scripts/backend-server.sh start
-.claude/scripts/backend-server.sh status   # Should say "Running"
-.claude/scripts/backend-server.sh start    # Should say "Already running" (idempotent)
-.claude/scripts/backend-server.sh stop
-.claude/scripts/backend-server.sh status   # Should say "Not running"
-```
-
----
-
-## Files Changed
-
-### New Files (16)
+### Files Created
 
 | File | Description |
 |------|-------------|
-| `development/backend/package.json` | Backend project manifest |
-| `development/backend/tsconfig.json` | TypeScript configuration |
-| `development/backend/.env.example` | Environment variable template |
-| `development/backend/.gitignore` | Git ignore rules for backend |
-| `development/backend/fly.toml` | Fly.io deployment config |
-| `development/backend/src/index.ts` | Server entry point (Hono + WS) |
-| `development/backend/src/config.ts` | Environment config + assertConfig() |
-| `development/backend/src/routes/health.ts` | GET /health liveness probe |
-| `development/backend/src/routes/import.ts` | POST /import HTTP endpoint |
-| `development/backend/src/types/messages.ts` | WebSocket message type definitions |
-| `development/backend/src/ws/server.ts` | WebSocket server setup |
-| `development/backend/src/ws/handlers/import.ts` | WebSocket import handler |
-| `development/backend/src/lib/sheets/parse-url.ts` | Sheet URL parsing utilities |
-| `development/backend/src/lib/sheets/prompt.ts` | Anthropic prompt builder |
-| `development/backend/src/lib/sheets/fetch-csv.ts` | CSV fetch with error handling |
-| `development/backend/src/lib/anthropic/extract.ts` | Anthropic API call wrapper |
+| `designs/architecture/route-ownership.md` | Documents which routes live in Next.js vs. backend, env var mapping, and design principles |
 
-### Modified Files (1)
+### Files Modified
 
 | File | Change |
 |------|--------|
-| `development/qa-handoff.md` | Updated with this handoff document |
+| `development/src/src/app/api/sheets/import/route.ts` | Replaced full Anthropic/Zod import implementation with thin HTTP proxy to backend `/import` endpoint |
+| `development/src/.env.example` | Added `BACKEND_URL=http://localhost:9753` with documentation comments |
+| `development/qa-handoff.md` | This file (overwritten per sprint convention) |
+
+---
+
+## How to Deploy
+
+1. Pull the `feat/route-ownership-config` branch
+2. `cd development/src && npm install`
+3. Ensure `.env.local` has `BACKEND_URL=http://localhost:9753` (or the deployed backend URL)
+4. `npm run build` -- verify successful build
+5. `npm run dev` -- start the Next.js dev server
+
+---
+
+## Testing Instructions
+
+### Acceptance Criteria Checklist
+
+- [ ] **No Anthropic SDK in route**: Open `development/src/src/app/api/sheets/import/route.ts` and verify there are no imports of `@anthropic-ai/sdk`, `zod`, `extractSheetId`, `buildCsvExportUrl`, `buildExtractionPrompt`, or `CSV_TRUNCATION_LIMIT`
+- [ ] **Thin proxy only**: The route should be under 45 lines. It accepts a URL in the body, forwards it to `BACKEND_URL/import`, and returns the response
+- [ ] **503 on backend unreachable**: With no backend running, POST to `/api/sheets/import` with `{"url": "https://docs.google.com/spreadsheets/d/test"}` and verify it returns HTTP 503 with `{"error": {"code": "FETCH_ERROR", "message": "The import service is currently unavailable. Please try again later."}}`
+- [ ] **504 on timeout**: If the backend takes over 55 seconds, the route returns 504 (hard to test manually; verify the `AbortSignal.timeout(55_000)` code is present)
+- [ ] **BACKEND_URL in .env.example**: Verify `development/src/.env.example` contains `BACKEND_URL=http://localhost:9753` with documentation
+- [ ] **Route ownership doc**: Verify `designs/architecture/route-ownership.md` contains the route table, env var table, and 4 design principles
+- [ ] **TypeScript compiles**: `cd development/src && npx tsc --noEmit` exits 0
+- [ ] **Build succeeds**: `cd development/src && npm run build` exits 0
+
+### Test Commands
+
+```bash
+# TypeScript check
+cd development/src && npx tsc --noEmit
+
+# Production build
+cd development/src && npm run build
+
+# Test 503 error (no backend running)
+cd development/src && npm run dev &
+curl -X POST http://localhost:9653/api/sheets/import \
+  -H "Content-Type: application/json" \
+  -d '{"url": "https://docs.google.com/spreadsheets/d/test"}'
+# Expected: 503 with FETCH_ERROR
+
+# Test invalid body
+curl -X POST http://localhost:9653/api/sheets/import \
+  -H "Content-Type: application/json" \
+  -d '{}'
+# Expected: 400 with INVALID_URL
+
+# Test invalid JSON
+curl -X POST http://localhost:9653/api/sheets/import \
+  -H "Content-Type: text/plain" \
+  -d 'not json'
+# Expected: 400 with INVALID_URL
+```
 
 ---
 
 ## Known Limitations
 
-1. **No frontend integration yet.** The frontend still uses the existing Next.js `/api/sheets/import` route. WebSocket client integration is Phase 2 frontend work.
-2. **No production deployment.** The `fly.toml` is ready but `fly deploy` has not been run. This is a future sprint story.
-3. **ANTHROPIC_API_KEY required for import.** The server starts without it (health-only mode), but import routes return 500 without the key.
-4. **No rate limiting.** WebSocket connections are not rate-limited. A future story should add connection limits.
-5. **No authentication.** The backend has no auth middleware. Import routes are open. This matches the frontend's anonymous-first model but should be revisited at GA.
-6. **CORS is set to `*` (allow all origins).** Appropriate for development; should be tightened for production.
-
----
-
-## Suggested Test Focus Areas
-
-1. **Health endpoint** — Verify it returns correct JSON structure.
-2. **WebSocket lifecycle** — Connect, send import_start, verify phase events arrive in order, verify import_complete contains valid card objects.
-3. **Error handling** — Invalid URLs, non-public sheets, missing API key, malformed JSON messages.
-4. **Cancellation** — Verify import_cancel interrupts the pipeline cleanly.
-5. **Type safety** — `npm run typecheck` passes with zero errors.
-6. **Idempotent start** — `backend-server.sh start` is safe to run multiple times.
+- The `NEXT_PUBLIC_BACKEND_WS_URL` env var is documented in `route-ownership.md` but not yet added to `.env.example` -- it will be added when the WebSocket client code is implemented.
+- The `@anthropic-ai/sdk` and `zod` packages remain in `package.json` as they may be used by other parts of the application or the future backend. They are no longer imported by the import route.

--- a/development/src/.env.example
+++ b/development/src/.env.example
@@ -43,3 +43,9 @@ GOOGLE_CLIENT_SECRET=your-google-client-secret
 # Obtain from: https://console.anthropic.com/
 # No NEXT_PUBLIC_ prefix — Next.js will NOT include this in the client bundle.
 ANTHROPIC_API_KEY=
+
+# ─── Backend Server URL ──────────────────────────────────────────────────────
+# HTTP URL of the Fenrir Ledger backend server (server-side proxy, not exposed
+# to browser). Used by /api/sheets/import to proxy long-running import requests
+# to the backend. No NEXT_PUBLIC_ prefix — this is server-side only.
+BACKEND_URL=http://localhost:9753

--- a/development/src/src/app/api/sheets/import/route.ts
+++ b/development/src/src/app/api/sheets/import/route.ts
@@ -1,195 +1,45 @@
 import { NextRequest, NextResponse } from "next/server";
-import Anthropic from "@anthropic-ai/sdk";
-import { z } from "zod";
-import { extractSheetId, buildCsvExportUrl } from "@/lib/sheets/parse-url";
-import { buildExtractionPrompt, CSV_TRUNCATION_LIMIT } from "@/lib/sheets/prompt";
-import type { SheetImportError, SheetImportSuccess } from "@/lib/sheets/types";
+import type { SheetImportError } from "@/lib/sheets/types";
 
 export const maxDuration = 60;
 
-const CardSchema = z.object({
-  issuerId: z.string(),
-  cardName: z.string(),
-  openDate: z.string(),
-  creditLimit: z.number().int().min(0),
-  annualFee: z.number().int().min(0),
-  annualFeeDate: z.string(),
-  promoPeriodMonths: z.number().int().min(0),
-  signUpBonus: z
-    .object({
-      type: z.enum(["points", "miles", "cashback"]),
-      amount: z.number(),
-      spendRequirement: z.number().int().min(0),
-      deadline: z.string(),
-      met: z.boolean(),
-    })
-    .nullable(),
-  notes: z.string(),
-});
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:9753";
 
-const CardsArraySchema = z.array(CardSchema);
-
-function errorResponse(
-  code: SheetImportError["code"],
-  message: string,
-  status: number = 400,
-): NextResponse {
-  return NextResponse.json(
-    { error: { code, message } satisfies SheetImportError },
-    { status },
-  );
+function errorResponse(code: SheetImportError["code"], message: string, status: number = 400): NextResponse {
+  return NextResponse.json({ error: { code, message } satisfies SheetImportError }, { status });
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  // 1. Parse + validate body
   let url: string;
   try {
     const body = await request.json();
     url = body?.url;
     if (!url || typeof url !== "string") {
-      return errorResponse(
-        "INVALID_URL",
-        "Request body must include a 'url' string.",
-      );
+      return errorResponse("INVALID_URL", "Request body must include a 'url' string.");
     }
   } catch {
     return errorResponse("INVALID_URL", "Invalid JSON body.");
   }
 
-  // 2. Extract sheet ID
-  const sheetId = extractSheetId(url);
-  if (!sheetId) {
-    return errorResponse(
-      "INVALID_URL",
-      "URL does not appear to be a Google Sheets link.",
-    );
-  }
-
-  // 3. Fetch CSV
-  let csv: string;
-  let warning: string | undefined;
   try {
-    const csvUrl = buildCsvExportUrl(sheetId);
-    const csvResponse = await fetch(csvUrl, { redirect: "follow" });
+    const upstream = await fetch(`${BACKEND_URL}/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ url }),
+      signal: AbortSignal.timeout(55_000), // Leave 5s buffer before maxDuration
+    });
 
-    if (csvResponse.status === 403 || csvResponse.status === 404) {
-      return errorResponse(
-        "SHEET_NOT_PUBLIC",
-        "The spreadsheet is not publicly accessible. Make sure it's shared as 'Anyone with the link can view'.",
-      );
-    }
-
-    if (!csvResponse.ok) {
-      return errorResponse(
-        "FETCH_ERROR",
-        `Failed to fetch spreadsheet (HTTP ${csvResponse.status}).`,
-      );
-    }
-
-    csv = await csvResponse.text();
-
-    if (!csv.trim()) {
-      return errorResponse(
-        "NO_CARDS_FOUND",
-        "The spreadsheet appears to be empty.",
-      );
-    }
-
-    // Truncate if needed
-    if (csv.length > CSV_TRUNCATION_LIMIT) {
-      csv = csv.slice(0, CSV_TRUNCATION_LIMIT);
-      warning = `CSV was truncated at ${CSV_TRUNCATION_LIMIT.toLocaleString()} characters. Some rows may be missing.`;
-    }
+    const data = await upstream.json();
+    return NextResponse.json(data, { status: upstream.status });
   } catch (err) {
+    // Backend unreachable — return 503
+    if (err instanceof Error && err.name === "TimeoutError") {
+      return errorResponse("FETCH_ERROR", "Import timed out. The backend server may be overloaded.", 504);
+    }
     return errorResponse(
       "FETCH_ERROR",
-      `Failed to fetch spreadsheet: ${err instanceof Error ? err.message : "Unknown error"}`,
-    );
-  }
-
-  // 4. Anthropic API call
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    return errorResponse(
-      "ANTHROPIC_ERROR",
-      "Server configuration error: missing API key.",
-      500,
-    );
-  }
-
-  const client = new Anthropic({ apiKey });
-  const prompt = buildExtractionPrompt(csv);
-
-  let responseText: string = "";
-
-  // Single retry on transient errors
-  for (let attempt = 0; attempt < 2; attempt++) {
-    try {
-      const message = await client.messages.create({
-        model: "claude-haiku-4-5-20251001",
-        max_tokens: 4096,
-        messages: [{ role: "user", content: prompt }],
-      });
-
-      const textBlock = message.content.find((b) => b.type === "text");
-      responseText = textBlock?.text ?? "";
-      break;
-    } catch (err) {
-      if (attempt === 1) {
-        return errorResponse(
-          "ANTHROPIC_ERROR",
-          `AI extraction failed: ${err instanceof Error ? err.message : "Unknown error"}`,
-          500,
-        );
-      }
-      // First attempt failed — retry
-    }
-  }
-
-  // 5. Parse and validate response
-  try {
-    // Extract JSON from response (handle markdown code blocks)
-    let jsonStr = responseText.trim();
-    if (jsonStr.startsWith("```")) {
-      jsonStr = jsonStr
-        .replace(/^```(?:json)?\n?/, "")
-        .replace(/\n?```$/, "");
-    }
-
-    const parsed = JSON.parse(jsonStr);
-    const validated = CardsArraySchema.parse(parsed);
-
-    if (validated.length === 0) {
-      return errorResponse(
-        "NO_CARDS_FOUND",
-        "No credit card data could be extracted from the spreadsheet.",
-      );
-    }
-
-    // 6. Assign fresh IDs and timestamps
-    const now = new Date().toISOString();
-    const cards = validated.map((card) => ({
-      ...card,
-      id: crypto.randomUUID(),
-      status: "active" as const,
-      createdAt: now,
-      updatedAt: now,
-    }));
-
-    const result: SheetImportSuccess = { cards };
-    if (warning) result.warning = warning;
-
-    return NextResponse.json(result);
-  } catch (err) {
-    if (err instanceof z.ZodError) {
-      return errorResponse(
-        "PARSE_ERROR",
-        `Extracted data validation failed: ${err.errors.map((e) => e.message).join(", ")}`,
-      );
-    }
-    return errorResponse(
-      "PARSE_ERROR",
-      "Failed to parse AI response as valid card data.",
+      "The import service is currently unavailable. Please try again later.",
+      503
     );
   }
 }


### PR DESCRIPTION
## Summary
- Replaced `/api/sheets/import` with a thin HTTP proxy that delegates to the backend server, removing all Anthropic SDK and Zod schema logic from the Next.js route
- Added `BACKEND_URL` environment variable to `.env.example` for configuring the server-side proxy target
- Created `designs/architecture/route-ownership.md` documenting which routes live in Next.js vs. the backend, environment variable mapping, and the four design principles governing the split

## Test plan
- [ ] Verify `development/src/src/app/api/sheets/import/route.ts` contains no `@anthropic-ai/sdk`, `zod`, or direct import logic
- [ ] Verify `npx tsc --noEmit` passes in `development/src/`
- [ ] Verify `npm run build` passes in `development/src/`
- [ ] POST to `/api/sheets/import` with no backend running returns 503 with `FETCH_ERROR`
- [ ] POST with empty body returns 400 with `INVALID_URL`
- [ ] Verify `BACKEND_URL=http://localhost:9753` is in `.env.example`
- [ ] Verify `designs/architecture/route-ownership.md` has route table, env var table, and 4 design principles

Generated with [Claude Code](https://claude.com/claude-code)