### PR TITLE
fix: add vercel.live to CSP and improve token proxy diagnostics

### DIFF
--- a/development/frontend/next.config.ts
+++ b/development/frontend/next.config.ts
@@ -14,9 +14,9 @@ const cspDirectives = [
   // Default: only same-origin
   "default-src 'self'",
 
-  // Scripts: self + Google APIs + Vercel analytics + unsafe-inline (Next.js requirement)
+  // Scripts: self + Google APIs + Vercel analytics/live + unsafe-inline (Next.js requirement)
   // In development, Next.js HMR / React Fast Refresh requires 'unsafe-eval'.
-  `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV !== "production" ? " 'unsafe-eval'" : ""} https://accounts.google.com https://apis.google.com https://va.vercel-scripts.com`,
+  `script-src 'self' 'unsafe-inline'${process.env.NODE_ENV !== "production" ? " 'unsafe-eval'" : ""} https://accounts.google.com https://apis.google.com https://va.vercel-scripts.com https://vercel.live`,
 
   // Styles: self + unsafe-inline (Tailwind inline styles) + Google Fonts
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com",
@@ -27,7 +27,7 @@ const cspDirectives = [
   // Fonts: self + Google Fonts CDN + data: URIs
   "font-src 'self' https://fonts.gstatic.com data:",
 
-  // Connections: self + Google APIs + Anthropic + OpenAI + Vercel analytics
+  // Connections: self + Google APIs + Anthropic + OpenAI + Vercel analytics/live
   [
     "connect-src 'self'",
     "https://accounts.google.com",
@@ -39,10 +39,11 @@ const cspDirectives = [
     "https://api.anthropic.com",
     "https://api.openai.com",
     "https://va.vercel-scripts.com",
+    "https://vercel.live",
   ].join(" "),
 
-  // Frames: Google Picker and OAuth consent
-  "frame-src https://accounts.google.com https://docs.google.com https://drive.google.com",
+  // Frames: Google Picker, OAuth consent, and Vercel toolbar
+  "frame-src https://accounts.google.com https://docs.google.com https://drive.google.com https://vercel.live",
 
   // Form actions: self only
   "form-action 'self'",


### PR DESCRIPTION
## Summary
- Adds `https://vercel.live` to CSP `script-src`, `connect-src`, and `frame-src` directives to unblock Vercel's collaboration toolbar on production/preview deployments
- Improves diagnostic logging in `/api/auth/token` to help troubleshoot `invalid_client` (401) errors from Google — logs which env vars are present/missing and credential lengths without exposing secrets

## Context
Production was showing two errors:
1. **CSP violation**: `vercel.live/_next-live/feedback/feedback.js` blocked by `script-src`
2. **Auth 401**: Google returning `invalid_client` / `Unauthorized` on token exchange

The CSP fix is a direct code change. The auth 401 is likely a stale deployment — env vars were set *after* the last production deploy, so `NEXT_PUBLIC_GOOGLE_CLIENT_ID` (inlined at build time) may be missing. A redeploy after merge should resolve it; the improved logging will confirm if the issue persists.

## Test plan
- [ ] Verify `vercel.live` feedback script loads without CSP errors on preview deploy
- [ ] Verify Google sign-in completes successfully after redeploy
- [ ] Check Vercel function logs for improved diagnostic output if auth still fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)