### PR TITLE
fix: redesign Settings page — two-column layout with tier benefits

### DIFF
--- a/development/frontend/src/app/settings/page.tsx
+++ b/development/frontend/src/app/settings/page.tsx
@@ -4,13 +4,13 @@
  * Settings Page -- /settings route
  *
  * Central settings hub for the Fenrir Ledger. Contains:
- *   - Subscription management (Stripe)
- *   - Gated premium feature placeholders (Cloud Sync, Multi-Household, Data Export)
+ *   - Subscription management (Stripe) -- left column on desktop
+ *   - Gated premium feature placeholders (Cloud Sync, Multi-Household, Data Export) -- right column
  *
  * Anonymous-first: accessible without a signed-in session. The settings
  * and gated sections handle their own auth/entitlement checks internally.
  *
- * Layout: single-column, max-width constrained, consistent with Valhalla page.
+ * Layout: two-column on desktop (md+), single-column stacked on mobile.
  * Mobile-first: 375px minimum, stacked sections with consistent spacing.
  */
 
@@ -111,12 +111,13 @@ function DataExportSection() {
 /**
  * SettingsPage -- the /settings route.
  *
- * Renders the Stripe subscription settings and gated premium feature
- * placeholders in a single-column layout.
+ * Two-column layout on desktop: subscription card on the left, tier benefit
+ * cards on the right. Collapses to single-column on mobile (benefits stack
+ * below the subscription card).
  */
 export default function SettingsPage() {
   return (
-    <div className="px-6 py-6 max-w-2xl">
+    <div className="px-6 py-6 max-w-5xl">
       {/* Page heading */}
       <header className="mb-6 border-b border-border pb-4">
         <h1 className="font-display text-xl text-gold tracking-wide mb-1">
@@ -127,23 +128,27 @@ export default function SettingsPage() {
         </p>
       </header>
 
-      {/* Settings sections */}
-      <div className="flex flex-col gap-6">
-        {/* Subscription management */}
-        <StripeSettings />
+      {/* Two-column layout: subscription left, tier benefits right */}
+      <div className="flex flex-col md:grid md:grid-cols-2 gap-6">
+        {/* Left column: Subscription management */}
+        <div className="flex flex-col gap-6">
+          <StripeSettings />
+        </div>
 
-        {/* Premium feature placeholders -- each wrapped in SubscriptionGate */}
-        <SubscriptionGate feature="cloud-sync">
-          <CloudSyncSection />
-        </SubscriptionGate>
+        {/* Right column: Tier benefit cards */}
+        <div className="flex flex-col gap-6">
+          <SubscriptionGate feature="cloud-sync">
+            <CloudSyncSection />
+          </SubscriptionGate>
 
-        <SubscriptionGate feature="multi-household">
-          <MultiHouseholdSection />
-        </SubscriptionGate>
+          <SubscriptionGate feature="multi-household">
+            <MultiHouseholdSection />
+          </SubscriptionGate>
 
-        <SubscriptionGate feature="data-export">
-          <DataExportSection />
-        </SubscriptionGate>
+          <SubscriptionGate feature="data-export">
+            <DataExportSection />
+          </SubscriptionGate>
+        </div>
       </div>
     </div>
   );

--- a/development/frontend/src/components/entitlement/StripeSettings.tsx
+++ b/development/frontend/src/components/entitlement/StripeSettings.tsx
@@ -140,7 +140,7 @@ export function StripeSettings() {
   return (
     <>
       <section
-        className="border border-border p-5 flex flex-col gap-4 max-w-[520px]"
+        className="border border-border p-5 flex flex-col gap-4"
         role="region"
         aria-label="Subscription"
       >
@@ -238,14 +238,6 @@ export function StripeSettings() {
               The wolf is bound. The chains hold true.
             </p>
 
-            {/* Status row */}
-            <div className="flex items-center gap-2.5">
-              <span className="inline-flex items-center px-2.5 py-0.5 border border-gold/30 text-[11px] font-mono font-bold uppercase tracking-wide text-gold">
-                KARL
-              </span>
-              <span className="text-[13px] text-realm-asgard font-body">Active</span>
-            </div>
-
             {/* Subscription details */}
             <div className="text-xs text-saga/80 font-body leading-relaxed">
               <p>$3.99/month</p>
@@ -332,14 +324,6 @@ export function StripeSettings() {
             >
               The chain weakens -- but it holds until the moon turns.
             </p>
-
-            {/* Status row */}
-            <div className="flex items-center gap-2.5">
-              <span className="inline-flex items-center px-2.5 py-0.5 border border-gold/30 text-[11px] font-mono font-bold uppercase tracking-wide text-gold">
-                KARL
-              </span>
-              <span className="text-[13px] text-rune font-body">Canceled</span>
-            </div>
 
             {/* Cancellation details */}
             <div className="text-xs text-saga/80 font-body leading-relaxed">


### PR DESCRIPTION
## Summary

- Redesigns the Settings page to a two-column desktop layout: subscription card on the left, tier benefit cards (Cloud Sync, Multi-Household, Data Export) on the right
- Collapses to single-column on mobile using `flex flex-col md:grid md:grid-cols-2` pattern
- Consolidates the KARL tier badge to appear exactly once in the subscription card header row, paired with an Active/CANCELED status badge
- Removes duplicate KARL badge from the card body in both active and canceled states

Fixes #151

## Test plan

- [ ] Verify two-column layout renders on desktop (md+ breakpoint)
- [ ] Verify single-column stacking on mobile (below md breakpoint, min 375px)
- [ ] Verify KARL badge appears exactly once in subscription card header (active state)
- [ ] Verify CANCELED badge appears in header alongside KARL badge (canceled state)
- [ ] Verify Thrall (unsubscribed) state renders correctly with no badges in header
- [ ] Verify tier benefit cards have equal visual weight in right column
- [ ] Verify Saga Ledger dark Nordic aesthetic is preserved

Generated with [Claude Code](https://claude.com/claude-code)