### PR TITLE
chore: add ADR for OpenAPI specification on backend

### DIFF
--- a/designs/architecture/adr-openapi-spec.md
+++ b/designs/architecture/adr-openapi-spec.md
@@ -189,8 +189,9 @@ const healthRoute = createRoute({
 **3. Serve spec and docs**
 
 ```typescript
-// OpenAPI JSON spec
-app.doc("/openapi.json", {
+// OpenAPI 3.1.0 JSON spec — doc31() is required for 3.1.0 output;
+// doc() produces 3.0.x regardless of the openapi field value.
+app.doc31("/openapi.json", {
   openapi: "3.1.0",
   info: {
     title: "Fenrir Ledger Backend API",
@@ -233,7 +234,7 @@ This is a pragmatic approach: it keeps WebSocket documentation co-located with t
 
 | Package | Version | Purpose |
 |---------|---------|---------|
-| `@hono/zod-openapi` | `^0.18` | Route-level OpenAPI definitions from Zod schemas |
+| `@hono/zod-openapi` | `^1.2` | Route-level OpenAPI definitions from Zod schemas |
 | `@hono/swagger-ui` | `^0.5` | Interactive API documentation UI |
 
 Both are official `@hono/*` packages maintained by the Hono team.


### PR DESCRIPTION
## Summary

- Adds an Architecture Decision Record documenting the decision to adopt `@hono/zod-openapi` + `@hono/swagger-ui` for generating an OpenAPI 3.1.0 specification from the existing Hono backend.
- The ADR evaluates five alternatives (manual YAML, tsoa, zod-to-openapi standalone, OpenAPI 3.2.0, and the recommended @hono/zod-openapi approach) with full pros/cons analysis.
- Defines the implementation approach: migrate `Hono()` to `OpenAPIHono()`, convert routes to `createRoute()` definitions, serve spec at `GET /openapi.json` and Swagger UI at `GET /docs`.
- Documents a pragmatic WebSocket message documentation strategy using a custom `x-websocket-messages` OpenAPI extension, since OpenAPI does not natively support WebSocket protocols.

## Test plan

- [ ] Verify ADR follows the established format (matches `adr-backend-server.md` style)
- [ ] Verify all referenced files and packages are accurate
- [ ] Verify Mermaid diagrams (if any) render correctly
- [ ] Review technical accuracy of alternatives analysis

Generated with [Claude Code](https://claude.com/claude-code)