### PR TITLE
chore: route playwright-bowser artifacts to tmp/

### DIFF
--- a/.claude/agents/playwright-bowser-agent.md
+++ b/.claude/agents/playwright-bowser-agent.md
@@ -14,7 +14,26 @@ skills:
 
 You are a headless browser automation agent. Use the `playwright-bowser` skill to execute browser requests.
 
+## Output Directory (UNBREAKABLE RULE)
+
+**All intermediate artifacts (screenshots, logs, network captures, PDFs, and any other
+files generated during a session) MUST be written to `tmp/playwright-bowser/`** relative
+to the repository root. Never write artifacts directly into `development/`, `src/`, or
+any other source directory.
+
+Before writing any file, ensure the output directory exists:
+```bash
+mkdir -p tmp/playwright-bowser
+```
+
+Use `--filename=tmp/playwright-bowser/<name>` for screenshots and route all other file
+output (console logs, network request dumps, reports) to the same directory.
+
+The `tmp/` directory is gitignored — artifacts there will not pollute the working tree.
+
 ## Workflow
 
-1. Execute the `/playwright-bowser` skill with the user's prompt — derive a named session and run `playwright-bowser` commands
-2. Report the results back to the caller
+1. Create the output directory: `mkdir -p tmp/playwright-bowser`
+2. Execute the `/playwright-bowser` skill with the user's prompt — derive a named session and run `playwright-bowser` commands
+3. Save all intermediate artifacts to `tmp/playwright-bowser/`
+4. Report the results back to the caller

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,12 @@ trees/
 # doc-sync run artifacts (ephemeral, coordinator reads then discards)
 .sync-report.md
 
+# Stray agent artifacts (safety net — agents should write to tmp/)
+development/*.log
+development/security-audit-*.png
+development/console-*.log
+development/network-requests-*.log
+
 # Auto-generated session artifacts
 TOOLS.md
 .condense-report.md

--- a/specs/security-review-google-api-integration.md
+++ b/specs/security-review-google-api-integration.md
@@ -169,8 +169,8 @@ Use these files to complete the task:
 - Attempt to call `POST /api/sheets/import` without auth — verify 401 response
 - Attempt to call `POST /api/auth/token` with invalid body — verify error response doesn't leak secrets
 - Check the JS bundle for string patterns: grep the fetched JS for API key patterns, secret patterns
-- Capture screenshots of error states for the report
-- Save findings to `development/browser-traffic-report.md`
+- Capture screenshots of error states to `tmp/playwright-bowser/`
+- Save findings to `tmp/playwright-bowser/browser-traffic-report.md`
 
 ### 4. Consolidate Security Report
 - **Task ID**: consolidate-report
@@ -178,7 +178,7 @@ Use these files to complete the task:
 - **Assigned To**: orchestrator (self)
 - **Agent Type**: N/A (orchestrator merges reports)
 - **Parallel**: false
-- Read `development/heimdall-static-review.md` and `development/browser-traffic-report.md`
+- Read `development/heimdall-static-review.md` and `tmp/playwright-bowser/browser-traffic-report.md`
 - Merge findings into a single consolidated report at `development/security-review-report.md`
 - Deduplicate findings found by both static and runtime analysis
 - Assign final severity ratings


### PR DESCRIPTION
## Summary
- Adds UNBREAKABLE RULE to playwright-bowser agent requiring all artifacts go to `tmp/playwright-bowser/`
- Updates security review spec output paths from `development/` to `tmp/playwright-bowser/`
- Adds gitignore safety-net patterns for stray agent artifacts in `development/`

## Test plan
- [x] Docs/config only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)