### PR TITLE
chore: downgrade remote agent models

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -194,11 +194,11 @@ Max 50 characters. The orchestrator does NOT create the branch — the agent doe
 
 | Agent | `--model` flag |
 |-------|----------------|
-| Luna | `--model opus` |
-| FiremanDecko | `--model opus` |
-| Freya | `--model opus` |
-| Loki | `--model sonnet` |
-| Heimdall | `--model sonnet` |
+| Luna | `--model sonnet` |
+| FiremanDecko | `--model sonnet` |
+| Freya | `--model sonnet` |
+| Loki | `--model haiku` |
+| Heimdall | `--model haiku` |
 
 ### Agent Prompt Templates (read on demand)
 


### PR DESCRIPTION
Downgrade Depot remote agent models to reduce costs.

- Luna/FiremanDecko/Freya: opus → sonnet
- Loki/Heimdall: sonnet → haiku