### PR TITLE
docs: sync architecture documentation — Ref #247

### DIFF
--- a/designs/architecture/README.md
+++ b/designs/architecture/README.md
@@ -7,17 +7,17 @@ Technical architecture documents owned by FiremanDecko (Principal Engineer).
 | File | Type | Status | Description |
 |------|------|--------|-------------|
 | [README.md](README.md) | Index | Current | This file: directory index for all architecture documents. |
-| [adr-api-auth.md](adr-api-auth.md) | ADR | Accepted | ADR-008: Server-side API route authentication via Google id_token JWKS verification using the `jose` library. |
-| [adr-backend-server.md](adr-backend-server.md) | ADR | Superseded | Originally introduced a dedicated Node/TS backend server. Backend removed in favor of serverless-only (see addendum at top of file). |
+| [adr-api-auth.md](adr-api-auth.md) | ADR | Accepted | ADR-008: Server-side API route authentication via Google id_token JWKS verification using the `jose` library. Updated 2026-03-07: protected routes table expanded to include all current routes (picker, all Stripe routes). |
+| [adr-backend-server.md](adr-backend-server.md) | ADR | Superseded | Originally introduced a dedicated Node/TS backend server. Backend removed in favor of serverless-only. |
 | [adr-clerk-auth.md](adr-clerk-auth.md) | ADR | Proposed | ADR-007: Clerk as auth platform with GitHub as initial identity provider. Deferred until GA planning. |
 | [adr-openapi-spec.md](adr-openapi-spec.md) | ADR | Superseded | OpenAPI specification for the (now-removed) backend API. Backend removed; spec is no longer applicable. |
 | [backend-implementation-plan.md](backend-implementation-plan.md) | Implementation Plan | Archived | Phased implementation plan for the (now-removed) backend server. Kept for historical reference. |
 | [clerk-implementation-plan.md](clerk-implementation-plan.md) | Implementation Plan | Proposed (deferred) | 5-phase Clerk auth integration plan. Deferred until GA planning is triggered. |
-| [route-ownership.md](route-ownership.md) | Reference | Current | Route placement table: all routes now live in Next.js (Vercel). |
+| [route-ownership.md](route-ownership.md) | Reference | Current | Route placement table: all routes in Next.js (Vercel). Updated 2026-03-07: added `/api/config/picker`, all 5 Stripe routes, and full env var table. |
 | [backend-ws-qa-report.md](backend-ws-qa-report.md) | QA Report | Archived | Loki's QA validation of the (now-removed) backend ADR and implementation plan. Kept for historical reference. |
 | [clerk-auth-qa-report.md](clerk-auth-qa-report.md) | QA Report | Complete | Loki's QA validation of the Clerk ADR and implementation plan. Verdict: Approved with notes. |
-| [adr-feature-flags.md](adr-feature-flags.md) | ADR | Superseded | Feature flag system for subscription platform toggle. Superseded — Patreon removed, Stripe is sole platform. |
-| [adr-010-stripe-direct.md](adr-010-stripe-direct.md) | ADR | Accepted | ADR-010: Stripe Direct integration — Checkout, Customer Portal, webhook-driven entitlements, Vercel KV storage. |
+| [adr-feature-flags.md](adr-feature-flags.md) | ADR | Superseded | Feature flag system for subscription platform toggle. Superseded — Patreon removed, Stripe is sole platform, `feature-flags.ts` deleted. |
+| [adr-010-stripe-direct.md](adr-010-stripe-direct.md) | ADR | Accepted | ADR-010: Stripe Direct integration — Checkout, Customer Portal, webhook-driven entitlements, Vercel KV storage. Updated 2026-03-07: addendum notes Patreon removal and feature flag deletion. |
 
 ## Directory Layout
 
@@ -40,9 +40,10 @@ designs/architecture/
 ## Key Relationships
 
 - The backend ADR (`adr-backend-server.md`) and its OpenAPI ADR (`adr-openapi-spec.md`) are both superseded; the backend was removed in favor of serverless-only.
-- `adr-api-auth.md` (ADR-008) defines the current API route auth pattern — Google id_token verification via `jose` JWKS. This is the active auth mechanism.
-- The Clerk ADR (`adr-clerk-auth.md`) is the decision; `clerk-implementation-plan.md` is the execution plan. Both are deferred until GA planning.
-- `route-ownership.md` documents all routes, now exclusively in Next.js (Vercel).
+- `adr-api-auth.md` (ADR-008) defines the current API route auth pattern — Google id_token verification via `jose` JWKS. This is the active auth mechanism for all routes except `/api/auth/token` (exempt by design) and `/api/stripe/webhook` (secured by Stripe HMAC).
+- `adr-010-stripe-direct.md` is the active subscription ADR. Patreon has been fully removed; Stripe is the sole platform. `adr-feature-flags.md` is superseded.
+- The Clerk ADR (`adr-clerk-auth.md`) is the decision; `clerk-implementation-plan.md` is the execution plan. Both are deferred until GA planning is declared.
+- `route-ownership.md` is the canonical route registry — documents all 9 routes (UI + API) with auth status and env vars.
 - QA reports validate each ADR + plan pair before implementation begins.
 
 ## Project Structure Reference

--- a/designs/architecture/adr-010-stripe-direct.md
+++ b/designs/architecture/adr-010-stripe-direct.md
@@ -2,11 +2,17 @@
 
 ## Status: Accepted
 
+> **Addendum (2026-03-07):** Patreon has been fully removed. Stripe is the sole subscription
+> platform. The `SUBSCRIPTION_PLATFORM` feature flag, `isPatreon()`, `isStripe()` helpers,
+> and `src/lib/feature-flags.ts` have all been deleted. The feature flag guards on routes
+> are no longer needed — all Stripe routes are always active. See `adr-feature-flags.md`
+> (superseded) for the transition history.
+
 ## Context
 
-Fenrir Ledger currently uses Patreon as its subscription platform (ADR-009). The product team has decided to add Stripe as an alternative subscription platform to provide a more streamlined payment experience with lower fees and better control over the billing lifecycle.
+Fenrir Ledger originally used Patreon as its subscription platform (ADR-009). The product team decided to add Stripe as an alternative subscription platform, and subsequently migrated fully to Stripe to provide a more streamlined payment experience with lower fees and better control over the billing lifecycle.
 
-The SUBSCRIPTION_PLATFORM feature flag (see adr-feature-flags.md) already supports toggling between "patreon" and "stripe". This ADR documents the technical architecture for the Stripe Direct integration.
+The SUBSCRIPTION_PLATFORM feature flag (see adr-feature-flags.md, now superseded) was used to toggle between "patreon" and "stripe" during migration. This ADR documents the technical architecture for the Stripe Direct integration.
 
 Key requirements:
 - Stripe Checkout for subscription creation (no custom payment forms)

--- a/designs/architecture/adr-api-auth.md
+++ b/designs/architecture/adr-api-auth.md
@@ -39,8 +39,14 @@ Per-route auth guard (not middleware):
 
 | Route | Protected | Reason |
 |-------|-----------|--------|
+| `GET /api/config/picker` | Yes | Serves server-side API key to client |
 | `POST /api/sheets/import` | Yes | Consumes LLM API credits |
+| `POST /api/stripe/checkout` | Yes | Creates paid checkout sessions on behalf of user |
+| `GET /api/stripe/membership` | Yes | Returns user-specific entitlement data |
+| `POST /api/stripe/portal` | Yes | Creates billing portal sessions on behalf of user |
+| `POST /api/stripe/unlink` | Yes | Cancels user subscription |
 | `POST /api/auth/token` | No | Token exchange — no token exists yet |
+| `POST /api/stripe/webhook` | No (Stripe signature) | Stripe sends webhooks — secured by SHA-256 HMAC via `constructEvent()` |
 
 All future API routes must use `requireAuth()` (CLAUDE.md unbreakable rule).
 

--- a/designs/architecture/route-ownership.md
+++ b/designs/architecture/route-ownership.md
@@ -1,28 +1,40 @@
 # Route Ownership — Fenrir Ledger
 
-**Date:** 2026-03-01 (updated: backend removed)
+**Date:** 2026-03-01 (updated: 2026-03-07 — added Stripe and picker routes)
 **Author:** FiremanDecko (Principal Engineer)
-**Related:** ADR: `adr-backend-server.md` (superseded — serverless-only)
+**Related:** ADR: `adr-backend-server.md` (superseded — serverless-only), ADR-008: `adr-api-auth.md`, ADR-010: `adr-010-stripe-direct.md`
 
 ## Route Placement
 
-| Route | Host | Method | Purpose | Rationale |
-|-------|------|--------|---------|-----------|
-| `/` (app routes) | Next.js (Vercel) | GET | All UI pages (dashboard, cards, valhalla, auth) | App Router serves the React SPA |
-| `POST /api/auth/token` | Next.js (Vercel) | POST | Google OAuth2 PKCE token exchange proxy | Fast (~200ms), stateless, keeps GOOGLE_CLIENT_SECRET server-side |
-| `POST /api/sheets/import` | Next.js (Vercel) | POST | Import pipeline: fetch CSV + Anthropic call + Zod validation | Runs as a Vercel serverless function (`maxDuration = 60`) |
+| Route | Method | Auth | Purpose |
+|-------|--------|------|---------|
+| `/` (app routes) | GET | None (anonymous-first) | All UI pages (dashboard, cards, valhalla, auth) |
+| `POST /api/auth/token` | POST | None (token exchange) | Google OAuth2 PKCE token exchange proxy — exempt from requireAuth by design |
+| `GET /api/config/picker` | GET | requireAuth | Serve Google Picker API key to authenticated clients |
+| `POST /api/sheets/import` | POST | requireAuth | Import pipeline: fetch CSV + Anthropic call + Zod validation (`maxDuration = 60`) |
+| `POST /api/stripe/checkout` | POST | requireAuth | Create Stripe Checkout session, return redirect URL |
+| `POST /api/stripe/webhook` | POST | Stripe signature only | Process Stripe webhook events — no Bearer auth, secured by SHA-256 HMAC |
+| `GET /api/stripe/membership` | GET | requireAuth | Return cached Stripe entitlement from Vercel KV |
+| `POST /api/stripe/portal` | POST | requireAuth | Create Stripe Customer Portal session, return redirect URL |
+| `POST /api/stripe/unlink` | POST | requireAuth | Cancel Stripe subscription, delete KV entitlement record |
 
 ## Environment Variables
 
 | Variable | Runtime | Scope | Description |
 |----------|---------|-------|-------------|
-| `GOOGLE_CLIENT_SECRET` | Next.js (server) | Server-side only | Used by auth token proxy |
-| `ANTHROPIC_API_KEY` | Next.js (server) | Server-side only | Used by import pipeline |
-| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Next.js (client) | Browser-exposed | Used for the auth redirect |
+| `GOOGLE_CLIENT_SECRET` | Next.js (server) | Server-side only | Used by auth token proxy (`/api/auth/token`) |
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Next.js (client) | Browser-exposed | Used for the Google OAuth redirect |
+| `GOOGLE_PICKER_API_KEY` | Next.js (server) | Server-side only | Used by picker config route (`/api/config/picker`) |
+| `ANTHROPIC_API_KEY` | Next.js (server) | Server-side only | Used by import pipeline (`/api/sheets/import`) |
+| `STRIPE_SECRET_KEY` | Next.js (server) | Server-side only | Stripe API authentication (all Stripe routes) |
+| `STRIPE_WEBHOOK_SECRET` | Next.js (server) | Server-side only | Webhook HMAC signature verification (`/api/stripe/webhook`) |
+| `STRIPE_PRICE_ID` | Next.js (server) | Server-side only | Stripe product price for checkout sessions |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Next.js (client) | Browser-exposed | Future: Stripe.js initialization |
 
 ## Design Principles
 
 1. **All routes live in Next.js**: With the backend removed, all API routes are Vercel serverless functions.
-2. **Server-side secrets stay server-side**: No `NEXT_PUBLIC_` prefix on secret values.
-3. **Graceful degradation**: The app works without auth for anonymous users (localStorage-only mode).
-4. **Single secret per route**: Each secret is consumed by exactly one route handler.
+2. **All routes call `requireAuth()` except**: `/api/auth/token` (no token exists yet) and `/api/stripe/webhook` (Stripe sends webhooks — secured by HMAC signature).
+3. **Server-side secrets stay server-side**: No `NEXT_PUBLIC_` prefix on secret values (except publishable keys).
+4. **Graceful degradation**: The app works without auth for anonymous users (localStorage-only mode).
+5. **Stripe is the sole subscription platform**: Patreon has been removed. See `adr-feature-flags.md` (superseded) and `adr-010-stripe-direct.md`.


### PR DESCRIPTION
Ref #247

Syncs all architecture documentation in designs/architecture/.

## Changes

**`route-ownership.md`** — Updated (was stale, missing 6 routes)
- Added `GET /api/config/picker` route with auth status
- Added all 5 Stripe routes (`/api/stripe/checkout`, `/api/stripe/webhook`, `/api/stripe/membership`, `/api/stripe/portal`, `/api/stripe/unlink`) with auth status
- Expanded env var table with Stripe and Picker vars
- Updated design principles to reflect requireAuth unbreakable rule and Stripe-only platform

**`adr-api-auth.md` (ADR-008)** — Updated (protected routes table was incomplete)
- Expanded protected routes table from 2 rows to 8 rows covering all current API routes
- Added auth rationale for each route including the webhook HMAC exception

**`adr-010-stripe-direct.md`** — Updated (context was stale re: Patreon/feature flags)
- Added addendum noting Patreon has been fully removed
- Notes that `feature-flags.ts`, `isPatreon()`, `isStripe()`, and `SUBSCRIPTION_PLATFORM` are all deleted
- All Stripe routes are always active (no feature flag guards needed)

**`README.md`** — Updated index and Key Relationships
- Updated descriptions for changed files to reflect 2026-03-07 updates
- Updated Key Relationships section to name the webhook HMAC exception, call out Stripe sole platform, and describe route-ownership.md as the canonical route registry

## Verification

- `npx tsc --noEmit` ✅ no errors
- `npx next build` ✅ clean build, all 9 routes confirmed in output