### PR TITLE
fix: prevent SealedRuneModal stacking on settings page

### DIFF
--- a/development/frontend/src/components/entitlement/PatreonGate.tsx
+++ b/development/frontend/src/components/entitlement/PatreonGate.tsx
@@ -21,6 +21,7 @@
  */
 
 import { useState, type ReactNode } from "react";
+import { useAuth } from "@/hooks/useAuth";
 import { useEntitlement } from "@/hooks/useEntitlement";
 import { SealedRuneModal } from "./SealedRuneModal";
 import type { PremiumFeature } from "@/lib/entitlement/types";
@@ -70,8 +71,17 @@ function GateSkeleton() {
  * @param props - Feature slug and children
  */
 export function PatreonGate({ feature, children }: PatreonGateProps) {
+  const { status } = useAuth();
   const { hasFeature, isLoading } = useEntitlement();
-  const [modalDismissed, setModalDismissed] = useState(false);
+  const [modalOpen, setModalOpen] = useState(false);
+
+  // Anonymous users: render children directly — no Patreon-related UI.
+  // Per spec: "Anonymous users see no Patreon-related UI."
+  // The placeholder sections (e.g. "Coming soon to Karl supporters") are
+  // informational and safe to show; the Sealed Rune Modal is Patreon-specific.
+  if (status !== "authenticated") {
+    return <>{children}</>;
+  }
 
   // Loading state: show skeleton shimmer
   if (isLoading) {
@@ -83,33 +93,31 @@ export function PatreonGate({ feature, children }: PatreonGateProps) {
     return <>{children}</>;
   }
 
-  // Feature is locked: show the Sealed Rune Modal
-  // When dismissed, we show nothing (the gate remains locked)
+  // Feature is locked: show the locked placeholder with an option to open the modal.
+  // The modal is NOT auto-opened — this prevents multiple modals stacking when
+  // several PatreonGate components render on the same page.
   return (
     <>
       <SealedRuneModal
         feature={feature}
-        open={!modalDismissed}
-        onDismiss={() => setModalDismissed(true)}
+        open={modalOpen}
+        onDismiss={() => setModalOpen(false)}
       />
-      {/* When the modal is dismissed, show a locked placeholder */}
-      {modalDismissed && (
-        <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
-          <span className="text-3xl text-gold/40 mb-3" aria-hidden="true">
-            &#5765;
-          </span>
-          <p className="text-sm text-rune font-body">
-            This feature requires a Karl subscription.
-          </p>
-          <button
-            type="button"
-            onClick={() => setModalDismissed(false)}
-            className="mt-3 text-sm text-gold underline hover:text-gold-bright transition-colors font-heading min-h-[44px] inline-flex items-center"
-          >
-            Learn more
-          </button>
-        </div>
-      )}
+      <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
+        <span className="text-3xl text-gold/40 mb-3" aria-hidden="true">
+          &#5765;
+        </span>
+        <p className="text-sm text-rune font-body">
+          This feature requires a Karl subscription.
+        </p>
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className="mt-3 text-sm text-gold underline hover:text-gold-bright transition-colors font-heading min-h-[44px] inline-flex items-center"
+        >
+          Learn more
+        </button>
+      </div>
     </>
   );
 }

--- a/development/frontend/src/components/entitlement/SealedRuneModal.tsx
+++ b/development/frontend/src/components/entitlement/SealedRuneModal.tsx
@@ -90,8 +90,8 @@ export function SealedRuneModal({
     <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onDismiss()}>
       <DialogContent
         className="w-[92vw] max-w-[480px] max-h-[90vh] overflow-y-auto border-2 border-gold/40 bg-[#07070d] p-0 gap-0"
-        aria-labelledby="sealed-rune-heading"
-        aria-describedby="sealed-rune-desc"
+        aria-labelledby={`sealed-rune-heading-${feature}`}
+        aria-describedby={`sealed-rune-desc-${feature}`}
       >
         {/* Rune glyph — Algiz (protection) */}
         <div className="text-center pt-6 pb-2" aria-hidden="true">
@@ -102,7 +102,7 @@ export function SealedRuneModal({
 
         {/* Heading */}
         <DialogTitle
-          id="sealed-rune-heading"
+          id={`sealed-rune-heading-${feature}`}
           className="text-center font-display text-lg md:text-[22px] font-bold uppercase tracking-[0.12em] text-saga px-6 pb-4"
         >
           THIS RUNE IS SEALED
@@ -115,7 +115,7 @@ export function SealedRuneModal({
               {featureDef.name}
             </span>
             <DialogDescription
-              id="sealed-rune-desc"
+              id={`sealed-rune-desc-${feature}`}
               className="text-sm text-saga/90 leading-relaxed font-body"
             >
               {featureDesc.description}


### PR DESCRIPTION
## Summary
- **Anonymous users**: PatreonGate now renders children directly (feature placeholders) without opening modals. Per spec: "Anonymous users see no Patreon-related UI."
- **Authenticated thrall users**: Modals start closed (locked placeholder shown). Users click "Learn more" to open the modal on demand — prevents 3 modals stacking simultaneously.
- **Duplicate DOM IDs**: `sealed-rune-heading` and `sealed-rune-desc` are now scoped per feature slug to avoid conflicts.

## What was broken
Visiting `/settings` as an anonymous user caused 3 `SealedRuneModal` dialogs to open simultaneously (Cloud Sync, Multi-Household, Data Export), obscuring all page content. Console errors: `DialogContent requires a DialogTitle` and `Missing Description or aria-describedby` (×3 each).

## Test plan
- [ ] Visit `/settings` as anonymous user — see feature placeholders, no modals
- [ ] Sign in as thrall user — see locked placeholders with "Learn more" buttons
- [ ] Click "Learn more" — modal opens for that feature only
- [ ] Dismiss modal — returns to locked placeholder
- [ ] Zero console errors/warnings on settings page

🤖 Generated with [Claude Code](https://claude.com/claude-code)