### PR TITLE
feat: add research review flow to fire-next-up

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -17,7 +17,7 @@ Pulls the next "Up Next" item from the GitHub Project board and runs the full ag
 | `security` | Heimdall (fix/audit) | Loki (validate) | -- |
 | `research` | *(varies)* | -- | -- |
 
-**Research:** Technical → FiremanDecko, Product → Freya. Sole agent, posts findings as issue comment. No Loki step.
+**Research:** Technical → FiremanDecko, Product → Freya. Sole agent, posts findings and creates PR. No Loki step. After PR merges, orchestrator presents findings to Odin for **Review** (plan into issues, shelve, or drop).
 
 **Chain rules:** Same branch throughout. First agent creates PR with `Ref #<NUMBER>`. Final agent (Loki) changes `Ref` to `Fixes`. If any agent fails, chain stops and orchestrator reports.
 
@@ -79,11 +79,55 @@ Render `--status` JSON as this markdown:
 ### Up Next Queue
 N items queued. Top 3: #X (critical/bug), #Y (high/ux), #Z (normal/enhancement)
 
+### Research Awaiting Review
+- #168 Marketing campaign plan — `/fire-next-up --resume #168`
+
 ### Suggested Next Actions (copy-paste ready)
 gh pr merge 286 --squash --delete-branch   # #269 Loki PASS — merge it
 /fire-next-up --resume #277                # Loki QA needed
 /fire-next-up --resume #279                # FiremanDecko needed
+/fire-next-up --resume #168                # Research review needed
 ```
+
+---
+
+## Research Review Flow
+
+When `--resume` detects a completed research chain (handoff comment exists, PR merged, issue still open), the orchestrator runs the review flow instead of spawning another agent.
+
+### Detection
+
+The `--status` dashboard and `resumeDetect()` identify research issues where:
+- Has a `## Freya Handoff` or `## FiremanDecko Handoff` comment (without `→ Loki`)
+- PR is merged (check via `gh pr list --state merged --head <branch>`)
+- Issue is still open
+- These show as `next_action: "review"` in the dashboard
+
+### Review Presentation
+
+Read the deliverable file(s) from the merged PR, then present to Odin:
+
+```
+**Research Complete: #<N> — <TITLE>**
+**Agent:** <Freya/FiremanDecko>
+**Deliverable:** `<file path>`
+
+**Key findings:**
+- <3-5 bullet summary from the deliverable>
+
+**Odin — what's the call?**
+1. **Plan it** → Break findings into actionable issues via /plan-w-team
+2. **Shelve it** → Close issue, findings stay in repo for future reference
+3. **Drop it** → Close issue, delete the deliverable file
+```
+
+### Odin's Decision
+
+| Response | Action |
+|----------|--------|
+| **Plan it** | Read the deliverable, invoke `/plan-w-team` with the research as input context. Close the research issue with a comment linking to the new issues. Move to **Done**. |
+| **Shelve it** | Close the issue with comment: "Shelved — deliverable at `<path>` for future reference." Move to **Done**. |
+| **Drop it** | Delete the deliverable file, commit, close issue. Move to **Done**. |
 
 ---
 

--- a/.claude/skills/fire-next-up/scripts/pack-status.mjs
+++ b/.claude/skills/fire-next-up/scripts/pack-status.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S npx tsx
 
-// .claude/skills/fire-next-up/scripts/pack-status.ts
+// pack-status.ts
 import { execSync } from "child_process";
 var OWNER = "declanshanaghy";
 var REPO = "fenrir-ledger";
@@ -168,10 +168,32 @@ function analyzeChain(item, comments, prs) {
   const hasLunaHandoff = comments.some(
     (c) => c.includes("## Luna \u2192 FiremanDecko Handoff")
   );
+  const hasResearchHandoff = comments.some(
+    (c) => c.includes("## Freya Handoff") || c.includes("## FiremanDecko Handoff") && !c.includes("\u2192 Loki")
+  );
   let position;
   let verdict = null;
   let next_action;
   let command;
+  if (hasResearchHandoff && type === "research") {
+    position = "Research complete \u2014 awaiting review";
+    next_action = "review";
+    command = `/fire-next-up --resume #${item.num}`;
+    return {
+      issue: item.num,
+      title: item.title,
+      type,
+      priority,
+      chain,
+      position,
+      pr: matchingPR?.number ?? null,
+      branch: matchingPR?.headRefName ?? "",
+      verdict: null,
+      ci: null,
+      next_action,
+      command
+    };
+  }
   if (hasLokiPass) {
     verdict = "PASS";
     if (matchingPR) {
@@ -244,7 +266,8 @@ async function statusDashboard() {
       awaiting_decko: chains.filter((c) => c.position.includes("Awaiting FiremanDecko")).map((c) => c.issue),
       no_response: chains.filter(
         (c) => c.position.includes("No PR") || c.position.includes("running")
-      ).map((c) => c.issue)
+      ).map((c) => c.issue),
+      research_review: chains.filter((c) => c.next_action === "review").map((c) => c.issue)
     },
     actions: chains.map((c) => ({
       issue: c.issue,
@@ -367,6 +390,9 @@ async function resumeDetect(issueNum) {
   const lokiFail = effectiveComments.some(
     (c) => c.includes("## Loki QA Verdict") && /Verdict.*FAIL/.test(c)
   );
+  const hasResearchHandoff = effectiveComments.some(
+    (c) => c.includes("## Freya Handoff") || c.includes("## FiremanDecko Handoff") && !c.includes("\u2192 Loki")
+  );
   let completedSteps = [];
   let nextAgent = "";
   let nextStep = 0;
@@ -419,6 +445,17 @@ async function resumeDetect(issueNum) {
         nextStep = 0;
       } else {
         nextAgent = "Heimdall";
+        nextStep = 1;
+      }
+      break;
+    case "research":
+      totalSteps = 1;
+      if (hasResearchHandoff) {
+        completedSteps = [hasResearchHandoff ? "Research Agent" : ""];
+        nextAgent = "Orchestrator Review";
+        nextStep = 0;
+      } else {
+        nextAgent = "FiremanDecko";
         nextStep = 1;
       }
       break;

--- a/.claude/skills/fire-next-up/scripts/pack-status.ts
+++ b/.claude/skills/fire-next-up/scripts/pack-status.ts
@@ -241,11 +241,39 @@ function analyzeChain(
   const hasLunaHandoff = comments.some((c) =>
     c.includes("## Luna \u2192 FiremanDecko Handoff")
   );
+  // Research handoffs: "## Freya Handoff" or "## FiremanDecko Handoff" (without → Loki)
+  const hasResearchHandoff = comments.some(
+    (c) =>
+      (c.includes("## Freya Handoff") ||
+        (c.includes("## FiremanDecko Handoff") &&
+          !c.includes("\u2192 Loki")))
+  );
 
   let position: string;
   let verdict: string | null = null;
   let next_action: string;
   let command: string;
+
+  // Research chains: agent posted handoff, no Loki step
+  if (hasResearchHandoff && type === "research") {
+    position = "Research complete \u2014 awaiting review";
+    next_action = "review";
+    command = `/fire-next-up --resume #${item.num}`;
+    return {
+      issue: item.num,
+      title: item.title,
+      type,
+      priority,
+      chain,
+      position,
+      pr: matchingPR?.number ?? null,
+      branch: matchingPR?.headRefName ?? "",
+      verdict: null,
+      ci: null,
+      next_action,
+      command,
+    };
+  }
 
   if (hasLokiPass) {
     verdict = "PASS";
@@ -332,6 +360,9 @@ async function statusDashboard() {
         .filter(
           (c) => c.position.includes("No PR") || c.position.includes("running")
         )
+        .map((c) => c.issue),
+      research_review: chains
+        .filter((c) => c.next_action === "review")
         .map((c) => c.issue),
     },
     actions: chains.map((c) => ({
@@ -476,6 +507,11 @@ async function resumeDetect(issueNum: number) {
   const lokiFail = effectiveComments.some(
     (c) => c.includes("## Loki QA Verdict") && /Verdict.*FAIL/.test(c)
   );
+  const hasResearchHandoff = effectiveComments.some(
+    (c) =>
+      c.includes("## Freya Handoff") ||
+      (c.includes("## FiremanDecko Handoff") && !c.includes("\u2192 Loki"))
+  );
 
   let completedSteps: string[] = [];
   let nextAgent = "";
@@ -530,6 +566,17 @@ async function resumeDetect(issueNum: number) {
         nextStep = 0;
       } else {
         nextAgent = "Heimdall";
+        nextStep = 1;
+      }
+      break;
+    case "research":
+      totalSteps = 1;
+      if (hasResearchHandoff) {
+        completedSteps = [hasResearchHandoff ? "Research Agent" : ""];
+        nextAgent = "Orchestrator Review";
+        nextStep = 0;
+      } else {
+        nextAgent = "FiremanDecko";
         nextStep = 1;
       }
       break;

--- a/.claude/skills/fire-next-up/templates/resume-flow.md
+++ b/.claude/skills/fire-next-up/templates/resume-flow.md
@@ -28,6 +28,8 @@ When a chain is interrupted (session ended, agent failed, context lost), use `--
    | `## FiremanDecko → Loki Handoff` | FiremanDecko | Loki |
    | `## Heimdall → Loki Handoff` | Heimdall | Loki |
    | `## Loki QA Verdict` | Loki (chain complete) | — |
+   | `## Freya Handoff` | Freya (research) | Orchestrator Review |
+   | `## FiremanDecko Handoff` (no `→ Loki`) | FiremanDecko (research) | Orchestrator Review |
 
    The **last handoff comment** tells you exactly where the chain stopped and who's next.
 
@@ -42,6 +44,7 @@ When a chain is interrupted (session ended, agent failed, context lost), use `--
    - `Luna → FiremanDecko Handoff` exists but no further → spawn FiremanDecko.
    - `FiremanDecko → Loki Handoff` or `Heimdall → Loki Handoff` exists but no verdict → spawn Loki.
    - `Loki QA Verdict` exists → check CI status (see Step 5b below).
+   - `Freya Handoff` or `FiremanDecko Handoff` (without `→ Loki`) on a research issue → **Research Review** (see Step 5c below).
 
 5b. **If Loki QA Verdict exists — check CI before declaring complete:**
 
@@ -58,6 +61,19 @@ When a chain is interrupted (session ended, agent failed, context lost), use `--
    | CI green + verdict PASS + not merged | **Orchestrator merges** (see below). Then move to **Done**. |
    | **CI failing + verdict PASS or FAIL** | **Bounce back to Loki** — read `templates/loki-bounce-back.md`. |
    | Verdict FAIL (regardless of CI) | Chain is blocked. Report to user: needs manual intervention or re-dispatch. |
+
+5c. **If research handoff exists — run Research Review:**
+
+   Research chains have no Loki step. When the agent's handoff is found:
+
+   1. Check if the PR is merged: `gh pr list --state merged --head "<BRANCH>" --json number`
+   2. If merged, read the deliverable file(s) from the PR's changed files.
+   3. Present findings to Odin using the Research Review format from SKILL.md.
+   4. Execute Odin's decision (plan it / shelve it / drop it).
+
+   Do NOT spawn any agents — the orchestrator handles this step directly.
+
+---
 
 ## Orchestrator Merge
 


### PR DESCRIPTION
## Summary
- Research chains now have a **Review** step: after the agent delivers findings and the PR merges, `--resume` triggers an orchestrator review with Odin
- `pack-status.ts` detects research handoffs (`## Freya Handoff` / `## FiremanDecko Handoff` without `→ Loki`)
- Status dashboard surfaces `research_review` in verdicts section
- Resume flow presents findings to Odin with 3 options: **plan it** (→ /plan-w-team), **shelve it**, or **drop it**

## Test plan
- [ ] `--status` shows research issues as "Research complete — awaiting review"
- [ ] `--resume #N` on a completed research issue triggers the review presentation
- [ ] Odin's decision (plan/shelve/drop) executes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)