### PR TITLE
fix: auto-build when --tests-only has no .next directory

### DIFF
--- a/quality/scripts/verify.sh
+++ b/quality/scripts/verify.sh
@@ -83,7 +83,24 @@ if [ "$TESTS_ONLY" = false ]; then
     tail -30 "$REPORTS_DIR/build-output.txt"
   fi
 else
-  echo "(skipping tsc + build — --tests-only)"
+  # --tests-only: skip tsc, but ensure a build exists for `npm start`
+  if [ ! -d "$FRONTEND_DIR/.next" ]; then
+    printf "[--tests-only] no .next build found, building "
+    start_progress
+    if cd "$FRONTEND_DIR" && npx next build > "$REPORTS_DIR/build-output.txt" 2>&1; then
+      stop_progress
+      echo "OK"
+    else
+      stop_progress
+      echo "FAIL"
+      ((FAILS++))
+      echo ""
+      echo "BUILD ERRORS (last 30 lines):"
+      tail -30 "$REPORTS_DIR/build-output.txt"
+    fi
+  else
+    echo "(skipping tsc + build — --tests-only)"
+  fi
 fi
 
 # ─── 3. Playwright ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes a gap where `verify.sh --tests-only` on a fresh Depot sandbox fails because
`npm start` requires `.next` to exist. Now auto-detects and builds if missing.

## Summary
- Check for `.next` directory before Playwright step
- If missing, run `next build` automatically (with progress dots)
- If `.next` exists, skip as before

## Test plan
- [x] `verify.sh --tests-only dashboard` works on local (has .next → skips build)
- [x] Logic correct for fresh sandbox (no .next → auto-builds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)