### PR TITLE
feat: assign Elder Futhark runes to issuers and add bank logos

### DIFF
--- a/development/frontend/public/static/logos/issuers/amex.svg
+++ b/development/frontend/public/static/logos/issuers/amex.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="13" font-weight="700" fill="#FFFFFF" letter-spacing="0.5">AMERICAN EXPRESS</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/bank-of-america.svg
+++ b/development/frontend/public/static/logos/issuers/bank-of-america.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF" letter-spacing="0.3">BANK OF AMERICA</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/barclays.svg
+++ b/development/frontend/public/static/logos/issuers/barclays.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" fill="#FFFFFF" letter-spacing="0.5">BARCLAYS</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/capital-one.svg
+++ b/development/frontend/public/static/logos/issuers/capital-one.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF" letter-spacing="0.3">CAPITAL ONE</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/chase.svg
+++ b/development/frontend/public/static/logos/issuers/chase.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#FFFFFF" letter-spacing="0.5">CHASE</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/citi.svg
+++ b/development/frontend/public/static/logos/issuers/citi.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#FFFFFF" letter-spacing="0.5">CITIBANK</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/discover.svg
+++ b/development/frontend/public/static/logos/issuers/discover.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 140 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" fill="#FFFFFF" letter-spacing="0.5">DISCOVER</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/hsbc.svg
+++ b/development/frontend/public/static/logos/issuers/hsbc.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="16" font-weight="700" fill="#FFFFFF" letter-spacing="1">HSBC</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/us-bank.svg
+++ b/development/frontend/public/static/logos/issuers/us-bank.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="15" font-weight="700" fill="#FFFFFF" letter-spacing="0.5">US BANK</text>
+</svg>

--- a/development/frontend/public/static/logos/issuers/wells-fargo.svg
+++ b/development/frontend/public/static/logos/issuers/wells-fargo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 24" fill="none">
+  <text x="0" y="18" font-family="Arial, Helvetica, sans-serif" font-size="14" font-weight="700" fill="#FFFFFF" letter-spacing="0.3">WELLS FARGO</text>
+</svg>

--- a/development/frontend/src/app/valhalla/page.tsx
+++ b/development/frontend/src/app/valhalla/page.tsx
@@ -32,7 +32,8 @@ import { getClosedCards, initializeHousehold, migrateIfNeeded } from "@/lib/stor
 import { isGleipnirComplete } from "@/lib/gleipnir-utils";
 import { GleipnirBirdSpittle, useGleipnirFragment6 } from "@/components/cards/GleipnirBirdSpittle";
 import { formatDate, formatCurrency } from "@/lib/card-utils";
-import { KNOWN_ISSUERS } from "@/lib/constants";
+import { getIssuerName, getIssuerRune } from "@/lib/issuer-utils";
+import { IssuerLogo } from "@/components/shared/IssuerLogo";
 import { getRealmLabel } from "@/lib/realm-utils";
 import type { Card } from "@/lib/types";
 
@@ -48,14 +49,6 @@ const MAX_STAGGER_DELAY_S = 0.56; // 8 cards × 0.07 s
 const EXPO_OUT: [number, number, number, number] = [0.16, 1, 0.3, 1];
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Returns the human-readable issuer name from the issuer ID.
- */
-function getIssuerName(issuerId: string): string {
-  const issuer = KNOWN_ISSUERS.find((i) => i.id === issuerId);
-  return issuer?.name ?? issuerId;
-}
 
 /**
  * Computes the number of months between two ISO date strings.
@@ -155,7 +148,6 @@ interface TombstoneCardProps {
 function TombstoneCard({ card, index }: TombstoneCardProps) {
   const staggerDelay = Math.min(index * 0.07, MAX_STAGGER_DELAY_S);
 
-  const issuerName = getIssuerName(card.issuerId);
   const openedFormatted = formatDate(card.openDate);
   const closedFormatted = card.closedAt ? formatDate(card.closedAt) : "—";
   const heldDuration = card.closedAt
@@ -219,11 +211,16 @@ function TombstoneCard({ card, index }: TombstoneCardProps) {
         </span>
       </div>
 
-      {/* Meta: issuer · opened · held duration */}
-      <p className="text-xs text-muted-foreground">
-        {issuerName}
-        {openedFormatted ? ` · Opened ${openedFormatted}` : ""}
-        {heldDuration ? ` · Held ${heldDuration}` : ""}
+      {/* Meta: issuer (rune + logo) · opened · held duration */}
+      <p className="text-xs text-muted-foreground flex items-center gap-1 flex-wrap">
+        {getIssuerRune(card.issuerId) && (
+          <span className="text-gold/60 text-[0.7rem]" aria-hidden="true">
+            {getIssuerRune(card.issuerId)}
+          </span>
+        )}
+        <IssuerLogo issuerId={card.issuerId} className="inline-block align-middle opacity-70" />
+        {openedFormatted ? <span>· Opened {openedFormatted}</span> : null}
+        {heldDuration ? <span>· Held {heldDuration}</span> : null}
       </p>
 
       {/* Hairline rule */}

--- a/development/frontend/src/components/cards/CardForm.tsx
+++ b/development/frontend/src/components/cards/CardForm.tsx
@@ -53,6 +53,7 @@ import {
   localDateStringToIso,
 } from "@/lib/card-utils";
 import { KNOWN_ISSUERS } from "@/lib/constants";
+import { getIssuerRune } from "@/lib/issuer-utils";
 import { GleipnirBearSinews, useGleipnirFragment4 } from "@/components/cards/GleipnirBearSinews";
 
 // ─── Zod validation schema ────────────────────────────────────────────────────
@@ -318,11 +319,14 @@ export function CardForm({ initialValues, householdId }: CardFormProps) {
               <SelectValue placeholder="Select issuer" />
             </SelectTrigger>
             <SelectContent>
-              {KNOWN_ISSUERS.map((issuer) => (
-                <SelectItem key={issuer.id} value={issuer.id}>
-                  {issuer.name}
-                </SelectItem>
-              ))}
+              {KNOWN_ISSUERS.map((issuer) => {
+                const rune = getIssuerRune(issuer.id);
+                return (
+                  <SelectItem key={issuer.id} value={issuer.id}>
+                    {rune ? `${rune} ` : ""}{issuer.name}
+                  </SelectItem>
+                );
+              })}
             </SelectContent>
           </Select>
           {errors.issuerId && (

--- a/development/frontend/src/components/dashboard/CardTile.tsx
+++ b/development/frontend/src/components/dashboard/CardTile.tsx
@@ -27,7 +27,8 @@ import { StatusBadge } from "./StatusBadge";
 import { StatusRing } from "./StatusRing";
 import type { Card as CreditCard } from "@/lib/types";
 import { formatCurrency, formatDate, daysUntil } from "@/lib/card-utils";
-import { KNOWN_ISSUERS } from "@/lib/constants";
+import { getIssuerBadgeChar, getIssuerMeta } from "@/lib/issuer-utils";
+import { IssuerLogo } from "@/components/shared/IssuerLogo";
 
 interface CardTileProps {
   card: CreditCard;
@@ -37,31 +38,6 @@ interface CardTileProps {
    * Set to `undefined` in normal operation.
    */
   lokiLabel?: string | undefined;
-}
-
-/**
- * Returns the human-readable issuer name from the issuer ID.
- */
-function getIssuerName(issuerId: string): string {
-  const issuer = KNOWN_ISSUERS.find((i) => i.id === issuerId);
-  return issuer?.name ?? issuerId;
-}
-
-/**
- * Derives 1–2 character initials from the issuer name.
- *
- * Multi-word names (e.g. "Capital One") → "CO" (first letter of each word).
- * Single-word names (e.g. "Chase") → "C" (first letter only).
- * Falls back to the first character of issuerId if name lookup fails.
- */
-function getIssuerInitials(issuerId: string): string {
-  const issuer = KNOWN_ISSUERS.find((i) => i.id === issuerId);
-  const name = issuer?.name ?? issuerId;
-  const words = name.trim().split(/\s+/);
-  if (words.length >= 2) {
-    return (words[0]![0]! + words[1]![0]!).toUpperCase();
-  }
-  return name[0]!.toUpperCase();
 }
 
 /**
@@ -114,7 +90,8 @@ export function CardTile({ card, lokiLabel }: CardTileProps) {
   })();
 
   const ringTotalDays = getTotalDays(card.openDate, ringDeadlineIso);
-  const ringInitials = getIssuerInitials(card.issuerId);
+  const ringBadgeChar = getIssuerBadgeChar(card.issuerId);
+  const issuerMeta = getIssuerMeta(card.issuerId);
 
   return (
     /*
@@ -137,17 +114,20 @@ export function CardTile({ card, lokiLabel }: CardTileProps) {
           <CardHeader className="pb-3">
             <div className="flex items-start justify-between gap-2">
               <div className="flex items-center gap-2 min-w-0">
-                {/* StatusRing: SVG countdown ring around issuer initials */}
+                {/* StatusRing: SVG countdown ring with rune (known) or initials (unknown) */}
                 <StatusRing
                   status={card.status}
                   daysRemaining={ringDaysRemaining}
                   totalDays={ringTotalDays}
-                  initials={ringInitials}
+                  initials={ringBadgeChar}
                   cardName={card.cardName}
                 />
                 <div className="min-w-0">
-                  <CardDescription className="text-xs uppercase tracking-wide mb-1">
-                    {getIssuerName(card.issuerId)}
+                  <CardDescription
+                    className="text-xs uppercase tracking-wide mb-1"
+                    title={issuerMeta ? `${issuerMeta.rune} ${issuerMeta.runeName} — ${issuerMeta.runeConnection}` : undefined}
+                  >
+                    <IssuerLogo issuerId={card.issuerId} className="inline-block align-middle opacity-90" />
                   </CardDescription>
                   <CardTitle className="text-base font-semibold leading-tight truncate">
                     {card.cardName}

--- a/development/frontend/src/components/dashboard/StatusRing.tsx
+++ b/development/frontend/src/components/dashboard/StatusRing.tsx
@@ -95,7 +95,11 @@ interface StatusRingProps {
   daysRemaining: number;
   /** Total day span: from card open date to the deadline. */
   totalDays: number;
-  /** 1–2 character issuer initial displayed inside the ring. */
+  /**
+   * Character(s) displayed inside the ring.
+   * For known issuers this is an Elder Futhark rune; for unknown issuers
+   * it is 1-2 character initials (fallback).
+   */
   initials: string;
   /**
    * Card name for the accessible aria-label.

--- a/development/frontend/src/components/layout/HowlPanel.tsx
+++ b/development/frontend/src/components/layout/HowlPanel.tsx
@@ -26,7 +26,8 @@ import { AnimatePresence, motion } from "framer-motion";
 import Link from "next/link";
 import type { Card } from "@/lib/types";
 import { daysUntil, formatDate, formatCurrency } from "@/lib/card-utils";
-import { KNOWN_ISSUERS } from "@/lib/constants";
+import { getIssuerRune } from "@/lib/issuer-utils";
+import { IssuerLogo } from "@/components/shared/IssuerLogo";
 import { cn } from "@/lib/utils";
 import { useRagnarok } from "@/contexts/RagnarokContext";
 
@@ -44,15 +45,6 @@ interface UrgentCardRow {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
-
-/**
- * Returns the human-readable issuer name from KNOWN_ISSUERS, or the raw
- * issuerId if not found.
- */
-function getIssuerName(issuerId: string): string {
-  const issuer = KNOWN_ISSUERS.find((i) => i.id === issuerId);
-  return issuer?.name ?? issuerId;
-}
 
 /**
  * Computes UrgentCardRow entries for a list of cards that have status
@@ -131,13 +123,18 @@ function UrgentRow({ row }: UrgentRowProps) {
         </span>
       </div>
 
-      {/* Row 2: card name + issuer */}
+      {/* Row 2: card name + issuer (rune badge + logo) */}
       <div className="mb-1">
         <p className="text-sm font-heading text-foreground leading-tight truncate">
           {card.cardName}
         </p>
-        <p className="text-xs text-muted-foreground truncate">
-          {getIssuerName(card.issuerId)}
+        <p className="text-xs text-muted-foreground truncate flex items-center gap-1.5">
+          {getIssuerRune(card.issuerId) && (
+            <span className="text-gold/70 text-[0.7rem]" aria-hidden="true">
+              {getIssuerRune(card.issuerId)}
+            </span>
+          )}
+          <IssuerLogo issuerId={card.issuerId} className="inline-block align-middle opacity-80" />
         </p>
       </div>
 

--- a/development/frontend/src/components/shared/IssuerLogo.tsx
+++ b/development/frontend/src/components/shared/IssuerLogo.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * IssuerLogo — displays an issuer's SVG logo image or falls back to text name.
+ *
+ * For known issuers: renders an <img> with the SVG logo from
+ * public/static/logos/issuers/. The issuer text name is used as alt text
+ * and appears as a tooltip on hover.
+ *
+ * For unknown/custom issuers: renders the issuer name as plain text
+ * (same as the previous behavior).
+ *
+ * All logos are white text on transparent backgrounds, designed for the
+ * dark Norse War Room theme.
+ */
+
+import { getIssuerLogoPath, getIssuerName } from "@/lib/issuer-utils";
+
+interface IssuerLogoProps {
+  /** The issuer ID from the card data (e.g. "chase", "amex"). */
+  issuerId: string;
+  /** Optional className for the container element. */
+  className?: string;
+}
+
+/**
+ * IssuerLogo — renders an SVG logo for known issuers or text name fallback.
+ *
+ * @param issuerId  - Issuer identifier from KNOWN_ISSUERS.
+ * @param className - Optional CSS class for the wrapper.
+ */
+export function IssuerLogo({ issuerId, className }: IssuerLogoProps) {
+  const logoPath = getIssuerLogoPath(issuerId);
+  const issuerName = getIssuerName(issuerId);
+
+  if (!logoPath) {
+    // Unknown issuer — fall back to text name
+    return (
+      <span className={className} title={issuerName}>
+        {issuerName}
+      </span>
+    );
+  }
+
+  return (
+    <img
+      src={logoPath}
+      alt={issuerName}
+      title={issuerName}
+      className={className}
+      // Fixed height, auto width to preserve aspect ratio
+      style={{ height: "1em", width: "auto", display: "inline-block" }}
+      loading="lazy"
+    />
+  );
+}

--- a/development/frontend/src/lib/issuer-utils.ts
+++ b/development/frontend/src/lib/issuer-utils.ts
@@ -1,0 +1,186 @@
+/**
+ * Issuer Utilities — Rune mappings and logo paths for known card issuers.
+ *
+ * Each known issuer is assigned a unique Elder Futhark rune and a logo path.
+ * Unknown/custom issuers fall back to text initials and no logo.
+ *
+ * Rune assignments follow the mythology map — each rune's meaning connects
+ * thematically to the issuer's brand identity.
+ *
+ * Logos are minimal SVG representations stored in public/static/logos/issuers/.
+ * They are used under nominative fair use — identifying the issuer, not
+ * implying endorsement.
+ */
+
+import { KNOWN_ISSUERS } from "@/lib/constants";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** Issuer display metadata: rune, logo path, and brand color. */
+export interface IssuerMeta {
+  /** The Elder Futhark rune character assigned to this issuer. */
+  rune: string;
+  /** Rune name in Old Norse (for tooltip). */
+  runeName: string;
+  /** Thematic connection between rune meaning and issuer brand. */
+  runeConnection: string;
+  /** Path to the SVG logo in public/static/logos/issuers/. */
+  logoPath: string;
+  /** Primary brand color (used for the rune badge on dark backgrounds). */
+  brandColor: string;
+}
+
+// ── Rune Mapping ─────────────────────────────────────────────────────────────
+
+/**
+ * Maps issuer IDs to their Elder Futhark rune and logo metadata.
+ *
+ * Each rune is unique — no two issuers share a rune.
+ */
+const ISSUER_META: Record<string, IssuerMeta> = {
+  chase: {
+    rune: "\u16B1",       // Raidho
+    runeName: "Raidho",
+    runeConnection: "Journeys, movement (sapphire travel cards)",
+    logoPath: "/static/logos/issuers/chase.svg",
+    brandColor: "#0060A9",
+  },
+  bank_of_america: {
+    rune: "\u16A0",       // Fehu
+    runeName: "Fehu",
+    runeConnection: "Wealth, cattle (America's bank)",
+    logoPath: "/static/logos/issuers/bank-of-america.svg",
+    brandColor: "#E31837",
+  },
+  capital_one: {
+    rune: "\u16A6",       // Thurisaz
+    runeName: "Thurisaz",
+    runeConnection: "Power, force (what's in your wallet)",
+    logoPath: "/static/logos/issuers/capital-one.svg",
+    brandColor: "#D03027",
+  },
+  wells_fargo: {
+    rune: "\u16B9",       // Wunjo
+    runeName: "Wunjo",
+    runeConnection: "Joy, prosperity (stagecoach)",
+    logoPath: "/static/logos/issuers/wells-fargo.svg",
+    brandColor: "#D71E28",
+  },
+  amex: {
+    rune: "\u16CA",       // Sowilo
+    runeName: "Sowilo",
+    runeConnection: "Sun, success (premium)",
+    logoPath: "/static/logos/issuers/amex.svg",
+    brandColor: "#006FCF",
+  },
+  citibank: {
+    rune: "\u16C1",       // Isa
+    runeName: "Isa",
+    runeConnection: "Ice, focus (global reach)",
+    logoPath: "/static/logos/issuers/citi.svg",
+    brandColor: "#003B70",
+  },
+  discover: {
+    rune: "\u16BE",       // Naudiz
+    runeName: "Naudiz",
+    runeConnection: "Need, discovery",
+    logoPath: "/static/logos/issuers/discover.svg",
+    brandColor: "#FF6600",
+  },
+  us_bank: {
+    rune: "\u16A2",       // Uruz
+    runeName: "Uruz",
+    runeConnection: "Strength, endurance",
+    logoPath: "/static/logos/issuers/us-bank.svg",
+    brandColor: "#D50032",
+  },
+  barclays: {
+    rune: "\u16B7",       // Gebo
+    runeName: "Gebo",
+    runeConnection: "Gift, partnership (global banking)",
+    logoPath: "/static/logos/issuers/barclays.svg",
+    brandColor: "#00AEEF",
+  },
+  hsbc: {
+    rune: "\u16C7",       // Ehwaz
+    runeName: "Ehwaz",
+    runeConnection: "Horse, movement (worldwide presence)",
+    logoPath: "/static/logos/issuers/hsbc.svg",
+    brandColor: "#DB0011",
+  },
+};
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Returns the IssuerMeta for a known issuer, or null for unknown/custom issuers.
+ *
+ * @param issuerId - The issuer ID from the card data (e.g. "chase", "amex").
+ * @returns IssuerMeta if the issuer has a rune mapping, null otherwise.
+ */
+export function getIssuerMeta(issuerId: string): IssuerMeta | null {
+  return ISSUER_META[issuerId] ?? null;
+}
+
+/**
+ * Returns the Elder Futhark rune for a known issuer, or null for unknown issuers.
+ * Used by StatusRing and card badge components.
+ *
+ * @param issuerId - The issuer ID.
+ * @returns The rune character string, or null.
+ */
+export function getIssuerRune(issuerId: string): string | null {
+  return ISSUER_META[issuerId]?.rune ?? null;
+}
+
+/**
+ * Returns the logo path for a known issuer, or null for unknown issuers.
+ *
+ * @param issuerId - The issuer ID.
+ * @returns Path to the SVG logo (relative to public/), or null.
+ */
+export function getIssuerLogoPath(issuerId: string): string | null {
+  return ISSUER_META[issuerId]?.logoPath ?? null;
+}
+
+/**
+ * Returns the human-readable issuer name from the issuer ID.
+ * Centralised here so all components use the same lookup.
+ *
+ * @param issuerId - The issuer ID from KNOWN_ISSUERS.
+ * @returns The display name, or the raw issuerId as fallback.
+ */
+export function getIssuerName(issuerId: string): string {
+  const issuer = KNOWN_ISSUERS.find((i) => i.id === issuerId);
+  return issuer?.name ?? issuerId;
+}
+
+/**
+ * Derives 1-2 character initials from the issuer name.
+ * Used as fallback when no rune is available (unknown/custom issuers).
+ *
+ * Multi-word names (e.g. "Capital One") produce "CO" (first letter of each word).
+ * Single-word names (e.g. "Chase") produce "C" (first letter only).
+ *
+ * @param issuerId - The issuer ID.
+ * @returns 1-2 uppercase initials.
+ */
+export function getIssuerInitials(issuerId: string): string {
+  const name = getIssuerName(issuerId);
+  const words = name.trim().split(/\s+/);
+  if (words.length >= 2) {
+    return (words[0]![0]! + words[1]![0]!).toUpperCase();
+  }
+  return name[0]!.toUpperCase();
+}
+
+/**
+ * Returns the display character for the StatusRing badge.
+ * Known issuers get their rune; unknown issuers get initials.
+ *
+ * @param issuerId - The issuer ID.
+ * @returns The rune character or initials string.
+ */
+export function getIssuerBadgeChar(issuerId: string): string {
+  return getIssuerRune(issuerId) ?? getIssuerInitials(issuerId);
+}


### PR DESCRIPTION
## Summary

- New `issuer-utils.ts` mapping 10 known issuers to unique Elder Futhark runes, logo paths, and brand colors
- `IssuerLogo.tsx` component renders SVG logos for known issuers, falls back to text for unknown
- 10 minimal SVG logos in `public/static/logos/issuers/` (white on transparent, dark-bg friendly)
- `CardTile`, `HowlPanel`, `Valhalla`, and `CardForm` updated to use runes + logos
- Unknown/custom issuers fall back gracefully to initials

Fixes #153

## Test plan

- [ ] Known issuer cards show rune in badge and logo instead of text name
- [ ] Unknown issuers fall back to initials + text name
- [ ] Logos visible on dark background
- [ ] HowlPanel and Valhalla show rune + logo
- [ ] CardForm dropdown prefixed with runes
- [ ] Mobile layout not broken (375px)

🤖 Generated with [Claude Code](https://claude.com/claude-code)