### PR TITLE
chore: remove Patreon env vars from Vercel

### DIFF
--- a/development/frontend/.env.example
+++ b/development/frontend/.env.example
@@ -7,13 +7,6 @@
 # moves server-side so that GOOGLE_CLIENT_SECRET stays off the client.
 # See ADR-005 for the auth architecture decision.
 
-# ─── Subscription Platform Feature Flag ──────────────────────────────────────
-# Controls which subscription platform is active.
-# Valid values: "patreon" (default) | "stripe"
-# When set to "stripe", all Patreon API routes return 404.
-# See designs/architecture/adr-feature-flags.md for rationale.
-SUBSCRIPTION_PLATFORM=patreon
-
 # ─── App version (non-secret, safe for NEXT_PUBLIC_ prefix) ──────────────────
 NEXT_PUBLIC_APP_VERSION=1.0.0-sprint3
 
@@ -69,34 +62,8 @@ GOOGLE_PICKER_API_KEY=
 # No NEXT_PUBLIC_ prefix — Next.js will NOT include this in the client bundle.
 FENRIR_ANTHROPIC_API_KEY=
 
-# ─── Patreon Integration ───────────────────────────────────────────────────
-# Required for the Patreon subscription / entitlement feature (ADR-009).
-# All values are server-side only — never exposed to the client bundle.
-#
-# Obtain from: https://www.patreon.com/portal/registration/register-clients
-#   1. Create an OAuth client
-#   2. Set redirect URIs:
-#        http://localhost:9653/api/patreon/callback      (local dev)
-#        https://fenrir-ledger.vercel.app/api/patreon/callback  (production)
-#   3. Copy Client ID, Client Secret
-#   4. Note your Campaign ID from the campaign URL
-#
-# No NEXT_PUBLIC_ prefix — Next.js will NOT include these in the client bundle.
-PATREON_CLIENT_ID=your-patreon-client-id
-PATREON_CLIENT_SECRET=your-patreon-client-secret
-PATREON_CAMPAIGN_ID=your-campaign-id
-
-# ─── Patreon Webhook Secret ───────────────────────────────────────────────
-# Used to validate webhook signatures (HMAC-MD5) from Patreon.
-#
-# Configure webhooks at: https://www.patreon.com/portal/registration/register-clients
-#   1. Add a webhook URL: https://fenrir-ledger.vercel.app/api/patreon/webhook
-#   2. Select triggers: members:pledge:create, members:pledge:update, members:pledge:delete
-#   3. Copy the webhook secret
-PATREON_WEBHOOK_SECRET=your-webhook-secret
-
 # ─── Entitlement Encryption Key ───────────────────────────────────────────
-# AES-256 encryption key for encrypting Patreon tokens stored in Vercel KV.
+# AES-256 encryption key for encrypting tokens stored in Vercel KV.
 # Must be exactly 64 hex characters (32 bytes).
 #
 # Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
@@ -111,13 +78,13 @@ ENTITLEMENT_ENCRYPTION_KEY=your-32-byte-hex-key-64-chars-long-generate-with-cryp
 # - Local dev:   http://localhost:9653  (or leave unset — header fallback works)
 # - Preview:     Leave unset — preview URLs vary per deployment, header fallback is correct
 #
-# When set, Patreon OAuth authorize and callback routes use this value instead of
+# When set, OAuth authorize and callback routes use this value instead of
 # constructing the URL from request headers. Also used by Stripe checkout/portal
 # routes for success/cancel redirect URLs (SEV-002 fix).
 # APP_BASE_URL=https://fenrir-ledger.vercel.app
 
 # ─── Stripe Integration ────────────────────────────────────────────────────
-# Required when SUBSCRIPTION_PLATFORM=stripe (ADR-010).
+# Required for subscription/entitlement features (ADR-010).
 # All values are server-side only -- never exposed to the client bundle.
 #
 # Obtain from: https://dashboard.stripe.com/


### PR DESCRIPTION
## Summary

- Removed 16 Patreon-related environment variables from Vercel via `vercel env rm`
- Updated `development/frontend/.env.example` to remove all Patreon references

### Vercel Env Vars Removed

| Variable | Environments |
|---|---|
| `PATREON_CLIENT_ID` | development, preview, production |
| `PATREON_CLIENT_SECRET` | development, preview, production |
| `PATREON_CAMPAIGN_ID` | development, preview, production |
| `PATREON_WEBHOOK_SECRET` | development, preview, production |
| `SUBSCRIPTION_PLATFORM` | preview, production |
| `NEXT_PUBLIC_SUBSCRIPTION_PLATFORM` | preview, production |

### .env.example Changes

- Removed `SUBSCRIPTION_PLATFORM` section and variable
- Removed `PATREON_CLIENT_ID`, `PATREON_CLIENT_SECRET`, `PATREON_CAMPAIGN_ID` section
- Removed `PATREON_WEBHOOK_SECRET` section
- Cleaned Patreon references from remaining comments (entitlement key, APP_BASE_URL, Stripe)

### Note
No production redeploy triggered -- that happens after Story 1 (code removal) is merged.

## Test plan

- [x] `vercel env ls | grep -i patreon` returns nothing
- [x] `vercel env ls | grep -i SUBSCRIPTION_PLATFORM` returns nothing
- [ ] Verify `.env.example` no longer contains any `PATREON_*` or `SUBSCRIPTION_PLATFORM` references

🤖 Generated with [Claude Code](https://claude.com/claude-code)