### PR TITLE
fix: playwright workers type error

### DIFF
--- a/development/frontend/playwright.config.ts
+++ b/development/frontend/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: false,
   retries: 0,
-  workers: process.env.CI ? 2 : undefined,
+  ...(process.env.CI ? { workers: 2 } : {}),
   reporter: process.env.CI
     ? [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]]
     : "list",


### PR DESCRIPTION
## Summary
- Fix `exactOptionalPropertyTypes` error: `workers: undefined` not assignable to `string | number`
- Use conditional spread `...(process.env.CI ? { workers: 2 } : {})` to omit the property entirely when not in CI

## Test plan
- [x] Local tsc passes (no playwright config errors)
- [ ] CI build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)