### PR TITLE
fix: gracefully handle getMembership failure in Patreon callback

### DIFF
--- a/development/frontend/src/app/api/patreon/callback/route.ts
+++ b/development/frontend/src/app/api/patreon/callback/route.ts
@@ -141,7 +141,28 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       );
     }
 
-    const membership = await getMembership(tokens.access_token, campaignId);
+    // Fetch membership — if this fails (e.g. creator account, API error),
+    // still link the account as thrall rather than failing the entire flow.
+    let membership: { tier: "thrall" | "karl"; active: boolean; patreonUserId: string };
+    try {
+      membership = await getMembership(tokens.access_token, campaignId);
+    } catch (membershipErr) {
+      log.error("GET /api/patreon/callback: getMembership failed, linking as thrall", {
+        error: membershipErr instanceof Error ? membershipErr.message : String(membershipErr),
+      });
+      // Extract patreonUserId from a simpler identity call as fallback
+      let patreonUserId = "unknown";
+      try {
+        const idResp = await fetch("https://www.patreon.com/api/oauth2/v2/identity", {
+          headers: { Authorization: `Bearer ${tokens.access_token}` },
+        });
+        if (idResp.ok) {
+          const idData = await idResp.json() as { data: { id: string } };
+          patreonUserId = idData.data.id;
+        }
+      } catch { /* best-effort */ }
+      membership = { tier: "thrall", active: false, patreonUserId };
+    }
 
     // --- Encrypt tokens for KV storage ---
     const encryptedAccessToken = encrypt(tokens.access_token);


### PR DESCRIPTION
## Summary
- If `getMembership()` throws (e.g. Patreon API error, creator account), the callback now links the account as thrall instead of failing
- Fallback identity call extracts the Patreon user ID for KV storage
- Account can be upgraded later via webhook or membership refresh

## Context
Campaign creators aren't "members" of their own campaign. The Patreon identity API with membership includes may return errors for creator accounts. This fix ensures the OAuth flow completes and the account gets linked regardless.

## Test plan
- [ ] Creator account: Link Patreon → lands on settings with "linked" state (thrall tier)
- [ ] Regular patron: Link Patreon → lands on settings with correct tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)