### PR TITLE
fix: update cards header text — Ref #199

### DIFF
--- a/development/frontend/src/app/page.tsx
+++ b/development/frontend/src/app/page.tsx
@@ -108,7 +108,7 @@ export default function DashboardPage() {
       <div className="flex items-center justify-between mb-6 gap-3">
         {/* Voice 2: atmospheric page heading from copywriting.md navigation labels */}
         <h1 className="font-display text-2xl text-gold tracking-wide">
-          The Ledger of Fates
+          The Ledger of Fates - Overhauled
         </h1>
 
         <div className="flex items-center gap-2">


### PR DESCRIPTION
Ref #199

Updated Cards page header from The Ledger of Fates to The Ledger of Fates - Overhauled.

**Changes:**
- `development/frontend/src/app/page.tsx` — updated h1 header text

**Verification:**
- Navigate to Cards page, verify header reads The Ledger of Fates - Overhauled