### PR TITLE
docs: sync security documentation — Ref #249

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -19,7 +19,6 @@ This directory contains all security documentation for the Fenrir Ledger project
 | Date | Scope | Risk Summary | Status | Path |
 |------|-------|-------------|--------|------|
 | 2026-03-02 | Google API Integration | 0C / 3H / 3M / 3L / 3I | Active — findings partially open | [reports/2026-03-02-google-api-integration.md](reports/2026-03-02-google-api-integration.md) |
-| 2026-03-02 | Patreon Integration | 0C / 2H / 3M / 3L / 3I | **SUPERSEDED** — Patreon removed | [reports/2026-03-02-patreon-integration.md](reports/2026-03-02-patreon-integration.md) |
 | 2026-03-04 | Stripe Direct Integration | 0C / 0H / 0M / 3L / 3I | Active — CRITICAL/MEDIUM resolved | [reports/2026-03-04-stripe-direct-integration.md](reports/2026-03-04-stripe-direct-integration.md) |
 | 2026-03-05 | LLM Prompt Injection Remediation (#157) | 0C / 0H / 0M / 0L / 2I | Active | [reports/2026-03-05-llm-prompt-injection-remediation.md](reports/2026-03-05-llm-prompt-injection-remediation.md) |
 

--- a/security/architecture/auth-architecture.md
+++ b/security/architecture/auth-architecture.md
@@ -248,16 +248,16 @@ These are the minimum scopes required for Path B. `drive.file` is narrower than
 
 ### 5.1 Overview
 
-Subscription management uses Stripe Direct. There is no longer a Patreon integration.
-Users subscribe via Stripe Checkout (hosted payment page). Entitlements are stored
-in Vercel KV keyed on the Google `sub` claim.
+Subscription management uses Stripe Direct exclusively. Users subscribe via Stripe
+Checkout (hosted payment page). Entitlements are stored in Vercel KV keyed on the
+Google `sub` claim.
 
 The Stripe integration creates a **layered model**:
 - Google `id_token` in `localStorage` — identity on every API request
 - Stripe subscription status in Vercel KV — entitlement lookup
 
-Unlike the previous Patreon design, no Stripe secrets are stored in KV. The Stripe
-secret key is a server-side process.env variable used server-to-server only.
+No Stripe secrets are stored in KV. The Stripe secret key is a server-side
+process.env variable used server-to-server only.
 
 ### 5.2 Checkout Flow
 

--- a/security/architecture/threat-model.md
+++ b/security/architecture/threat-model.md
@@ -173,13 +173,14 @@
 - Import route: exactly one of `url` or `csv` required; both checked as strings
 - Stripe checkout redirect URLs: `APP_BASE_URL`/`VERCEL_URL` only (no user-controlled headers)
 
-### Stripe-Specific
+### Stripe-Specific (Stripe Direct)
 
 - SHA-256 HMAC webhook signature verification (`stripe.webhooks.constructEvent()`)
 - Raw body read before JSON parsing for webhook signature validation
 - `STRIPE_WEBHOOK_SECRET` never logged or returned to clients
 - Stripe entitlements in KV with 30-day TTL
 - Reverse index (`stripe-customer:{id}`) for webhook-to-user mapping
+- No token encryption in KV (unlike previous platforms) — only subscription status stored
 
 ---
 

--- a/security/architecture/trust-boundaries.md
+++ b/security/architecture/trust-boundaries.md
@@ -90,10 +90,10 @@ is trusted for payment processing and subscription lifecycle events.
 | `GOOGLE_PICKER_API_KEY` | `process.env` (server) | Yes — served on request | Auth-gated; GCP referrer restriction required |
 | `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | `process.env` (public) | Yes — by design | OAuth Client ID is public; embedded in auth URL |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | `process.env` (public) | Yes — by design | Stripe publishable key is safe for client exposure |
-| Google `access_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; 1-hour TTL |
+| Google `access_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; ~1-hour TTL |
 | Google `id_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; used as API Bearer token |
-| Google `refresh_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; long-lived |
-| Drive `access_token` | `localStorage["fenrir:drive-token"]` | Yes — same-origin JS | XSS risk; 1-hour TTL |
+| Google `refresh_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; long-lived (no TTL) |
+| Drive `access_token` | `localStorage["fenrir:drive-token"]` | Yes — same-origin JS | XSS risk; ~1-hour TTL |
 | PKCE `code_verifier` | `sessionStorage["fenrir:pkce"]` | Yes — same-origin JS | Transient; removed after callback |
 
 ---


### PR DESCRIPTION
## Summary

- Audited all security documentation for stale content
- Removed Patreon Integration report (2026-03-02) from reports index (superseded by Stripe Direct)
- Updated architecture documents to remove Patreon references and clarify Stripe Direct design

## Files Updated

- `security/README.md` — removed Patreon report from reports table
- `security/architecture/auth-architecture.md` — simplified Stripe subsection
- `security/architecture/threat-model.md` — clarified Stripe-specific mitigations
- `security/architecture/trust-boundaries.md` — refined token TTL descriptions

## Verification

✅ TypeScript: no errors  
✅ Next.js build: successful

🤖 Generated with [Claude Code](https://claude.com/claude-code)