### PR TITLE
fix: handle empty env vars so services start on clean clone

### DIFF
--- a/.claude/scripts/services.sh
+++ b/.claude/scripts/services.sh
@@ -19,11 +19,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 FRONTEND_SCRIPT="${SCRIPT_DIR}/frontend-server.sh"
 BACKEND_SCRIPT="${SCRIPT_DIR}/backend-server.sh"
 
-# Propagate env vars so individual scripts pick them up
-export FENRIR_FRONTEND_PORT="${FENRIR_FRONTEND_PORT:-${FENRIR_PORT:-}}"
-export FENRIR_FRONTEND_DIR="${FENRIR_FRONTEND_DIR:-${FENRIR_DEV_DIR:-}}"
-export FENRIR_BACKEND_PORT="${FENRIR_BACKEND_PORT:-}"
-export FENRIR_BACKEND_DIR="${FENRIR_BACKEND_DIR:-}"
+# Propagate env vars so individual scripts pick them up.
+# Only export if a real value exists — empty strings cause parseInt("") → NaN crashes.
+[[ -n "${FENRIR_FRONTEND_PORT:-${FENRIR_PORT:-}}" ]] && export FENRIR_FRONTEND_PORT="${FENRIR_FRONTEND_PORT:-${FENRIR_PORT:-}}"
+[[ -n "${FENRIR_FRONTEND_DIR:-${FENRIR_DEV_DIR:-}}" ]] && export FENRIR_FRONTEND_DIR="${FENRIR_FRONTEND_DIR:-${FENRIR_DEV_DIR:-}}"
+[[ -n "${FENRIR_BACKEND_PORT:-}" ]] && export FENRIR_BACKEND_PORT="${FENRIR_BACKEND_PORT}"
+[[ -n "${FENRIR_BACKEND_DIR:-}" ]] && export FENRIR_BACKEND_DIR="${FENRIR_BACKEND_DIR}"
 
 action="${1:-}"
 target="${2:-}"

--- a/development/backend/src/config.ts
+++ b/development/backend/src/config.ts
@@ -9,13 +9,13 @@
  */
 export const config = {
   /** Port the backend listens on. Default: 9753. Override via FENRIR_BACKEND_PORT. */
-  port: parseInt(process.env.FENRIR_BACKEND_PORT ?? "9753", 10),
+  port: parseInt(process.env.FENRIR_BACKEND_PORT || "9753", 10),
 
   /** Anthropic API key for Claude Haiku calls during sheet import. */
   anthropicApiKey: process.env.ANTHROPIC_API_KEY ?? "",
 
   /** Node environment. "development" | "production" | "test". */
-  nodeEnv: process.env.NODE_ENV ?? "development",
+  nodeEnv: process.env.NODE_ENV || "development",
 } as const;
 
 /**

--- a/development/frontend/src/app/api/sheets/import/route.ts
+++ b/development/frontend/src/app/api/sheets/import/route.ts
@@ -3,7 +3,7 @@ import type { SheetImportError } from "@/lib/sheets/types";
 
 export const maxDuration = 60;
 
-const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:9753";
+const BACKEND_URL = process.env.BACKEND_URL || "http://localhost:9753";
 
 function errorResponse(code: SheetImportError["code"], message: string, status: number = 400): NextResponse {
   return NextResponse.json({ error: { code, message } satisfies SheetImportError }, { status });

--- a/development/frontend/src/hooks/useSheetImport.ts
+++ b/development/frontend/src/hooks/useSheetImport.ts
@@ -30,12 +30,12 @@ interface ServerMessage {
 
 /** Derive the HTTP base URL from the WS env var (ws:// -> http://, wss:// -> https://). */
 const WS_BACKEND_HTTP_URL =
-  process.env.NEXT_PUBLIC_BACKEND_WS_URL?.replace(/^ws(s?)/, "http$1") ??
+  process.env.NEXT_PUBLIC_BACKEND_WS_URL?.replace(/^ws(s?)/, "http$1") ||
   "http://localhost:9753";
 
 /** WebSocket URL for the backend. */
 const WS_BACKEND_WS_URL =
-  process.env.NEXT_PUBLIC_BACKEND_WS_URL ?? "ws://localhost:9753";
+  process.env.NEXT_PUBLIC_BACKEND_WS_URL || "ws://localhost:9753";
 
 /** Health check timeout in milliseconds. */
 const HEALTH_CHECK_TIMEOUT_MS = 2_000;


### PR DESCRIPTION
## Summary
- Replace `??` with `||` for all env var defaults with fallback values across backend config, frontend API route, and WS import hook — empty strings (`""`) bypass nullish coalescing but are caught by logical OR
- Guard `services.sh` to only export env vars when non-empty, preventing propagation of `""` to child processes

## Context
On a clean clone (or when env vars are set but empty), `parseInt("")` returns `NaN`, crashing the backend with `ERR_SOCKET_BAD_PORT`. The root cause is `??` treating `""` as a real value.

## Files changed
- `.claude/scripts/services.sh` — conditional export guards
- `development/backend/src/config.ts` — `port`, `nodeEnv`
- `development/frontend/src/app/api/sheets/import/route.ts` — `BACKEND_URL`
- `development/frontend/src/hooks/useSheetImport.ts` — `WS_BACKEND_HTTP_URL`, `WS_BACKEND_WS_URL`

## Test plan
- [ ] `git clone` fresh → `npm install` in both dirs → `services.sh start` → both services stay up
- [ ] Set `FENRIR_BACKEND_PORT=""` explicitly → backend falls back to 9753
- [ ] Set `FENRIR_BACKEND_PORT=8080` → backend listens on 8080

🤖 Generated with [Claude Code](https://claude.com/claude-code)