### PR TITLE
feat: add privacy policy and terms of service pages

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -687,6 +687,28 @@
       cursor: help;
       border-bottom: 1px dotted var(--text-void);
     }
+    .footer-legal {
+      display: flex;
+      justify-content: center;
+      gap: 24px;
+      margin-bottom: 16px;
+    }
+    .footer-legal a {
+      font-family: var(--font-body);
+      font-size: 13px;
+      color: var(--text-rune);
+      text-decoration: none;
+      letter-spacing: 0.03em;
+      transition: color 150ms ease-out;
+    }
+    .footer-legal a:hover {
+      color: var(--gold);
+    }
+    .footer-legal-sep {
+      color: var(--text-void);
+      font-size: 13px;
+      user-select: none;
+    }
 
     /* ── Mythology Links ─────────────────────────────────── */
     /* Subtly visible enrichment links to Wikipedia for Norse
@@ -993,6 +1015,12 @@
       <hr class="footer-rule" />
 
       <a href="/sessions/" class="step-log-link" style="display:block;margin-bottom:24px;">ᛏ Session Chronicles →</a>
+
+      <div class="footer-legal">
+        <a href="/static/privacy.html">Privacy Policy</a>
+        <span class="footer-legal-sep" aria-hidden="true">&middot;</span>
+        <a href="/static/terms.html">Terms of Service</a>
+      </div>
 
       <p class="footer-credit">
         <span data-gleipnir="breath-of-a-fish" class="copyright-c">©</span> 2026 Fenrir Ledger ·

--- a/static/privacy.html
+++ b/static/privacy.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Privacy Policy — Fenrir Ledger</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: "Source Serif 4", Georgia, serif;
+      background: #12100e;
+      color: #f0ede4;
+      line-height: 1.7;
+      padding: 2rem 1rem 4rem;
+      max-width: 48rem;
+      margin: 0 auto;
+    }
+    a { color: #d4a520; text-decoration: underline; }
+    a:hover { color: #e8bf44; }
+    h1 {
+      font-family: "Cinzel Decorative", "Cinzel", Georgia, serif;
+      font-size: 1.75rem;
+      color: #d4a520;
+      margin-bottom: 0.25rem;
+    }
+    h2 {
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 1.25rem;
+      color: #d4a520;
+      margin-top: 2rem;
+      margin-bottom: 0.5rem;
+      border-bottom: 1px solid #3a3530;
+      padding-bottom: 0.25rem;
+    }
+    h3 {
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 1.05rem;
+      color: #f0ede4;
+      margin-top: 1.5rem;
+      margin-bottom: 0.4rem;
+    }
+    p, li { margin-bottom: 0.75rem; }
+    ul { padding-left: 1.5rem; list-style: disc; }
+    .meta {
+      color: #a09888;
+      font-size: 0.9rem;
+      margin-bottom: 2rem;
+    }
+    .back {
+      display: inline-block;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+    }
+    .attribution {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid #3a3530;
+      font-size: 0.85rem;
+      color: #a09888;
+    }
+    .site-footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid #3a3530;
+      text-align: center;
+    }
+    .site-footer nav {
+      margin-bottom: 0.75rem;
+    }
+    .site-footer nav a {
+      color: #a09888;
+      text-decoration: none;
+      font-size: 0.9rem;
+      transition: color 150ms ease-out;
+    }
+    .site-footer nav a:hover {
+      color: #d4a520;
+    }
+    .site-footer nav .sep {
+      color: #6a6560;
+      margin: 0 0.75rem;
+      user-select: none;
+    }
+    .site-footer p {
+      color: #6a6560;
+      font-size: 0.8rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <a class="back" href="/">&larr; Back to Fenrir Ledger</a>
+  <h1>Privacy Policy</h1>
+  <p class="meta">Last Updated: March 3, 2026</p>
+
+  <p>Your privacy is important to us. Fenrir Ledger is a credit card rewards tracker
+    that is designed to keep your data under your control. This Privacy Policy explains
+    what information we collect, how we use it, and your choices.</p>
+
+  <h2>1. Who We Are</h2>
+  <p>Fenrir Ledger is an open-source web application for tracking credit card signup
+    bonuses, annual fees, and reward milestones. The service is operated by
+    Declan Shanaghy ("we", "us", "our"). You can reach us at
+    <a href="mailto:privacy@fenrirledger.com">privacy@fenrirledger.com</a>.</p>
+
+  <h2>2. Information We Collect</h2>
+
+  <h3>Information You Provide</h3>
+  <ul>
+    <li><strong>Account information:</strong> When you sign in with Google, we receive
+      your name, email address, and profile picture from Google's OAuth service. We use
+      this solely to authenticate you.</li>
+    <li><strong>Patreon membership:</strong> If you connect your Patreon account, we
+      check your membership status to determine feature access. We receive your Patreon
+      user ID and membership tier. We do not access your payment details or billing
+      history on Patreon.</li>
+    <li><strong>Card and financial tracking data:</strong> Credit card names, issuers,
+      annual fees, bonus targets, and related data you enter into the application.
+      <strong>This data is stored locally in your browser (localStorage) and is not
+      transmitted to our servers.</strong></li>
+  </ul>
+
+  <h3>Information Collected Automatically</h3>
+  <ul>
+    <li><strong>Analytics data:</strong> We use analytics services to understand how
+      the application is used. This may include pages visited, features used, browser
+      type, device type, approximate location (country/region derived from IP address),
+      and referral source. We do not use analytics to identify you personally.</li>
+    <li><strong>Server logs:</strong> Our hosting provider (Vercel) may collect standard
+      server logs including IP addresses, request timestamps, and HTTP headers. These
+      are retained per Vercel's data retention policies.</li>
+  </ul>
+
+  <h3>Information from Third Parties</h3>
+  <ul>
+    <li><strong>Google OAuth:</strong> Name, email address, and profile picture when
+      you sign in.</li>
+    <li><strong>Google Sheets / Drive:</strong> If you use the import feature, we
+      access spreadsheet data you explicitly select via Google Picker. We read the
+      data to extract card information and do not store your Google Drive files.</li>
+    <li><strong>Patreon:</strong> Membership tier and user ID when you connect your
+      Patreon account.</li>
+  </ul>
+
+  <h2>3. How We Use Your Information</h2>
+  <ul>
+    <li>Authenticate you and maintain your session</li>
+    <li>Determine your Patreon membership tier for feature access</li>
+    <li>Import card data from spreadsheets you select</li>
+    <li>Improve the application based on aggregate usage patterns</li>
+    <li>Diagnose technical issues via server logs</li>
+  </ul>
+
+  <h2>4. Analytics and Opting Out</h2>
+  <p>We use analytics to understand aggregate usage patterns — for example, which
+    features are used most and where users encounter issues. Analytics data is
+    collected in a way that does not personally identify you.</p>
+  <p><strong>You may opt out of analytics tracking</strong> at any time via the
+    Settings page in the application. When you opt out, no analytics data will be
+    collected from your browser. You can also use browser extensions such as ad
+    blockers or privacy tools to block analytics scripts.</p>
+
+  <h2>5. Data Storage and Security</h2>
+  <ul>
+    <li><strong>Card data</strong> is stored in your browser's localStorage. It never
+      leaves your device unless you explicitly use the import/export features.</li>
+    <li><strong>Authentication tokens</strong> are stored as secure, HTTP-only cookies
+      or in-memory and are not accessible to JavaScript.</li>
+    <li>We use HTTPS for all data transmission.</li>
+    <li>We do not maintain a database of your card or financial data on our servers.</li>
+  </ul>
+
+  <h2>6. Data Sharing</h2>
+  <p>We do not sell, rent, or trade your personal information. We may share information
+    only in the following circumstances:</p>
+  <ul>
+    <li><strong>Service providers:</strong> Vercel (hosting), Google (authentication,
+      Sheets API), Patreon (membership verification), and Anthropic (LLM-based data
+      extraction during import). These providers receive only the minimum data
+      necessary to perform their function.</li>
+    <li><strong>Legal requirements:</strong> If required by law, subpoena, or court
+      order.</li>
+    <li><strong>Safety:</strong> To protect the rights, safety, or property of our
+      users or the public.</li>
+  </ul>
+
+  <h2>7. Data Retention</h2>
+  <ul>
+    <li><strong>localStorage data:</strong> Persists until you clear it or uninstall
+      the application. We have no access to it.</li>
+    <li><strong>Authentication sessions:</strong> Expire based on token lifetime
+      (typically hours to days).</li>
+    <li><strong>Server logs:</strong> Retained per our hosting provider's policies
+      (typically 30 days).</li>
+    <li><strong>Analytics data:</strong> Retained in aggregate form. No personally
+      identifiable information is stored.</li>
+  </ul>
+
+  <h2>8. Your Rights</h2>
+  <p>Depending on your jurisdiction, you may have the right to:</p>
+  <ul>
+    <li>Access the personal information we hold about you</li>
+    <li>Request correction or deletion of your personal information</li>
+    <li>Opt out of analytics tracking (see Section 4)</li>
+    <li>Withdraw consent for data processing</li>
+    <li>Lodge a complaint with a data protection authority</li>
+  </ul>
+  <p>Since your card data is stored locally in your browser, you have full control
+    over it at all times. You can delete it by clearing your browser's localStorage
+    for this site.</p>
+  <p>To exercise any other rights, contact us at
+    <a href="mailto:privacy@fenrirledger.com">privacy@fenrirledger.com</a>.</p>
+
+  <h2>9. Children's Privacy</h2>
+  <p>Fenrir Ledger is not directed at children under the age of 13 (or 16 in the
+    European Economic Area). We do not knowingly collect personal information from
+    children. If you believe a child has provided us with personal information,
+    please contact us and we will delete it.</p>
+
+  <h2>10. Changes to This Policy</h2>
+  <p>We may update this Privacy Policy from time to time. When we make changes, we
+    will update the "Last Updated" date above. We encourage you to review this
+    policy periodically. Continued use of the service after changes constitutes
+    acceptance of the updated policy.</p>
+
+  <h2>11. Contact</h2>
+  <p>If you have questions about this Privacy Policy, please contact us at
+    <a href="mailto:privacy@fenrirledger.com">privacy@fenrirledger.com</a>.</p>
+
+  <footer class="site-footer">
+    <nav>
+      <a href="/static/privacy.html">Privacy Policy</a>
+      <span class="sep" aria-hidden="true">&middot;</span>
+      <a href="/static/terms.html">Terms of Service</a>
+    </nav>
+    <p>&copy; 2026 Fenrir Ledger</p>
+  </footer>
+
+  <div class="attribution">
+    <p>This Privacy Policy is adapted from <a href="https://github.com/Automattic/legalmattic">Automattic's
+    open-source legal documents</a>, available under the
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0</a>
+    license. This adapted version is shared under the same license.</p>
+  </div>
+</body>
+</html>

--- a/static/terms.html
+++ b/static/terms.html
@@ -1,0 +1,228 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Terms of Service — Fenrir Ledger</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: "Source Serif 4", Georgia, serif;
+      background: #12100e;
+      color: #f0ede4;
+      line-height: 1.7;
+      padding: 2rem 1rem 4rem;
+      max-width: 48rem;
+      margin: 0 auto;
+    }
+    a { color: #d4a520; text-decoration: underline; }
+    a:hover { color: #e8bf44; }
+    h1 {
+      font-family: "Cinzel Decorative", "Cinzel", Georgia, serif;
+      font-size: 1.75rem;
+      color: #d4a520;
+      margin-bottom: 0.25rem;
+    }
+    h2 {
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 1.25rem;
+      color: #d4a520;
+      margin-top: 2rem;
+      margin-bottom: 0.5rem;
+      border-bottom: 1px solid #3a3530;
+      padding-bottom: 0.25rem;
+    }
+    h3 {
+      font-family: "Cinzel", Georgia, serif;
+      font-size: 1.05rem;
+      color: #f0ede4;
+      margin-top: 1.5rem;
+      margin-bottom: 0.4rem;
+    }
+    p, li { margin-bottom: 0.75rem; }
+    ul, ol { padding-left: 1.5rem; }
+    ul { list-style: disc; }
+    ol { list-style: decimal; }
+    .meta {
+      color: #a09888;
+      font-size: 0.9rem;
+      margin-bottom: 2rem;
+    }
+    .back {
+      display: inline-block;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+    }
+    .caps {
+      text-transform: uppercase;
+      font-size: 0.92rem;
+    }
+    .attribution {
+      margin-top: 3rem;
+      padding-top: 1rem;
+      border-top: 1px solid #3a3530;
+      font-size: 0.85rem;
+      color: #a09888;
+    }
+    .site-footer {
+      margin-top: 3rem;
+      padding-top: 1.5rem;
+      border-top: 1px solid #3a3530;
+      text-align: center;
+    }
+    .site-footer nav {
+      margin-bottom: 0.75rem;
+    }
+    .site-footer nav a {
+      color: #a09888;
+      text-decoration: none;
+      font-size: 0.9rem;
+      transition: color 150ms ease-out;
+    }
+    .site-footer nav a:hover {
+      color: #d4a520;
+    }
+    .site-footer nav .sep {
+      color: #6a6560;
+      margin: 0 0.75rem;
+      user-select: none;
+    }
+    .site-footer p {
+      color: #6a6560;
+      font-size: 0.8rem;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <a class="back" href="/">&larr; Back to Fenrir Ledger</a>
+  <h1>Terms of Service</h1>
+  <p class="meta">Last Updated: March 3, 2026</p>
+
+  <p>These Terms of Service ("Terms") govern your access to and use of Fenrir Ledger
+    (the "Service"). Please read them carefully. By accessing or using the Service,
+    you agree to be bound by these Terms. If you do not agree, do not use the
+    Service.</p>
+
+  <h2>1. Who We Are</h2>
+  <p>Fenrir Ledger is a credit card rewards tracking application operated by
+    Declan Shanaghy ("we", "us", "our"). The Service is available at
+    <a href="https://fenrirledger.com">fenrirledger.com</a>.</p>
+
+  <h2>2. Your Account</h2>
+  <p>To use certain features of the Service, you must sign in with a Google account.
+    You may also optionally connect a Patreon account for access to premium features.
+    You are responsible for maintaining the security of your account credentials and
+    for all activity that occurs under your account.</p>
+  <p>You must be at least 13 years old (or 16 in the European Economic Area) to use
+    the Service. By using the Service, you represent that you meet this age
+    requirement.</p>
+
+  <h2>3. The Service</h2>
+  <p>Fenrir Ledger helps you track credit card signup bonuses, annual fees, and reward
+    milestones. Key aspects of the Service:</p>
+  <ul>
+    <li><strong>Local-first data:</strong> Your card and financial tracking data is
+      stored in your browser's localStorage. We do not store this data on our
+      servers.</li>
+    <li><strong>Import features:</strong> You may import data from Google Sheets or
+      CSV files. Imported data is processed to extract card information and is not
+      retained on our servers after processing.</li>
+    <li><strong>Patreon integration:</strong> Connecting your Patreon account allows
+      access to premium features based on your membership tier.</li>
+  </ul>
+
+  <h2>4. Acceptable Use</h2>
+  <p>You agree not to:</p>
+  <ul>
+    <li>Use the Service for any unlawful purpose or in violation of any applicable
+      laws or regulations</li>
+    <li>Attempt to interfere with, compromise, or disrupt the Service or its
+      infrastructure</li>
+    <li>Reverse engineer, decompile, or disassemble any part of the Service, except
+      as permitted by the open-source license governing the source code</li>
+    <li>Use automated means (bots, scrapers, etc.) to access the Service in a manner
+      that imposes an unreasonable load on our infrastructure</li>
+    <li>Impersonate any person or entity, or misrepresent your affiliation with any
+      person or entity</li>
+  </ul>
+
+  <h2>5. Intellectual Property</h2>
+  <p>The Fenrir Ledger source code is available under the
+    <a href="https://www.elastic.co/licensing/elastic-license">Elastic License 2.0 (ELv2)</a>.
+    The Service's visual design, branding, name, and logo are the property of
+    Declan Shanaghy and may not be used without permission.</p>
+  <p>Your data remains yours. We claim no ownership over any data you enter into or
+    import into the Service.</p>
+
+  <h2>6. Third-Party Services</h2>
+  <p>The Service integrates with third-party services including Google (authentication,
+    Sheets API), Patreon (membership verification), Anthropic (data extraction during
+    import), and Vercel (hosting). Your use of these services is subject to their
+    respective terms and privacy policies. We are not responsible for the practices
+    of third-party services.</p>
+
+  <h2>7. Disclaimer of Warranties</h2>
+  <p class="caps">The Service is provided "as is" and "as available" without warranties
+    of any kind, whether express or implied, including but not limited to implied
+    warranties of merchantability, fitness for a particular purpose, and
+    non-infringement.</p>
+  <p>We do not warrant that the Service will be uninterrupted, secure, or error-free.
+    Fenrir Ledger is a tracking tool — it does not provide financial advice. You are
+    solely responsible for your financial decisions.</p>
+
+  <h2>8. Limitation of Liability</h2>
+  <p class="caps">To the maximum extent permitted by applicable law, in no event shall
+    we be liable for any indirect, incidental, special, consequential, or punitive
+    damages, or any loss of profits or revenue, whether incurred directly or
+    indirectly, or any loss of data, use, goodwill, or other intangible losses,
+    resulting from:</p>
+  <ul>
+    <li>Your use or inability to use the Service</li>
+    <li>Any unauthorized access to or alteration of your data</li>
+    <li>Loss of data stored in localStorage (e.g., due to browser clearing, device
+      failure, or browser updates)</li>
+    <li>Any third-party conduct or content on the Service</li>
+    <li>Any other matter relating to the Service</li>
+  </ul>
+
+  <h2>9. Changes to the Service</h2>
+  <p>We reserve the right to modify, suspend, or discontinue the Service (or any
+    part of it) at any time, with or without notice. We are not liable to you or
+    any third party for any modification, suspension, or discontinuation of the
+    Service.</p>
+
+  <h2>10. Changes to These Terms</h2>
+  <p>We may revise these Terms from time to time. When we make changes, we will
+    update the "Last Updated" date above. Your continued use of the Service after
+    revised Terms take effect constitutes acceptance of the changes. If you do not
+    agree to the revised Terms, please stop using the Service.</p>
+
+  <h2>11. Governing Law</h2>
+  <p>These Terms are governed by and construed in accordance with the laws of the
+    State of Colorado, United States, without regard to its conflict of law
+    provisions.</p>
+
+  <h2>12. Contact</h2>
+  <p>If you have questions about these Terms, please contact us at
+    <a href="mailto:legal@fenrirledger.com">legal@fenrirledger.com</a>.</p>
+
+  <footer class="site-footer">
+    <nav>
+      <a href="/static/privacy.html">Privacy Policy</a>
+      <span class="sep" aria-hidden="true">&middot;</span>
+      <a href="/static/terms.html">Terms of Service</a>
+    </nav>
+    <p>&copy; 2026 Fenrir Ledger</p>
+  </footer>
+
+  <div class="attribution">
+    <p>These Terms of Service are adapted from <a href="https://github.com/Automattic/legalmattic">Automattic's
+    open-source legal documents</a> and the
+    <a href="https://github.com/appdotnet/template-terms-of-service">App.net Terms of Service template</a>,
+    available under the
+    <a href="https://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0</a>
+    license. This adapted version is shared under the same license.</p>
+  </div>
+</body>
+</html>

--- a/ux/README.md
+++ b/ux/README.md
@@ -42,6 +42,7 @@ What follows is the full visual and verbal soul of Fenrir Ledger. Freya shaped t
 - [wireframes/easter-eggs/gleipnir-hunt-complete.html](wireframes/easter-eggs/gleipnir-hunt-complete.html) — Full Gleipnir Hunt: Fragment 4 + 6 triggers, reward Valhalla entry, DEF-001 fix (Story 4.3).
 - [wireframes/accessibility/accessibility-polish.html](wireframes/accessibility/accessibility-polish.html) — Accessibility polish: focus rings, skip-nav, ARIA landmarks, touch targets, reduced motion (Story 4.4).
 - [wireframes/cards/wolves-hunger-about-modal.html](wireframes/cards/wolves-hunger-about-modal.html) — Wolf's Hunger Meter + About Modal: hunger section, display variants, shared component spec (Story 4.5).
+- [wireframes/marketing/static-site-footer.html](wireframes/marketing/static-site-footer.html) — Static site footer: legal links row (Privacy Policy + Terms of Service), easter egg preservation, responsive spec.
 - [../architecture/README.md](../architecture/README.md) — FiremanDecko's domain: implementation brief, pipeline, system design, sprint plan, and ADRs.
 - [../architecture/implementation-brief.md](../architecture/implementation-brief.md) — FiremanDecko integration plan: wave strategy, sprint stories, open questions.
 - [../architecture/pipeline.md](../architecture/pipeline.md) — Kanban orchestration: model assignments, stage gates, WIP limits, handoff chain.

--- a/ux/wireframes.md
+++ b/ux/wireframes.md
@@ -56,7 +56,8 @@ Wireframes are standalone HTML5 documents. They use only structural layout — n
 | **accessibility** | | |
 | Accessibility + UX Polish | [wireframes/accessibility/accessibility-polish.html](wireframes/accessibility/accessibility-polish.html) | Focus ring spec, skip-nav, ARIA landmarks, heading hierarchy, touch target audit, mobile layouts, reduced-motion |
 | **marketing** | | |
-| Marketing Site | [wireframes/marketing/marketing-site.html](wireframes/marketing/marketing-site.html) | 5-section static page: nav, hero, problems, features, steps, footer |
+| Marketing Site | [wireframes/marketing/marketing-site.html](wireframes/marketing/marketing-site.html) | 5-section static page: nav, hero, problems, features, steps, footer (updated: legal links in footer) |
+| Static Site Footer | [wireframes/marketing/static-site-footer.html](wireframes/marketing/static-site-footer.html) | Dedicated footer spec: brand, quote, runes, CTA, session link, legal row (Privacy Policy + Terms of Service), team credits; easter egg triggers preserved |
 
 ---
 
@@ -237,7 +238,7 @@ Z-index: 50 (see z-index table below). Mobile: bottom drawer toggle.
 
 ## Marketing Site — `/static/index.html`
 
-[→ marketing-site.html](wireframes/marketing/marketing-site.html)
+[→ marketing-site.html](wireframes/marketing/marketing-site.html) | [→ static-site-footer.html](wireframes/marketing/static-site-footer.html) (dedicated footer spec)
 
 Single-page, no framework, inline CSS/JS. Five sections:
 
@@ -248,7 +249,9 @@ Single-page, no framework, inline CSS/JS. Five sections:
 | CHAINS | 3-col problems | Fee-Serpent · Promo Tide · Unclaimed Plunder |
 | FEATURES | 3×2 grid | Six product pillars (Sköll & Hati, Norns, Ledger, Valhalla, Howl, Nine Realms) |
 | STEPS | 3-step flow | Forge → Watch → Break Free |
-| FOOTER | | Logo · quote · runic cipher · CTA · credits |
+| FOOTER | | Logo · quote · runic cipher · CTA · legal links · credits |
+
+**Footer legal links (new):** The footer now includes a legal links row between the Session Chronicles link and the team credits. Structure: `(c) 2026 Fenrir Ledger · Privacy Policy · Terms of Service`. Links navigate same-tab to `/static/privacy.html` and `/static/terms.html`. Required for Patreon OAuth compliance. See [static-site-footer.html](wireframes/marketing/static-site-footer.html) for the dedicated footer wireframe with full annotations.
 
 Easter egg placements visible in wireframe annotations (Gleipnir Hunt #5 on ©, Loki Mode on "Loki").
 

--- a/ux/wireframes/marketing/marketing-site.html
+++ b/ux/wireframes/marketing/marketing-site.html
@@ -174,8 +174,15 @@
         <button>[Enter the Ledger ▶]</button>
       </div>
     </div>
-    <p style="margin-top: 16px; font-size: 12px;">
-      © 2026 Fenrir Ledger · Forged by FiremanDecko · Guarded by Freya · Tested by
+    <!-- Legal links row: copyright + privacy + terms -->
+    <nav aria-label="Legal" style="margin-top: 16px; font-size: 12px; text-align: center;">
+      <span title="[EE#5] Gleipnir Hunt — hover for fragment">&copy;</span> 2026 Fenrir Ledger
+      &middot; <a href="/static/privacy.html">Privacy Policy</a>
+      &middot; <a href="/static/terms.html">Terms of Service</a>
+    </nav>
+    <p class="note">Legal links: same-tab nav to /static/privacy.html and /static/terms.html. Required for Patreon OAuth.</p>
+    <p style="margin-top: 8px; font-size: 12px;">
+      Forged by FiremanDecko · Guarded by Freya · Tested by
       <span title="Loki Mode: click 7 times">Loki</span>
       <span class="note"> ← hover "Loki" shows easter egg tooltip; click 7× triggers Loki Mode</span>
     </p>

--- a/ux/wireframes/marketing/static-site-footer.html
+++ b/ux/wireframes/marketing/static-site-footer.html
@@ -1,0 +1,313 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Wireframe: Static Site Footer — /static/ pages</title>
+  <style>
+    /* Layout and structure only.
+       No colors, no custom fonts, no shadows, no border-radius.
+       Theme styling is defined in ../../theme-system.md. */
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body { font-family: sans-serif; font-size: 14px; }
+    .note { font-size: 11px; font-style: italic; opacity: 0.6; }
+
+    /* ── Page stub ─────────────────────────────────────────────────── */
+    .page-stub {
+      min-height: 300px;
+      border-bottom: 1px solid;
+      padding: 40px 32px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+
+    /* ── Footer shell ──────────────────────────────────────────────── */
+    footer {
+      border-top: 1px solid;
+      padding: 48px 32px 32px;
+    }
+
+    .footer-container {
+      max-width: 1100px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 24px;
+    }
+
+    /* ── Logo + quote block (existing) ─────────────────────────────── */
+    .footer-brand {
+      font-size: 18px;
+      font-weight: bold;
+      letter-spacing: 0.15em;
+      text-align: center;
+    }
+
+    .footer-quote {
+      font-style: italic;
+      font-size: 14px;
+      text-align: center;
+      max-width: 440px;
+    }
+
+    .footer-quote cite {
+      display: block;
+      margin-top: 4px;
+      font-style: normal;
+      font-size: 12px;
+      opacity: 0.6;
+    }
+
+    /* ── Runic cipher (existing) ───────────────────────────────────── */
+    .footer-runes {
+      font-size: 16px;
+      letter-spacing: 0.5em;
+      text-align: center;
+    }
+
+    /* ── CTA button (existing) ─────────────────────────────────────── */
+    .footer-cta {
+      border: 1px solid;
+      padding: 10px 22px;
+      font-size: 13px;
+      font-weight: bold;
+      letter-spacing: 0.1em;
+      text-transform: uppercase;
+      cursor: pointer;
+      text-align: center;
+    }
+
+    /* ── Separator rule (existing) ─────────────────────────────────── */
+    .footer-rule {
+      border: none;
+      border-top: 1px solid;
+      width: 100%;
+      max-width: 320px;
+    }
+
+    /* ── Session Chronicles link (existing) ────────────────────────── */
+    .footer-session-link {
+      font-size: 10px;
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      text-decoration: none;
+    }
+
+    /* ════════════════════════════════════════════════════════════════
+       NEW: Legal links row
+       ════════════════════════════════════════════════════════════════
+       A single flex row containing: copyright + middot + Privacy Policy
+       link + middot + Terms of Service link.
+       Sits between the Session Chronicles link and the team credits.
+       ════════════════════════════════════════════════════════════════ */
+    .footer-legal-row {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 4px;
+      font-size: 12px;
+    }
+
+    .footer-legal-row a {
+      text-decoration: none;
+      font-size: 12px;
+    }
+
+    /* ── Team credits (existing, now after legal row) ──────────────── */
+    .footer-credit {
+      font-size: 12px;
+      text-align: center;
+    }
+
+    .footer-credit .copyright-symbol {
+      display: inline-block;
+      cursor: default;
+      position: relative;
+    }
+
+    /* ── Responsive: mobile (<640px) ──────────────────────────────── */
+    @media (max-width: 639px) {
+      footer {
+        padding: 32px 16px 24px;
+      }
+
+      .footer-legal-row {
+        flex-direction: column;
+        gap: 8px;
+      }
+
+      /* On mobile, legal links stack vertically. Each link gets its
+         own line. Middot separators are hidden via CSS on small screens
+         if desired, but they also work fine inline. */
+    }
+  </style>
+</head>
+<body>
+
+  <!-- Page stub — represents the main content area above the footer -->
+  <div class="page-stub">
+    <p class="note">[ Static site main content — hero, chains, features, steps ]</p>
+  </div>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       STATIC SITE FOOTER
+       ─────────────────────────────────────────────────────────────────
+       Context: This is the footer for /static/index.html (the marketing
+       site), not the in-app footer (see chrome/footer.html for that).
+
+       The existing footer structure is preserved. The only change is
+       adding a legal links row between the Session Chronicles link
+       and the team credits line.
+
+       Legal pages:
+         - /static/privacy.html  (Privacy Policy)
+         - /static/terms.html    (Terms of Service)
+
+       These pages are required for Patreon OAuth compliance.
+       ═══════════════════════════════════════════════════════════════════ -->
+  <footer role="contentinfo" aria-label="Site footer">
+    <div class="footer-container">
+
+      <!-- ── Brand logo (existing) ─────────────────────────────────── -->
+      <div class="footer-brand">
+        [rune] FENRIR LEDGER
+      </div>
+
+      <!-- ── Edda quote (existing) ─────────────────────────────────── -->
+      <blockquote class="footer-quote">
+        "Though it looks like silk ribbon, no chain is stronger."
+        <cite>-- Prose Edda, Gylfaginning</cite>
+      </blockquote>
+
+      <!-- ── Runic cipher (existing) ───────────────────────────────── -->
+      <div class="footer-runes" aria-hidden="true">
+        F E N R I R
+      </div>
+
+      <!-- ── CTA (existing) ────────────────────────────────────────── -->
+      <a href="#" class="footer-cta">[Open the Ledger]</a>
+
+      <!-- ── Separator (existing) ──────────────────────────────────── -->
+      <hr class="footer-rule" />
+
+      <!-- ── Session Chronicles (existing) ─────────────────────────── -->
+      <a href="/sessions/" class="footer-session-link">
+        [rune] Session Chronicles [arrow]
+      </a>
+
+      <!-- ════════════════════════════════════════════════════════════
+           NEW: Legal Links Row
+           ────────────────────────────────────────────────────────────
+           Structure:
+             [copyright] 2026 Fenrir Ledger  ·  Privacy Policy  ·  Terms of Service
+
+           Design decisions:
+           - Same font-size (12px) as the existing footer-credit line.
+           - Links use theme gold color in implementation (not in wireframe).
+           - Middot separators between items for visual rhythm.
+           - Links open in the same tab (same-site navigation).
+           - On mobile, items wrap naturally or stack vertically.
+           - Touch targets: links have sufficient padding for 44px tap
+             area via line-height + inline padding.
+
+           Accessibility:
+           - Links are standard <a> elements with descriptive text.
+           - No aria-label needed -- link text is self-descriptive.
+           - The nav element groups legal links semantically.
+           ════════════════════════════════════════════════════════════ -->
+      <nav aria-label="Legal">
+        <div class="footer-legal-row">
+          <span>
+            <!--
+              The copyright symbol here is the same Gleipnir Hunt #5
+              trigger as in the app footer. data-gleipnir="breath-of-a-fish"
+              attribute must be present. On hover: CSS ::after tooltip
+              "The breath of a fish". See easter-eggs.md section 1.
+            -->
+            <span
+              class="copyright-symbol"
+              data-gleipnir="breath-of-a-fish"
+              aria-label="Copyright"
+              title="[Easter Egg #5] Hover to reveal a Gleipnir fragment"
+            >&copy;</span>
+            2026 Fenrir Ledger
+          </span>
+          <span aria-hidden="true">&middot;</span>
+          <a href="/static/privacy.html">Privacy Policy</a>
+          <span aria-hidden="true">&middot;</span>
+          <a href="/static/terms.html">Terms of Service</a>
+        </div>
+      </nav>
+
+      <!-- ── Team credits (existing, now below legal row) ──────────── -->
+      <p class="footer-credit">
+        Forged by FiremanDecko &middot;
+        Guarded by Freya &middot;
+        Tested by
+        <span title="[Easter Egg #3] Click 7 times for Loki Mode">Loki</span>
+      </p>
+
+    </div>
+  </footer>
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       LAYOUT NOTES
+       ─────────────────────────────────────────────────────────────────
+       The footer is a single centered column. Elements stack vertically:
+
+       1. Brand wordmark (ᛟ FENRIR LEDGER) — display font, gold in impl
+       2. Edda quote blockquote — italic, muted text
+       3. Runic cipher (ᚠ ᛖ ᚾ ᚱ ᛁ ᚱ) — decorative, aria-hidden
+       4. CTA button (Open the Ledger) — gold button, links to app
+       5. Horizontal rule (320px max-width)
+       6. Session Chronicles link — monospace, uppercase
+       7. NEW: Legal links row:
+          © 2026 Fenrir Ledger · Privacy Policy · Terms of Service
+       8. Team credits — colophon with easter egg triggers
+
+       Responsive:
+       - Desktop (>1024px): all items centered, single column
+       - Tablet (640-1024px): same layout, comfortable spacing
+       - Mobile (<640px): padding shrinks, legal row may wrap to
+         multiple lines. Each link remains tappable (44px target).
+
+       The legal row is intentionally minimal. It does not draw
+       attention — it is infrastructure, not marketing. The links
+       use the same muted text color as the team credits in
+       implementation, with gold on hover (consistent with
+       .myth-link treatment elsewhere on the static site).
+       ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       INTERACTION SPEC: Legal Links
+       ─────────────────────────────────────────────────────────────────
+       Trigger:    Click on "Privacy Policy" or "Terms of Service"
+       Behavior:   Standard same-tab navigation to /static/privacy.html
+                   or /static/terms.html respectively.
+       States:
+         - Default: muted text color (--text-void in theme)
+         - Hover:   gold color (--gold), no underline change
+         - Focus:   standard focus ring per accessibility spec
+         - Active:  standard browser active state
+       Animations: None. These are utilitarian links.
+       Edge cases:
+         - If accessed via file:// protocol, the hrefs resolve
+           relative to the current directory. The existing JS in
+           static/index.html resolves APP_URL but does not rewrite
+           legal links (they are same-directory, not app links).
+       ═══════════════════════════════════════════════════════════════════ -->
+
+  <!-- ═══════════════════════════════════════════════════════════════════
+       EASTER EGG PRESERVATION
+       ─────────────────────────────────────────────────────────────────
+       Both existing easter egg triggers remain intact:
+         - © symbol: Gleipnir Hunt Fragment #5 (breath-of-a-fish)
+         - "Loki" in credits: Easter Egg #3 (Loki Mode, 7 clicks)
+       The legal links do not interfere with either trigger.
+       ═══════════════════════════════════════════════════════════════════ -->
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add static Privacy Policy and Terms of Service pages for Patreon OAuth app registration
- Both adapted from Automattic's open-source legal docs (CC BY-SA 4.0), tailored to Fenrir Ledger
- Footer with legal links added to all three static pages (index, privacy, terms)
- UX wireframes updated with footer wireframe and interaction spec

## Test plan
- [ ] Verify `/static/privacy.html` renders correctly
- [ ] Verify `/static/terms.html` renders correctly
- [ ] Verify footer links appear on all three static pages
- [ ] Verify links navigate correctly between pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)