### PR TITLE
chore: add CLAUDE.md rules for secrets, shell paths, and worktree safety

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,39 @@
 
 See `.claude/skills/git-commit/SKILL.md` for branch naming conventions and the full workflow.
 
+## Repository Self-Containment (UNBREAKABLE RULE)
+
+**This repo MUST be fully self-contained. No file in this repo — and no artifact it
+installs outside the repo (e.g. shell snippets in `~/.zshrc`) — may reference paths
+inside `.claude/worktrees/`.** Worktrees are ephemeral and deleted after use.
+
+Specifically:
+- **Scripts that write paths into external config files** (e.g. `terminal/install.sh`
+  writing to `~/.zshrc`) MUST resolve to the **main worktree / repo root**, never
+  a sub-worktree path. Use `git worktree list --porcelain | head -1` to find the
+  primary checkout.
+- **Symlinks** created by installers MUST target files in the main repo, not a worktree.
+- **Source statements, imports, and include directives** written to files outside this
+  repo MUST use stable paths that survive worktree cleanup.
+- Before writing any path to an external file, **verify it does not contain
+  `.claude/worktrees/`** in the path string.
+- **Source/include directives written to external files** (e.g. `~/.zshrc`) MUST
+  guard with an existence check so the shell does not error if the repo is missing
+  or moved. Use `[[ -f "<path>" ]] && source "<path>"` — never a bare `source`.
+
+## Shell Customization Locations (UNBREAKABLE RULE)
+
+**Never append shell customizations directly to `~/.zshrc`.** Use the appropriate
+profile file based on scope:
+
+| Scope | File | When to use |
+|---|---|---|
+| Common / shared | `~/.config/zsh/zshrc` | Aliases, functions, and env vars that apply everywhere |
+| Personal projects | `~/.config/zsh/zshrc.dshanaghy` | Personal project paths, tokens, tool configs |
+| Work (Cribl) | `~/.config/zsh/zshrc.cribl` | Work-specific env, paths, tool configs |
+
+`~/.zshrc` sources these files — treat it as read-only infrastructure.
+
 ## Security
 
 ### Secret Masking (UNBREAKABLE RULE)
@@ -44,6 +77,24 @@ masked = secret[0..3] + "x".repeat(secret.length - 8) + secret[-4..]
 
 **When a tool result contains an unmasked secret**, restate it masked before continuing.
 Never re-echo the raw value in any follow-up message.
+
+### No Secrets in Conversation (UNBREAKABLE RULE)
+
+**Never ask the user to paste, type, or provide secrets, tokens, keys, or credentials
+directly into the Claude Code conversation.** Always read secrets from the files the
+app already uses for configuration:
+
+- `.env`, `.env.local`, `.env.production` — Next.js / Node environment files
+- `.secret` files — any project-specific secret stores
+- Vercel env vars — read via `vercel env pull` or `vercel env ls`
+- GitHub Actions secrets — managed via `gh secret set` / `gh secret list`
+
+When a secret needs to be set or updated:
+1. **Read it from the source file** (e.g. `.env.local`) — never ask the user to paste it.
+2. **Pipe from file to CLI** when configuring external services
+   (e.g. `vercel env add KEY production < <(grep '^KEY=' .env.local | cut -d= -f2-)`).
+3. If the value doesn't exist in any file yet, **ask the user to add it to the
+   appropriate `.env` file first**, then read it from there.
 
 ### No Secrets in Public-Facing Output (UNBREAKABLE RULE)
 

--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -55,10 +55,18 @@ info() {
 }
 
 # ---------------------------------------------------------------------------
-# Resolve repo root (directory containing this script's parent)
+# Resolve repo root — ALWAYS the main worktree, never a sub-worktree.
+# If run from inside a git worktree, resolve back to the primary checkout
+# so that paths written to ~/.zshrc remain stable after worktrees are removed.
 # ---------------------------------------------------------------------------
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" worktree list --porcelain 2>/dev/null \
+             | head -1 | sed 's/^worktree //')" \
+  || REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Fallback if git is unavailable or repo is not a worktree
+if [ -z "$REPO_ROOT" ]; then
+    REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
 
 # ---------------------------------------------------------------------------
 # Prerequisite check: jq
@@ -178,9 +186,10 @@ else
     cat >> "$ZSHRC" << ZSHEOF
 
 ${GUARD_COMMENT}
-# Wraps the claude command with the Fenrir Elder Futhark splash screen.
+# Defines fenrir-claude command with the Fenrir Elder Futhark splash screen.
 # To remove: delete everything between the >>> and <<< markers.
-source "${SNIPPET_SRC}"
+[[ -f "${SNIPPET_SRC}" ]] \\
+  && source "${SNIPPET_SRC}"
 ${END_COMMENT}
 ZSHEOF
 

--- a/terminal/zshrc-snippet.sh
+++ b/terminal/zshrc-snippet.sh
@@ -1,12 +1,14 @@
 # Fenrir Ledger — Claude Code splash wrapper
 # Source this in your .zshrc or let terminal/install.sh do it automatically.
 #
-# This wraps the `claude` command to display the Fenrir Elder Futhark
+# Defines the `fenrir-claude` command which displays the Fenrir Elder Futhark
 # splash screen before launching Claude Code. All arguments are forwarded
 # to the real `claude` binary unchanged.
 #
 # Usage:
 #   source /path/to/fenrir-ledger/terminal/zshrc-snippet.sh
+#   fenrir-claude          # launch with splash screen
+#   claude                 # launch normally (unmodified)
 
 # Guard: only define once
 if ! type fenrir-claude > /dev/null 2>&1; then
@@ -18,5 +20,4 @@ if ! type fenrir-claude > /dev/null 2>&1; then
     fi
     command claude "$@"
   }
-  alias claude="fenrir-claude"
 fi


### PR DESCRIPTION
## Summary
- Add **No Secrets in Conversation** rule: never ask user to paste secrets; read from `.env` files and pipe to CLI
- Add **Repository Self-Containment** rule: all paths must resolve to main worktree, never sub-worktrees
- Add **Shell Customization Locations** rule: use `~/.config/zsh/` files, not `~/.zshrc` directly
- Update `terminal/install.sh` to resolve main worktree path and add existence guards for source directives
- Update `terminal/zshrc-snippet.sh` to use `fenrir-claude` command name

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Run `terminal/install.sh` from a worktree — paths should resolve to main repo root
- [ ] Verify `[[ -f ... ]] && source` guard works when repo is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)