### PR TITLE
research: document subreddit rules and culture profiles — Ref #303

### DIFF
--- a/designs/product/backlog/subreddit-profiles.md
+++ b/designs/product/backlog/subreddit-profiles.md
@@ -1,0 +1,457 @@
+# Subreddit Profiles -- Reddit Soft Launch Engagement Guide
+
+**Status**: Living Document | **Owner**: Freya | **Ref**: Issue #303
+**Last updated**: 2026-03-07 | **Next review**: 2026-04-07
+
+> **Purpose**: Operational reference for engaging r/churning, r/creditcards, and r/CreditCardChurning
+> as part of the Reddit soft launch campaign described in `designs/product/backlog/marketing-campaign-plan.md`.
+> Update this document whenever rule changes, mod announcements, or new sticky threads are observed.
+
+---
+
+## Quick Reference
+
+| Subreddit | Members | Strictness | Self-Promo Policy | Best Use Case |
+|---|---|---|---|---|
+| r/churning | ~700k | Very High | Mod approval required via modmail | Expert DPs, tool threads, advanced answers |
+| r/creditcards | ~1.5M | Medium | No promo without mod permission | Beginner Q&A, annual fee advice, card comparisons |
+| r/CreditCardChurning | ~100k | Medium | More permissive with contribution history | Tracker discussion, velocity questions, tool testing |
+
+---
+
+## 1. r/churning
+
+**URL**: https://www.reddit.com/r/churning/
+**Wiki**: https://www.reddit.com/r/churning/wiki/
+**Members**: ~700k | **Activity**: Very high (20-50 new posts/day)
+**Audience**: Intermediate to expert credit card churners
+
+### 1.1 Rules
+
+r/churning enforces rules strictly. Serious violations (referral links) result in immediate bans; lesser violations result in post removal.
+
+| Rule | Detail | Consequence |
+|---|---|---|
+| **No referral links** | Absolute ban. r/churning permanently retired referral threads (mods cited inability to manage abuse with full-time jobs). Referrals are now handled externally via r/churningreferrals and rankt.com, which requires minimum comment karma in r/churning over the prior 3 months. | Immediate ban |
+| **No affiliate content** | Any post or comment monetized via affiliate relationships is removed. | Removal / ban |
+| **No self-promotion without mod approval** | Promoting a product, app, or service requires explicit mod approval obtained via modmail before posting. There is no public approval form. Repeated violations result in bans. | Removal, potential ban |
+| **No duplicate posts** | Search before posting. The wiki is extensive and well-maintained. Questions already covered in the wiki or recurring threads are downvoted or removed. | Downvoted / removed |
+| **Use the correct thread** | Questions belong in the Daily Question thread or "What Card Should I Get?" thread, not as standalone posts. Standalone question posts are routinely removed. | Removed |
+| **Data points must be real** | DPs (data points) must reflect genuine personal experience. Fabricated DPs are treated as severe trust violations. | Ban |
+| **Read the wiki first** | Culturally enforced. Moderators and veteran users direct newcomers to the wiki and close threads already answered there. | Downvoted / redirected |
+| **Self-moderation culture** | The community self-polices aggressively. Poor-quality contributions are buried quickly by experienced members. | Social downvotes |
+
+**Source**: Rules verified via community documentation at rankt.com, DoctorofCredit.com referral thread retirement announcement, and indexed community guides. Direct sidebar verification should be done manually before first engagement.
+
+### 1.2 Culture Notes
+
+**Tone**: Data-driven, skeptical, and rewards expertise paired with humility. Users have seen every angle of credit card churning. Generic advice is downvoted. The community values precision: specific card names, specific dates, specific approval/denial data points.
+
+**What gets upvoted**:
+- Real DPs with specifics ("Applied on X date, approved for Y with Z score at 3/24")
+- Corrections to factual errors backed by sources (wiki links, issuer docs, prior DPs)
+- Nuanced analysis of velocity rules and issuer-specific quirks
+- Concise, actionable answers to complex questions
+- Trip reports showing the math and strategy behind redemptions
+
+**What gets downvoted**:
+- Generic advice ("just call the bank")
+- Promoting a tool or product without established karma and trust
+- Asking questions clearly answered in the wiki
+- Fabricated or misremembered DPs
+- New accounts posting standalone questions
+- Anything resembling marketing copy or sales language
+- Discussing manufactured spending methods publicly (unwritten norm: "first rule of churning" is not to broadcast methods that banks could close)
+
+**Community philosophy**: "This hobby is a marathon, not a sprint." The community promotes methodical, patient approaches. Members are encouraged to wait at least 3 months between applications and consider retention offers before canceling.
+
+### 1.3 Jargon Dictionary
+
+Essential terms to understand and use naturally in r/churning.
+
+| Term | Meaning |
+|---|---|
+| DP | Data point -- a real personal experience shared as evidence |
+| SUB | Sign-up bonus |
+| MSR | Minimum spend requirement -- spending needed to earn SUB |
+| MS / MSing | Manufactured spending -- using cards to purchase cash equivalents |
+| NLL | No Lifetime Language -- an offer not restricted to "once per lifetime" |
+| PC | Product change -- downgrading/upgrading a card without closing the account |
+| 5/24 | Chase rule: denied for most Chase cards if 5+ personal cards opened in 24 months |
+| 2/30 | Chase velocity: max 2 Chase card applications within 30 days |
+| 1/8, 1/65, 2/65 | Citi velocity rules: 1 Citi card per 8 days, 1 per 65 days, max 2 per 65 days |
+| 2/90 | Amex limit: max 2 credit card approvals within 90 days |
+| P2 | Player 2 -- a spouse or partner who also churns |
+| AF | Annual fee |
+| AOR | App-o-rama -- applying for multiple cards simultaneously |
+| AU | Authorized user |
+| CLI | Credit limit increase |
+| CPC | Chase Private Client |
+| CPP | Cents per point -- value metric for point redemptions |
+| FYF | First year free (annual fee waived year 1) |
+| HP | Hard pull -- credit inquiry that affects score |
+| NWTH | Not worth the hassle |
+| Popup jail | Amex popup blocking the sign-up bonus during application |
+| RECON | Reconsideration -- calling to overturn a denied application |
+| Bust-out risk | Bank's concern that applicant will max cards and default |
+| Velocity | Pace of credit card applications; triggers issuer flags if too fast |
+| YMMV | Your mileage may vary |
+| AAoA | Average age of accounts -- credit score factor |
+| CB | Cash back |
+
+### 1.4 Recurring Threads
+
+| Thread | Frequency | Engagement Value | Notes |
+|---|---|---|---|
+| **Daily Discussion (DD)** | Daily (pinned) | High | General DPs, news, strategy. Best entry point for new accounts. Bookmark: `/r/churning/dd` |
+| **Daily Question (DQ)** | Daily (pinned) | High | Specific questions. Good for building karma with accurate answers. Bookmark: `/r/churning/dq` |
+| **What Card Should I Get? (WCYG)** | Periodic (pinned) | High | Card recommendations based on user profiles. Tracking and velocity questions surface here. |
+| **Data Points Central** | As posted | High | High-signal thread for sharing real approval/denial experiences |
+| **Trip Report / Storytime** | As posted | Medium-High | Point redemption discussions where tracking tools are naturally relevant |
+| **Bank Account Bonus** | As posted | Medium | Bank bonuses, not credit card focused |
+| **Frustration Friday** | Weekly | Medium | Venting thread; engage with empathy, not product pitches |
+| **Manufactured Spending** | As posted | Low (avoid) | Do not engage for legal/compliance reasons |
+| **Spreadsheet / tracker discussions** | Occasional | Very High | Most relevant thread type for eventual Fenrir mentions (Phase 3+) |
+| **Annual fee / retention threads** | As posted | High | Directly in Fenrir's value lane |
+
+**Best posting times**: 8-10am ET weekdays (peak activity, US-centric community).
+
+### 1.5 Self-Promotion Policy
+
+**Summary**: No self-promotion without explicit mod approval. Strictly enforced.
+
+**Process for eventual Fenrir mention**:
+1. Build comment karma to 500+ (see marketing-campaign-plan.md section 6.7)
+2. Establish account age of 2+ months with zero warnings or negative mod interactions
+3. Message modmail at r/churning BEFORE posting anything promotional: explain what Fenrir is, share the landing page, ask for guidance on appropriate thread/flair
+4. Wait for mod response -- they may approve, suggest a specific thread, or deny
+5. If approved, post per their instructions
+6. If denied, do NOT post promotional content -- continue value-first commenting
+
+**Realistic expectation**: r/churning mods are skeptical of tool promotion. Many tool makers have failed here by posting prematurely. Approval is possible but not guaranteed.
+
+**Alternative path**: Build enough karma and presence that other community members mention Fenrir organically. This carries more weight than any self-promotion.
+
+### 1.6 Skip Criteria
+
+Do NOT engage in r/churning when:
+- Thread is more than 48 hours old (diminishing visibility)
+- Thread concerns manufactured spending (legal/compliance risk)
+- A moderator is already active in the thread (tread very carefully)
+- Thread is requesting referral links (stay out entirely)
+- Topic is CFPB regulation, bank policy complaints, or political credit card issues
+- A direct competitor (AwardWallet, MaxRewards, Card Pointers) is already the top-voted answer -- do not open a product comparison
+- Question is fully answered by the wiki -- adding a redundant answer may be downvoted
+- Account has fewer than 50 karma -- focus on Daily Discussion/Question threads only
+- Thread has fewer than 5 comments and is less than 1 hour old -- wait for traction
+
+### 1.7 Key Links
+
+- **Subreddit**: https://www.reddit.com/r/churning/
+- **Wiki index**: https://www.reddit.com/r/churning/wiki/index/
+- **Card recommendation flowchart**: https://m16p-churning.s3.us-east-2.amazonaws.com/Card+Recommendation+Flowchart+Latest.html
+- **Glossary (rankt)**: https://churning.rankt.com/glossary/
+- **Referrals system (rankt)**: https://churning.rankt.com/referrals/
+- **Community tools (rankt)**: https://churning.rankt.com/
+- **Modmail**: https://www.reddit.com/message/compose?to=/r/churning
+- **Daily Discussion search**: https://www.reddit.com/r/churning/search?q=Daily+Discussion&restrict_sr=on&sort=new
+- **WCYG search**: https://www.reddit.com/r/churning/search?q=What+card+should+I+get&restrict_sr=on&sort=new
+- **DoctorofCredit (referral thread retirement)**: https://www.doctorofcredit.com/r-churning-kills-referral-threads-our-policy-going-forward/
+
+---
+
+## 2. r/creditcards
+
+**URL**: https://www.reddit.com/r/creditcards/
+**Wiki**: https://www.reddit.com/r/creditcards/wiki/
+**Members**: ~1.5M | **Activity**: Very high (100+ new posts/day)
+**Audience**: Beginner to intermediate; mix of churners and everyday credit card users
+
+### 2.1 Rules
+
+| Rule | Detail | Consequence |
+|---|---|---|
+| **No referral links** | Standard across all personal finance subreddits. Referral links in any form are removed. | Removal / ban |
+| **No spam or self-promotion** | Promotional content requires mod permission. Unsolicited promotion is removed. | Removal |
+| **Flair your posts** | Posts must use appropriate flair (Question, Discussion, News, etc.). Unflaired posts may be caught by AutoMod. | AutoMod removal possible |
+| **Be helpful, not sales-y** | Comments that read like marketing copy are downvoted and removed. The standard is "would a knowledgeable friend say this?" | Downvoted / removed |
+| **Read the wiki and sidebar** | Common questions are documented. Duplicates are tolerated more than r/churning but still downvoted if low-effort. | Downvoted |
+| **No hate or political content** | Standard Reddit rules. Credit card regulation debates are borderline. | Removed |
+| **No personal information** | Do not share or request account numbers, SSNs, or other PII. | Removed / reported |
+
+**AutoMod note**: r/creditcards likely has AutoModerator rules requiring minimum karma or account age. New accounts may have posts/comments held for mod review. Watch for AutoMod messages after posting.
+
+### 2.2 Culture Notes
+
+**Tone**: More forgiving than r/churning. Beginners are welcomed. Thorough, patient answers do well even on repeated questions. The community skews toward "I want to optimize my credit card spend" rather than "I run a multi-card SUB farming operation."
+
+**What gets upvoted**:
+- Clear, beginner-friendly explanations of credit card concepts
+- Honest assessments including "this card isn't right for you"
+- Actionable advice tied to specific spending patterns ("for groceries at $300+/month, Blue Cash Preferred's 6% beats most options")
+- Annual fee math breakdowns showing when a card is/isn't worth keeping
+- Respectful disagreements with wrong top answers, backed by reasoning
+
+**What gets downvoted**:
+- "It depends" answers without guidance
+- Shill-sounding recommendations without context or disclosure
+- New accounts promoting tools or services
+- Condescension toward beginners
+- Advice that maximizes churning while ignoring credit score health for a beginner
+
+**Key differences from r/churning**:
+- Less acronym-heavy -- spell out terms (sign-up bonus, not SUB; annual fee, not AF)
+- More tolerance for repeated questions, but sidebar reading is still expected
+- Users may not know jargon like "DP" -- define terms or avoid them
+- Beginner posts about first credit cards, credit score improvement, and balance transfers are common and expected
+- The 90/10 rule (Reddit's general guideline: 90% genuine participation, 10% promotional) is the operative standard here
+
+### 2.3 Recurring Threads and Engagement Opportunities
+
+| Thread Type | Frequency | Engagement Value | Notes |
+|---|---|---|---|
+| **"Which card for [category]?" posts** | Many daily | Very High | Grocery, dining, travel, gas questions -- directly relevant to Fenrir's value prop |
+| **"Should I cancel/keep my card?"** | Daily | High | Annual fee math -- core Fenrir use case |
+| **"How does 5/24 work?" / application timing** | Daily | Medium | Velocity tracking interest; define terms when explaining |
+| **"Best card for beginners" discussions** | Frequent | Medium | Build karma with accurate, patient answers |
+| **Card comparison threads** | Daily | High | Chase vs Amex, UR vs MR -- establish expertise |
+| **"I got my first card" posts** | Daily | Medium | Opportunity: advise setting up fee reminders and bonus tracking early |
+| **SUB / bonus redemption questions** | Frequent | High | "How do I track my bonus progress?" -- direct Fenrir use case |
+| **Balance transfer / interest questions** | Frequent | Low | Less relevant to Fenrir; engage only with genuine value to add |
+
+**Best posting times**: 10am-12pm ET weekdays (broader audience, more time zones active).
+
+### 2.4 Self-Promotion Policy
+
+**Summary**: No self-promotion without mod permission. Less strictly enforced than r/churning if content is genuinely helpful, but still a rule violation without authorization.
+
+**Process for Fenrir mention**:
+1. Build karma to 200+ via helpful comments in r/creditcards threads
+2. Ensure account is at least 6 weeks old
+3. Message modmail: introduce Fenrir, explain it is free, share landing page, ask what flair to use
+4. Post after mod approval or confirmation
+5. Use appropriate flair -- likely "Discussion" or "Tools" if available
+
+**Why r/creditcards may be more receptive**: The broader audience values tools that serve beginners. A card tracker with annual fee reminders is genuinely useful to this audience, not just advanced churners.
+
+### 2.5 Skip Criteria
+
+Do NOT engage in r/creditcards when:
+- Thread is about balance transfers, credit score repair, or debt management -- out of Fenrir's lane
+- Thread concerns credit card fraud, chargebacks, or disputes
+- Thread is more than 48 hours old
+- Political or regulatory discussion (CFPB, interest rate caps)
+- Thread already has a well-upvoted competitor tool recommendation
+- Question is "how do I qualify with bad credit?" -- not Fenrir's user base
+- Freya does not have a genuinely helpful answer -- never post just to post
+
+### 2.6 Key Links
+
+- **Subreddit**: https://www.reddit.com/r/creditcards/
+- **Wiki**: https://www.reddit.com/r/creditcards/wiki/
+- **Modmail**: https://www.reddit.com/message/compose?to=/r/creditcards
+
+---
+
+## 3. r/CreditCardChurning
+
+**URL**: https://www.reddit.com/r/CreditCardChurning/
+**Wiki**: https://www.reddit.com/r/CreditCardChurning/wiki/ *(verify availability -- smaller subs may have sparse wikis)*
+**Members**: ~100k | **Activity**: Medium (10-20 posts/day)
+**Audience**: Dedicated churners, intermediate to advanced
+
+### 3.1 Rules
+
+r/CreditCardChurning is a smaller sub with potentially less formally published rules than r/churning. Verify the sidebar directly before engaging.
+
+| Rule | Detail | Consequence |
+|---|---|---|
+| **No referral links** | Standard across all churning-adjacent subs. | Removal |
+| **No spam or self-promotion** | Standard Reddit rule applies. However, the sub is anecdotally more permissive about tool recommendations when posted with genuine context and established contribution history. | Removal if no history |
+| **Community norms over written rules** | Smaller community means self-policing is more visible. Established members carry significant weight. | Social downvotes |
+| **Active mod team** | Mods are present and responsive. They notice account behavior patterns more quickly than in higher-volume subs. | Potential ban for repeated issues |
+
+### 3.2 Culture Notes
+
+**Tone**: Intermediate-to-advanced, collegial within a tight-knit community. Users here recognize each other's posting history. More open to discussing tools and strategies openly than r/churning.
+
+**What gets upvoted**:
+- Tool recommendations when contextually relevant and explicitly asked for
+- Velocity rule discussions with specific data and DPs
+- "Here's what I do" personal system descriptions (not marketing copy)
+- Corrections backed by data points
+- Questions that demonstrate prior research
+
+**What gets downvoted**:
+- First posts that are obviously promotional
+- Generic churning advice (the community already knows the basics)
+- Accounts with no post history that suddenly appear recommending a tool
+- Spam-like behavior (same comment pattern across multiple threads)
+
+**Key advantages over r/churning**:
+- Less noise -- quality comments are more likely to be noticed
+- More receptive to tool discussions -- tracker and app threads perform well
+- Good testing ground for messaging before r/churning engagement
+- Higher likelihood of building genuine relationships with regular posters
+
+**Key differences from r/creditcards**:
+- Assumes churning knowledge -- do not explain 5/24, DPs, or basic terms
+- More focused on optimization and strategy than beginner card selection
+- Users are more likely to be interested in velocity tracking and multi-card management
+
+### 3.3 Recurring Threads and Engagement Opportunities
+
+| Thread Type | Frequency | Engagement Value | Notes |
+|---|---|---|---|
+| **Tracker / spreadsheet threads** | Occasional | Very High | Most direct Fenrir engagement opportunity |
+| **Velocity / application timing** | Frequent | High | 2/30, 5/24, Citi 1/8 discussions -- Fenrir velocity feature relevant |
+| **Bonus tracking questions** | Frequent | High | "How do I track minimum spend progress?" -- core Fenrir use case |
+| **Annual fee decision threads** | As posted | High | Keep/cancel/PC decisions -- Fenrir reminder feature relevant |
+| **P2 coordination threads** | Occasional | Medium | Multi-user tracking (future roadmap item) |
+| **"Best tools for churning" threads** | Occasional | Very High | Organic mention opportunity when it surfaces |
+| **Bank-specific data point threads** | Frequent | Medium | Build credibility with real DPs before product mentions |
+
+**Best posting times**: Weekday mornings (US-centric; smaller volume means timing is less critical).
+
+### 3.4 Self-Promotion Policy
+
+**Summary**: More permissive than r/churning if contribution history exists. Still requires genuine value.
+
+**Process for Fenrir mention**:
+1. Build comment history (target: 10+ quality comments, not just karma count)
+2. When a thread appears where Fenrir is naturally relevant, mention it as a natural comment (Phase 3+)
+3. Consider a short "I built this" post after establishing presence -- the sub tolerates community-made tools if the builder is a known contributor
+4. No formal mod approval required based on community norms, but read the current sidebar before posting
+
+**Strategic use**: Post to r/CreditCardChurning first (before the other two subs) to:
+- Test what language resonates
+- See what questions arise
+- Refine the product description based on feedback
+- Build a reference point for r/churning modmail ("already well-received in r/CreditCardChurning")
+
+### 3.5 Skip Criteria
+
+Do NOT engage in r/CreditCardChurning when:
+- Thread is about manufactured spending -- same caution as r/churning
+- Referral link requests appear
+- Thread is clearly low-effort bait or a rant
+- Question is beginner-level and better served by r/creditcards -- redirect them there (builds goodwill)
+- Account is brand new -- lurk first, comment in simpler threads to establish presence
+
+### 3.6 Key Links
+
+- **Subreddit**: https://www.reddit.com/r/CreditCardChurning/
+- **Wiki**: https://www.reddit.com/r/CreditCardChurning/wiki/ *(check if exists)*
+- **Modmail**: https://www.reddit.com/message/compose?to=/r/CreditCardChurning
+
+---
+
+## 4. Cross-Subreddit Strategy
+
+### 4.1 Engagement Phasing by Subreddit
+
+| Phase | r/churning | r/creditcards | r/CreditCardChurning |
+|---|---|---|---|
+| Weeks 1-2 | Lurk only. Read all threads, understand culture. | Lurk + 1-2 comments on easy threads | 1-2 comments to establish presence |
+| Weeks 3-6 | Daily Discussion/Question threads only | 2-3 comments/week on beginner questions | 2 comments/week; share DPs |
+| Weeks 7-10 | Add WCYG thread engagement | Annual fee and bonus tracking threads | First tool mention if thread is directly relevant |
+| Weeks 11+ | Modmail for "I Built This"; maintain 10:1 help-to-promo ratio | "I Built This" post with mod guidance | "I Built This" post; deepen relationships |
+
+### 4.2 Posting Frequency Targets
+
+| Subreddit | Karma Building (Weeks 3-6) | Soft Reveal (Weeks 7-10) | Ongoing (Weeks 11+) |
+|---|---|---|---|
+| r/churning | 1-2 comments/week max | 2-3 comments/week | 3-5 comments/week |
+| r/creditcards | 2-3 comments/week | 3-4 comments/week | 4-5 comments/week |
+| r/CreditCardChurning | 1 comment/week | 1-2 comments/week | 2-3 comments/week |
+
+**Total target**: 3-5 quality comments per week across all three subs. Quality over volume.
+
+### 4.3 Jargon Usage by Subreddit
+
+| Term | r/churning | r/CreditCardChurning | r/creditcards |
+|---|---|---|---|
+| DP | Use freely | Use freely | Spell out: "data point" |
+| SUB | Use freely | Use freely | Spell out: "sign-up bonus" |
+| AF | Use freely | Use freely | Spell out: "annual fee" |
+| 5/24, 2/30 | Use freely | Use freely | Explain: "Chase's 5/24 rule (limits you to 5 new cards in 24 months)" |
+| P2 | Use freely | Use freely | Explain: "my partner who also churns" |
+| NLL | Use freely | Use freely | Avoid or spell out fully |
+| MS/MSing | Avoid (sensitive) | Avoid | Avoid |
+
+### 4.4 Competitor Awareness
+
+Tools commonly mentioned in these subreddits:
+
+| Tool | Primary Use | Community Reception | Fenrir Position |
+|---|---|---|---|
+| **AwardWallet** | Points balance tracking across programs | Widely trusted, mentioned regularly | Complementary: AwardWallet tracks point balances; Fenrir tracks card-level fees and bonuses |
+| **MaxRewards** | Auto-activates Amex offers; real-time card recommendations | Popular with Amex-heavy users | Different focus: MaxRewards is real-time spend optimization; Fenrir is long-term card management |
+| **Card Pointers** | Category-based purchase routing | Popular for day-to-day spend decisions | Different focus: Card Pointers is "which card today?"; Fenrir is "manage all my cards over time" |
+| **Travel Freely** | Portfolio-level card tracking | Moderate reception | Closest to Fenrir's niche; research current feature set before positioning |
+| **Personal Google Sheets** | Custom tracking (the default for advanced users) | The gold standard for power users | Fenrir's primary migration target: "upgrade from your spreadsheet" |
+
+**Positioning rule**: Frame Fenrir as "the thing that replaces the spreadsheet" -- not as a competitor to any of the tools above. Most churners use multiple tools and will accept adding Fenrir if the specific value is clear.
+
+### 4.5 The "No Turf Wars" Rule
+
+If a competitor tool is being recommended in a thread:
+- Do NOT engage in a product comparison
+- Do NOT speak negatively about competitor tools
+- Upvote the helpful comment and move on, or add complementary context
+- If someone directly asks "is there anything else like X?", that is a Phase 3+ opportunity to mention Fenrir naturally
+
+---
+
+## 5. Manual Verification Checklist
+
+Reddit blocks automated fetching of subreddit pages. The rules documented here are sourced from community guides, DoctorofCredit.com, rankt.com, and the marketing campaign plan. **Before the u/FenrirLedger account makes its first post, manually verify the following in a browser:**
+
+- [ ] r/churning -- read sidebar, click "Rules," note flair requirements
+- [ ] r/churning/wiki -- bookmark index, read Getting Started, note tool policy if any
+- [ ] r/churning -- check for recent mod announcements (pinned posts) about tool/app promotion
+- [ ] r/creditcards -- note flair options, read Rules, check for AutoMod FAQ sticky
+- [ ] r/creditcards -- identify exact minimum karma/account age for posting (if AutoMod enforces)
+- [ ] r/CreditCardChurning -- check if wiki exists, read sidebar rules
+- [ ] r/CreditCardChurning -- identify any flair requirements
+- [ ] Screenshot current rules for each sub and save to `designs/product/backlog/subreddit-rules-screenshots/`
+- [ ] Create browser bookmark folder "Reddit Churning Research" with all three subs + their wikis
+
+---
+
+## 6. Rule Update Log
+
+Track all observed rule changes here.
+
+| Date | Subreddit | Change Noted | Source |
+|---|---|---|---|
+| 2026-03-07 | r/churning | No referral links is an absolute, standing rule. Referral threads permanently retired (~2018). Referrals handled via r/churningreferrals + rankt.com. | DoctorofCredit.com; rankt.com FAQ |
+| 2026-03-07 | r/churning | r/churningreferrals requires minimum comment karma in r/churning over past 3 months to post referral links | churning.rankt.com |
+| 2026-03-07 | All three | Direct Reddit page fetching blocked from research environment -- rules verified via indexed sources and community documentation | Research notes |
+
+---
+
+## 7. Research Sources
+
+### Sources Consulted
+
+- `designs/product/backlog/marketing-campaign-plan.md` -- Freya's initial subreddit profiles (sections 2.2, 7)
+- churning.rankt.com -- community FAQ, referral system, glossary
+- DoctorofCredit.com -- r/churning referral thread retirement announcement
+- FinanciallyAlert.com -- r/churning community guide (recurring threads, wiki structure, rules)
+- OreateAI.com -- r/churning community overview (weekly threads, culture)
+- PointsFeed.com -- r/churning flowchart guide (community structure, engagement model)
+- RedditService.com -- Reddit self-promotion rules and best practices
+- SubredditSignals.com -- Reddit subreddit rules for marketers (2026 guidance)
+
+### Limitations
+
+- Reddit blocks automated fetching of subreddit wiki and rules pages
+- Exact AutoMod karma thresholds for r/creditcards could not be determined externally
+- r/CreditCardChurning wiki availability could not be confirmed
+- Rule text documented here reflects community documentation and third-party guides, not direct sidebar screenshots
+
+---
+
+*Document owner: Freya (Product Owner) | Ref: Issue #303 | Source plan: marketing-campaign-plan.md*
+*Update this document when rules change, new sticky threads appear, or community norms shift.*


### PR DESCRIPTION
Ref #303

Documents rules, culture, and engagement guidelines for target subreddits (r/churning, r/creditcards, r/CreditCardChurning).

**Deliverable:** `designs/product/backlog/subreddit-profiles.md`

## Summary
- Comprehensive rules documented for all three target subreddits with consequences for violations
- Culture notes covering tone, what gets upvoted/downvoted, and community philosophy
- Complete jargon dictionary with 25+ churning-specific terms
- Recurring thread types mapped with engagement value ratings
- Self-promotion policies and step-by-step processes for eventual Fenrir mentions
- Skip criteria for each subreddit (when NOT to engage)
- Cross-subreddit strategy: phasing, posting frequency, jargon usage guide
- Competitor awareness table (AwardWallet, MaxRewards, Card Pointers, Travel Freely)
- Manual verification checklist for pre-launch browser confirmation
- Rule update log for tracking changes over time