### PR TITLE
fix: use semicolons in worktree skill shell patterns

### DIFF
--- a/.claude/commands/create-worktree.md
+++ b/.claude/commands/create-worktree.md
@@ -13,6 +13,21 @@ Create a new git worktree in the trees directory (sibling to repo root) with com
 
 **Ports are auto-assigned by the OS** (port 0). The frontend-server.sh script starts Next.js with `--port 0`, parses the assigned port from stdout, and writes it to `development/frontend/.port`. Agents read this file to discover their server URL.
 
+## Shell Command Rules (UNBREAKABLE)
+
+**Variable assignments chained with `&&` lose context in the Bash tool's eval execution.**
+Always use `;` (semicolons) to chain variable assignments, NOT `&&`.
+
+```bash
+# BROKEN — variables are empty after &&
+REPO_ROOT=$(git rev-parse --show-toplevel) && WORKTREE_DIR="${REPO_ROOT}-trees/mybranch" && cd "$WORKTREE_DIR"
+
+# CORRECT — semicolons preserve variable context
+REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/mybranch"; cd "$WORKTREE_DIR"
+```
+
+Use `&&` only for non-assignment commands (e.g., `cd /path && npm install`).
+
 ## Variables
 
 ```
@@ -30,6 +45,16 @@ NOTE: Main repo uses frontend port 9653 (fixed)
       Worktrees use port 0 (OS-assigned) — no collisions possible
       WORKTREE_BASE_DIR is a sibling to the repo, NOT inside it
 ```
+
+### Resolving Paths
+
+At the start of every Bash call, resolve all paths with semicolons:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; APP_DIR="${WORKTREE_DIR}/development/frontend"
+```
+
+Then use the resolved variables in subsequent commands.
 
 ## Instructions
 
@@ -52,8 +77,12 @@ NOTE: Main repo uses frontend port 9653 (fixed)
 
 ### 2. Pre-Creation Validation
 
+- Resolve paths first:
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"
+  ```
 - Check if WORKTREE_BASE_DIR exists, create if not: `mkdir -p "${REPO_ROOT}-trees"`
-- Check if worktree already exists at WORKTREE_DIR
+- Check if worktree already exists at WORKTREE_DIR — if it does, skip to step 5 (idempotent)
 - Check if branch exists: `git branch --list <BRANCH_NAME>`
   - If branch doesn't exist, will create it in next step
   - If branch exists, will checkout to create worktree
@@ -77,9 +106,12 @@ NOTE: Main repo uses frontend port 9653 (fixed)
 
 ### 5. Install Dependencies
 
-- Install dependencies:
-  - `cd <WORKTREE_DIR>/development/frontend && npm install`
-  - Verify `<WORKTREE_DIR>/development/frontend/node_modules` directory was created
+- Install dependencies (use resolved APP_DIR path, not variable expansion in `&&`):
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); APP_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>/development/frontend"; cd "$APP_DIR" && npm install
+  ```
+- If `node_modules` already exists (idempotent re-run), skip `npm install`
+- Verify `<WORKTREE_DIR>/development/frontend/node_modules` directory was created
 
 ### 6. Start Dev Servers
 
@@ -95,7 +127,10 @@ NOTE: Main repo uses frontend port 9653 (fixed)
 
 **Backend (Node/TS):**
 - If `<WORKTREE_DIR>/development/backend` exists and has a `package.json`:
-  - Install dependencies: `cd <WORKTREE_DIR>/development/backend && npm install`
+  - Install dependencies:
+    ```bash
+    REPO_ROOT=$(git rev-parse --show-toplevel); BACKEND_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>/development/backend"; cd "$BACKEND_DIR" && npm install
+    ```
   - Start the backend server (use similar PORT=0 approach if backend-server.sh supports it)
 - If backend directory does not exist, skip and note "Backend: not configured" in report
 

--- a/.claude/commands/remove-worktree.md
+++ b/.claude/commands/remove-worktree.md
@@ -9,6 +9,21 @@ allowed-tools: Bash, Read, Glob, Grep
 
 Remove an existing git worktree from the trees directory (sibling to repo root) AND delete the associated git branch. This includes stopping the dev server, cleaning up processes, removing the worktree directory, and permanently deleting the branch.
 
+## Shell Command Rules (UNBREAKABLE)
+
+**Variable assignments chained with `&&` lose context in the Bash tool's eval execution.**
+Always use `;` (semicolons) to chain variable assignments, NOT `&&`.
+
+```bash
+# BROKEN — variables are empty after &&
+REPO_ROOT=$(git rev-parse --show-toplevel) && WORKTREE_DIR="${REPO_ROOT}-trees/mybranch" && cd "$WORKTREE_DIR"
+
+# CORRECT — semicolons preserve variable context
+REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/mybranch"; cd "$WORKTREE_DIR"
+```
+
+Use `&&` only for non-assignment commands (e.g., `cd /path && npm install`).
+
 ## Variables
 
 ```
@@ -19,6 +34,16 @@ WORKTREE_DIR: ${REPO_ROOT}-trees/<BRANCH_NAME>
 FRONTEND_SERVER_SCRIPT: ${REPO_ROOT}/.claude/scripts/frontend-server.sh
 BACKEND_SERVER_SCRIPT: ${REPO_ROOT}/.claude/scripts/backend-server.sh
 ```
+
+### Resolving Paths
+
+At the start of every Bash call, resolve all paths with semicolons:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"
+```
+
+Then use the resolved variables in subsequent commands.
 
 ## Instructions
 
@@ -48,29 +73,42 @@ BACKEND_SERVER_SCRIPT: ${REPO_ROOT}/.claude/scripts/backend-server.sh
 
 ### 3. Identify Port
 
-- Read the port from the `.port` file: `cat ${REPO_ROOT}-trees/<BRANCH_NAME>/development/frontend/.port 2>/dev/null`
+- Resolve paths first, then read the port:
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; cat "${WORKTREE_DIR}/development/frontend/.port" 2>/dev/null
+  ```
 - If `.port` file doesn't exist, try to find processes in the worktree directory
 
 ### 4. Stop Servers
 
 **Stop Frontend Dev Server:**
 - If port was identified from `.port` file:
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; FENRIR_FRONTEND_DIR="${WORKTREE_DIR}/development/frontend" "${REPO_ROOT}/.claude/scripts/frontend-server.sh" stop
   ```
-  FENRIR_FRONTEND_DIR=${REPO_ROOT}-trees/<BRANCH_NAME>/development/frontend .claude/scripts/frontend-server.sh stop
+- Verify stopped:
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; FENRIR_FRONTEND_DIR="${WORKTREE_DIR}/development/frontend" "${REPO_ROOT}/.claude/scripts/frontend-server.sh" status
   ```
-- Verify stopped: `FENRIR_FRONTEND_DIR=${REPO_ROOT}-trees/<BRANCH_NAME>/development/frontend .claude/scripts/frontend-server.sh status`
 
 - If `.port` file didn't exist, try to find and kill any process in the worktree directory:
-  - `lsof -t +D <WORKTREE_DIR>/development/frontend | xargs kill 2>/dev/null`
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; lsof -t +D "${WORKTREE_DIR}/development/frontend" | xargs kill 2>/dev/null
+  ```
 - Wait 2 seconds for processes to fully terminate
 
 ### 5. Remove Git Worktree
 
-- Remove worktree: `git worktree remove ${REPO_ROOT}-trees/<BRANCH_NAME>`
+- Remove worktree:
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; git worktree remove "$WORKTREE_DIR"
+  ```
 - If removal fails (uncommitted changes):
-  - Try force removal: `git worktree remove ${REPO_ROOT}-trees/<BRANCH_NAME> --force`
+  ```bash
+  REPO_ROOT=$(git rev-parse --show-toplevel); WORKTREE_DIR="${REPO_ROOT}-trees/<BRANCH_NAME>"; git worktree remove "$WORKTREE_DIR" --force
+  ```
   - Note the force removal in the report
-- Verify worktree was removed: `git worktree list | grep ${REPO_ROOT}-trees/<BRANCH_NAME>` (should return nothing)
+- Verify worktree was removed: `git worktree list` (should not contain the worktree path)
 
 ### 6. Delete Git Branch
 


### PR DESCRIPTION
## Summary
- Adds **Shell Command Rules (UNBREAKABLE)** section to both `create-worktree.md` and `remove-worktree.md`
- Replaces all `&&`-chained variable assignments with `;` in shell examples
- Adds idempotency: skip worktree creation if exists, skip npm install if node_modules exists
- Adds "Resolving Paths" pattern showing correct semicolon usage at top of every Bash call

## Why
The Bash tool runs commands through `eval`, which causes variable assignments chained with `&&` to lose context — variables are empty in subsequent commands. This caused worktree creation failures when agents followed the skill file examples.

## Test plan
- [ ] Run `/create-worktree test-branch` and verify it completes without path resolution errors
- [ ] Run `/remove-worktree test-branch` and verify cleanup works
- [ ] Re-run `/create-worktree` on an existing worktree to verify idempotency

🤖 Generated with [Claude Code](https://claude.com/claude-code)