### PR TITLE
fix: rename LLM env vars to avoid shell collision

### DIFF
--- a/development/frontend/.env.example
+++ b/development/frontend/.env.example
@@ -58,5 +58,6 @@ GOOGLE_PICKER_API_KEY=
 # Used server-side only by /api/sheets/import to extract card data from CSV.
 #
 # Obtain from: https://console.anthropic.com/
+# FENRIR_ prefix avoids collision with shell-level ANTHROPIC_API_KEY (e.g. Claude Code).
 # No NEXT_PUBLIC_ prefix — Next.js will NOT include this in the client bundle.
-ANTHROPIC_API_KEY=
+FENRIR_ANTHROPIC_API_KEY=

--- a/development/frontend/src/lib/llm/extract.ts
+++ b/development/frontend/src/lib/llm/extract.ts
@@ -87,14 +87,14 @@ export function getLlmProvider(): LlmProvider {
 
   switch (provider) {
     case "anthropic": {
-      const key = process.env.ANTHROPIC_API_KEY;
-      if (!key) throw new Error("ANTHROPIC_API_KEY is required when LLM_PROVIDER=anthropic.");
+      const key = process.env.FENRIR_ANTHROPIC_API_KEY;
+      if (!key) throw new Error("FENRIR_ANTHROPIC_API_KEY is required when LLM_PROVIDER=anthropic.");
       _instance = new AnthropicProvider(key);
       break;
     }
     case "openai": {
-      const key = process.env.OPENAI_API_KEY;
-      if (!key) throw new Error("OPENAI_API_KEY is required when LLM_PROVIDER=openai.");
+      const key = process.env.FENRIR_OPENAI_API_KEY;
+      if (!key) throw new Error("FENRIR_OPENAI_API_KEY is required when LLM_PROVIDER=openai.");
       _instance = new OpenAIProvider(key);
       break;
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `ANTHROPIC_API_KEY` set in the developer's shell (by Claude Code) silently overrides the `.env.local` value via `process.env` inheritance, causing `invalid x-api-key` errors from the Anthropic SDK
- **Fix**: Rename `ANTHROPIC_API_KEY` → `FENRIR_ANTHROPIC_API_KEY` and `OPENAI_API_KEY` → `FENRIR_OPENAI_API_KEY` so the app's keys never collide with tooling credentials
- **Files**: `extract.ts` (env var reads), `.env.example` (template), `.env.local` (gitignored, updated locally)

## Test plan

- [x] `npm run build` — zero errors
- [x] Verified runtime reads `FENRIR_ANTHROPIC_API_KEY` from `.env.local` (key ending `...NQAA`, not shell key ending `...2QAA`)
- [x] Anthropic API call succeeds with correct key (got 529 overloaded — transient, not auth failure)
- [ ] Full import test when API load subsides

🤖 Generated with [Claude Code](https://claude.com/claude-code)