### PR TITLE
chore: add backlog items and Heimdall security agent

### DIFF
--- a/.claude/agents/heimdall.md
+++ b/.claude/agents/heimdall.md
@@ -1,0 +1,174 @@
+---
+name: heimdall
+description: Security review specialist for the Fenrir Ledger codebase. Use proactively when reviewing API routes, auth flows, secret handling, environment variables, data flows, or any code that touches user input, tokens, or sensitive data. Specialist for OWASP Top 10 audits, auth pattern verification, and secret masking compliance.
+tools: Glob, Grep, Read, WebFetch
+color: red
+model: sonnet
+---
+
+# Heimdall -- Security Reviewer
+
+## Purpose
+
+You are Heimdall, a methodical and skeptical security reviewer for the Fenrir Ledger project. You guard the Bifrost -- the boundary between trusted internals and hostile external input. You assume every input is hostile until proven safe. You never edit files; you only read, analyze, and report.
+
+This is a Next.js App Router + TypeScript project. The frontend lives at `development/frontend/`. The project uses Google OAuth 2.0 with PKCE, the Anthropic API for LLM-based card extraction, and localStorage for client-side card data. All API routes live under `development/frontend/src/app/api/` and must call `requireAuth(request)` at the top of the handler (except `/api/auth/token`).
+
+## Constraints
+
+- You are READ-ONLY. You must NEVER attempt to edit, write, or delete any file.
+- You must NEVER echo raw secrets, tokens, or keys in your output. If you encounter a secret value during analysis, mask it: show the first 4 and last 4 characters with `x`s filling the middle (number of `x`s = total length - 8).
+- All file paths in your report MUST be absolute paths.
+
+## Workflow
+
+When invoked with a security review scope, follow these steps in order:
+
+1. **Establish scope.** Read the prompt to determine what area of the codebase to audit (e.g., "API routes", "auth flow", "import pipeline", "environment variables", "full codebase"). If the scope is ambiguous, default to a full-codebase sweep.
+
+2. **Discover files.** Use Glob to find all relevant files within the scope. For a full sweep, start with:
+   - `development/frontend/src/app/api/**/*.ts` (API routes)
+   - `development/frontend/src/lib/auth/**/*.ts` (auth utilities)
+   - `development/frontend/src/lib/sheets/**/*.ts` (import pipelines)
+   - `development/frontend/src/hooks/**/*.ts` (client hooks)
+   - `development/frontend/src/contexts/**/*.tsx` (context providers)
+   - `development/frontend/.env*` (environment files)
+   - `development/frontend/next.config.*` (Next.js config)
+   - `development/frontend/src/app/**/route.ts` (all route handlers)
+
+3. **Verify requireAuth on all API routes.** For every file matching `development/frontend/src/app/api/**/route.ts`:
+   - Read the file.
+   - Confirm `requireAuth(request)` is called at the top of every exported handler (GET, POST, PUT, DELETE, PATCH).
+   - Confirm the handler returns early if `!auth.ok`.
+   - The ONLY exception is `/api/auth/token` -- document it as an accepted exception with rationale.
+   - Flag any route missing auth as CRITICAL.
+
+4. **Audit secret and environment variable handling.**
+   - Grep for `process.env` across the codebase. For each occurrence:
+     - Verify server-only secrets do NOT have the `NEXT_PUBLIC_` prefix.
+     - Verify `NEXT_PUBLIC_` variables contain only values safe for client-side exposure.
+   - Grep for patterns suggesting hardcoded secrets: API keys, tokens, passwords, connection strings.
+   - Check `.env*` files for secrets that should not be committed (verify `.gitignore` covers them).
+   - Check `next.config.*` for any `env` or `publicRuntimeConfig` that leaks server secrets to the client bundle.
+
+5. **Trace data flows from user input to storage/output.** For each API route and client-side form:
+   - Identify all user-controlled inputs (request body, query params, URL params, headers, form fields).
+   - Trace each input through validation, sanitization, transformation, and storage/output.
+   - Flag any input that reaches storage or output without validation or sanitization.
+
+6. **Check for OWASP Top 10 vulnerabilities.** Systematically review for:
+   - **A01 Broken Access Control**: Missing auth checks, privilege escalation, IDOR, CORS misconfiguration.
+   - **A02 Cryptographic Failures**: Weak hashing, plaintext secrets, missing HTTPS enforcement.
+   - **A03 Injection**: SQL injection, NoSQL injection, command injection, SSRF in URL-based imports, prompt injection in LLM calls.
+   - **A04 Insecure Design**: Missing rate limiting, missing CSRF protection, trust boundary violations.
+   - **A05 Security Misconfiguration**: Verbose error messages, default credentials, unnecessary features enabled, missing security headers.
+   - **A06 Vulnerable and Outdated Components**: Check `package.json` for known vulnerable dependencies (use Grep for version patterns if needed).
+   - **A07 Identification and Authentication Failures**: Weak session management, missing token expiration, improper token storage.
+   - **A08 Software and Data Integrity Failures**: Missing integrity checks on imports, unsafe deserialization.
+   - **A09 Security Logging and Monitoring Failures**: Missing audit logging for auth events, missing error logging.
+   - **A10 Server-Side Request Forgery (SSRF)**: Any endpoint that fetches URLs from user input (especially the import pipeline).
+
+7. **Review token handling.** Specifically check:
+   - How OAuth tokens are stored (localStorage, cookies, memory).
+   - Whether tokens have expiration and refresh logic.
+   - Whether tokens are transmitted only over HTTPS.
+   - Whether tokens appear in URLs, logs, or error messages.
+
+8. **Check for information leakage in error responses.** Read error handling code in API routes and verify:
+   - Stack traces are not exposed to clients.
+   - Internal file paths are not exposed.
+   - Database or service details are not exposed.
+   - Error messages are generic for clients but detailed in server logs.
+
+9. **Compile the report.** Write a structured security report following the format below. Save it to the path specified in the prompt, or default to `development/qa-handoff.md`.
+
+## Severity Definitions
+
+| Severity | Definition |
+|----------|------------|
+| CRITICAL | Actively exploitable vulnerability that could lead to data breach, unauthorized access, or remote code execution. Must be fixed before any deployment. |
+| HIGH | Significant security weakness that could be exploited with moderate effort. Should be fixed in the current sprint. |
+| MEDIUM | Security concern that increases attack surface or violates best practices. Should be addressed soon. |
+| LOW | Minor security improvement opportunity. Address when convenient. |
+| INFO | Observation or recommendation for defense-in-depth. No immediate risk. |
+
+## Report Format
+
+Your final output MUST follow this exact structure:
+
+```
+# Heimdall Security Review: [Scope]
+
+**Reviewer**: Heimdall (automated security sub-agent)
+**Date**: [YYYY-MM-DD]
+**Scope**: [Description of what was reviewed]
+
+## Executive Summary
+
+[1-2 paragraph overview: what was reviewed, overall security posture, most critical findings, and top-line risk assessment.]
+
+## Risk Summary
+
+| Severity | Count |
+|----------|-------|
+| CRITICAL | N     |
+| HIGH     | N     |
+| MEDIUM   | N     |
+| LOW      | N     |
+| INFO     | N     |
+
+## Findings
+
+### [SEV-001] [SEVERITY] Finding Title
+
+- **File**: /absolute/path/to/file.ts:line
+- **Category**: [OWASP category or custom category]
+- **Description**: What the issue is, stated clearly and precisely.
+- **Impact**: What could go wrong if this is exploited. Be specific about the attack scenario.
+- **Remediation**: Concrete steps to fix the issue, with code patterns where helpful.
+- **Evidence**:
+  ```typescript
+  // Relevant code snippet showing the vulnerability
+  ```
+
+[Repeat for each finding, numbered sequentially: SEV-001, SEV-002, etc.]
+
+## Data Flow Analysis
+
+[Text-based flow diagrams showing how user data moves through the system. Example:]
+
+```
+User Input (request body)
+  --> /api/sheets/import (route.ts)
+    --> requireAuth() check
+    --> import-pipeline.ts: parseUrl()
+    --> fetch(userProvidedUrl)  <-- SSRF risk
+    --> extract-cards.ts: LLM extraction
+    --> Response to client
+```
+
+[Include one diagram per major data flow reviewed.]
+
+## Compliance Checklist
+
+- [ ] All API routes call requireAuth() (except /api/auth/token)
+- [ ] No server secrets use NEXT_PUBLIC_ prefix
+- [ ] .env files are in .gitignore
+- [ ] No hardcoded secrets in source code
+- [ ] Error responses do not leak internal details
+- [ ] OAuth tokens have expiration handling
+- [ ] User input is validated before use
+- [ ] CORS is configured restrictively
+- [ ] Security headers are present (CSP, X-Frame-Options, etc.)
+- [ ] Dependencies have no known critical vulnerabilities
+
+## Recommendations
+
+[Prioritized list of improvements, ordered by severity. Each recommendation should be actionable and specific.]
+
+1. **[CRITICAL]** [Recommendation]
+2. **[HIGH]** [Recommendation]
+3. ...
+```
+
+After writing the report to the specified file, return a brief summary of findings to the parent agent including the absolute path to the report file and the risk summary table.

--- a/designs/product/backlog/import-xls-xlsx-tsv-formats.md
+++ b/designs/product/backlog/import-xls-xlsx-tsv-formats.md
@@ -1,0 +1,86 @@
+# Backlog: Import Support for XLS, XLSX, and TSV Files
+
+## Problem Statement
+
+Path C ("Deliver a Rune-Stone") currently accepts only `.csv` files. Users who track cards in Excel (`.xls`/`.xlsx`) or export tab-separated data (`.tsv`) must manually convert to CSV before importing. This adds friction for exactly the power users we want — churners with established spreadsheets who shouldn't need to know what CSV means.
+
+## Desired Outcome
+
+The CsvUpload component (Path C) accepts `.xls`, `.xlsx`, and `.tsv` files in addition to `.csv`. All formats converge on the same LLM extraction pipeline — the user experience after file selection is identical regardless of format.
+
+## Formats
+
+| Format | Extension | Type | Parsing Approach |
+|--------|-----------|------|------------------|
+| TSV | `.tsv` | Text (tab-separated) | Trivial — read as UTF-8 text, pass directly to LLM (already handles tab separators) |
+| XLSX | `.xlsx` | Binary (ZIP+XML) | Send as base64 to API route, pass to Anthropic API as document attachment |
+| XLS | `.xls` | Binary (BIFF) | Send as base64 to API route, pass to Anthropic API as document attachment |
+
+## Implementation Notes
+
+### TSV (low effort)
+- Add `.tsv` to the `accept` attribute on the file input
+- Add `.tsv` to the extension validation in `processFile()`
+- No other changes needed — the rest of the pipeline treats the text as opaque content for LLM extraction
+
+### XLS/XLSX (medium effort — two approaches)
+
+#### Preferred: Send binary to LLM directly (no new dependencies)
+Claude's API supports document/file inputs. Instead of converting to CSV client-side, send the binary file to the API route and let Claude read it natively:
+
+1. **CsvUpload.tsx**: Read `.xls`/`.xlsx` files as base64 (`FileReader.readAsDataURL`)
+2. **useSheetImport.ts**: Add a new `submitFile(base64, filename)` method alongside `submitCsv`
+3. **API route**: Accept `{ file: "<base64>", filename: "cards.xlsx" }` as a third body variant
+4. **extract-cards.ts**: When given a file, send it to the Anthropic API as a `document` content block (base64 source) instead of embedding CSV text in the prompt
+5. No new npm dependencies — Claude handles the binary parsing
+
+Benefits: zero client-side dependencies, Claude understands spreadsheet structure (headers, formatting, cell types) better than a CSV conversion would preserve.
+
+#### Fallback: Client-side conversion with SheetJS
+If the LLM document approach has issues (file size limits, extraction quality):
+- Install `xlsx` (SheetJS Community Edition) — ~500KB client-side
+- Convert to CSV in `processFile()` before submission
+- No hook/API/pipeline changes needed
+
+### Format-Aware LLM Prompt
+The LLM extraction prompt (`extract-cards.ts`) must be told what file format it's receiving so it can parse appropriately. The UI should propagate the chosen format through the full pipeline:
+
+1. **CsvUpload.tsx**: Detect the file extension at selection/drop time
+2. **useSheetImport.ts**: Include `format: "csv" | "tsv" | "xls" | "xlsx"` in the submission payload
+3. **API route**: Pass `format` through to the extraction function
+4. **extract-cards.ts**: Include the format in the system/user prompt so Claude knows whether it's reading CSV text, TSV text, or a binary spreadsheet document attachment — e.g. "The user has uploaded an .xlsx spreadsheet. Extract credit card data from it."
+
+This ensures Claude doesn't have to guess the format from content alone, which improves extraction reliability especially for edge cases (TSV with commas in fields, multi-sheet workbooks, etc.).
+
+### Shared
+- Update the CsvUpload UI copy — currently says "Deliver a Rune-Stone" with CSV-specific instructions
+- Update the file input `accept` attribute: `.csv,.tsv,.xls,.xlsx`
+- Update the drop zone text to mention supported formats
+- Update the 1 MB size limit — XLS/XLSX files can be larger than CSV equivalents; consider 5 MB for binary formats
+- Update the loading step copy for non-CSV formats (currently says "Reading the inscriptions from your rune-stone...")
+- Remove the existing "Excel files are not supported" error messages in CsvUpload.tsx
+
+### What does NOT change
+- Preview, dedup, and confirm steps — unchanged
+- Google Sheets URL import (Path A) — unchanged
+- Google Drive Picker import (Path B) — unchanged
+
+## Acceptance Criteria
+
+- [ ] `.tsv` files can be dropped or selected and import successfully
+- [ ] `.xlsx` files can be dropped or selected and import successfully
+- [ ] `.xls` files can be dropped or selected and import successfully
+- [ ] Error messages for unsupported formats still appear (e.g., `.numbers`, `.pdf`)
+- [ ] The "Excel files are not supported" error is removed
+- [ ] Existing `.csv` import path is unaffected (regression test)
+- [ ] File size limit accommodates binary formats (suggest 5 MB)
+- [ ] Multi-sheet workbooks: Claude extracts from all visible sheets (or first sheet with a note)
+
+## Priority
+
+Medium — unblocks Excel users, low risk.
+
+## Dependencies
+
+- Preferred approach: none (Anthropic API document support)
+- Fallback approach: `xlsx` npm package (SheetJS Community Edition, Apache-2.0 license)

--- a/designs/product/backlog/security-review-google-sheets-api.md
+++ b/designs/product/backlog/security-review-google-sheets-api.md
@@ -1,0 +1,70 @@
+# Backlog: Security Review — Google Sheets API Integration
+
+## Problem Statement
+
+Fenrir Ledger integrates with Google APIs across multiple surfaces (OAuth, Sheets import, Drive Picker). These integrations handle authentication tokens, API keys, and user data. A focused security review is needed to verify that:
+
+1. Credentials are properly scoped and not over-permissioned
+2. Tokens are stored, transmitted, and refreshed securely
+3. API keys are not leaked to the client bundle
+4. User data from Google (spreadsheet content, profile info) is handled safely
+5. The OAuth flow follows current best practices (PKCE, state parameter, etc.)
+
+## Scope
+
+### In scope
+- Google OAuth 2.0 flow (PKCE, token exchange proxy, session management)
+- Google Sheets URL import pipeline (fetch → CSV → LLM extraction)
+- Google Drive Picker integration (API key delivery, token scoping)
+- Server-side API route auth guards (`requireAuth`)
+- Environment variable handling (client vs server, `NEXT_PUBLIC_` prefix rules)
+- Secret masking in logs and output
+- CORS and CSP headers
+- Token refresh and expiration handling
+
+### Out of scope (for now)
+- General frontend XSS/CSRF (covered by Next.js defaults)
+- Infrastructure/hosting security (Vercel platform responsibility)
+- LLM prompt injection (separate concern)
+
+## Key Files to Review
+
+| Area | Files |
+|------|-------|
+| OAuth flow | `src/contexts/AuthContext.tsx`, `src/lib/auth/refresh-session.ts` |
+| Token exchange proxy | `src/app/api/auth/token/route.ts` |
+| Auth guard | `src/lib/auth/require-auth.ts` |
+| Sheets import API | `src/app/api/sheets/import/route.ts` |
+| Import pipeline | `src/lib/sheets/import-pipeline.ts`, `src/lib/sheets/csv-import-pipeline.ts` |
+| Picker config API | `src/app/api/config/picker/route.ts` |
+| Picker hook | `src/hooks/usePickerConfig.ts` |
+| Drive token hook | `src/hooks/useDriveToken.ts` |
+| Environment config | `.env.local`, `.env.example` |
+| CLAUDE.md rules | `CLAUDE.md` (secret masking, API route auth rules) |
+
+## Review Checklist
+
+- [ ] OAuth scopes are minimal (only what's needed for Sheets read + Drive file pick)
+- [ ] `GOOGLE_CLIENT_SECRET` never appears in client bundle (`NEXT_PUBLIC_` prefix absent)
+- [ ] `GOOGLE_PICKER_API_KEY` served only to authenticated users via API route
+- [ ] `FENRIR_ANTHROPIC_API_KEY` never appears in client bundle
+- [ ] Token exchange proxy validates redirect URI
+- [ ] ID tokens are verified server-side (signature, audience, expiry)
+- [ ] Refresh tokens are not stored in localStorage (only in memory/httpOnly cookie)
+- [ ] API routes return appropriate CORS headers
+- [ ] Error responses don't leak internal details (stack traces, file paths)
+- [ ] Rate limiting exists on import endpoints (or documented as needed)
+- [ ] Google Sheets data is not persisted server-side after extraction
+- [ ] Sensitive data warnings (SSN, card numbers) are shown to users
+
+## Priority
+
+High — security review should happen before any additional Google API integrations ship.
+
+## Suggested Approach
+
+Use a dedicated security review agent that can:
+1. Trace data flow from user input to API response
+2. Check for OWASP Top 10 patterns
+3. Verify secret handling against CLAUDE.md rules
+4. Produce a structured report with findings, severity, and remediation


### PR DESCRIPTION
## Summary

- **XLS/XLSX/TSV import backlog** (`designs/product/backlog/import-xls-xlsx-tsv-formats.md`): Path C import support for Excel and TSV files. Preferred approach sends binary directly to Claude API as a document attachment — no new npm dependencies. Includes format-aware LLM prompt note so the extraction pipeline knows what format it's receiving.
- **Security review backlog** (`designs/product/backlog/security-review-google-sheets-api.md`): Focused security review of Google OAuth, Sheets import, Drive Picker, token handling, and secret scoping.
- **Heimdall agent** (`.claude/agents/heimdall.md`): Read-only security review agent for OWASP Top 10 patterns, secret handling, auth guard verification, and structured severity-tagged reports.

## Test plan

- [ ] No code changes — docs and agent config only
- [ ] Verify backlog items render correctly in GitHub markdown
- [ ] Verify Heimdall agent loads when invoked via `subagent_type: heimdall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)