### PR TITLE
research: initialize Reddit engagement tracking log — Ref #305

### DIFF
--- a/designs/product/backlog/reddit-engagement-log.md
+++ b/designs/product/backlog/reddit-engagement-log.md
@@ -1,0 +1,75 @@
+# Reddit Engagement Log — u/FenrirLedger
+
+**Purpose**: Track all Reddit activity for the u/FenrirLedger brand account. Used by Freya to measure campaign performance, record comments, and report weekly KPIs. Updated weekly (Friday review cadence).
+
+**Source**: [Marketing Campaign Plan](./marketing-campaign-plan.md) §6.6, §6.7
+
+**Account**: u/FenrirLedger | **Target Subreddits**: r/churning · r/creditcards · r/CreditCardChurning
+
+---
+
+## Engagement Log
+
+| Date | Subreddit | Thread Title | Comment Link | Upvotes | Replies | Notes |
+|------|-----------|--------------|--------------|---------|---------|-------|
+| — | — | — | — | — | — | — |
+
+---
+
+## Weekly KPI Tracking
+
+Update each Friday during the weekly review (see §6.1 of campaign plan).
+
+| Week | Dates | Comments Posted | Avg Upvotes / Comment | Karma Delta (WoW) | Direct Replies Received | Notes |
+|------|-------|-----------------|----------------------|-------------------|------------------------|-------|
+| W1 | — | — | — | — | — | — |
+| W2 | — | — | — | — | — | — |
+| W3 | — | — | — | — | — | — |
+| W4 | — | — | — | — | — | — |
+| W5 | — | — | — | — | — | — |
+| W6 | — | — | — | — | — | — |
+| W7 | — | — | — | — | — | — |
+| W8 | — | — | — | — | — | — |
+| W9 | — | — | — | — | — | — |
+| W10 | — | — | — | — | — | — |
+| W11 | — | — | — | — | — | — |
+| W12 | — | — | — | — | — | — |
+
+### KPI Definitions
+
+- **Comments Posted**: Total new comments published that week across all three subreddits
+- **Avg Upvotes / Comment**: Sum of all upvotes on that week's comments ÷ number of comments posted
+- **Karma Delta (WoW)**: u/FenrirLedger post karma at end of week minus karma at end of prior week
+- **Direct Replies Received**: Number of users who replied directly to a u/FenrirLedger comment (not OP replies)
+
+---
+
+## Milestone Targets
+
+| Milestone | Karma Target | Timeline | What It Unlocks |
+|-----------|-------------|----------|-----------------|
+| Phase 2 gate | 50 karma | Week 3–4 | Confirms account is not shadow-banned; safe to continue building |
+| Text post eligibility | 100 karma | Week 5–6 | Ability to post text posts in r/creditcards |
+| Soft reveal | 200 karma | Week 7–8 | First natural product mention allowed (Phase 3 begins) |
+| 'I Built This' post | 500 karma | Week 10–12 | Eligible to post "I Built This" announcement across all three subreddits |
+| Community authority | 1,000 karma | Month 4–6 | AMA consideration; basis for mod relationship-building |
+
+**Gate condition (Phase 3)**: Do NOT mention Fenrir Ledger until all three criteria are met:
+- [ ] 200+ post karma
+- [ ] Account is at least 6 weeks old
+- [ ] At least 3 comments have received 10+ upvotes organically
+
+---
+
+## Quality Signals (Beyond Raw Karma)
+
+Track these alongside KPIs — they indicate genuine community trust:
+
+- Comments receiving 10+ upvotes (log thread link in engagement log above)
+- Users replying to ask follow-up questions
+- No downvote streaks or mod interventions (flag any immediately)
+- Being tagged in other users' comments ("u/FenrirLedger had a good breakdown of this")
+
+---
+
+*Log owner: Freya (Product Owner) | Initialized: 2026-03-08 | Next review: Friday weekly*


### PR DESCRIPTION
Ref #305

Created the Reddit engagement tracking log template for recording all Reddit activity and measuring campaign KPIs.

**Deliverable:** designs/product/backlog/reddit-engagement-log.md

**Contents:**
- Engagement log table (date, subreddit, thread, link, upvotes, replies, notes)
- Weekly KPI tracking (comments, avg upvotes, karma delta, replies)
- Milestone targets (50 → 200 → 500 → 1000 karma)