### PR TITLE
feat: add Vercel Web Analytics integration

### DIFF
--- a/development/frontend/package-lock.json
+++ b/development/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "@radix-ui/react-label": "^2.1.1",
         "@radix-ui/react-select": "^2.1.4",
         "@radix-ui/react-slot": "^1.1.1",
+        "@vercel/analytics": "^1.6.1",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "framer-motion": "^12.34.3",
@@ -2226,6 +2227,44 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.6.1.tgz",
+      "integrity": "sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==",
+      "license": "MPL-2.0",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/development/frontend/package.json
+++ b/development/frontend/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-label": "^2.1.1",
     "@radix-ui/react-select": "^2.1.4",
     "@radix-ui/react-slot": "^1.1.1",
+    "@vercel/analytics": "^1.6.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.34.3",

--- a/development/frontend/src/app/layout.tsx
+++ b/development/frontend/src/app/layout.tsx
@@ -23,6 +23,7 @@ import {
   Source_Serif_4,
   JetBrains_Mono,
 } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
 import { ConsoleSignature } from "@/components/layout/ConsoleSignature";
 import { AppShell } from "@/components/layout/AppShell";
 import { AuthProvider } from "@/contexts/AuthContext";
@@ -105,6 +106,7 @@ export default function RootLayout({
             <AppShell>{children}</AppShell>
           </RagnarokProvider>
         </AuthProvider>
+        <Analytics />
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary

- Install `@vercel/analytics` ^1.6.1 in the frontend
- Import `Analytics` from `@vercel/analytics/next` and render `<Analytics />` in the root layout (`layout.tsx`)
- Zero-config: Vercel automatically collects page views once Analytics is enabled in the Vercel dashboard

## Test plan

- [ ] Verify `npm run build` passes with zero type errors
- [ ] Deploy to Vercel preview and confirm `/_vercel/insights/view` fetch request fires on page load (visible in browser Network tab)
- [ ] Confirm Analytics dashboard in Vercel shows page view data after deployment

Generated with [Claude Code](https://claude.com/claude-code)