### PR TITLE
fix: prevent import wizard from closing when Google Picker dismisses

### DIFF
--- a/development/frontend/src/components/sheets/ImportWizard.tsx
+++ b/development/frontend/src/components/sheets/ImportWizard.tsx
@@ -184,6 +184,7 @@ export function ImportWizard({ open, onClose, onConfirmImport, existingCards }: 
       <DialogContent
         className="w-[92vw] max-w-[680px] max-h-[90vh] overflow-hidden flex flex-col border-border bg-background"
         aria-label="Import Wizard"
+        onInteractOutside={(e) => e.preventDefault()}
       >
         {/* Step indicator */}
         <StepIndicator activeStep={getStepIndex(step)} />


### PR DESCRIPTION
## Summary

- Adds `onInteractOutside={(e) => e.preventDefault()}` to the ImportWizard's `DialogContent`
- Fixes a bug where the Radix UI dialog dismissed the entire import wizard when the Google Picker's `<dialog>` element closed after file selection
- The full pipeline (Picker → Sheets API → LLM extraction → Preview) now completes without the wizard closing prematurely

## Root Cause

When the Google Picker's native `<dialog>` closes after the user selects a file, Radix UI's Dialog detects this as an "interact outside" event and auto-closes the import wizard. This happened before the API response could render the preview step, causing extracted card data to be lost.

## Test plan

- [x] Path B: Sign in → Import → Browse the Archives → Allow Access → Search "credit card" → Select file → Picker closes → Loading spinner → **Preview shows 9 cards** → Import → Success
- [x] Path A (URL) and Path C (CSV) unaffected — wizard still closes via explicit Cancel/X buttons
- [x] TypeScript: `npx tsc --noEmit` passes
- [x] ESC key still closes the wizard (controlled by `onEscapeKeyDown`, separate from `onInteractOutside`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)