### PR TITLE
chore: add Playwright webServer hook for sandbox dev server

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -192,6 +192,18 @@ Max 50 characters. The orchestrator does NOT create the branch — the agent doe
 
 ### Agent Model Mapping
 
+#### Remote (Depot) — use full model IDs (aliases may resolve to deprecated versions)
+
+| Agent | `--model` flag |
+|-------|----------------|
+| Luna | `--model claude-sonnet-4-6` |
+| FiremanDecko | `--model claude-sonnet-4-6` |
+| Freya | `--model claude-sonnet-4-6` |
+| Loki | `--model claude-haiku-4-5-20251001` |
+| Heimdall | `--model claude-haiku-4-5-20251001` |
+
+#### Local (`--local`) — aliases are fine
+
 | Agent | `--model` flag |
 |-------|----------------|
 | Luna | `--model sonnet` |

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -28,7 +28,7 @@ cd <REPO_ROOT>/development/frontend && npx tsc --noEmit
 cd <REPO_ROOT>/development/frontend && npx next build
 
 **Step 4b — Run the FULL Playwright test suite (CI gate):**
-cd <REPO_ROOT>/development/frontend && SERVER_URL=http://localhost:9653 npx playwright test --reporter=list
+cd <REPO_ROOT>/development/frontend && npx playwright test --reporter=list
 If ANY tests fail — fix either the code or the test. Do NOT push with failing tests.
 Pre-existing test failures are YOUR responsibility — they block CI and bounce the PR.
 

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -19,11 +19,11 @@ Use the previous agent's handoff comment to understand what was built, how to ve
 **Step 3 — Write and run tests:**
 - Write new Playwright tests in `quality/test-suites/<feature-slug>/` covering the acceptance criteria.
 - Use the previous agent's "How to verify" and "Edge cases" sections to guide your test design.
-- Run the new tests: `cd <REPO_ROOT>/development/frontend && SERVER_URL=http://localhost:9653 npx playwright test ../../quality/test-suites/<feature-slug>/ --reporter=list`
+- Run the new tests: `cd <REPO_ROOT>/development/frontend && npx playwright test ../../quality/test-suites/<feature-slug>/ --reporter=list`
 - Verify build passes: `cd <REPO_ROOT>/development/frontend && npx tsc --noEmit && npx next build`
 
 **Step 3b — Run the FULL test suite and fix ANY failures:**
-- Run ALL Playwright tests: `cd <REPO_ROOT>/development/frontend && SERVER_URL=http://localhost:9653 npx playwright test --reporter=list`
+- Run ALL Playwright tests: `cd <REPO_ROOT>/development/frontend && npx playwright test --reporter=list`
 - If ANY tests fail — whether your new tests or pre-existing tests — you MUST fix them.
 - Pre-existing test failures are NOT acceptable. They block CI and prevent merging.
 - Read each failing test file, understand what it expects, read the actual page/component

--- a/development/frontend/playwright.config.ts
+++ b/development/frontend/playwright.config.ts
@@ -26,4 +26,18 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
   ],
+
+  // Start the dev server automatically when no SERVER_URL is provided.
+  // Reuses an existing server if one is already running (local dev).
+  // Skipped entirely when SERVER_URL is set (CI hitting a Vercel preview).
+  ...(!process.env.SERVER_URL
+    ? {
+        webServer: {
+          command: "npm run dev",
+          url: "http://localhost:9653",
+          reuseExistingServer: true,
+          timeout: 120_000,
+        },
+      }
+    : {}),
 });


### PR DESCRIPTION
## Summary

- Adds Playwright's built-in `webServer` config to auto-start `npm run dev` on port 9653 when no `SERVER_URL` env var is set
- `reuseExistingServer: true` means local dev (server already running) is unaffected
- When `SERVER_URL` is set (CI pointing at Vercel preview), the `webServer` block is omitted entirely
- Removes explicit `SERVER_URL=http://localhost:9653` from agent templates (FiremanDecko, Loki) so the hook activates in Depot sandboxes

Fixes the root cause of all sandbox Playwright failures — no dev server was running at localhost:9653.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>