### PR TITLE
chore: add fenrir logger with automatic secret masking

### DIFF
--- a/development/frontend/package-lock.json
+++ b/development/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^2.6.0",
         "tailwindcss-animate": "^1.0.7",
+        "tslog": "^4.10.2",
         "zod": "^3.24.1"
       },
       "devDependencies": {
@@ -7132,6 +7133,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tslog": {
+      "version": "4.10.2",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.10.2.tgz",
+      "integrity": "sha512-XuELoRpMR+sq8fuWwX7P0bcj+PRNiicOKDEb3fGNURhxWVyykCi9BNq7c4uVz7h7P0sj8qgBsr5SWS6yBClq3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/fullstack-build/tslog?sponsor=1"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/development/frontend/package.json
+++ b/development/frontend/package.json
@@ -30,6 +30,7 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^2.6.0",
     "tailwindcss-animate": "^1.0.7",
+    "tslog": "^4.10.2",
     "zod": "^3.24.1"
   },
   "devDependencies": {

--- a/development/frontend/src/app/api/auth/token/route.ts
+++ b/development/frontend/src/app/api/auth/token/route.ts
@@ -27,6 +27,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rate-limit";
+import { log } from "@/lib/logger";
 
 /**
  * Whitelisted origins that may call this endpoint.
@@ -65,20 +66,27 @@ function isRefreshRequest(body: TokenRequestBody): body is RefreshRequestBody {
  * can trigger a token exchange through this proxy.
  */
 function isAllowedRedirectUri(redirectUri: string): boolean {
+  log.debug("isAllowedRedirectUri called", { redirectUri });
   try {
     const { origin } = new URL(redirectUri);
-    return ALLOWED_ORIGINS.has(origin);
+    const allowed = ALLOWED_ORIGINS.has(origin);
+    log.debug("isAllowedRedirectUri returning", { origin, allowed });
+    return allowed;
   } catch {
+    log.debug("isAllowedRedirectUri returning", { allowed: false, reason: "invalid URL" });
     return false;
   }
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
-  // Rate limit by IP — 10 requests per minute per IP address.
   const ip =
     request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  log.debug("POST /api/auth/token called", { ip });
+
+  // Rate limit by IP — 10 requests per minute per IP address.
   const { success } = rateLimit(`token:${ip}`, { limit: 10, windowMs: 60_000 });
   if (!success) {
+    log.debug("POST /api/auth/token returning", { status: 429, error: "rate_limited" });
     return NextResponse.json(
       {
         error: "rate_limited",
@@ -93,18 +101,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   try {
     body = (await request.json()) as TokenRequestBody;
   } catch {
+    log.debug("POST /api/auth/token returning", { status: 400, error: "invalid_request", reason: "invalid JSON" });
     return NextResponse.json(
       { error: "invalid_request", error_description: "Request body must be valid JSON." },
       { status: 400 }
     );
   }
 
+  const grantType = isRefreshRequest(body) ? "refresh_token" : "authorization_code";
+  log.debug("POST /api/auth/token parsed body", {
+    grantType,
+    hasCode: "code" in body,
+    hasCodeVerifier: "code_verifier" in body,
+    hasRedirectUri: "redirect_uri" in body,
+    hasRefreshToken: "refresh_token" in body,
+  });
+
   // Load OAuth credentials (needed for both flows).
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   const clientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
   if (!clientId || !clientSecret) {
-    console.error("[Fenrir] Token proxy: missing NEXT_PUBLIC_GOOGLE_CLIENT_ID or GOOGLE_CLIENT_SECRET");
+    log.error("POST /api/auth/token: missing env vars", { hasClientId: !!clientId, hasClientSecret: !!clientSecret });
+    log.debug("POST /api/auth/token returning", { status: 500, error: "server_error" });
     return NextResponse.json(
       { error: "server_error", error_description: "Auth configuration error." },
       { status: 500 }
@@ -117,6 +136,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   if (isRefreshRequest(body)) {
     // --- Refresh token flow (DEF-001) ---
     if (!body.refresh_token) {
+      log.debug("POST /api/auth/token returning", { status: 400, error: "invalid_request", reason: "missing refresh_token" });
       return NextResponse.json(
         { error: "invalid_request", error_description: "Missing required field: refresh_token." },
         { status: 400 }
@@ -134,6 +154,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     const { code, code_verifier, redirect_uri } = body;
 
     if (!code || !code_verifier || !redirect_uri) {
+      log.debug("POST /api/auth/token returning", { status: 400, error: "invalid_request", reason: "missing fields" });
       return NextResponse.json(
         {
           error: "invalid_request",
@@ -144,6 +165,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     }
 
     if (!isAllowedRedirectUri(redirect_uri)) {
+      log.debug("POST /api/auth/token returning", { status: 400, error: "invalid_request", reason: "redirect_uri not whitelisted" });
       return NextResponse.json(
         {
           error: "invalid_request",
@@ -164,6 +186,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   }
 
   // Proxy to Google's token endpoint.
+  log.debug("POST /api/auth/token proxying to Google", { grantType, clientIdLength: clientId.length, clientSecretLength: clientSecret.length });
   let googleResponse: Response;
   try {
     googleResponse = await fetch(GOOGLE_TOKEN_URL, {
@@ -173,7 +196,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    console.error("[Fenrir] Token proxy: fetch to Google failed:", message);
+    log.error("POST /api/auth/token: fetch to Google failed", { error: message });
+    log.debug("POST /api/auth/token returning", { status: 502, error: "server_error" });
     return NextResponse.json(
       { error: "server_error", error_description: "Failed to reach Google token endpoint." },
       { status: 502 }
@@ -183,8 +207,9 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // Forward Google's response (status + body) unchanged.
   const responseBody = await googleResponse.text();
   if (!googleResponse.ok) {
-    console.error(`[Fenrir] Token proxy: Google returned ${googleResponse.status}:`, responseBody);
+    log.error("POST /api/auth/token: Google error", { status: googleResponse.status, grantType, body: responseBody });
   }
+  log.debug("POST /api/auth/token returning", { status: googleResponse.status, grantType });
   return new NextResponse(responseBody, {
     status: googleResponse.status,
     headers: { "Content-Type": "application/json" },

--- a/development/frontend/src/app/api/config/picker/route.ts
+++ b/development/frontend/src/app/api/config/picker/route.ts
@@ -1,18 +1,26 @@
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/require-auth";
+import { log } from "@/lib/logger";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
+  log.debug("GET /api/config/picker called");
+
   const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  if (!auth.ok) {
+    log.debug("GET /api/config/picker returning", { status: 401, reason: "auth failed" });
+    return auth.response;
+  }
 
   const pickerApiKey = process.env.GOOGLE_PICKER_API_KEY;
   if (!pickerApiKey) {
+    log.debug("GET /api/config/picker returning", { status: 500, error: "not_configured" });
     return NextResponse.json(
       { error: "not_configured", error_description: "Google Picker API key is not configured." },
       { status: 500 },
     );
   }
 
+  log.debug("GET /api/config/picker returning", { status: 200, hasKey: true });
   return NextResponse.json({ pickerApiKey }, {
     headers: { "Cache-Control": "no-store" },
   });

--- a/development/frontend/src/app/api/sheets/import/route.ts
+++ b/development/frontend/src/app/api/sheets/import/route.ts
@@ -3,17 +3,24 @@ import type { SheetImportError } from "@/lib/sheets/types";
 import { importFromSheet } from "@/lib/sheets/import-pipeline";
 import { importFromCsv } from "@/lib/sheets/csv-import-pipeline";
 import { requireAuth } from "@/lib/auth/require-auth";
+import { log } from "@/lib/logger";
 
 export const maxDuration = 60;
 
 function errorResponse(code: SheetImportError["code"], message: string, status: number = 400): NextResponse {
+  log.debug("errorResponse called", { code, status });
   return NextResponse.json({ error: { code, message } satisfies SheetImportError }, { status });
 }
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
+  log.debug("POST /api/sheets/import called");
+
   // Verify caller is authenticated (ADR-008)
   const auth = await requireAuth(request);
-  if (!auth.ok) return auth.response;
+  if (!auth.ok) {
+    log.debug("POST /api/sheets/import returning", { status: 401, reason: "auth failed" });
+    return auth.response;
+  }
 
   let url: string | undefined;
   let csv: string | undefined;
@@ -23,23 +30,29 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     url = body?.url;
     csv = body?.csv;
   } catch {
+    log.debug("POST /api/sheets/import returning", { status: 400, error: "INVALID_URL", reason: "invalid JSON" });
     return errorResponse("INVALID_URL", "Invalid JSON body.");
   }
 
   // Exactly one of url or csv must be provided
   const hasUrl = url && typeof url === "string";
   const hasCsv = csv && typeof csv === "string";
+  log.debug("POST /api/sheets/import parsed body", { hasUrl, hasCsv, csvLength: csv?.length });
 
   if (hasUrl && hasCsv) {
+    log.debug("POST /api/sheets/import returning", { status: 400, error: "INVALID_URL", reason: "both url and csv" });
     return errorResponse("INVALID_URL", "Provide either 'url' or 'csv', not both.");
   }
 
   if (!hasUrl && !hasCsv) {
+    log.debug("POST /api/sheets/import returning", { status: 400, error: "INVALID_URL", reason: "neither url nor csv" });
     return errorResponse("INVALID_URL", "Request body must include a 'url' or 'csv' string.");
   }
 
   // Run the appropriate import pipeline
   try {
+    const mode = hasUrl ? "url" : "csv";
+    log.debug("POST /api/sheets/import running pipeline", { mode });
     const result = hasUrl
       ? await importFromSheet(url!)
       : await importFromCsv(csv!);
@@ -50,11 +63,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         : result.error.code === "SHEET_NOT_PUBLIC" ? 403
         : result.error.code === "NO_CARDS_FOUND" ? 404
         : 500;
+      log.debug("POST /api/sheets/import returning", { status, errorCode: result.error.code });
       return NextResponse.json(result, { status });
     }
 
+    log.debug("POST /api/sheets/import returning", { status: 200, cardCount: result.cards.length, hasWarning: !!("warning" in result) });
     return NextResponse.json(result);
   } catch {
+    log.debug("POST /api/sheets/import returning", { status: 500, error: "FETCH_ERROR", reason: "unexpected error" });
     return errorResponse(
       "FETCH_ERROR",
       "The import service encountered an unexpected error. Please try again.",

--- a/development/frontend/src/lib/auth/require-auth.ts
+++ b/development/frontend/src/lib/auth/require-auth.ts
@@ -21,6 +21,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { verifyIdToken, type VerifiedUser } from "./verify-id-token";
+import { log } from "@/lib/logger";
 
 /** Auth check succeeded — verified user is available. */
 export type AuthSuccess = { ok: true; user: VerifiedUser };
@@ -41,8 +42,10 @@ export type AuthResult = AuthSuccess | AuthFailure;
  */
 export async function requireAuth(request: NextRequest): Promise<AuthResult> {
   const authHeader = request.headers.get("authorization");
+  log.debug("requireAuth called", { hasAuthHeader: !!authHeader, hasBearerPrefix: authHeader?.startsWith("Bearer ") ?? false });
 
   if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    log.debug("requireAuth returning", { ok: false, error: "missing_token", status: 401 });
     return {
       ok: false,
       response: NextResponse.json(
@@ -61,6 +64,7 @@ export async function requireAuth(request: NextRequest): Promise<AuthResult> {
   const result = await verifyIdToken(token);
 
   if (!result.ok) {
+    log.debug("requireAuth returning", { ok: false, error: "invalid_token", status: result.status });
     return {
       ok: false,
       response: NextResponse.json(
@@ -73,5 +77,6 @@ export async function requireAuth(request: NextRequest): Promise<AuthResult> {
     };
   }
 
+  log.debug("requireAuth returning", { ok: true, userSub: result.user.sub, email: result.user.email });
   return { ok: true, user: result.user };
 }

--- a/development/frontend/src/lib/auth/verify-id-token.ts
+++ b/development/frontend/src/lib/auth/verify-id-token.ts
@@ -15,6 +15,7 @@
  */
 
 import { jwtVerify, createRemoteJWKSet } from "jose";
+import { log } from "@/lib/logger";
 
 /** Google's public JWKS endpoint for verifying id_token signatures. */
 const GOOGLE_JWKS_URL = new URL("https://www.googleapis.com/oauth2/v3/certs");
@@ -56,9 +57,12 @@ export type VerifyResult =
  * @returns VerifyResult — either { ok: true, user } or { ok: false, error, status }
  */
 export async function verifyIdToken(token: string): Promise<VerifyResult> {
+  log.debug("verifyIdToken called", { tokenLength: token.length });
+
   const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;
   if (!clientId) {
-    console.error("[Fenrir] verifyIdToken: NEXT_PUBLIC_GOOGLE_CLIENT_ID is not set");
+    log.error("verifyIdToken: NEXT_PUBLIC_GOOGLE_CLIENT_ID is not set");
+    log.debug("verifyIdToken returning", { ok: false, error: "Auth not configured.", status: 500 });
     return { ok: false, error: "Auth not configured.", status: 500 };
   }
 
@@ -68,24 +72,27 @@ export async function verifyIdToken(token: string): Promise<VerifyResult> {
       audience: clientId,
     });
 
-    return {
-      ok: true,
-      user: {
-        sub: payload.sub as string,
-        email: (payload as Record<string, unknown>).email as string,
-        name: (payload as Record<string, unknown>).name as string,
-        picture: (payload as Record<string, unknown>).picture as string,
-      },
+    const user: VerifiedUser = {
+      sub: payload.sub as string,
+      email: (payload as Record<string, unknown>).email as string,
+      name: (payload as Record<string, unknown>).name as string,
+      picture: (payload as Record<string, unknown>).picture as string,
     };
+
+    log.debug("verifyIdToken returning", { ok: true, sub: user.sub, email: user.email });
+    return { ok: true, user };
   } catch (err) {
     const message = err instanceof Error ? err.message : "Token verification failed";
 
     if (message.includes("expired") || message.includes('"exp"')) {
+      log.debug("verifyIdToken returning", { ok: false, error: "Token expired.", status: 401 });
       return { ok: false, error: "Token expired.", status: 401 };
     }
     if (message.includes("audience") || message.includes('"aud"')) {
+      log.debug("verifyIdToken returning", { ok: false, error: "Token audience mismatch.", status: 403 });
       return { ok: false, error: "Token audience mismatch.", status: 403 };
     }
+    log.debug("verifyIdToken returning", { ok: false, error: "Invalid token.", status: 401 });
     return { ok: false, error: "Invalid token.", status: 401 };
   }
 }

--- a/development/frontend/src/lib/llm/extract.ts
+++ b/development/frontend/src/lib/llm/extract.ts
@@ -8,6 +8,7 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import OpenAI from "openai";
+import { log } from "@/lib/logger";
 
 /** Structured prompt with system/user separation to prevent prompt injection. */
 export interface StructuredPrompt {
@@ -36,6 +37,8 @@ class AnthropicProvider implements LlmProvider {
 
   async extractText(prompt: string | StructuredPrompt): Promise<string> {
     const isStructured = typeof prompt !== "string";
+    log.debug("AnthropicProvider.extractText called", { model: this.model, isStructured, promptLength: isStructured ? prompt.user.length : prompt.length });
+
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         const message = await this.client.messages.create({
@@ -46,8 +49,11 @@ class AnthropicProvider implements LlmProvider {
             : { messages: [{ role: "user" as const, content: prompt }] }),
         });
         const textBlock = message.content.find((b) => b.type === "text");
-        return textBlock?.text ?? "";
+        const result = textBlock?.text ?? "";
+        log.debug("AnthropicProvider.extractText returning", { attempt, resultLength: result.length });
+        return result;
       } catch (err) {
+        log.error("AnthropicProvider.extractText attempt failed", { attempt, error: err instanceof Error ? err.message : String(err) });
         if (attempt === 1) throw err;
       }
     }
@@ -66,6 +72,8 @@ class OpenAIProvider implements LlmProvider {
 
   async extractText(prompt: string | StructuredPrompt): Promise<string> {
     const isStructured = typeof prompt !== "string";
+    log.debug("OpenAIProvider.extractText called", { model: this.model, isStructured, promptLength: isStructured ? prompt.user.length : prompt.length });
+
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         const completion = await this.client.chat.completions.create({
@@ -78,8 +86,11 @@ class OpenAIProvider implements LlmProvider {
               ]
             : [{ role: "user" as const, content: prompt }],
         });
-        return completion.choices[0]?.message?.content ?? "";
+        const result = completion.choices[0]?.message?.content ?? "";
+        log.debug("OpenAIProvider.extractText returning", { attempt, resultLength: result.length });
+        return result;
       } catch (err) {
+        log.error("OpenAIProvider.extractText attempt failed", { attempt, error: err instanceof Error ? err.message : String(err) });
         if (attempt === 1) throw err;
       }
     }
@@ -96,7 +107,12 @@ let _instance: LlmProvider | null = null;
  * Requires the corresponding API key env var to be set.
  */
 export function getLlmProvider(): LlmProvider {
-  if (_instance) return _instance;
+  log.debug("getLlmProvider called", { cached: !!_instance });
+
+  if (_instance) {
+    log.debug("getLlmProvider returning", { provider: _instance.name, model: _instance.model, cached: true });
+    return _instance;
+  }
 
   const provider = process.env.LLM_PROVIDER || "anthropic";
 
@@ -117,5 +133,6 @@ export function getLlmProvider(): LlmProvider {
       throw new Error(`Unknown LLM provider: "${provider}". Expected "anthropic" or "openai".`);
   }
 
+  log.debug("getLlmProvider returning", { provider: _instance.name, model: _instance.model, cached: false });
   return _instance;
 }

--- a/development/frontend/src/lib/logger.ts
+++ b/development/frontend/src/lib/logger.ts
@@ -1,0 +1,82 @@
+/**
+ * Fenrir Logger — structured logging with automatic secret masking.
+ *
+ * Wraps tslog with project-specific configuration:
+ *   - JSON output in production, pretty output in development
+ *   - Automatic masking of keys that commonly hold secrets
+ *   - Regex masking for secret patterns (API keys, JWTs, Google tokens)
+ *   - `[fenrir-backend]` prefix on all log entries
+ *
+ * Usage:
+ *   import { log } from "@/lib/logger";
+ *   log.debug("myFunction called", { url, csvLength: csv.length });
+ *   log.error("myFunction failed", { error: err.message });
+ *
+ * Masking is applied automatically — you can safely pass objects containing
+ * secret keys and they will be replaced with the mask placeholder before
+ * output. Regex patterns catch common secret formats even when the key
+ * name is not in the mask list.
+ *
+ * @module logger
+ */
+
+import { Logger } from "tslog";
+
+/**
+ * Keys whose values are automatically masked in log output.
+ * Case-insensitive matching is enabled via maskValuesOfKeysCaseInsensitive.
+ */
+const MASKED_KEYS = [
+  "password",
+  "secret",
+  "token",
+  "apiKey",
+  "api_key",
+  "authorization",
+  "cookie",
+  "credential",
+  "client_secret",
+  "clientSecret",
+  "refresh_token",
+  "refreshToken",
+  "access_token",
+  "accessToken",
+  "id_token",
+  "idToken",
+  "code_verifier",
+  "codeVerifier",
+  "code",
+  "pickerApiKey",
+];
+
+/**
+ * Regex patterns that catch common secret formats in string values,
+ * regardless of the key name.
+ */
+const MASKED_PATTERNS = [
+  /sk-ant-api\S+/gi,                                        // Anthropic API keys
+  /sk-[a-zA-Z0-9]{20,}/gi,                                  // OpenAI API keys
+  /GOCSPX-\S+/gi,                                           // Google client secrets
+  /AIzaSy[a-zA-Z0-9_-]{30,}/gi,                             // Google API keys
+  /ya29\.[a-zA-Z0-9_-]+/gi,                                 // Google access tokens
+  /eyJ[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}\.[a-zA-Z0-9_-]{10,}/gi, // JWTs
+];
+
+const isProd = process.env.NODE_ENV === "production";
+
+/**
+ * Singleton logger instance for all server-side code.
+ *
+ * - Production: JSON output (one structured object per line, Vercel-friendly)
+ * - Development: Pretty output (human-readable, coloured)
+ */
+export const log = new Logger({
+  name: "fenrir-backend",
+  type: isProd ? "json" : "pretty",
+  minLevel: isProd ? 2 : 0,        // prod: debug+  dev: silly+
+  maskValuesOfKeys: MASKED_KEYS,
+  maskValuesOfKeysCaseInsensitive: true,
+  maskValuesRegEx: MASKED_PATTERNS,
+  maskPlaceholder: "[***]",
+  hideLogPositionForProduction: isProd,
+});

--- a/development/frontend/src/lib/rate-limit.ts
+++ b/development/frontend/src/lib/rate-limit.ts
@@ -9,6 +9,8 @@
  * @module rate-limit
  */
 
+import { log } from "@/lib/logger";
+
 interface RateLimitEntry {
   count: number;
   resetAt: number;
@@ -28,18 +30,26 @@ export function rateLimit(
   key: string,
   { limit = 10, windowMs = 60_000 }: { limit?: number; windowMs?: number } = {}
 ): { success: boolean; remaining: number } {
+  log.debug("rateLimit called", { key, limit, windowMs });
+
   const now = Date.now();
   const entry = store.get(key);
 
   if (!entry || now >= entry.resetAt) {
     store.set(key, { count: 1, resetAt: now + windowMs });
-    return { success: true, remaining: limit - 1 };
+    const result = { success: true, remaining: limit - 1 };
+    log.debug("rateLimit returning", { key, ...result, reason: "new window" });
+    return result;
   }
 
   entry.count++;
   if (entry.count > limit) {
-    return { success: false, remaining: 0 };
+    const result = { success: false, remaining: 0 };
+    log.debug("rateLimit returning", { key, ...result, reason: "exceeded" });
+    return result;
   }
 
-  return { success: true, remaining: limit - entry.count };
+  const result = { success: true, remaining: limit - entry.count };
+  log.debug("rateLimit returning", { key, ...result });
+  return result;
 }

--- a/development/frontend/src/lib/sheets/csv-import-pipeline.ts
+++ b/development/frontend/src/lib/sheets/csv-import-pipeline.ts
@@ -8,6 +8,7 @@
 import { extractCardsFromCsv } from "./extract-cards";
 import { CSV_TRUNCATION_LIMIT } from "./prompt";
 import type { SheetImportResponse } from "./types";
+import { log } from "@/lib/logger";
 
 /** Minimum CSV length to be considered valid (header + at least one row). */
 const MIN_CSV_LENGTH = 10;
@@ -19,8 +20,11 @@ const MIN_CSV_LENGTH = 10;
  * @returns SheetImportResponse with cards array or error
  */
 export async function importFromCsv(csv: string): Promise<SheetImportResponse> {
+  log.debug("importFromCsv called", { csvLength: csv.length });
+
   // 1. Validate CSV content
   if (!csv || typeof csv !== "string" || csv.trim().length < MIN_CSV_LENGTH) {
+    log.debug("importFromCsv returning", { errorCode: "INVALID_CSV", reason: "empty or too short" });
     return {
       error: {
         code: "INVALID_CSV",
@@ -38,22 +42,30 @@ export async function importFromCsv(csv: string): Promise<SheetImportResponse> {
     ? `CSV was truncated from ${csv.length.toLocaleString()} to ${CSV_TRUNCATION_LIMIT.toLocaleString()} characters. Some rows may have been dropped.`
     : undefined;
 
+  if (truncationWarning) {
+    log.info("importFromCsv: CSV truncated", { originalLength: csv.length, truncatedLength: CSV_TRUNCATION_LIMIT });
+  }
+
   // 3. Extract cards using shared LLM pipeline
   const result = await extractCardsFromCsv(truncated);
 
   // Merge truncation warning if present
   if ("error" in result) {
+    log.debug("importFromCsv returning", { errorCode: result.error.code });
     return result;
   }
 
   if (truncationWarning) {
-    return {
+    const merged = {
       ...result,
       warning: result.warning
         ? `${result.warning} ${truncationWarning}`
         : truncationWarning,
     };
+    log.debug("importFromCsv returning", { cardCount: merged.cards.length, hasWarning: true });
+    return merged;
   }
 
+  log.debug("importFromCsv returning", { cardCount: result.cards.length, hasWarning: !!result.warning });
   return result;
 }

--- a/development/frontend/src/lib/sheets/extract-cards.ts
+++ b/development/frontend/src/lib/sheets/extract-cards.ts
@@ -10,6 +10,7 @@ import { buildExtractionPrompt } from "./prompt";
 import { CardsArraySchema, ImportResponseSchema } from "./card-schema";
 import { getLlmProvider } from "@/lib/llm/extract";
 import type { SheetImportResponse } from "./types";
+import { log } from "@/lib/logger";
 
 /**
  * Extract card data from raw CSV text via LLM.
@@ -18,13 +19,18 @@ import type { SheetImportResponse } from "./types";
  * @returns SheetImportResponse with cards array or error
  */
 export async function extractCardsFromCsv(csv: string): Promise<SheetImportResponse> {
+  log.debug("extractCardsFromCsv called", { csvLength: csv.length });
+
   // 1. Build structured prompt (system/user separated) and call LLM
   const prompt = buildExtractionPrompt(csv);
   let rawText: string;
   try {
     const provider = getLlmProvider();
+    log.debug("extractCardsFromCsv calling LLM", { provider: provider.name, model: provider.model });
     rawText = await provider.extractText(prompt);
+    log.debug("extractCardsFromCsv LLM response received", { rawTextLength: rawText.length });
   } catch {
+    log.debug("extractCardsFromCsv returning", { errorCode: "ANTHROPIC_ERROR" });
     return {
       error: {
         code: "ANTHROPIC_ERROR",
@@ -40,6 +46,7 @@ export async function extractCardsFromCsv(csv: string): Promise<SheetImportRespo
     const cleaned = rawText.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
     parsed = JSON.parse(cleaned);
   } catch {
+    log.debug("extractCardsFromCsv returning", { errorCode: "PARSE_ERROR", reason: "invalid JSON" });
     return {
       error: {
         code: "PARSE_ERROR",
@@ -56,10 +63,12 @@ export async function extractCardsFromCsv(csv: string): Promise<SheetImportRespo
   if (wrappedValidation.success) {
     extractedCards = wrappedValidation.data.cards;
     sensitiveDataWarning = wrappedValidation.data.sensitiveDataWarning;
+    log.debug("extractCardsFromCsv parsed wrapped format", { cardCount: extractedCards.length, sensitiveDataWarning });
   } else {
     // Fall back to plain array format (backwards compatibility)
     const arrayValidation = CardsArraySchema.safeParse(parsed);
     if (!arrayValidation.success) {
+      log.debug("extractCardsFromCsv returning", { errorCode: "PARSE_ERROR", reason: "schema mismatch" });
       return {
         error: {
           code: "PARSE_ERROR",
@@ -68,9 +77,11 @@ export async function extractCardsFromCsv(csv: string): Promise<SheetImportRespo
       };
     }
     extractedCards = arrayValidation.data;
+    log.debug("extractCardsFromCsv parsed array format", { cardCount: extractedCards.length });
   }
 
   if (extractedCards.length === 0) {
+    log.debug("extractCardsFromCsv returning", { errorCode: "NO_CARDS_FOUND" });
     return {
       error: {
         code: "NO_CARDS_FOUND",
@@ -94,5 +105,6 @@ export async function extractCardsFromCsv(csv: string): Promise<SheetImportRespo
     (result as { cards: typeof cards; sensitiveDataWarning?: boolean }).sensitiveDataWarning = true;
   }
 
+  log.debug("extractCardsFromCsv returning", { cardCount: cards.length, sensitiveDataWarning });
   return result;
 }

--- a/development/frontend/src/lib/sheets/fetch-csv.ts
+++ b/development/frontend/src/lib/sheets/fetch-csv.ts
@@ -2,10 +2,10 @@
  * Fetch CSV data from a Google Sheets export URL.
  *
  * Ported from development/backend/src/lib/sheets/fetch-csv.ts
- * without the backend logging prefix.
  */
 
 import { CSV_TRUNCATION_LIMIT } from "./prompt";
+import { log } from "@/lib/logger";
 
 export interface FetchCsvResult {
   csv: string;
@@ -32,9 +32,12 @@ export class FetchCsvError extends Error {
  * @throws {FetchCsvError} With structured code on failure
  */
 export async function fetchCsv(csvUrl: string): Promise<FetchCsvResult> {
+  log.debug("fetchCsv called", { csvUrl });
+
   const response = await fetch(csvUrl, { redirect: "follow" });
 
   if (response.status === 403 || response.status === 404) {
+    log.debug("fetchCsv throwing", { code: "SHEET_NOT_PUBLIC", status: response.status });
     throw new FetchCsvError(
       "SHEET_NOT_PUBLIC",
       "The spreadsheet is not publicly accessible. Make sure it's shared as 'Anyone with the link can view'.",
@@ -42,6 +45,7 @@ export async function fetchCsv(csvUrl: string): Promise<FetchCsvResult> {
   }
 
   if (!response.ok) {
+    log.debug("fetchCsv throwing", { code: "FETCH_ERROR", status: response.status });
     throw new FetchCsvError(
       "FETCH_ERROR",
       `Failed to fetch spreadsheet (HTTP ${response.status}).`,
@@ -51,6 +55,7 @@ export async function fetchCsv(csvUrl: string): Promise<FetchCsvResult> {
   let csv = await response.text();
 
   if (!csv.trim()) {
+    log.debug("fetchCsv throwing", { code: "NO_CARDS_FOUND", reason: "empty" });
     throw new FetchCsvError(
       "NO_CARDS_FOUND",
       "The spreadsheet appears to be empty.",
@@ -59,11 +64,14 @@ export async function fetchCsv(csvUrl: string): Promise<FetchCsvResult> {
 
   if (csv.length > CSV_TRUNCATION_LIMIT) {
     csv = csv.slice(0, CSV_TRUNCATION_LIMIT);
-    return {
+    const result: FetchCsvResult = {
       csv,
       warning: `CSV was truncated at ${CSV_TRUNCATION_LIMIT.toLocaleString()} characters. Some rows may be missing.`,
     };
+    log.debug("fetchCsv returning", { csvLength: csv.length, truncated: true });
+    return result;
   }
 
+  log.debug("fetchCsv returning", { csvLength: csv.length, truncated: false });
   return { csv };
 }

--- a/development/frontend/src/lib/sheets/import-pipeline.ts
+++ b/development/frontend/src/lib/sheets/import-pipeline.ts
@@ -9,6 +9,7 @@ import { extractSheetId, buildCsvExportUrl } from "./parse-url";
 import { fetchCsv, FetchCsvError } from "./fetch-csv";
 import { extractCardsFromCsv } from "./extract-cards";
 import type { SheetImportResponse } from "./types";
+import { log } from "@/lib/logger";
 
 /**
  * Run the full import pipeline: URL -> CSV -> LLM -> validated cards.
@@ -17,15 +18,19 @@ import type { SheetImportResponse } from "./types";
  * @returns SheetImportResponse with cards array or error
  */
 export async function importFromSheet(url: string): Promise<SheetImportResponse> {
+  log.debug("importFromSheet called", { url });
+
   // 1. Parse the sheet URL
   const sheetId = extractSheetId(url);
   if (!sheetId) {
-    return {
+    const result: SheetImportResponse = {
       error: {
         code: "INVALID_URL",
         message: "Could not extract a Google Sheets ID from the provided URL.",
       },
     };
+    log.debug("importFromSheet returning", { errorCode: "INVALID_URL" });
+    return result;
   }
 
   const csvUrl = buildCsvExportUrl(sheetId);
@@ -39,8 +44,10 @@ export async function importFromSheet(url: string): Promise<SheetImportResponse>
     csvWarning = result.warning;
   } catch (err) {
     if (err instanceof FetchCsvError) {
+      log.debug("importFromSheet returning", { errorCode: err.code });
       return { error: { code: err.code, message: err.message } };
     }
+    log.debug("importFromSheet returning", { errorCode: "FETCH_ERROR" });
     return {
       error: {
         code: "FETCH_ERROR",
@@ -54,17 +61,21 @@ export async function importFromSheet(url: string): Promise<SheetImportResponse>
 
   // Merge CSV fetch warning if present
   if ("error" in result) {
+    log.debug("importFromSheet returning", { errorCode: result.error.code });
     return result;
   }
 
   if (csvWarning) {
-    return {
+    const merged = {
       ...result,
       warning: result.warning
         ? `${result.warning} ${csvWarning}`
         : csvWarning,
     };
+    log.debug("importFromSheet returning", { cardCount: merged.cards.length, hasWarning: true });
+    return merged;
   }
 
+  log.debug("importFromSheet returning", { cardCount: result.cards.length, hasWarning: !!result.warning });
   return result;
 }

--- a/development/frontend/src/lib/sheets/parse-url.ts
+++ b/development/frontend/src/lib/sheets/parse-url.ts
@@ -5,17 +5,30 @@
  *   https://docs.google.com/spreadsheets/d/SHEET_ID/edit#gid=0
  *   https://docs.google.com/spreadsheets/d/SHEET_ID
  */
+
+import { log } from "@/lib/logger";
+
 export function extractSheetId(url: string): string | null {
+  log.debug("extractSheetId called", { url });
   try {
     const parsed = new URL(url);
-    if (!parsed.hostname.endsWith("google.com")) return null;
+    if (!parsed.hostname.endsWith("google.com")) {
+      log.debug("extractSheetId returning", { sheetId: null, reason: "not google.com" });
+      return null;
+    }
     const match = parsed.pathname.match(/\/spreadsheets\/d\/([a-zA-Z0-9_-]+)/);
-    return match?.[1] ?? null;
+    const sheetId = match?.[1] ?? null;
+    log.debug("extractSheetId returning", { sheetId });
+    return sheetId;
   } catch {
+    log.debug("extractSheetId returning", { sheetId: null, reason: "invalid URL" });
     return null;
   }
 }
 
 export function buildCsvExportUrl(sheetId: string): string {
-  return `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv`;
+  log.debug("buildCsvExportUrl called", { sheetId });
+  const csvUrl = `https://docs.google.com/spreadsheets/d/${sheetId}/export?format=csv`;
+  log.debug("buildCsvExportUrl returning", { csvUrl });
+  return csvUrl;
 }


### PR DESCRIPTION
## Summary
- Adds `tslog`-based structured logger at `src/lib/logger.ts` with automatic secret masking
- Replaces all raw `console.*` calls in server-side code with the shared `log` instance
- Every backend function now logs at entry (with inputs) and before every return (with result summary)
- Updates team norms in auto-memory with the new logging standard

## Logger features
- **Key-based masking**: `maskValuesOfKeys` covers 20+ secret key patterns (password, token, secret, apiKey, client_secret, refresh_token, id_token, code_verifier, etc.) with case-insensitive matching
- **Regex-based masking**: Catches Anthropic keys (`sk-ant-api*`), OpenAI keys (`sk-*`), Google secrets (`GOCSPX-*`), Google API keys (`AIzaSy*`), Google access tokens (`ya29.*`), and JWTs — even when passed in non-standard key names
- **Environment-aware output**: JSON in production (Vercel log-friendly), pretty in development
- **Zero config for callers**: `import { log } from "@/lib/logger"` — just use it

## Files changed (15)
| File | What changed |
|------|-------------|
| `src/lib/logger.ts` | **New** — fenrir logger singleton |
| `src/app/api/auth/token/route.ts` | Entry/exit logging + secret-safe diagnostics |
| `src/app/api/config/picker/route.ts` | Entry/exit logging |
| `src/app/api/sheets/import/route.ts` | Entry/exit logging |
| `src/lib/auth/require-auth.ts` | Entry/exit logging |
| `src/lib/auth/verify-id-token.ts` | Entry/exit logging |
| `src/lib/rate-limit.ts` | Entry/exit logging |
| `src/lib/sheets/import-pipeline.ts` | Entry/exit logging |
| `src/lib/sheets/csv-import-pipeline.ts` | Entry/exit logging |
| `src/lib/sheets/extract-cards.ts` | Entry/exit logging + LLM call tracing |
| `src/lib/sheets/fetch-csv.ts` | Entry/exit logging |
| `src/lib/sheets/parse-url.ts` | Entry/exit logging |
| `src/lib/llm/extract.ts` | Entry/exit logging + retry tracing |
| `package.json` | Added `tslog` dependency |
| `package-lock.json` | Lock file update |

## Test plan
- [x] `next build` passes cleanly
- [ ] Verify structured JSON output in Vercel function logs after deploy
- [ ] Verify secret values are masked (not visible) in any log output
- [ ] Verify pretty output works in local `next dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)