### PR TITLE
fix: restore depot grievances page broken by CSS migration

### DIFF
--- a/.claude/skills/brandify-session/scripts/migrate-to-shared-css.ts
+++ b/.claude/skills/brandify-session/scripts/migrate-to-shared-css.ts
@@ -17,9 +17,13 @@ const files = process.argv.slice(2).filter(f => !f.endsWith('index.html'));
 for (const file of files) {
   let html = readFileSync(file, 'utf-8');
 
-  // Check if already migrated
+  // Check if already migrated or explicitly excluded
   if (html.includes('chronicle.css')) {
     console.log(`SKIP ${file} (already migrated)`);
+    continue;
+  }
+  if (html.includes('chronicle:skip')) {
+    console.log(`SKIP ${file} (marked chronicle:skip)`);
     continue;
   }
 

--- a/sessions/depot-integration-issues.html
+++ b/sessions/depot-integration-issues.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- chronicle:skip — standalone blog post, not a session chronicle. Do not migrate to shared CSS. -->
 <!--
   ╔══════════════════════════════════════════════════════╗
   ║     DEPOT INTEGRATION — THE WOLF'S GRIEVANCES       ║
@@ -15,7 +16,444 @@
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Cinzel+Decorative:wght@700;900&family=Cinzel:wght@400;600;700&family=Source+Serif+4:ital,wght@0,300;0,400;0,600;1,300;1,400;1,600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-  <link rel="stylesheet" href="/sessions/chronicle.css">
+  <style>
+    :root {
+      --void: #12100e;
+      --forge: #1c1917;
+      --chain: #242120;
+      --border: #3a3530;
+      --border-strong: #4a4540;
+      --gold: #d4a520;
+      --gold-bright: #f0c040;
+      --gold-dim: #8a6a10;
+      --gold-glow: rgba(212, 165, 32, 0.15);
+      --ice-blue: #5b9ec9;
+      --ice-blue-dim: rgba(91, 158, 201, 0.12);
+      --text-saga: #f5f3ed;
+      --text-rune: #d0c8b8;
+      --text-void: #6a6560;
+      --fire-muspel: #c94a0a;
+      --red-ragnarok: #ef4444;
+      --teal-asgard: #0a8c6e;
+      --amber-hati: #f59e0b;
+      --font-display: 'Cinzel Decorative', serif;
+      --font-heading: 'Cinzel', serif;
+      --font-body: 'Source Serif 4', serif;
+      --font-mono: 'JetBrains Mono', monospace;
+      --radius: 3px;
+      --max-width: 960px;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+
+    body {
+      margin: 0; padding: 0;
+      background-color: var(--void);
+      background-image:
+        radial-gradient(ellipse 60% 40% at 50% -5%, rgba(212, 165, 32, 0.05) 0%, transparent 60%),
+        url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='300' height='300'%3E%3Cfilter id='s'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='300' height='300' filter='url(%23s)' opacity='0.05'/%3E%3C/svg%3E");
+      background-attachment: fixed;
+      color: var(--text-saga);
+      font-family: var(--font-body);
+      font-size: 22px;
+      line-height: 1.8;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    code {
+      font-family: var(--font-mono);
+      font-size: 0.85em;
+      color: #4ade80;
+      background: rgba(74, 222, 128, 0.08);
+      padding: 1px 5px;
+      border-radius: 2px;
+    }
+
+    a { color: var(--gold); text-decoration: none; }
+    a:hover { color: var(--gold-bright); }
+
+    .back-nav { padding: 24px 0 0; }
+    .back-link {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: 0.72rem;
+      color: var(--text-void);
+      text-decoration: none;
+      letter-spacing: 0.06em;
+      transition: color 0.2s;
+    }
+    .back-link:hover { color: var(--gold-bright); }
+
+    a.norse {
+      color: var(--text-void);
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-underline-offset: 3px;
+      text-decoration-color: var(--gold-dim);
+      transition: color 200ms ease-out;
+    }
+    a.norse:hover {
+      color: var(--gold);
+      text-decoration-color: var(--gold);
+    }
+
+    .container {
+      max-width: var(--max-width);
+      margin: 0 auto;
+      padding: 0 24px;
+    }
+
+    .rune-rule {
+      width: 80px; height: 1px;
+      background: linear-gradient(90deg, transparent, var(--gold), transparent);
+      margin: 24px auto; border: none;
+    }
+
+    .rune-rule-left {
+      width: 60px; height: 1px;
+      background: linear-gradient(90deg, var(--gold), transparent);
+      margin: 16px 0; border: none;
+    }
+
+    /* ── Animations ───────────────────────────── */
+    .saga-reveal > * {
+      opacity: 0; transform: translateY(14px);
+      animation: saga-enter 0.45s cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    }
+    .saga-reveal > *:nth-child(1) { animation-delay: 100ms; }
+    .saga-reveal > *:nth-child(2) { animation-delay: 180ms; }
+    .saga-reveal > *:nth-child(3) { animation-delay: 260ms; }
+    .saga-reveal > *:nth-child(4) { animation-delay: 340ms; }
+    .saga-reveal > *:nth-child(5) { animation-delay: 420ms; }
+    .saga-reveal > *:nth-child(n+6) { animation-delay: 500ms; }
+    @keyframes saga-enter { to { opacity: 1; transform: translateY(0); } }
+
+    @keyframes gold-pulse {
+      0%, 100% { box-shadow: 0 0 12px rgba(212, 165, 32, 0.3); }
+      50%      { box-shadow: 0 0 28px rgba(212, 165, 32, 0.6), 0 0 48px rgba(212, 165, 32, 0.2); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      .saga-reveal > * { animation: none; opacity: 1; transform: none; }
+    }
+
+    /* ── Hero ─────────────────────────────────── */
+    .hero {
+      padding: 80px 0 48px;
+      text-align: center;
+      position: relative;
+      background:
+        radial-gradient(ellipse 50% 40% at 50% 0%, rgba(91, 158, 201, 0.12) 0%, transparent 65%),
+        radial-gradient(ellipse 80% 40% at 50% 100%, rgba(18, 16, 14, 0.9) 0%, transparent 60%),
+        linear-gradient(to bottom, #04091a 0%, #08152a 25%, #0f1c2e 50%, #12100e 100%);
+    }
+
+    .hero-eyebrow {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      color: var(--gold);
+      letter-spacing: 0.4em;
+      opacity: 0.7;
+      margin-bottom: 16px;
+    }
+
+    .hero h1 {
+      font-family: var(--font-display);
+      font-weight: 900;
+      font-size: clamp(28px, 5vw, 52px);
+      color: var(--text-saga);
+      line-height: 1.1;
+      letter-spacing: 0.02em;
+      margin: 0 0 16px;
+      text-shadow: 0 1px 0 rgba(255,255,255,0.12), 0 -1px 0 rgba(0,0,0,0.8),
+        2px 4px 8px rgba(0,0,0,0.95), 0 0 40px rgba(91, 158, 201, 0.1);
+    }
+
+    .hero-sub {
+      font-family: var(--font-body);
+      font-style: italic;
+      font-size: 22px;
+      color: var(--text-rune);
+      max-width: 600px;
+      margin: 0 auto 8px;
+      line-height: 1.7;
+    }
+
+    .hero-meta {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-void);
+      letter-spacing: 0.1em;
+    }
+
+    /* ── Epigraph ─────────────────────────────── */
+    .epigraph {
+      padding: 40px 0;
+      text-align: center;
+    }
+    .epigraph blockquote {
+      margin: 0 auto;
+      max-width: 760px;
+      font-family: var(--font-body);
+      font-weight: 300;
+      font-style: italic;
+      font-size: 22px;
+      color: var(--text-rune);
+      line-height: 1.8;
+      border-left: 2px solid var(--gold-dim);
+      padding-left: 24px;
+      text-align: left;
+    }
+
+    /* ── Grievance Cards ──────────────────────── */
+    .grievances { padding: 24px 0 64px; }
+
+    .grievance {
+      background: var(--forge);
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--fire-muspel);
+      border-radius: var(--radius);
+      padding: 40px 36px;
+      margin-bottom: 32px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.02);
+      transition: border-color 200ms ease-out, box-shadow 200ms ease-out;
+    }
+    .grievance:hover {
+      border-color: var(--gold);
+      box-shadow: 0 0 0 1px var(--gold), 0 0 28px rgba(212, 165, 32, 0.15), 0 8px 32px rgba(0,0,0,0.5);
+    }
+
+    .grievance-number {
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.3em;
+      text-transform: uppercase;
+      color: var(--fire-muspel);
+      margin-bottom: 8px;
+      display: block;
+    }
+
+    .grievance h2 {
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: clamp(20px, 3vw, 26px);
+      color: var(--text-saga);
+      letter-spacing: 0.06em;
+      margin: 0 0 8px;
+    }
+
+    .grievance-pain {
+      font-family: var(--font-body);
+      font-style: italic;
+      font-size: 20px;
+      color: var(--gold);
+      margin: 0 0 16px;
+      line-height: 1.6;
+    }
+
+    .grievance p {
+      color: var(--text-rune);
+      font-size: 20px;
+      line-height: 1.75;
+      margin: 0 0 16px;
+    }
+
+    .grievance p:last-child { margin-bottom: 0; }
+
+    /* Code blocks */
+    .code-block {
+      background: var(--void);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 20px 24px;
+      margin: 16px 0;
+      overflow-x: auto;
+    }
+
+    .code-block pre {
+      margin: 0;
+      font-family: var(--font-mono);
+      font-size: 16px;
+      line-height: 1.6;
+      color: var(--text-rune);
+      white-space: pre;
+    }
+
+    .code-block code {
+      color: inherit;
+      background: none;
+      padding: 0;
+      font-size: inherit;
+    }
+
+    .code-label {
+      display: block;
+      font-family: var(--font-mono);
+      font-size: 11px;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+
+    .code-label.want { color: var(--teal-asgard); }
+    .code-label.have { color: var(--fire-muspel); }
+
+    .code-block .comment { color: var(--text-void); }
+    .code-block .cmd { color: var(--text-saga); }
+    .code-block .flag { color: var(--gold); }
+    .code-block .string { color: var(--ice-blue); }
+    .code-block .output { color: var(--teal-asgard); }
+
+    /* Verdict line */
+    .wolf-says {
+      font-family: var(--font-body);
+      font-style: italic;
+      font-size: 19px;
+      color: var(--text-rune);
+      margin-top: 20px;
+      padding-top: 16px;
+      border-top: 1px solid var(--border);
+    }
+
+    /* ── Summary Table ────────────────────────── */
+    .summary-section {
+      padding: 48px 0;
+      background: var(--forge);
+    }
+
+    .summary-section h2 {
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: 24px;
+      color: var(--text-saga);
+      text-align: center;
+      letter-spacing: 0.06em;
+      margin: 0 0 32px;
+    }
+
+    .summary-table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 14px;
+    }
+
+    .summary-table th {
+      font-family: var(--font-heading);
+      font-weight: 600;
+      font-size: 12px;
+      letter-spacing: 0.15em;
+      text-transform: uppercase;
+      color: var(--gold);
+      text-align: left;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--gold-dim);
+    }
+
+    .summary-table td {
+      font-family: var(--font-body);
+      font-size: 18px;
+      color: var(--text-rune);
+      padding: 14px 16px;
+      border-bottom: 1px solid var(--border);
+      vertical-align: top;
+    }
+
+    .summary-table td code {
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--ice-blue);
+      background: var(--void);
+      padding: 2px 6px;
+      border-radius: 2px;
+    }
+
+    .summary-table tr:hover td {
+      background: rgba(212, 165, 32, 0.03);
+    }
+
+    /* ── Architecture Diagram ─────────────────── */
+    .arch-section { padding: 48px 0; }
+
+    .arch-section h2 {
+      font-family: var(--font-heading);
+      font-weight: 700;
+      font-size: 24px;
+      color: var(--text-saga);
+      text-align: center;
+      letter-spacing: 0.06em;
+      margin: 0 0 12px;
+    }
+
+    .arch-sub {
+      text-align: center;
+      font-family: var(--font-body);
+      font-style: italic;
+      font-size: 15px;
+      color: var(--text-rune);
+      margin: 0 0 32px;
+    }
+
+    .arch-diagram {
+      background: var(--forge);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 32px;
+      font-family: var(--font-mono);
+      font-size: 13px;
+      line-height: 1.8;
+      color: var(--text-rune);
+      overflow-x: auto;
+    }
+
+    .arch-diagram .label { color: var(--gold); }
+    .arch-diagram .arrow { color: var(--text-void); }
+    .arch-diagram .agent { color: var(--ice-blue); }
+    .arch-diagram .action { color: var(--text-rune); }
+    .arch-diagram .highlight { color: var(--fire-muspel); }
+
+    /* ── Footer ───────────────────────────────── */
+    .closing {
+      padding: 64px 0;
+      text-align: center;
+    }
+
+    .closing blockquote {
+      margin: 0 auto;
+      max-width: 700px;
+      font-family: var(--font-body);
+      font-weight: 300;
+      font-style: italic;
+      font-size: 22px;
+      color: var(--text-rune);
+      line-height: 1.8;
+    }
+
+    .closing cite {
+      display: block;
+      margin-top: 12px;
+      font-style: normal;
+      font-family: var(--font-mono);
+      font-size: 12px;
+      color: var(--text-void);
+      letter-spacing: 0.15em;
+    }
+
+    .footer-runes {
+      font-family: var(--font-mono);
+      font-size: 16px;
+      color: var(--text-void);
+      letter-spacing: 0.5em;
+      margin-top: 32px;
+    }
+
+    @media (max-width: 639px) {
+      .grievance { padding: 28px 20px; }
+      .code-block { padding: 16px; }
+      .code-block pre { font-size: 11px; }
+      .summary-table { font-size: 12px; }
+      .summary-table th, .summary-table td { padding: 10px 8px; }
+    }
+  </style>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary
- Restore `sessions/depot-integration-issues.html` to its pre-migration state (inline CSS) — it's a standalone blog post, not a session chronicle
- Add `chronicle:skip` HTML comment marker to prevent future migrations
- Update `migrate-to-shared-css.ts` to respect the `chronicle:skip` marker

## Context
PR #297 migrated all session HTML files from inline CSS to shared `chronicle.css`. The depot grievances page has its own unique design (ice-blue color scheme, different layout) and was incorrectly stripped of its styles.

## Test plan
- [ ] Verify https://fenrir-ledger.vercel.app/sessions/depot-integration-issues.html renders correctly after deploy
- [ ] Run `npx tsx migrate-to-shared-css.ts sessions/*.html` — should SKIP this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)