### PR TITLE
chore: add VERCEL_PREVIEW toggle to skip preview deploys

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -25,6 +25,7 @@ env:
 
 jobs:
   deploy-preview:
+    if: vars.VERCEL_PREVIEW != 'false'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Adds `vars.VERCEL_PREVIEW != 'false'` condition to the vercel-preview workflow job
- When repo variable `VERCEL_PREVIEW` is `false`, the entire deploy+test job is skipped
- Set to `true` or delete the variable to re-enable
- Currently set to `false` to work around Vercel free-tier rate limit (5000 uploads/16h cooldown)

## Test plan
- [x] Variable set to `false` via `gh variable set`
- [ ] Verify PRs no longer trigger preview deploys
- [ ] Re-enable later by setting to `true`