### PR TITLE
fix: cap Playwright workers at 2 for Depot sandboxes

### DIFF
--- a/development/frontend/playwright.config.ts
+++ b/development/frontend/playwright.config.ts
@@ -7,7 +7,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: false,
   retries: 0,
-  ...(process.env.CI ? { workers: 2 } : {}),
+  workers: 2,
   reporter: process.env.CI
     ? [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]]
     : "list",


### PR DESCRIPTION
## Summary
- Depot containers expose host CPU count (9 cores) despite having only 2 vCPUs / 4GB RAM
- Playwright auto-detects ~4-5 workers, each launching Chromium, causing memory pressure
- Hardcode `workers: 2` globally — test suite is small, more parallelism just wastes memory

## Test plan
- [ ] `npx playwright test` runs with 2 workers locally
- [ ] Depot agents no longer OOM during Playwright runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)