### PR TITLE
chore: track observability settings, remove tmux observer hook

### DIFF
--- a/.claude/settings-observability.json
+++ b/.claude/settings-observability.json
@@ -1,0 +1,189 @@
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "teammateMode": "in-process",
+  "enabledPlugins": {
+    "playwright@claude-plugins-official": true,
+    "vercel@claude-plugins-official": true
+  },
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/statusline-command.sh"
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/pre_tool_use.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PreToolUse --summarize"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/post_tool_use.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PostToolUse --summarize"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/notification.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type Notification --summarize"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/stop.py --chat"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type Stop --add-chat"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/subagent_stop.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SubagentStop"
+          }
+        ]
+      }
+    ],
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/pre_compact.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PreCompact"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/user_prompt_submit.py --log-only --store-last-prompt --name-agent"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type UserPromptSubmit --summarize"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/session_start.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SessionStart"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/session_end.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SessionEnd"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/permission_request.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PermissionRequest --summarize"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/post_tool_use_failure.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type PostToolUseFailure --summarize"
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/subagent_start.py"
+          },
+          {
+            "type": "command",
+            "command": "uv run /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.claude/hooks/send_event.py --source-app fenrir-ledger --event-type SubagentStart"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,8 +42,6 @@ logs/
 tmp/
 development/frontend/.claude/
 
-# Machine-specific Claude settings (contains absolute paths)
-.claude/settings-observability.json
 
 # doc-sync run artifacts (ephemeral, coordinator reads then discards)
 .sync-report.md


### PR DESCRIPTION
## Summary
- Remove `.claude/settings-observability.json` from `.gitignore` so it's tracked
- Remove `observe_subagent.sh` from `SubagentStart` hooks — it was splitting tmux panes on every agent launch, causing screen flashing

## Test plan
- [x] Launch a background agent — no tmux flashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)