### PR TITLE
feat: Norse terminal color palette files

### DIFF
--- a/development/qa-handoff-palette.md
+++ b/development/qa-handoff-palette.md
@@ -1,0 +1,65 @@
+# QA Handoff: Terminal Color Palette Files
+
+## What Was Implemented
+
+Story 3 from the Claude Terminal Skin sprint: Norse terminal color palette config files for four terminal emulators.
+
+## Files Created
+
+| File | Format | Target Terminal |
+|------|--------|-----------------|
+| `terminal/fenrir.itermcolors` | XML plist | iTerm2 |
+| `terminal/ghostty.conf` | Key-value config | Ghostty |
+| `terminal/wezterm-colors.lua` | Lua table | WezTerm |
+| `terminal/kitty.conf` | Key-value config | Kitty |
+
+## Color Palette Mapped
+
+All 16 ANSI colors (0-15) plus background, foreground, cursor, and selection colors. Full mapping:
+
+| Slot | Name | Hex |
+|------|------|-----|
+| 0 | Void Black | #07070d |
+| 1 | Ragnarok Red | #ef4444 |
+| 2 | Asgard Teal | #0a8c6e |
+| 3 | Hati Amber | #f59e0b |
+| 4 | Deep Fjord | #2563eb |
+| 5 | Muspel Orange | #c94a0a |
+| 6 | Forge Gold | #c9920a |
+| 7 | Parchment | #f0ede4 |
+| 8 | Stone | #8a8578 |
+| 9 | Light Ragnarok | #f87171 |
+| 10 | Light Asgard | #34d399 |
+| 11 | Light Hati | #fbbf24 |
+| 12 | Light Fjord | #60a5fa |
+| 13 | Light Muspel | #fb923c |
+| 14 | Light Gold | #eab308 |
+| 15 | Pure Parchment | #faf9f6 |
+| BG | Void Black | #07070d |
+| FG | Parchment | #f0ede4 |
+| Cursor | Forge Gold | #c9920a |
+| Sel BG | Warm Charcoal | #1c1917 |
+| Sel FG | Pure Parchment | #faf9f6 |
+
+## Validation Already Performed
+
+- `plutil -lint terminal/fenrir.itermcolors` exits 0 (valid XML plist)
+- All 4 files contain correct background (#07070d), cursor (#c9920a), green (#0a8c6e), yellow (#f59e0b)
+- All files include import instructions in header comments
+- No hardcoded absolute paths in any file
+- Float conversions for iTerm2 verified against Python3 `hex / 255` computation
+
+## Suggested Test Focus Areas
+
+1. **iTerm2**: Import `fenrir.itermcolors` via Profiles > Colors > Color Presets > Import. Verify dark background, gold cursor, teal for green text.
+2. **Ghostty**: Append `ghostty.conf` to `~/.config/ghostty/config`. Verify palette renders correctly.
+3. **WezTerm**: Place `wezterm-colors.lua` in colors dir, set `config.color_scheme = "Fenrir"`. Verify ansi/brights arrays.
+4. **Kitty**: Include `kitty.conf` via `include themes/fenrir.conf`. Verify color0-color15 plus special colors.
+5. **Cross-file consistency**: All 4 files must use identical hex values for each ANSI slot.
+6. **Spot-check specific colors**: Run `echo -e "\033[32mGreen\033[0m"` and verify it appears as Asgard Teal (#0a8c6e), not a standard green.
+
+## Known Limitations
+
+- These are static config files, not runtime code. No deployment or server needed.
+- Ghostty background/foreground use bare hex (no `#` prefix) per Ghostty's config format.
+- WezTerm instructions mention both the color scheme registry approach and inline `dofile()` approach.

--- a/terminal/fenrir.itermcolors
+++ b/terminal/fenrir.itermcolors
@@ -1,0 +1,330 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Fenrir Ledger — Norse Terminal Palette for iTerm2
+  ==================================================
+  Import instructions:
+    1. Open iTerm2 > Settings > Profiles > Colors
+    2. Click "Color Presets..." dropdown (bottom right)
+    3. Select "Import..." and choose this file
+    4. Select "Fenrir" from the Color Presets dropdown
+
+  Palette: Saga Ledger dark Norse theme
+  Background: Void Black #07070d
+  Foreground: Parchment #f0ede4
+  Cursor: Forge Gold #c9920a
+-->
+<plist version="1.0">
+<dict>
+	<!-- ANSI 0: Void Black #07070d -->
+	<key>Ansi 0 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.02745098039215686</real>
+		<key>Green Component</key>
+		<real>0.02745098039215686</real>
+		<key>Blue Component</key>
+		<real>0.05098039215686274</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 1: Ragnarok Red #ef4444 -->
+	<key>Ansi 1 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.93725490196078431</real>
+		<key>Green Component</key>
+		<real>0.26666666666666666</real>
+		<key>Blue Component</key>
+		<real>0.26666666666666666</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 2: Asgard Teal #0a8c6e -->
+	<key>Ansi 2 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.03921568627450980</real>
+		<key>Green Component</key>
+		<real>0.54901960784313725</real>
+		<key>Blue Component</key>
+		<real>0.43137254901960786</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 3: Hati Amber #f59e0b -->
+	<key>Ansi 3 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.96078431372549020</real>
+		<key>Green Component</key>
+		<real>0.61960784313725492</real>
+		<key>Blue Component</key>
+		<real>0.04313725490196078</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 4: Deep Fjord #2563eb -->
+	<key>Ansi 4 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.14509803921568629</real>
+		<key>Green Component</key>
+		<real>0.38823529411764707</real>
+		<key>Blue Component</key>
+		<real>0.92156862745098034</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 5: Muspel Orange #c94a0a -->
+	<key>Ansi 5 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.78823529411764703</real>
+		<key>Green Component</key>
+		<real>0.29019607843137257</real>
+		<key>Blue Component</key>
+		<real>0.03921568627450980</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 6: Forge Gold #c9920a -->
+	<key>Ansi 6 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.78823529411764703</real>
+		<key>Green Component</key>
+		<real>0.57254901960784310</real>
+		<key>Blue Component</key>
+		<real>0.03921568627450980</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 7: Parchment #f0ede4 -->
+	<key>Ansi 7 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.94117647058823528</real>
+		<key>Green Component</key>
+		<real>0.92941176470588238</real>
+		<key>Blue Component</key>
+		<real>0.89411764705882357</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 8: Stone #8a8578 (Bright Black) -->
+	<key>Ansi 8 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.54117647058823526</real>
+		<key>Green Component</key>
+		<real>0.52156862745098043</real>
+		<key>Blue Component</key>
+		<real>0.47058823529411764</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 9: Light Ragnarok #f87171 (Bright Red) -->
+	<key>Ansi 9 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.97254901960784312</real>
+		<key>Green Component</key>
+		<real>0.44313725490196076</real>
+		<key>Blue Component</key>
+		<real>0.44313725490196076</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 10: Light Asgard #34d399 (Bright Green) -->
+	<key>Ansi 10 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.20392156862745098</real>
+		<key>Green Component</key>
+		<real>0.82745098039215681</real>
+		<key>Blue Component</key>
+		<real>0.60000000000000000</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 11: Light Hati #fbbf24 (Bright Yellow) -->
+	<key>Ansi 11 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.98431372549019602</real>
+		<key>Green Component</key>
+		<real>0.74901960784313726</real>
+		<key>Blue Component</key>
+		<real>0.14117647058823529</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 12: Light Fjord #60a5fa (Bright Blue) -->
+	<key>Ansi 12 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.37647058823529413</real>
+		<key>Green Component</key>
+		<real>0.64705882352941180</real>
+		<key>Blue Component</key>
+		<real>0.98039215686274506</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 13: Light Muspel #fb923c (Bright Magenta) -->
+	<key>Ansi 13 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.98431372549019602</real>
+		<key>Green Component</key>
+		<real>0.57254901960784310</real>
+		<key>Blue Component</key>
+		<real>0.23529411764705882</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 14: Light Gold #eab308 (Bright Cyan) -->
+	<key>Ansi 14 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.91764705882352937</real>
+		<key>Green Component</key>
+		<real>0.70196078431372544</real>
+		<key>Blue Component</key>
+		<real>0.03137254901960784</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- ANSI 15: Pure Parchment #faf9f6 (Bright White) -->
+	<key>Ansi 15 Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.98039215686274506</real>
+		<key>Green Component</key>
+		<real>0.97647058823529409</real>
+		<key>Blue Component</key>
+		<real>0.96470588235294119</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Background: Void Black #07070d -->
+	<key>Background Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.02745098039215686</real>
+		<key>Green Component</key>
+		<real>0.02745098039215686</real>
+		<key>Blue Component</key>
+		<real>0.05098039215686274</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Foreground: Parchment #f0ede4 -->
+	<key>Foreground Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.94117647058823528</real>
+		<key>Green Component</key>
+		<real>0.92941176470588238</real>
+		<key>Blue Component</key>
+		<real>0.89411764705882357</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Cursor: Forge Gold #c9920a -->
+	<key>Cursor Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.78823529411764703</real>
+		<key>Green Component</key>
+		<real>0.57254901960784310</real>
+		<key>Blue Component</key>
+		<real>0.03921568627450980</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Cursor Text: Void Black #07070d -->
+	<key>Cursor Text Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.02745098039215686</real>
+		<key>Green Component</key>
+		<real>0.02745098039215686</real>
+		<key>Blue Component</key>
+		<real>0.05098039215686274</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Selection: Warm Charcoal bg #1c1917, Pure Parchment fg #faf9f6 -->
+	<key>Selected Text Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.98039215686274506</real>
+		<key>Green Component</key>
+		<real>0.97647058823529409</real>
+		<key>Blue Component</key>
+		<real>0.96470588235294119</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<key>Selection Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.10980392156862745</real>
+		<key>Green Component</key>
+		<real>0.09803921568627451</real>
+		<key>Blue Component</key>
+		<real>0.09019607843137255</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Bold: Parchment #f0ede4 -->
+	<key>Bold Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.94117647058823528</real>
+		<key>Green Component</key>
+		<real>0.92941176470588238</real>
+		<key>Blue Component</key>
+		<real>0.89411764705882357</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+
+	<!-- Link: Deep Fjord #2563eb -->
+	<key>Link Color</key>
+	<dict>
+		<key>Red Component</key>
+		<real>0.14509803921568629</real>
+		<key>Green Component</key>
+		<real>0.38823529411764707</real>
+		<key>Blue Component</key>
+		<real>0.92156862745098034</real>
+		<key>Color Space</key>
+		<string>sRGB</string>
+	</dict>
+</dict>
+</plist>

--- a/terminal/ghostty.conf
+++ b/terminal/ghostty.conf
@@ -1,0 +1,50 @@
+# Fenrir Ledger — Norse Terminal Palette for Ghostty
+# ==================================================
+# Install instructions:
+#   Option A: Append these lines to ~/.config/ghostty/config
+#   Option B: Save this file as ~/.config/ghostty/themes/fenrir
+#             then set: theme = fenrir
+#
+# Palette: Saga Ledger dark Norse theme
+# Background: Void Black #07070d
+# Foreground: Parchment #f0ede4
+# Cursor: Forge Gold #c9920a
+
+background = 07070d
+foreground = f0ede4
+cursor-color = c9920a
+selection-background = 1c1917
+selection-foreground = faf9f6
+
+# ANSI 0:  Void Black
+palette = 0=#07070d
+# ANSI 1:  Ragnarok Red
+palette = 1=#ef4444
+# ANSI 2:  Asgard Teal
+palette = 2=#0a8c6e
+# ANSI 3:  Hati Amber
+palette = 3=#f59e0b
+# ANSI 4:  Deep Fjord
+palette = 4=#2563eb
+# ANSI 5:  Muspel Orange
+palette = 5=#c94a0a
+# ANSI 6:  Forge Gold
+palette = 6=#c9920a
+# ANSI 7:  Parchment
+palette = 7=#f0ede4
+# ANSI 8:  Stone (Bright Black)
+palette = 8=#8a8578
+# ANSI 9:  Light Ragnarok (Bright Red)
+palette = 9=#f87171
+# ANSI 10: Light Asgard (Bright Green)
+palette = 10=#34d399
+# ANSI 11: Light Hati (Bright Yellow)
+palette = 11=#fbbf24
+# ANSI 12: Light Fjord (Bright Blue)
+palette = 12=#60a5fa
+# ANSI 13: Light Muspel (Bright Magenta)
+palette = 13=#fb923c
+# ANSI 14: Light Gold (Bright Cyan)
+palette = 14=#eab308
+# ANSI 15: Pure Parchment (Bright White)
+palette = 15=#faf9f6

--- a/terminal/kitty.conf
+++ b/terminal/kitty.conf
@@ -1,0 +1,41 @@
+# Fenrir Ledger — Norse Terminal Palette for Kitty
+# ==================================================
+# Install instructions:
+#   1. Copy this file to ~/.config/kitty/themes/fenrir.conf
+#   2. In your kitty.conf, add:
+#        include themes/fenrir.conf
+#   Or use the built-in theme manager:
+#        kitty +kitten themes --custom-color-dir ~/.config/kitty/themes
+#
+# Palette: Saga Ledger dark Norse theme
+# Background: Void Black #07070d
+# Foreground: Parchment #f0ede4
+# Cursor: Forge Gold #c9920a
+
+# Special colors
+background            #07070d
+foreground            #f0ede4
+cursor                #c9920a
+cursor_text_color     #07070d
+selection_background  #1c1917
+selection_foreground  #faf9f6
+
+# Normal colors (ANSI 0-7)
+color0   #07070d
+color1   #ef4444
+color2   #0a8c6e
+color3   #f59e0b
+color4   #2563eb
+color5   #c94a0a
+color6   #c9920a
+color7   #f0ede4
+
+# Bright colors (ANSI 8-15)
+color8   #8a8578
+color9   #f87171
+color10  #34d399
+color11  #fbbf24
+color12  #60a5fa
+color13  #fb923c
+color14  #eab308
+color15  #faf9f6

--- a/terminal/wezterm-colors.lua
+++ b/terminal/wezterm-colors.lua
@@ -1,0 +1,50 @@
+-- Fenrir Ledger — Norse Terminal Palette for WezTerm
+-- ==================================================
+-- Install instructions:
+--   1. Copy this file to ~/.config/wezterm/colors/Fenrir.toml
+--      OR save it anywhere and register via wezterm.lua
+--   2. In your wezterm.lua, add:
+--        local wezterm = require("wezterm")
+--        config.color_scheme = "Fenrir"
+--
+--   Alternative (inline): In wezterm.lua, paste the table directly:
+--        config.colors = dofile(os.getenv("HOME") .. "/.config/wezterm/colors/Fenrir.lua")
+--
+-- Palette: Saga Ledger dark Norse theme
+-- Background: Void Black #07070d
+-- Foreground: Parchment #f0ede4
+-- Cursor: Forge Gold #c9920a
+
+return {
+  foreground = "#f0ede4",    -- Parchment
+  background = "#07070d",    -- Void Black
+
+  cursor_bg = "#c9920a",     -- Forge Gold
+  cursor_fg = "#07070d",     -- Void Black
+  cursor_border = "#c9920a", -- Forge Gold
+
+  selection_fg = "#faf9f6",  -- Pure Parchment
+  selection_bg = "#1c1917",  -- Warm Charcoal
+
+  ansi = {
+    "#07070d",  -- 0  Void Black
+    "#ef4444",  -- 1  Ragnarok Red
+    "#0a8c6e",  -- 2  Asgard Teal
+    "#f59e0b",  -- 3  Hati Amber
+    "#2563eb",  -- 4  Deep Fjord
+    "#c94a0a",  -- 5  Muspel Orange
+    "#c9920a",  -- 6  Forge Gold
+    "#f0ede4",  -- 7  Parchment
+  },
+
+  brights = {
+    "#8a8578",  -- 8  Stone (Bright Black)
+    "#f87171",  -- 9  Light Ragnarok (Bright Red)
+    "#34d399",  -- 10 Light Asgard (Bright Green)
+    "#fbbf24",  -- 11 Light Hati (Bright Yellow)
+    "#60a5fa",  -- 12 Light Fjord (Bright Blue)
+    "#fb923c",  -- 13 Light Muspel (Bright Magenta)
+    "#eab308",  -- 14 Light Gold (Bright Cyan)
+    "#faf9f6",  -- 15 Pure Parchment (Bright White)
+  },
+}


### PR DESCRIPTION
## Summary

- Add iTerm2 color preset (`terminal/fenrir.itermcolors`) with valid XML plist format
- Add Ghostty config snippet (`terminal/ghostty.conf`) with all 16 ANSI palette entries
- Add WezTerm Lua color scheme (`terminal/wezterm-colors.lua`) with ansi/brights tables
- Add Kitty theme config (`terminal/kitty.conf`) with color0-color15 plus special colors
- All files use the canonical Saga Ledger Norse palette: Void Black background (#07070d), Forge Gold cursor (#c9920a), Parchment foreground (#f0ede4)
- Each file includes header comments with import/install instructions for its terminal emulator

## Test plan

- [ ] `plutil -lint terminal/fenrir.itermcolors` exits 0 (valid XML plist)
- [ ] All 4 files contain correct background #07070d, cursor #c9920a, green #0a8c6e, yellow #f59e0b
- [ ] All files include import instructions in comments
- [ ] No hardcoded absolute paths in any file
- [ ] Cross-file consistency: all 4 files map identical hex values to each ANSI slot

🤖 Generated with [Claude Code](https://claude.com/claude-code)