### PR TITLE
fix: clean up logged-out empty state CTAs — Ref #156

### DIFF
--- a/development/frontend/src/app/page.tsx
+++ b/development/frontend/src/app/page.tsx
@@ -162,20 +162,26 @@ export default function DashboardPage() {
             </AuthGate>
           )}
 
-          <Link
-            href="/cards/new"
-            className="inline-flex items-center justify-center rounded-sm text-base font-heading tracking-wide ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-primary text-primary-foreground hover:bg-primary hover:brightness-110 h-9 px-4 py-2"
-          >
-            Add Card
-          </Link>
+          {/* Hide header "Add Card" when zero cards — the EmptyState has its own CTA */}
+          {loaded && cards.length > 0 && (
+            <Link
+              href="/cards/new"
+              className="inline-flex items-center justify-center rounded-sm text-base font-heading tracking-wide ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 bg-primary text-primary-foreground hover:bg-primary hover:brightness-110 h-9 px-4 py-2"
+            >
+              Add Card
+            </Link>
+          )}
         </div>
       </div>
 
       {/* Upsell banner -- shown to Thrall users above the card grid.
+          Hidden when zero cards to avoid overwhelming the empty state.
           The UpsellBanner self-hides for Karl/dismissed users. */}
-      <div className="mb-4">
-        <UpsellBanner />
-      </div>
+      {loaded && cards.length > 0 && (
+        <div className="mb-4">
+          <UpsellBanner />
+        </div>
+      )}
 
       {/* Main content row: card grid + HowlPanel side-by-side on desktop */}
       <div className="flex gap-6 items-start">

--- a/development/frontend/src/components/dashboard/EmptyState.tsx
+++ b/development/frontend/src/components/dashboard/EmptyState.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * EmptyState — displayed on the dashboard when no cards exist.
  *
@@ -9,9 +11,13 @@
  */
 
 import Link from "next/link";
+import { useAuth } from "@/hooks/useAuth";
 import { AuthGate } from "@/components/shared/AuthGate";
 
 export function EmptyState() {
+  const { status } = useAuth();
+  const isAnonymous = status === "anonymous";
+
   return (
     <div
       className="flex flex-col items-center justify-center py-24 text-center"
@@ -65,6 +71,19 @@ export function EmptyState() {
           Import from Google Sheets
         </button>
       </AuthGate>
+
+      {/* Subtle sign-in nudge for anonymous users — muted text, not a banner */}
+      {isAnonymous && (
+        <p className="mt-6 text-sm text-muted-foreground/60 font-body">
+          <Link
+            href="/sign-in"
+            className="underline underline-offset-2 hover:text-gold transition-colors"
+          >
+            Sign in
+          </Link>{" "}
+          to sync across devices.
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Ref #156

Simplifies the logged-out zero-cards state by removing competing CTAs and banners.

## Summary

- **page.tsx**: Hide header "Add Card" button when `cards.length === 0` — the EmptyState component has its own primary CTA
- **page.tsx**: Hide Karl upsell banner (`UpsellBanner`) when zero cards to eliminate visual noise on the empty state
- **EmptyState.tsx**: Add subtle sign-in nudge as muted text with underlined link (not a full-width bordered banner) for anonymous users
- **EmptyState.tsx**: Add `"use client"` directive to support `useAuth` hook

## Changes
- `development/frontend/src/app/page.tsx`
- `development/frontend/src/components/dashboard/EmptyState.tsx`

## Verification
- Visit app logged out with no cards — should see clean empty state with single "Add Card" CTA and subtle "Sign in to sync across devices" text
- Visit app logged in with cards — header "Add Card" button and upsell banner appear as before
- tsc clean, 545 Playwright tests pass

Generated with [Claude Code](https://claude.com/claude-code)