### PR TITLE
fix: update CI workflows for static files move

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'static/**'
+      - 'development/frontend/public/static/**'
       - 'sessions/**'
   workflow_dispatch:
 
@@ -34,7 +34,7 @@ jobs:
         run: |
           mkdir -p _site
           # Marketing site at root
-          cp -r static/. _site/
+          cp -r development/frontend/public/static/. _site/
           # Session archive at /sessions/
           mkdir -p _site/sessions
           cp -r sessions/. _site/sessions/

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -34,11 +34,10 @@ jobs:
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Copy static site into Next.js public/
+      - name: Copy sessions into Next.js public/
         run: |
-          rm -rf development/frontend/public/static development/frontend/public/sessions
-          mkdir -p development/frontend/public/static development/frontend/public/sessions
-          cp -r static/. development/frontend/public/static/
+          rm -rf development/frontend/public/sessions
+          mkdir -p development/frontend/public/sessions
           cp -r sessions/. development/frontend/public/sessions/
 
       - name: Build

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -29,11 +29,10 @@ jobs:
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Copy static site into Next.js public/
+      - name: Copy sessions into Next.js public/
         run: |
-          rm -rf development/frontend/public/static development/frontend/public/sessions
-          mkdir -p development/frontend/public/static development/frontend/public/sessions
-          cp -r static/. development/frontend/public/static/
+          rm -rf development/frontend/public/sessions
+          mkdir -p development/frontend/public/sessions
           cp -r sessions/. development/frontend/public/sessions/
 
       - name: Build


### PR DESCRIPTION
## Summary
- Static files moved to `development/frontend/public/static/` in PR #102 but CI still referenced `static/` at repo root
- Remove `cp -r static/.` from Vercel production and preview workflows (files already in place)
- Update GitHub Pages workflow to read from new path

## Test plan
- [ ] Vercel production deploy succeeds on merge
- [ ] `/static/privacy.html` and `/static/terms.html` serve correctly on Vercel

🤖 Generated with [Claude Code](https://claude.com/claude-code)