### PR TITLE
fix: require auth before Stripe checkout and show cancellation state

### DIFF
--- a/development/frontend/src/app/api/stripe/checkout/route.ts
+++ b/development/frontend/src/app/api/stripe/checkout/route.ts
@@ -2,21 +2,16 @@
  * POST /api/stripe/checkout
  *
  * Creates a Stripe Checkout Session and returns the session URL for
- * client-side redirect. Supports both authenticated and anonymous users.
+ * client-side redirect. Requires Google authentication (ADR-008).
  *
- *
- * Flow (authenticated — Google id_token present):
+ * Flow:
  *   1. Verify Google id_token from Authorization header
- *   2. Create Stripe Checkout Session with metadata.googleSub
+ *   2. Create Stripe Checkout Session with metadata.googleSub + customer_email
  *   3. Return the session URL for redirect
  *
- * Flow (anonymous — no Authorization header):
- *   1. Read `email` from the JSON request body
- *   2. Create Stripe Checkout Session with customer_email (no googleSub metadata)
- *   3. Return the session URL for redirect
- *
- * The checkout session metadata includes `googleSub` only for authenticated
- * users, so the webhook handler can map authenticated vs anonymous.
+ * Anonymous users are redirected to /sign-in by the frontend before reaching
+ * this endpoint. The checkout session always includes googleSub metadata so
+ * the webhook handler can map the subscription to the authenticated user.
  *
  * @see ADR-010 for the Stripe Direct integration decision
  */
@@ -49,23 +44,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     );
   }
 
-  // --- Dual auth path: authenticated (Google id_token) or anonymous (email in body) ---
+  // Require Google authentication — anonymous checkout is not supported.
+  // Anonymous users are redirected to sign-in first by the frontend.
   const auth = await requireAuth(request);
-  const isAuthenticated = auth.ok;
-
-  let customerEmail: string;
-  let googleSub: string | undefined;
-
-  if (isAuthenticated) {
-    customerEmail = auth.user.email;
-    googleSub = auth.user.sub;
-    log.debug("POST /api/stripe/checkout: authenticated user", { googleSub, customerEmail });
-  } else {
-    // Anonymous path — Stripe's hosted checkout page collects email
-    customerEmail = "";
-    googleSub = undefined;
-    log.debug("POST /api/stripe/checkout: anonymous user (email collected by Stripe)");
+  if (!auth.ok) {
+    log.debug("POST /api/stripe/checkout returning", { status: 401, reason: "auth required" });
+    return auth.response;
   }
+
+  const customerEmail = auth.user.email;
+  const googleSub = auth.user.sub;
+  log.debug("POST /api/stripe/checkout: authenticated user", { googleSub, customerEmail });
 
   const priceId = process.env.STRIPE_PRICE_ID;
 
@@ -91,11 +80,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
           quantity: 1,
         },
       ],
-      // Only pre-fill email for authenticated users; anonymous users enter it on Stripe's page
-      ...(customerEmail ? { customer_email: customerEmail } : {}),
-      success_url: `${baseUrl}/settings?stripe=success`,
+      customer_email: customerEmail,
+      success_url: `${baseUrl}/settings?stripe=success&session_id={CHECKOUT_SESSION_ID}`,
       cancel_url: `${baseUrl}/settings?stripe=cancel`,
-      metadata: googleSub ? { googleSub } : {},
+      metadata: { googleSub },
       // Allow promotion codes
       allow_promotion_codes: true,
     });
@@ -115,15 +103,13 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     log.debug("POST /api/stripe/checkout returning", {
       status: 200,
       sessionId: session.id,
-      isAuthenticated,
-      googleSub: googleSub ?? "anonymous",
+      googleSub,
     });
     return NextResponse.json(response);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error("POST /api/stripe/checkout: session creation failed", {
-      isAuthenticated,
-      googleSub: googleSub ?? "anonymous",
+      googleSub,
       error: message,
     });
     log.debug("POST /api/stripe/checkout returning", { status: 500, error: "stripe_error" });

--- a/development/frontend/src/app/api/stripe/membership/route.ts
+++ b/development/frontend/src/app/api/stripe/membership/route.ts
@@ -20,7 +20,8 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/require-auth";
-import { getStripeEntitlement } from "@/lib/kv/entitlement-store";
+import { getStripeEntitlement, setStripeEntitlement, migrateStripeEntitlement } from "@/lib/kv/entitlement-store";
+import { stripe } from "@/lib/stripe/api";
 import { rateLimit } from "@/lib/rate-limit";
 import { log } from "@/lib/logger";
 import type { StripeMembershipResponse } from "@/lib/stripe/types";
@@ -56,9 +57,47 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const googleSub = auth.user.sub;
 
   // Fetch cached entitlement from Vercel KV
-  const cached = await getStripeEntitlement(googleSub);
+  let cached = await getStripeEntitlement(googleSub);
 
-  // If no entitlement exists, user has not subscribed via Stripe
+  // If no entitlement found, attempt to migrate an anonymous Stripe entitlement
+  // using the checkout session_id from the success redirect
+  if (!cached) {
+    const sessionId = request.nextUrl.searchParams.get("session_id");
+    if (sessionId) {
+      log.debug("GET /api/stripe/membership: no entitlement found, attempting migration", {
+        googleSub,
+        sessionId,
+      });
+      try {
+        const checkoutSession = await stripe.checkout.sessions.retrieve(sessionId);
+        const customerId = typeof checkoutSession.customer === "string"
+          ? checkoutSession.customer
+          : checkoutSession.customer?.id;
+
+        if (customerId) {
+          const result = await migrateStripeEntitlement(customerId, googleSub);
+          log.debug("GET /api/stripe/membership: migration result", {
+            googleSub,
+            customerId,
+            ...result,
+          });
+          if (result.migrated) {
+            // Re-fetch after migration
+            cached = await getStripeEntitlement(googleSub);
+          }
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        log.debug("GET /api/stripe/membership: migration attempt failed", {
+          googleSub,
+          sessionId,
+          error: message,
+        });
+      }
+    }
+  }
+
+  // If still no entitlement exists, user has not subscribed via Stripe
   if (!cached) {
     const response: StripeMembershipResponse = {
       tier: "thrall",
@@ -76,6 +115,32 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     });
   }
 
+  // If cached entitlement is missing period end info (pre-existing records),
+  // do a live Stripe lookup to backfill it
+  let { cancelAtPeriodEnd, currentPeriodEnd } = cached;
+  if (currentPeriodEnd === undefined && cached.stripeSubscriptionId) {
+    try {
+      log.debug("GET /api/stripe/membership: backfilling period end from Stripe", {
+        subscriptionId: cached.stripeSubscriptionId,
+      });
+      const sub = await stripe.subscriptions.retrieve(cached.stripeSubscriptionId);
+      cancelAtPeriodEnd = sub.cancel_at_period_end;
+      currentPeriodEnd = new Date(sub.current_period_end * 1000).toISOString();
+
+      // Update KV cache with the new fields
+      await setStripeEntitlement(googleSub, {
+        ...cached,
+        cancelAtPeriodEnd,
+        currentPeriodEnd,
+        stripeStatus: sub.status,
+        checkedAt: new Date().toISOString(),
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      log.debug("GET /api/stripe/membership: Stripe backfill failed", { error: message });
+    }
+  }
+
   // Return the cached entitlement — Stripe webhooks keep it up to date
   const response: StripeMembershipResponse = {
     tier: cached.tier,
@@ -84,11 +149,16 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     checkedAt: cached.checkedAt,
     customerId: cached.stripeCustomerId,
     linkedAt: cached.linkedAt,
+    stripeStatus: cached.stripeStatus,
+    cancelAtPeriodEnd,
+    currentPeriodEnd,
   };
   log.debug("GET /api/stripe/membership returning", {
     status: 200,
     tier: cached.tier,
     active: cached.active,
+    cancelAtPeriodEnd,
+    currentPeriodEnd,
     reason: "cached entitlement",
   });
   return NextResponse.json(response, {

--- a/development/frontend/src/app/api/stripe/portal/route.ts
+++ b/development/frontend/src/app/api/stripe/portal/route.ts
@@ -75,7 +75,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
     const session = await stripe.billingPortal.sessions.create({
       customer: entitlement.stripeCustomerId,
-      return_url: `${baseUrl}/settings`,
+      return_url: `${baseUrl}/settings?stripe=portal_return`,
     });
 
     const response: StripePortalResponse = { url: session.url };

--- a/development/frontend/src/app/api/stripe/webhook/route.ts
+++ b/development/frontend/src/app/api/stripe/webhook/route.ts
@@ -151,6 +151,8 @@ async function handleSubscriptionUpdated(
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscription.id,
     stripeStatus: subscription.status,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    currentPeriodEnd: new Date(subscription.current_period_end * 1000).toISOString(),
     linkedAt: new Date().toISOString(),
     checkedAt: new Date().toISOString(),
   };
@@ -218,6 +220,8 @@ async function handleSubscriptionDeleted(
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscription.id,
     stripeStatus: "canceled",
+    cancelAtPeriodEnd: false,
+    currentPeriodEnd: new Date(subscription.current_period_end * 1000).toISOString(),
     linkedAt: new Date().toISOString(),
     checkedAt: new Date().toISOString(),
   };

--- a/development/frontend/src/app/sign-in/page.tsx
+++ b/development/frontend/src/app/sign-in/page.tsx
@@ -30,7 +30,7 @@
  */
 
 import { useEffect, useState, Suspense } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { generateCodeVerifier, generateCodeChallenge, generateState } from "@/lib/auth/pkce";
 import { isSessionValid } from "@/lib/auth/session";
 import { getAnonHouseholdId } from "@/lib/auth/household";
@@ -43,6 +43,7 @@ const PKCE_SESSION_KEY = "fenrir:pkce";
 
 function SignInContent() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [alreadyAuthed, setAlreadyAuthed] = useState(false);
   const [cardCount, setCardCount] = useState(0);
@@ -71,10 +72,11 @@ function SignInContent() {
     const state = generateState();
 
     // Persist PKCE transient values in sessionStorage (survives the redirect).
-    // callbackUrl is always "/" — after OAuth, user lands on the dashboard.
+    // callbackUrl: use returnTo query param if present, otherwise "/" (dashboard).
+    const returnTo = searchParams.get("returnTo") ?? "/";
     sessionStorage.setItem(
       PKCE_SESSION_KEY,
-      JSON.stringify({ verifier, state, callbackUrl: "/" })
+      JSON.stringify({ verifier, state, callbackUrl: returnTo })
     );
 
     const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID;

--- a/development/frontend/src/components/entitlement/SealedRuneModal.tsx
+++ b/development/frontend/src/components/entitlement/SealedRuneModal.tsx
@@ -86,8 +86,6 @@ export function SealedRuneModal({
       <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onDismiss()}>
         <DialogContent
           className="w-[92vw] max-w-[480px] max-h-[90vh] overflow-y-auto border-2 border-gold/40 bg-background p-0 gap-0"
-          aria-labelledby={`sealed-rune-heading-${feature}`}
-          aria-describedby={`sealed-rune-desc-${feature}`}
         >
           {/* Rune glyph -- Algiz (protection) */}
           <div className="text-center pt-6 pb-2" aria-hidden="true">
@@ -98,7 +96,6 @@ export function SealedRuneModal({
 
           {/* Heading */}
           <DialogTitle
-            id={`sealed-rune-heading-${feature}`}
             className="text-center font-display text-lg md:text-[22px] font-bold uppercase tracking-[0.12em] text-saga px-6 pb-4"
           >
             THIS RUNE IS SEALED
@@ -111,7 +108,6 @@ export function SealedRuneModal({
                 {featureDef.name}
               </span>
               <DialogDescription
-                id={`sealed-rune-desc-${feature}`}
                 className="text-sm text-saga/90 leading-relaxed font-body"
               >
                 {featureDesc.description}
@@ -147,7 +143,7 @@ export function SealedRuneModal({
               disabled={isSubscribing}
               className="w-full min-h-[48px] text-[15px] font-heading font-bold tracking-wide bg-gold text-primary-foreground hover:bg-gold-bright border-2 border-gold disabled:opacity-50"
             >
-              {isSubscribing ? "Starting checkout..." : "Subscribe for $3.99/month"}
+              {isSubscribing ? "Starting checkout..." : "Subscribe"}
             </Button>
           </div>
 

--- a/development/frontend/src/components/entitlement/StripeSettings.tsx
+++ b/development/frontend/src/components/entitlement/StripeSettings.tsx
@@ -75,6 +75,7 @@ export function StripeSettings() {
     isLinked,
     isLoading,
     platform,
+    cancelAtPeriodEnd,
     currentPeriodEnd,
     subscribeStripe,
     openPortal,
@@ -83,9 +84,14 @@ export function StripeSettings() {
   const [isSubscribing, setIsSubscribing] = useState(false);
 
   // Determine state
-  const isKarlActive = isLinked && isActive && tier === "karl" && platform === "stripe";
-  const isCanceled = isLinked && tier === "karl" && !isActive && platform === "stripe";
-  const isThrall = !isKarlActive && !isCanceled;
+  const isStripeLinked = isLinked && platform === "stripe";
+  // Active and NOT about to cancel
+  const isKarlActive = isStripeLinked && isActive && tier === "karl" && !cancelAtPeriodEnd;
+  // Active but set to cancel at period end (grandfathered)
+  const isCanceling = isStripeLinked && isActive && tier === "karl" && cancelAtPeriodEnd;
+  // Already fully canceled (subscription ended)
+  const isCanceled = isStripeLinked && tier === "karl" && !isActive;
+  const isThrall = !isKarlActive && !isCanceling && !isCanceled;
 
   // Format the current period end date
   const formattedPeriodEnd = currentPeriodEnd
@@ -151,6 +157,14 @@ export function StripeSettings() {
               KARL
             </span>
           )}
+          {isCanceling && (
+            <span
+              className="inline-flex items-center px-2.5 py-0.5 border border-dashed border-amber-500/40 text-[10px] font-mono font-bold uppercase tracking-wide text-amber-500/80 h-5"
+              aria-label="Subscription canceling"
+            >
+              CANCELING
+            </span>
+          )}
           {isCanceled && (
             <span
               className="inline-flex items-center px-2.5 py-0.5 border border-dashed border-rune/40 text-[10px] font-mono font-bold uppercase tracking-wide text-rune/60 h-5"
@@ -207,7 +221,7 @@ export function StripeSettings() {
                 disabled={isSubscribing}
                 className="min-h-[44px] w-full md:w-auto font-heading font-bold bg-gold text-primary-foreground hover:bg-gold-bright border-2 border-gold disabled:opacity-50"
               >
-                {isSubscribing ? "Starting checkout..." : "Subscribe for $3.99/month"}
+                {isSubscribing ? "Starting checkout..." : "Subscribe"}
               </Button>
             </div>
           </>
@@ -257,6 +271,52 @@ export function StripeSettings() {
                 aria-label="Cancel subscription"
               >
                 Cancel
+              </Button>
+            </div>
+          </>
+        )}
+
+        {/* ---- Canceling (grandfathered until period end) State ---- */}
+        {isCanceling && (
+          <>
+            {/* Atmospheric subhead */}
+            <p
+              className="text-xs italic text-rune/60 font-body leading-relaxed"
+              aria-hidden="true"
+            >
+              The chain loosens -- but it holds until the moon turns.
+            </p>
+
+            {/* Status row */}
+            <div className="flex items-center gap-2.5">
+              <span className="inline-flex items-center px-2.5 py-0.5 border border-gold/30 text-[11px] font-mono font-bold uppercase tracking-wide text-gold">
+                KARL
+              </span>
+              <span className="text-[13px] text-amber-500/80 font-body">Canceling</span>
+            </div>
+
+            {/* Cancellation details */}
+            <div className="text-xs text-saga/80 font-body leading-relaxed flex flex-col gap-1">
+              {formattedPeriodEnd ? (
+                <>
+                  <p>Your subscription is set to cancel on <strong className="text-saga">{formattedPeriodEnd}</strong>.</p>
+                  <p>You have full Karl access until then.</p>
+                </>
+              ) : (
+                <p>Your subscription is set to cancel at the end of your billing period.</p>
+              )}
+            </div>
+
+            <div className="border-t border-border" />
+
+            {/* Actions — resubscribe only, no cancel button */}
+            <div className="flex flex-col md:flex-row gap-3">
+              <Button
+                onClick={handleSubscribe}
+                disabled={isSubscribing}
+                className="min-h-[44px] w-full md:w-auto font-heading font-bold bg-gold text-primary-foreground hover:bg-gold-bright border-2 border-gold disabled:opacity-50"
+              >
+                {isSubscribing ? "Starting checkout..." : "Resubscribe"}
               </Button>
             </div>
           </>

--- a/development/frontend/src/components/entitlement/SubscriptionGate.tsx
+++ b/development/frontend/src/components/entitlement/SubscriptionGate.tsx
@@ -26,7 +26,8 @@
 import { useState, type ReactNode } from "react";
 import { useEntitlement } from "@/hooks/useEntitlement";
 import { SealedRuneModal } from "./SealedRuneModal";
-import type { PremiumFeature } from "@/lib/entitlement/types";
+import { PREMIUM_FEATURES, type PremiumFeature } from "@/lib/entitlement/types";
+import { FEATURE_DESCRIPTIONS } from "@/lib/entitlement/feature-descriptions";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -86,9 +87,10 @@ export function SubscriptionGate({ feature, children }: SubscriptionGateProps) {
     return <>{children}</>;
   }
 
-  // Feature is locked: show the locked placeholder with an option to open the modal.
-  // The modal is NOT auto-opened -- this prevents multiple modals stacking when
-  // several SubscriptionGate components render on the same page.
+  // Feature is locked: show the feature info as an upsell card.
+  const featureDef = PREMIUM_FEATURES[feature];
+  const featureDesc = FEATURE_DESCRIPTIONS[feature];
+
   return (
     <>
       <SealedRuneModal
@@ -96,21 +98,33 @@ export function SubscriptionGate({ feature, children }: SubscriptionGateProps) {
         open={modalOpen}
         onDismiss={() => setModalOpen(false)}
       />
-      <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
-        <span className="text-3xl text-gold/40 mb-3" aria-hidden="true">
-          &#5765;
-        </span>
-        <p className="text-sm text-rune font-body">
-          This feature requires a Karl subscription.
+      <section
+        className="border border-border p-5 flex flex-col gap-3"
+        aria-label={`${featureDef.name} (locked)`}
+      >
+        <div className="flex items-center gap-2.5">
+          <span className="text-lg text-gold/40" aria-hidden="true">&#5765;</span>
+          <h2 className="text-xs font-heading font-bold uppercase tracking-[0.08em] text-saga">
+            {featureDef.name}
+          </h2>
+          <span className="inline-flex items-center px-2 py-0.5 border border-gold/20 text-[9px] font-mono font-bold uppercase tracking-wide text-gold/60">
+            KARL
+          </span>
+        </div>
+        <p className="text-sm text-saga/90 leading-relaxed font-body">
+          {featureDesc.description}
+        </p>
+        <p className="text-[13px] italic text-rune/60 font-body">
+          &ldquo;{featureDesc.atmospheric}&rdquo;
         </p>
         <button
           type="button"
           onClick={() => setModalOpen(true)}
-          className="mt-3 text-sm text-gold underline hover:text-gold-bright transition-colors font-heading min-h-[44px] inline-flex items-center"
+          className="self-start mt-1 text-sm text-gold underline hover:text-gold-bright transition-colors font-heading min-h-[44px] inline-flex items-center"
         >
-          Learn more
+          Unlock with Karl
         </button>
-      </div>
+      </section>
     </>
   );
 }

--- a/development/frontend/src/components/entitlement/UnlinkConfirmDialog.tsx
+++ b/development/frontend/src/components/entitlement/UnlinkConfirmDialog.tsx
@@ -61,13 +61,10 @@ export function UnlinkConfirmDialog({
       <DialogContent
         className="w-[92vw] max-w-[440px] border-2 border-border bg-background p-0 gap-0"
         role="alertdialog"
-        aria-labelledby="unlink-heading"
-        aria-describedby="unlink-body"
       >
         {/* Header */}
         <div className="flex items-center justify-between px-5 pt-4 pb-3 border-b border-border">
           <DialogTitle
-            id="unlink-heading"
             className="text-lg font-heading font-bold text-saga"
           >
             Unlink Subscription?
@@ -76,7 +73,7 @@ export function UnlinkConfirmDialog({
 
         {/* Body */}
         <DialogDescription asChild>
-          <div id="unlink-body" className="px-5 py-4 flex flex-col gap-3">
+          <div className="px-5 py-4 flex flex-col gap-3">
             <p className="text-sm text-saga/90 leading-relaxed font-body">
               Your subscription will be disconnected from Fenrir Ledger.
               You will lose access to premium features, but your card data

--- a/development/frontend/src/contexts/EntitlementContext.tsx
+++ b/development/frontend/src/contexts/EntitlementContext.tsx
@@ -32,7 +32,6 @@ import {
   getEntitlementCache,
   setEntitlementCache,
   clearEntitlementCache,
-  isEntitlementStale,
 } from "@/lib/entitlement/cache";
 import {
   tierMeetsRequirement,
@@ -60,11 +59,13 @@ export interface EntitlementContextValue {
   platform: EntitlementPlatform | null;
   /** Stripe subscription status (e.g. "active", "canceled", "past_due") */
   stripeStatus: string | null;
+  /** Whether the subscription is set to cancel at period end */
+  cancelAtPeriodEnd: boolean;
   /** Stripe subscription current period end (ISO 8601 string) */
   currentPeriodEnd: string | null;
 
-  /** Re-verifies entitlement status via the server API. */
-  refreshEntitlement: () => Promise<void>;
+  /** Re-verifies entitlement status via the server API. Optional sessionId for migration. */
+  refreshEntitlement: (sessionId?: string) => Promise<void>;
 
   /** Creates a Stripe Checkout session and redirects to Stripe's hosted checkout. */
   subscribeStripe: () => Promise<void>;
@@ -86,6 +87,7 @@ const DEFAULT_VALUE: EntitlementContextValue = {
   isLoading: false,
   platform: null,
   stripeStatus: null,
+  cancelAtPeriodEnd: false,
   currentPeriodEnd: null,
   refreshEntitlement: async () => {},
   subscribeStripe: async () => {},
@@ -108,6 +110,9 @@ interface MembershipApiResponse {
   stale?: boolean;
   customerId?: string;
   linkedAt?: string;
+  stripeStatus?: string;
+  cancelAtPeriodEnd?: boolean;
+  currentPeriodEnd?: string;
 }
 
 // -- Provider ----------------------------------------------------------------
@@ -123,6 +128,7 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
   const [entitlement, setEntitlement] = useState<Entitlement | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [stripeStatus, setStripeStatus] = useState<string | null>(null);
+  const [cancelAtPeriodEnd, setCancelAtPeriodEnd] = useState(false);
   const [currentPeriodEnd, setCurrentPeriodEnd] = useState<string | null>(null);
 
   // Prevent concurrent API calls
@@ -139,12 +145,15 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
 
   // -- Fetch Stripe membership (authenticated) --------------------------------
 
-  const fetchStripeMembership = useCallback(async (): Promise<MembershipApiResponse | null> => {
+  const fetchStripeMembership = useCallback(async (sessionId?: string): Promise<MembershipApiResponse | null> => {
     const token = await ensureFreshToken();
     if (!token) return null;
 
     try {
-      const response = await fetch("/api/stripe/membership", {
+      const url = sessionId
+        ? `/api/stripe/membership?session_id=${encodeURIComponent(sessionId)}`
+        : "/api/stripe/membership";
+      const response = await fetch(url, {
         method: "GET",
         headers: {
           Authorization: `Bearer ${token}`,
@@ -193,7 +202,7 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
 
   // -- Refresh entitlement ---------------------------------------------------
 
-  const refreshEntitlement = useCallback(async () => {
+  const refreshEntitlement = useCallback(async (sessionId?: string) => {
     if (fetchInProgressRef.current) return;
 
     fetchInProgressRef.current = true;
@@ -203,7 +212,7 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
       let data: MembershipApiResponse | null = null;
 
       if (isAuthenticated) {
-        data = await fetchStripeMembership();
+        data = await fetchStripeMembership(sessionId);
       }
 
       if (data) {
@@ -216,6 +225,10 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
           clearEntitlementCache();
           setEntitlement(null);
         }
+        // Populate Stripe-specific fields
+        setStripeStatus(data.stripeStatus ?? null);
+        setCancelAtPeriodEnd(data.cancelAtPeriodEnd ?? false);
+        setCurrentPeriodEnd(data.currentPeriodEnd ?? null);
       }
     } finally {
       fetchInProgressRef.current = false;
@@ -227,25 +240,30 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
 
   /**
    * Creates a Stripe Checkout session and redirects the user.
-   * For authenticated users, email comes from Google profile.
-   * For anonymous users, Stripe's hosted checkout page collects email.
+   * Requires authentication — if not signed in, redirects to /sign-in first
+   * with a returnTo that will auto-start checkout after sign-in.
    */
   const subscribeStripe = useCallback(async () => {
-    const headers: Record<string, string> = {
-      "Content-Type": "application/json",
-    };
+    if (!isAuthenticated) {
+      // Redirect to sign-in, then back to settings to auto-start checkout
+      window.location.href = "/sign-in?returnTo=" + encodeURIComponent("/settings?stripe=checkout");
+      return;
+    }
 
-    if (isAuthenticated) {
-      const token = await ensureFreshToken();
-      if (token) {
-        headers["Authorization"] = `Bearer ${token}`;
-      }
+    const token = await ensureFreshToken();
+    if (!token) {
+      // Token expired mid-session — redirect to sign-in
+      window.location.href = "/sign-in?returnTo=" + encodeURIComponent("/settings?stripe=checkout");
+      return;
     }
 
     try {
       const response = await fetch("/api/stripe/checkout", {
         method: "POST",
-        headers,
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
         body: JSON.stringify({}),
       });
 
@@ -308,6 +326,7 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
     clearEntitlementCache();
     setEntitlement(null);
     setStripeStatus(null);
+    setCancelAtPeriodEnd(false);
     setCurrentPeriodEnd(null);
 
     if (isAuthenticated) {
@@ -359,18 +378,26 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
 
     queryParamsProcessedRef.current = true;
 
+    const sessionId = params.get("session_id") ?? undefined;
+
     const cleanUrl = new URL(window.location.href);
     cleanUrl.searchParams.delete("stripe");
     cleanUrl.searchParams.delete("session_id");
     window.history.replaceState({}, "", cleanUrl.toString());
 
     if (stripeParam === "success") {
-      console.debug("[Fenrir] Stripe checkout success callback");
+      console.debug("[Fenrir] Stripe checkout success callback", { sessionId });
+      void refreshEntitlement(sessionId);
+    } else if (stripeParam === "checkout") {
+      console.debug("[Fenrir] Stripe auto-checkout after sign-in");
+      void subscribeStripe();
+    } else if (stripeParam === "portal_return") {
+      console.debug("[Fenrir] Stripe portal return — refreshing entitlement");
       void refreshEntitlement();
     } else if (stripeParam === "cancel") {
       console.debug("[Fenrir] Stripe checkout cancelled by user");
     }
-  }, [status, refreshEntitlement]);
+  }, [status, refreshEntitlement, subscribeStripe]);
 
   // -- Initialize from cache + refresh if stale ------------------------------
 
@@ -378,15 +405,13 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
     if (typeof window === "undefined") return;
 
     if (isAuthenticated) {
+      // Load cache for instant UI (no loading flash), then always refresh
+      // from the server to pick up webhook-driven changes (cancellations, etc.)
       const cached = getEntitlementCache();
       if (cached) {
         setEntitlement(cached);
-        if (isEntitlementStale(cached)) {
-          void refreshEntitlement();
-        }
-      } else {
-        void refreshEntitlement();
       }
+      void refreshEntitlement();
     } else {
       // Anonymous: no entitlement by default
       setEntitlement(null);
@@ -402,6 +427,7 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
     isLoading,
     platform,
     stripeStatus,
+    cancelAtPeriodEnd,
     currentPeriodEnd,
     refreshEntitlement,
     subscribeStripe,

--- a/development/frontend/src/lib/stripe/types.ts
+++ b/development/frontend/src/lib/stripe/types.ts
@@ -57,6 +57,10 @@ export interface StoredStripeEntitlement {
   stripeSubscriptionId: string;
   /** Raw Stripe subscription status string */
   stripeStatus: string;
+  /** Whether the subscription is set to cancel at period end */
+  cancelAtPeriodEnd?: boolean;
+  /** ISO 8601 timestamp of current billing period end */
+  currentPeriodEnd?: string;
   /** ISO 8601 timestamp when Stripe was linked */
   linkedAt: string;
   /** ISO 8601 timestamp of last status check */
@@ -89,6 +93,12 @@ export interface StripeMembershipResponse {
   customerId?: string;
   /** ISO 8601 timestamp when Stripe was linked — included when linked */
   linkedAt?: string;
+  /** Raw Stripe subscription status (e.g. "active", "canceled") */
+  stripeStatus?: string;
+  /** Whether the subscription is set to cancel at period end */
+  cancelAtPeriodEnd?: boolean;
+  /** ISO 8601 timestamp of current billing period end */
+  currentPeriodEnd?: string;
 }
 
 /** Response from POST /api/stripe/checkout */

--- a/development/frontend/src/lib/stripe/webhook.ts
+++ b/development/frontend/src/lib/stripe/webhook.ts
@@ -103,6 +103,8 @@ export function buildEntitlementFromSubscription(
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscription.id,
     stripeStatus: subscription.status,
+    cancelAtPeriodEnd: subscription.cancel_at_period_end,
+    currentPeriodEnd: new Date(subscription.current_period_end * 1000).toISOString(),
     linkedAt: now,
     checkedAt: now,
   };


### PR DESCRIPTION
## Summary

- **Require Google sign-in before Stripe checkout** — eliminates the anonymous checkout path that caused entitlement to be stored under the wrong KV key. Subscribe CTA redirects to sign-in with `returnTo` that auto-starts checkout after authentication.
- **Show canceling/canceled subscription states** — new `cancelAtPeriodEnd` and `currentPeriodEnd` fields flow from Stripe webhooks → KV → membership API → EntitlementContext → StripeSettings UI. Shows period end date and appropriate actions (Resubscribe when canceling, no Cancel button).
- **Always refresh entitlement on mount** — localStorage cache used for instant UI only, server always consulted to pick up webhook-driven changes.
- **Portal return triggers refresh** — portal `return_url` now includes `?stripe=portal_return` param.
- **Rich upsell cards** in SubscriptionGate locked state with feature name, description, and atmospheric quote.
- **Fix Radix DialogTitle console errors** in SealedRuneModal and UnlinkConfirmDialog.
- **Backfill period end** from live Stripe API for pre-existing KV records missing the new fields.

## Files changed

| Area | Files |
|------|-------|
| API routes | `checkout/route.ts`, `membership/route.ts`, `portal/route.ts`, `webhook/route.ts` |
| Stripe lib | `types.ts`, `webhook.ts` |
| Context | `EntitlementContext.tsx` |
| Components | `StripeSettings.tsx`, `SubscriptionGate.tsx`, `SealedRuneModal.tsx`, `UnlinkConfirmDialog.tsx` |
| Auth | `sign-in/page.tsx` |

## Test plan

- [ ] Sign out → click Subscribe → redirected to sign-in → after sign-in, redirected to Stripe Checkout
- [ ] Complete checkout → returned to `/settings?stripe=success` → shows Karl active state
- [ ] Cancel subscription in Stripe portal → portal return shows "Canceling" state with period end date
- [ ] Full page refresh after cancel → still shows correct canceling state
- [ ] Resubscribe button works from canceling state
- [ ] SubscriptionGate locked features show rich descriptions (not generic message)
- [ ] No Radix DialogTitle console warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)