### PR TITLE
chore: rename fenrir-claude alias to claude-fenrir

### DIFF
--- a/terminal/install.sh
+++ b/terminal/install.sh
@@ -170,7 +170,7 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Step 4: Add fenrir-claude wrapper to ~/.zshrc
+# Step 4: Add claude-fenrir wrapper to ~/.zshrc
 # ---------------------------------------------------------------------------
 header "Step 4: Shell Wrapper"
 
@@ -186,14 +186,14 @@ else
     cat >> "$ZSHRC" << ZSHEOF
 
 ${GUARD_COMMENT}
-# Defines fenrir-claude command with the Fenrir Elder Futhark splash screen.
+# Defines claude-fenrir command with the Fenrir Elder Futhark splash screen.
 # To remove: delete everything between the >>> and <<< markers.
 [[ -f "${SNIPPET_SRC}" ]] \\
   && source "${SNIPPET_SRC}"
 ${END_COMMENT}
 ZSHEOF
 
-    ok "Appended fenrir-claude wrapper to ${ZSHRC}"
+    ok "Appended claude-fenrir wrapper to ${ZSHRC}"
     info "The wrapper sources: ${SNIPPET_SRC}"
 fi
 

--- a/terminal/zshrc-snippet.sh
+++ b/terminal/zshrc-snippet.sh
@@ -1,18 +1,18 @@
 # Fenrir Ledger — Claude Code splash wrapper
 # Source this in your .zshrc or let terminal/install.sh do it automatically.
 #
-# Defines the `fenrir-claude` command which displays the Fenrir Elder Futhark
+# Defines the `claude-fenrir` command which displays the Fenrir Elder Futhark
 # splash screen before launching Claude Code. All arguments are forwarded
 # to the real `claude` binary unchanged.
 #
 # Usage:
 #   source /path/to/fenrir-ledger/terminal/zshrc-snippet.sh
-#   fenrir-claude          # launch with splash screen
+#   claude-fenrir          # launch with splash screen
 #   claude                 # launch normally (unmodified)
 
 # Guard: only define once
-if ! type fenrir-claude > /dev/null 2>&1; then
-  fenrir-claude() {
+if ! type claude-fenrir > /dev/null 2>&1; then
+  claude-fenrir() {
     # Splash screen — uses the symlink placed by terminal/install.sh
     local splash="${HOME}/.claude/splash.sh"
     if [[ -x "$splash" ]]; then


### PR DESCRIPTION
## Summary
- Renames the `fenrir-claude` shell function/alias to `claude-fenrir` across `terminal/zshrc-snippet.sh` and `terminal/install.sh`

## Test plan
- [ ] `source ~/.zshrc` and verify `claude-fenrir` launches with splash screen
- [ ] Verify `fenrir-claude` is no longer defined

🤖 Generated with [Claude Code](https://claude.com/claude-code)