### PR TITLE
fix: add error handling for Patreon authorize 500

### DIFF
--- a/development/frontend/src/app/api/patreon/authorize/route.ts
+++ b/development/frontend/src/app/api/patreon/authorize/route.ts
@@ -127,7 +127,23 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   }
 
   // Generate encrypted state token containing the Google user sub
-  const state = generateState(auth.user.sub);
+  let state: string;
+  try {
+    state = generateState(auth.user.sub);
+  } catch (err) {
+    log.error("GET /api/patreon/authorize: generateState failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return NextResponse.json(
+      {
+        error: "state_generation_failed",
+        error_description:
+          "Failed to generate OAuth state. Check ENTITLEMENT_ENCRYPTION_KEY.",
+      },
+      { status: 500 },
+    );
+  }
+
   const redirectUri = buildRedirectUri(request);
 
   // Build the Patreon authorize URL


### PR DESCRIPTION
## Summary
- Wraps `generateState()` in try/catch in `/api/patreon/authorize`
- Returns a descriptive JSON error instead of an opaque HTTP 500
- Helps diagnose `ENTITLEMENT_ENCRYPTION_KEY` issues in production

## Context
Clicking "Link Patreon" on production triggers a 500. The unhandled throw from `generateState()` (which calls `encrypt()`) produces no useful error. This fix surfaces the actual error message.

## Test plan
- [ ] Click "Link Patreon" → see descriptive JSON error instead of blank 500
- [ ] If encryption key is correctly set, the redirect to Patreon works

🤖 Generated with [Claude Code](https://claude.com/claude-code)