### PR TITLE
fix: add rebase-on-main to agent pipeline

### DIFF
--- a/.claude/scripts/sandbox-setup.sh
+++ b/.claude/scripts/sandbox-setup.sh
@@ -34,7 +34,14 @@ if [ -n "$BRANCH" ]; then
   if git branch -r | grep -q "origin/${BRANCH}$"; then
     git checkout "$BRANCH"
     git pull origin "$BRANCH"
-    echo "[ok] checked out existing branch: $BRANCH"
+    # Rebase on main to avoid stale-branch merge conflicts.
+    # Agents run in parallel — main moves while branches are in flight.
+    git rebase origin/main || {
+      echo "[WARN] rebase conflict — attempting resolution"
+      git rebase --abort
+      echo "[FAIL] auto-rebase failed. Agent must rebase manually."
+    }
+    echo "[ok] checked out existing branch: $BRANCH (rebased on main)"
   else
     git checkout -b "$BRANCH"
     git push -u origin "$BRANCH"

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -32,6 +32,10 @@ cd <REPO_ROOT>/development/frontend && npx playwright test --reporter=list
 If ANY tests fail — fix either the code or the test. Do NOT push with failing tests.
 Pre-existing test failures are YOUR responsibility — they block CI and bounce the PR.
 
+**Step 4c — Rebase on main before pushing:**
+cd <REPO_ROOT> && git fetch origin && git rebase origin/main
+If conflicts arise, resolve them, then re-run Steps 4 and 4b to verify the build still passes.
+
 **Step 5 — Commit and push:**
 cd <REPO_ROOT> && git add -A && git commit -m 'fix: <description> — Ref #<NUMBER>' && git push origin <BRANCH>
 

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -32,6 +32,10 @@ Use the previous agent's handoff comment to understand what was built, how to ve
 - Do NOT skip this step. Do NOT mark your verdict as PASS if any test is failing.
 - Do NOT dismiss failures as "pre-existing" or "unrelated" — if it fails in CI, fix it.
 
+**Step 3c — Rebase on main before pushing:**
+cd <REPO_ROOT> && git fetch origin && git rebase origin/main
+If conflicts arise, resolve them, then re-run Steps 3 and 3b to verify tests still pass.
+
 **Step 4 — Commit and push:**
 cd <REPO_ROOT> && git add -A && git commit -m 'test: validate #<NUMBER> — <short description>' && git push origin <BRANCH>
 


### PR DESCRIPTION
## Summary
- **sandbox-setup.sh**: Auto-rebases on `origin/main` when checking out existing branches, so agents start from a fresh base
- **firemandecko.md**: Adds Step 4c — rebase on main before pushing, with re-verify if conflicts
- **loki.md**: Adds Step 3c — same rebase step before Loki pushes

## Why
When multiple agents run in parallel via Depot, `main` moves ahead as PRs merge. By the time the last agent (Loki) pushes, the branch is stale and the PR has merge conflicts. This happened with #190 — Loki PASS'd but the PR was unmergeable.

## Test plan
- [ ] Next Depot dispatch uses updated sandbox-setup.sh
- [ ] Verify agents rebase cleanly before push

🤖 Generated with [Claude Code](https://claude.com/claude-code)