### PR TITLE
feat: Norse statusline script with rune prefixes and realm-color thresholds

### DIFF
--- a/.claude/settings-bare.json
+++ b/.claude/settings-bare.json
@@ -6,5 +6,9 @@
   "enabledPlugins": {
     "playwright@claude-plugins-official": true,
     "vercel@claude-plugins-official": true
+  },
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/statusline-command.sh"
   }
-}  
+}

--- a/.claude/statusline-command.sh
+++ b/.claude/statusline-command.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# Fenrir Ledger -- Norse Statusline for Claude Code
+# Renders a single-line statusline with Elder Futhark rune prefixes,
+# realm-color thresholds, and responsive width breakpoints.
+#
+# Input:  JSON on stdin from Claude Code
+# Output: ANSI-colored statusline text on stdout
+#
+# JSON fields consumed:
+#   workspace.current_dir     -- for git detection
+#   model.display_name        -- model name
+#   context_window.used_percentage -- integer 0-100
+#   cost.total_cost_usd       -- float
+#   cost.total_duration_ms    -- milliseconds
+#   agent.name                -- optional, present in subagent mode
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# ANSI color variables (24-bit RGB)
+# ---------------------------------------------------------------------------
+FG_GOLD="\033[38;2;201;146;10m"
+FG_PARCHMENT="\033[38;2;240;237;228m"
+FG_STONE="\033[38;2;138;133;120m"
+FG_ASGARD="\033[38;2;10;140;110m"
+FG_HATI="\033[38;2;245;158;11m"
+FG_MUSPEL="\033[38;2;201;74;10m"
+FG_RAGNAROK="\033[38;2;239;68;68m"
+BOLD="\033[1m"
+DIM="\033[2m"
+RESET="\033[0m"
+
+# ---------------------------------------------------------------------------
+# Read JSON from stdin
+# ---------------------------------------------------------------------------
+INPUT="$(cat)"
+
+# ---------------------------------------------------------------------------
+# JSON parsing -- prefer jq, fallback to python3
+# ---------------------------------------------------------------------------
+parse_json_field() {
+    local field="$1"
+    local default="${2:-}"
+    local val=""
+
+    if command -v jq >/dev/null 2>&1; then
+        val="$(printf '%s' "$INPUT" | jq -r "$field // empty" 2>/dev/null)" || true
+    fi
+
+    if [ -z "$val" ] && command -v python3 >/dev/null 2>&1; then
+        val="$(printf '%s' "$INPUT" | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    keys = '''$field'''.strip('.').split('.')
+    v = d
+    for k in keys:
+        if isinstance(v, dict):
+            v = v.get(k)
+        else:
+            v = None
+            break
+    if v is not None:
+        print(v)
+except Exception:
+    pass
+" 2>/dev/null)" || true
+    fi
+
+    if [ -z "$val" ]; then
+        printf '%s' "$default"
+    else
+        printf '%s' "$val"
+    fi
+}
+
+CWD="$(parse_json_field '.workspace.current_dir' '.')"
+MODEL="$(parse_json_field '.model.display_name' 'unknown')"
+CTX_PCT="$(parse_json_field '.context_window.used_percentage' '0')"
+COST_USD="$(parse_json_field '.cost.total_cost_usd' '0')"
+DURATION_MS="$(parse_json_field '.cost.total_duration_ms' '0')"
+AGENT_NAME="$(parse_json_field '.agent.name' '')"
+
+# Ensure numeric values are integers where needed
+CTX_PCT="${CTX_PCT%%.*}"
+DURATION_MS="${DURATION_MS%%.*}"
+
+# ---------------------------------------------------------------------------
+# Git detection
+# ---------------------------------------------------------------------------
+GIT_BRANCH=""
+GIT_DIRTY=""
+GIT_UNTRACKED=""
+
+if git -C "$CWD" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    GIT_BRANCH="$(git -C "$CWD" symbolic-ref --short HEAD 2>/dev/null || git -C "$CWD" rev-parse --short HEAD 2>/dev/null || echo '')"
+
+    if ! git -C "$CWD" diff --quiet 2>/dev/null || ! git -C "$CWD" diff --cached --quiet 2>/dev/null; then
+        GIT_DIRTY="!"
+    fi
+
+    if [ -n "$(git -C "$CWD" ls-files --others --exclude-standard 2>/dev/null | head -1)" ]; then
+        GIT_UNTRACKED="?"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Git diff stats (lines added/deleted)
+# ---------------------------------------------------------------------------
+LINES_ADDED=0
+LINES_DELETED=0
+
+if [ -n "$GIT_BRANCH" ]; then
+    SHORTSTAT="$(git -C "$CWD" diff --shortstat HEAD 2>/dev/null || echo '')"
+    if [ -n "$SHORTSTAT" ]; then
+        # Extract insertions
+        INS="$(printf '%s' "$SHORTSTAT" | grep -oE '[0-9]+ insertion' | grep -oE '[0-9]+' || echo '0')"
+        DEL="$(printf '%s' "$SHORTSTAT" | grep -oE '[0-9]+ deletion' | grep -oE '[0-9]+' || echo '0')"
+        LINES_ADDED="${INS:-0}"
+        LINES_DELETED="${DEL:-0}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Terminal width detection
+# ---------------------------------------------------------------------------
+TERM_WIDTH="$(tput cols 2>/dev/null || echo 120)"
+
+# ---------------------------------------------------------------------------
+# Model name shortening
+# ---------------------------------------------------------------------------
+shorten_model() {
+    local m="$1"
+    case "$m" in
+        *opus-4-6*|*opus-4*)    printf 'opus-4' ;;
+        *sonnet-4-6*|*sonnet-4*|*sonnet*) printf 'sonnet' ;;
+        *haiku-4-5*|*haiku*)    printf 'haiku' ;;
+        *)                      printf '%s' "$m" ;;
+    esac
+}
+
+MODEL_SHORT="$(shorten_model "$MODEL")"
+
+# Compact abbreviations for 80-99 col mode
+abbreviate_model() {
+    local m="$1"
+    case "$m" in
+        opus-4)  printf 'op4' ;;
+        sonnet)  printf 'son' ;;
+        haiku)   printf 'hai' ;;
+        *)       printf '%s' "$m" ;;
+    esac
+}
+
+MODEL_ABBREV="$(abbreviate_model "$MODEL_SHORT")"
+
+# ---------------------------------------------------------------------------
+# Branch truncation
+# ---------------------------------------------------------------------------
+truncate_branch() {
+    local branch="$1"
+    local max="$2"
+    if [ "${#branch}" -gt "$max" ]; then
+        local cut=$((max - 1))
+        printf '%s' "${branch:0:$cut}…"
+    else
+        printf '%s' "$branch"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Cost formatting and color
+# ---------------------------------------------------------------------------
+format_cost() {
+    printf '$%.2f' "$COST_USD"
+}
+
+cost_color() {
+    # Use bc for floating-point comparison, fallback to python3
+    local cost="$COST_USD"
+    if command -v bc >/dev/null 2>&1; then
+        if [ "$(echo "$cost > 10" | bc -l 2>/dev/null)" = "1" ]; then
+            printf '%b%b' "$FG_RAGNAROK" "$BOLD"
+            return
+        elif [ "$(echo "$cost > 5" | bc -l 2>/dev/null)" = "1" ]; then
+            printf '%b' "$FG_MUSPEL"
+            return
+        elif [ "$(echo "$cost >= 2" | bc -l 2>/dev/null)" = "1" ]; then
+            printf '%b' "$FG_HATI"
+            return
+        else
+            printf '%b' "$FG_PARCHMENT"
+            return
+        fi
+    fi
+
+    # Fallback: python3
+    if command -v python3 >/dev/null 2>&1; then
+        local tier
+        tier="$(python3 -c "
+c = float('$cost')
+if c > 10: print('ragnarok')
+elif c > 5: print('muspel')
+elif c >= 2: print('hati')
+else: print('parchment')
+" 2>/dev/null)" || true
+        case "$tier" in
+            ragnarok) printf '%b%b' "$FG_RAGNAROK" "$BOLD" ;;
+            muspel)   printf '%b' "$FG_MUSPEL" ;;
+            hati)     printf '%b' "$FG_HATI" ;;
+            *)        printf '%b' "$FG_PARCHMENT" ;;
+        esac
+        return
+    fi
+
+    # Last resort: treat as parchment
+    printf '%b' "$FG_PARCHMENT"
+}
+
+# ---------------------------------------------------------------------------
+# Context bar color
+# ---------------------------------------------------------------------------
+ctx_color() {
+    local pct="$1"
+    if [ "$pct" -ge 90 ]; then
+        printf '%b%b' "$FG_RAGNAROK" "$BOLD"
+    elif [ "$pct" -ge 80 ]; then
+        printf '%b' "$FG_MUSPEL"
+    elif [ "$pct" -ge 60 ]; then
+        printf '%b' "$FG_HATI"
+    else
+        printf '%b' "$FG_ASGARD"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Progress bar (10 chars: filled=▓, empty=░)
+# ---------------------------------------------------------------------------
+progress_bar() {
+    local pct="$1"
+    local width=10
+    local filled=$(( (pct * width + 50) / 100 ))
+    if [ "$filled" -gt "$width" ]; then filled=$width; fi
+    if [ "$filled" -lt 0 ]; then filled=0; fi
+    local empty=$(( width - filled ))
+
+    local bar=""
+    local i=0
+    while [ "$i" -lt "$filled" ]; do
+        bar="${bar}▓"
+        i=$((i + 1))
+    done
+    i=0
+    while [ "$i" -lt "$empty" ]; do
+        bar="${bar}░"
+        i=$((i + 1))
+    done
+    printf '%s' "$bar"
+}
+
+# ---------------------------------------------------------------------------
+# Duration formatting
+# ---------------------------------------------------------------------------
+format_duration() {
+    local ms="$1"
+    local total_sec=$(( ms / 1000 ))
+    local hours=$(( total_sec / 3600 ))
+    local mins=$(( (total_sec % 3600) / 60 ))
+
+    if [ "$hours" -gt 0 ]; then
+        printf '%dh %dm' "$hours" "$mins"
+    else
+        printf '%dm' "$mins"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Ragnarok mode detection: context >= 90% AND cost > $10
+# ---------------------------------------------------------------------------
+is_ragnarok_mode() {
+    if [ "$CTX_PCT" -ge 90 ]; then
+        if command -v bc >/dev/null 2>&1; then
+            if [ "$(echo "$COST_USD > 10" | bc -l 2>/dev/null)" = "1" ]; then
+                return 0
+            fi
+        elif command -v python3 >/dev/null 2>&1; then
+            if python3 -c "exit(0 if float('$COST_USD') > 10 else 1)" 2>/dev/null; then
+                return 0
+            fi
+        fi
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# Separator: normal = gold │, Ragnarok = red ┃
+# ---------------------------------------------------------------------------
+separator() {
+    if is_ragnarok_mode; then
+        printf '%b┃%b' "${FG_RAGNAROK}" "${RESET}"
+    else
+        printf '%b│%b' "${FG_GOLD}" "${RESET}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Section builders
+# ---------------------------------------------------------------------------
+
+# Section 1: Git branch with dirty/untracked markers
+section_branch() {
+    local max_len="${1:-20}"
+    local branch_display
+    branch_display="$(truncate_branch "$GIT_BRANCH" "$max_len")"
+    local markers=""
+    if [ -n "$GIT_DIRTY" ] || [ -n "$GIT_UNTRACKED" ]; then
+        markers="${FG_HATI}${GIT_DIRTY}${GIT_UNTRACKED}${RESET}"
+    fi
+    printf '%b%bᚱ %b%s%b%b' "${FG_GOLD}" "" "${FG_PARCHMENT}" "$branch_display" "${RESET}" "$markers"
+}
+
+# Section 2: Model name
+section_model() {
+    local name="${1:-$MODEL_SHORT}"
+    printf '%bᛖ %b%s%b' "${FG_GOLD}" "${FG_PARCHMENT}" "$name" "${RESET}"
+}
+
+# Section 3: Cost
+section_cost() {
+    local cost_str
+    cost_str="$(format_cost)"
+    local color
+    color="$(cost_color)"
+    printf '%bᚠ %b%s%b' "${FG_GOLD}" "$color" "$cost_str" "${RESET}"
+}
+
+# Section 4: Context window with progress bar
+section_context() {
+    local color
+    color="$(ctx_color "$CTX_PCT")"
+    local bar
+    bar="$(progress_bar "$CTX_PCT")"
+    printf '%bᚾ %b%d%% %s%b' "${FG_GOLD}" "$color" "$CTX_PCT" "$bar" "${RESET}"
+}
+
+# Section 5: Lines added/deleted
+section_lines() {
+    if [ "$LINES_ADDED" -eq 0 ] && [ "$LINES_DELETED" -eq 0 ]; then
+        printf '%b+0/-0%b' "${FG_STONE}" "${RESET}"
+    else
+        printf '%b+%d%b/%b-%d%b' "${FG_ASGARD}" "$LINES_ADDED" "${RESET}" "${FG_RAGNAROK}" "$LINES_DELETED" "${RESET}"
+    fi
+}
+
+# Section 6: Duration
+section_duration() {
+    local dur
+    dur="$(format_duration "$DURATION_MS")"
+    printf '%bᛏ %b%s%b' "${FG_GOLD}" "${FG_STONE}" "$dur" "${RESET}"
+}
+
+# Section 7: Agent
+section_agent() {
+    if [ -n "$AGENT_NAME" ]; then
+        printf '%bᚲ %b%b%s%b' "${FG_GOLD}" "${FG_PARCHMENT}" "${BOLD}" "$AGENT_NAME" "${RESET}"
+    else
+        printf '%bᛁ%b' "${FG_STONE}" "${RESET}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Width-responsive rendering
+# ---------------------------------------------------------------------------
+SEP="$(separator)"
+
+if [ "$TERM_WIDTH" -ge 100 ]; then
+    # Full layout: all 7 sections
+    printf '%b' "$(section_branch 20) ${SEP} $(section_model "$MODEL_SHORT") ${SEP} $(section_cost) ${SEP} $(section_context) ${SEP} $(section_lines) ${SEP} $(section_duration) ${SEP} $(section_agent)"
+
+elif [ "$TERM_WIDTH" -ge 80 ]; then
+    # Compact: truncate branch to 15, abbreviate model, drop duration
+    printf '%b' "$(section_branch 15) ${SEP} $(section_model "$MODEL_ABBREV") ${SEP} $(section_cost) ${SEP} $(section_context) ${SEP} $(section_lines) ${SEP} $(section_agent)"
+
+elif [ "$TERM_WIDTH" -ge 60 ]; then
+    # Minimal: branch + cost + context bar only
+    printf '%b' "$(section_branch 12) ${SEP} $(section_cost) ${SEP} $(section_context)"
+
+else
+    # Ultra-compact: ctx:XX% | $cost
+    printf '%bctx:%d%%%b %b│%b %b%s%b' "${FG_PARCHMENT}" "$CTX_PCT" "${RESET}" "${FG_GOLD}" "${RESET}" "$(cost_color)" "$(format_cost)" "${RESET}"
+fi

--- a/development/qa-handoff-statusline.md
+++ b/development/qa-handoff-statusline.md
@@ -1,0 +1,116 @@
+# QA Handoff: Norse Statusline Script
+
+## What Was Implemented
+
+**Story**: Norse Statusline for Claude Code (from the Claude Terminal Skin product design brief)
+
+A bash script at `.claude/statusline-command.sh` that renders a single-line statusline with Elder Futhark rune prefixes, Norse realm-color thresholds, and responsive width breakpoints. The `statusLine` configuration has been added to `.claude/settings-bare.json`.
+
+## Files Created/Modified
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.claude/statusline-command.sh` | Created | Main statusline script (executable). Reads JSON on stdin, outputs ANSI-colored text. |
+| `.claude/settings-bare.json` | Modified | Added `statusLine.type: "command"` and `statusLine.command: ".claude/statusline-command.sh"` |
+| `development/qa-handoff-statusline.md` | Created | This file |
+
+## How to Test
+
+### Basic Functionality Test
+
+Run this command from the repo root to verify the script parses JSON and outputs valid ANSI:
+
+```bash
+echo '{"workspace":{"current_dir":"'"$(pwd)"'"},"model":{"display_name":"claude-sonnet-4-6"},"context_window":{"used_percentage":67},"cost":{"total_cost_usd":1.42,"total_duration_ms":900000},"agent":{"name":"Luna"}}' | bash .claude/statusline-command.sh
+```
+
+Expected: A single line with rune prefixes, branch name, model name, cost, context bar, line counts, duration, and agent name.
+
+### Width Breakpoint Tests
+
+Test each breakpoint by overriding `tput cols`:
+
+```bash
+# Full layout (>= 100 cols): all 7 sections
+echo '...' | COLUMNS=120 bash -c 'tput() { echo 120; }; export -f tput; source .claude/statusline-command.sh'
+
+# Compact (80-99 cols): drop duration, truncate branch to 15, abbreviate model
+echo '...' | COLUMNS=90 bash -c 'tput() { echo 90; }; export -f tput; source .claude/statusline-command.sh'
+
+# Minimal (60-79 cols): branch + cost + context only
+echo '...' | COLUMNS=70 bash -c 'tput() { echo 70; }; export -f tput; source .claude/statusline-command.sh'
+
+# Ultra-compact (< 60 cols): ctx:XX% | $X.XX
+echo '...' | COLUMNS=50 bash -c 'tput() { echo 50; }; export -f tput; source .claude/statusline-command.sh'
+```
+
+### Color Threshold Tests
+
+**Context bar colors** (verify with `cat -v` or visual inspection in a terminal):
+
+| Percentage | Expected Color | ANSI Code |
+|------------|---------------|-----------|
+| 23% | Asgard teal | `38;2;10;140;110` |
+| 67% | Hati amber | `38;2;245;158;11` |
+| 85% | Muspel orange | `38;2;201;74;10` |
+| 97% | Ragnarok red + bold | `38;2;239;68;68` + `1` |
+
+**Cost colors**:
+
+| Amount | Expected Color | ANSI Code |
+|--------|---------------|-----------|
+| $0.50 | Parchment | `38;2;240;237;228` |
+| $3.00 | Hati amber | `38;2;245;158;11` |
+| $7.00 | Muspel orange | `38;2;201;74;10` |
+| $12.00 | Ragnarok red + bold | `38;2;239;68;68` + `1` |
+
+### Ragnarok Mode Test
+
+When context >= 90% AND cost > $10, separators switch from `│` (light) to `┃` (heavy) in Ragnarok red:
+
+```bash
+echo '{"workspace":{"current_dir":"'"$(pwd)"'"},"model":{"display_name":"claude-opus-4-6"},"context_window":{"used_percentage":95},"cost":{"total_cost_usd":14.20,"total_duration_ms":11400000}}' | bash .claude/statusline-command.sh
+```
+
+### Agent Section Test
+
+- With agent: shows `ᚲ <name>` (Kenaz rune in gold, name in parchment bold)
+- Without agent: shows `ᛁ` (Isa rune in stone muted)
+
+### Branch Truncation Test
+
+Branches longer than 20 characters should truncate with `...` (ellipsis character). The current branch `feat/terminal-skin-statusline` is 30 chars, so it should truncate.
+
+### Git Detection Test
+
+- Script detects branch name via `git symbolic-ref`
+- Dirty flag `!` appears when there are uncommitted changes
+- Untracked flag `?` appears when there are untracked files
+- Lines added/deleted from `git diff --shortstat HEAD`
+
+## Acceptance Criteria Checklist
+
+- [ ] Script parses all JSON fields without errors
+- [ ] All 4 width breakpoints render correctly (>=100, 80-99, 60-79, <60)
+- [ ] Context bar: teal at 23%, amber at 67%, orange at 85%, red+bold at 97%
+- [ ] Cost: parchment at $0.50, amber at $3, orange at $7, red+bold at $12
+- [ ] Ragnarok mode: heavy separators when context >= 90% AND cost > $10
+- [ ] Agent section shows Kenaz rune when agent present, Isa rune when absent
+- [ ] Branch truncates at 20 chars with ellipsis
+- [ ] `settings-bare.json` has `statusLine.command` set
+- [ ] `.claude/statusline-command.sh` is executable (`chmod +x`)
+- [ ] Test command produces valid ANSI output
+
+## Known Limitations
+
+1. **Git diff stats**: The `+add/-del` section counts lines from `git diff --shortstat HEAD`. In a clean working tree, this shows `+0/-0`. It does not include staged-only changes or commits not yet pushed.
+2. **Width detection in non-TTY**: When piped (e.g., `echo ... | bash script`), `tput cols` may fall back to 120. In a real Claude Code session, the terminal width is correctly detected.
+3. **Font requirements**: Elder Futhark rune characters (U+16A0..U+16DF) require a font with runic support. Most modern terminal fonts (JetBrains Mono, Fira Code, etc.) support these via fallback fonts on macOS.
+4. **settings-observability.json**: The tracked `settings-bare.json` has the statusLine config. Users running with the observability hooks setup need to add the `statusLine` block to their local `settings-observability.json` manually.
+
+## Suggested Test Focus Areas
+
+1. Visual rendering in an actual terminal (iTerm2, Terminal.app, Ghostty) to confirm colors display correctly
+2. Edge cases: empty JSON, missing fields, very long branch names
+3. Ragnarok mode transitions (both entering and exiting the threshold)
+4. Performance: the script should execute in under 50ms per render


### PR DESCRIPTION
## Summary

- Add `.claude/statusline-command.sh` -- a Norse-themed statusline script for Claude Code with Elder Futhark rune prefixes, realm-color thresholds (Asgard/Hati/Muspel/Ragnarok), and a 10-char progress bar
- Add `statusLine` configuration to `.claude/settings-bare.json` to wire the script into Claude Code
- Add QA handoff document with test instructions for all breakpoints and thresholds

### Statusline Sections (7 total)

1. **ᚱ Branch** -- Raidho rune, branch name with dirty/untracked markers
2. **ᛖ Model** -- Ehwaz rune, shortened model name (opus-4, sonnet, haiku)
3. **ᚠ Cost** -- Fehu rune, dollar amount with 4-tier color threshold
4. **ᚾ Context** -- Naudiz rune, percentage + 10-char progress bar with 4-tier color
5. **+add/-del** -- Git diff stats (teal additions, red deletions)
6. **ᛏ Duration** -- Tiwaz rune, session time in Xm or Xh Ym format
7. **ᚲ/ᛁ Agent** -- Kenaz (active) or Isa (idle) rune with agent name

### Width Breakpoints

| Width | Layout |
|-------|--------|
| >= 100 | All 7 sections |
| 80-99 | Drop duration, truncate branch to 15, abbreviate model |
| 60-79 | Branch + cost + context only |
| < 60 | `ctx:XX% \| $X.XX` only |

### Ragnarok Mode

When context >= 90% AND cost > $10, all separators switch from light `│` to heavy `┃` in Ragnarok red.

## Test plan

- [ ] Run basic test: `echo '<json>' | bash .claude/statusline-command.sh` outputs valid ANSI
- [ ] Verify all 4 width breakpoints render correct sections
- [ ] Verify context bar colors: teal at 23%, amber at 67%, orange at 85%, red+bold at 97%
- [ ] Verify cost colors: parchment at $0.50, amber at $3, orange at $7, red+bold at $12
- [ ] Verify Ragnarok mode: heavy separators when ctx >= 90% AND cost > $10
- [ ] Verify agent section: Kenaz rune when present, Isa rune when absent
- [ ] Verify branch truncation at 20 chars with ellipsis
- [ ] Verify `settings-bare.json` has statusLine config
- [ ] Verify script is executable (chmod +x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)