### PR TITLE
chore: rich dispatch summary in fire-next-up reporting

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -794,30 +794,67 @@ Update this after each agent completes.
 
 ## Step 8 — Report
 
-After spawning Step 1, report to the user:
+After spawning Step 1, report a **dispatch summary** to the user:
 
 ```
-**#<NUMBER>**: <title>
-**Chain:** <Agent1> → <Agent2> → <Agent3>
-**Status:** Step 1/<N> — <AgentName> running in background
+## Dispatch Summary
+
+| Field | Value |
+|-------|-------|
+| **Issue** | #<NUMBER>: <TITLE> |
+| **Type** | <type label> |
+| **Priority** | <priority label> |
+| **Chain** | <Agent1> → <Agent2> [→ <Agent3>] |
+| **Branch** | `<BRANCH>` |
+| **Step** | 1/<TOTAL> — <AgentName> |
+| **Session** | `<SESSION_ID>` |
+| **Depot** | [View session](https://depot.dev/orgs/pqtm7s538l/claude/<SESSION_ID>) |
+| **Issue** | [#<NUMBER>](https://github.com/declanshanaghy/fenrir-ledger/issues/<NUMBER>) |
+| **Mode** | Remote (Depot) / Local (worktree) |
+| **Spawned** | <UTC timestamp> |
 
 **Remaining Up Next items:**
-| # | Issue | Chain |
-|---|-------|-------|
-| ... | ... | ... |
+| # | Title | Priority | Type | Chain |
+|---|-------|----------|------|-------|
+| ... | ... | ... | ... | ... |
 ```
 
-After each chain step completes, update the user:
+After each chain step completes, report a **step transition**:
 
 ```
-**#<NUMBER>**: Step <N>/<Total> complete (<AgentName>).
-Spawning Step <N+1>: <NextAgentName>...
+## Step Transition — #<NUMBER>
+
+| Field | Value |
+|-------|-------|
+| **Completed** | Step <N>/<TOTAL> — <AgentName> |
+| **Session** | [<PREV_SESSION_ID>](https://depot.dev/orgs/pqtm7s538l/claude/<PREV_SESSION_ID>) |
+| **Commits** | <N> commits on `<BRANCH>` |
+| **Handoff** | <Found / Missing> |
+| **Next** | Step <N+1>/<TOTAL> — <NextAgentName> |
+| **New Session** | [<NEW_SESSION_ID>](https://depot.dev/orgs/pqtm7s538l/claude/<NEW_SESSION_ID>) |
+| **Spawned** | <UTC timestamp> |
 ```
 
-After the final step:
+After the final step, report **chain completion**:
 
 ```
-**#<NUMBER>**: Chain complete. PR created: <PR_URL>
+## Chain Complete — #<NUMBER>
+
+| Field | Value |
+|-------|-------|
+| **Issue** | #<NUMBER>: <TITLE> |
+| **Chain** | <Agent1> → <Agent2> [→ <Agent3>] — ALL DONE |
+| **Branch** | `<BRANCH>` |
+| **PR** | [#<PR_NUMBER>](<PR_URL>) |
+| **Verdict** | PASS / FAIL |
+| **Total commits** | <N> |
+| **Duration** | ~<minutes> min (first spawn to PR) |
+
+### Session History
+| Step | Agent | Session | Status |
+|------|-------|---------|--------|
+| 1 | <Agent1> | [<SID>](https://depot.dev/orgs/pqtm7s538l/claude/<SID>) | Complete |
+| 2 | <Agent2> | [<SID>](https://depot.dev/orgs/pqtm7s538l/claude/<SID>) | Complete |
 ```
 
 ### Worktree Cleanup (Local Mode Only)


### PR DESCRIPTION
## Summary
- Step 8 (Report) now outputs structured markdown tables at each lifecycle point
- **Dispatch summary**: issue, type, priority, chain, branch, session ID, Depot link, timestamp, remaining queue
- **Step transition**: completed step, commit count, handoff status, next agent session link
- **Chain complete**: PR link, verdict, duration estimate, full session history table with links

All Depot session links use format: `https://depot.dev/orgs/pqtm7s538l/claude/<SESSION_ID>`

Ref #199

## Test plan
- [ ] Run `/fire-next-up #199` and verify dispatch summary renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)