### PR TITLE
fix: paginate pack-status GraphQL for >100 board items

### DIFF
--- a/.claude/skills/fire-next-up/scripts/pack-status.mjs
+++ b/.claude/skills/fire-next-up/scripts/pack-status.mjs
@@ -47,11 +47,12 @@ async function restGet(path) {
   return res.json();
 }
 async function fetchBoardAndComments() {
-  const query = `
-    query($owner: String!, $number: Int!) {
+  const itemsQuery = `
+    query($owner: String!, $number: Int!, $cursor: String) {
       user(login: $owner) {
         projectV2(number: $number) {
-          items(first: 100) {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               fieldValueByName(name: "Status") {
                 ... on ProjectV2ItemFieldSingleSelectValue {
@@ -75,7 +76,21 @@ async function fetchBoardAndComments() {
           }
         }
       }
-      repository(owner: $owner, name: "${REPO}") {
+    }
+  `;
+  let allProjectItems = [];
+  let cursor = null;
+  let hasNextPage = true;
+  while (hasNextPage) {
+    const result = await graphql(itemsQuery, { owner: OWNER, number: PROJECT_NUMBER, cursor });
+    const connection = result.data.user.projectV2.items;
+    allProjectItems.push(...connection.nodes);
+    hasNextPage = connection.pageInfo.hasNextPage;
+    cursor = connection.pageInfo.endCursor;
+  }
+  const prQuery = `
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
         pullRequests(states: OPEN, first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
@@ -87,8 +102,8 @@ async function fetchBoardAndComments() {
       }
     }
   `;
-  const result = await graphql(query, { owner: OWNER, number: PROJECT_NUMBER });
-  const projectItems = result.data.user.projectV2.items.nodes;
+  const prResult = await graphql(prQuery, { owner: OWNER, repo: REPO });
+  const projectItems = allProjectItems;
   const items = [];
   const issueComments = {};
   for (const item of projectItems) {
@@ -107,7 +122,7 @@ async function fetchBoardAndComments() {
       );
     }
   }
-  const prs = (result.data.repository.pullRequests.nodes ?? []).map(
+  const prs = (prResult.data.repository.pullRequests.nodes ?? []).map(
     (pr) => ({
       number: pr.number,
       title: pr.title,
@@ -298,10 +313,11 @@ async function moveIssue(issueNum, status) {
     process.exit(1);
   }
   const findQuery = `
-    query($owner: String!, $number: Int!) {
+    query($owner: String!, $number: Int!, $cursor: String) {
       user(login: $owner) {
         projectV2(number: $number) {
-          items(first: 100) {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
               content { ... on Issue { number } }
@@ -311,13 +327,22 @@ async function moveIssue(issueNum, status) {
       }
     }
   `;
-  const findResult = await graphql(findQuery, {
-    owner: OWNER,
-    number: PROJECT_NUMBER
-  });
-  const node = findResult.data.user.projectV2.items.nodes.find(
-    (n) => n.content?.number === issueNum
-  );
+  let node = null;
+  let findCursor = null;
+  let findHasNext = true;
+  while (findHasNext && !node) {
+    const findResult = await graphql(findQuery, {
+      owner: OWNER,
+      number: PROJECT_NUMBER,
+      cursor: findCursor
+    });
+    const connection = findResult.data.user.projectV2.items;
+    node = connection.nodes.find(
+      (n) => n.content?.number === issueNum
+    );
+    findHasNext = connection.pageInfo.hasNextPage;
+    findCursor = connection.pageInfo.endCursor;
+  }
   if (!node) {
     console.error(`Issue #${issueNum} not found on project board`);
     process.exit(1);

--- a/.claude/skills/fire-next-up/scripts/pack-status.ts
+++ b/.claude/skills/fire-next-up/scripts/pack-status.ts
@@ -101,11 +101,13 @@ async function fetchBoardAndComments(): Promise<{
     state: string;
   }>;
 }> {
-  const query = `
-    query($owner: String!, $number: Int!) {
+  // Paginated query — board may exceed 100 items
+  const itemsQuery = `
+    query($owner: String!, $number: Int!, $cursor: String) {
       user(login: $owner) {
         projectV2(number: $number) {
-          items(first: 100) {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               fieldValueByName(name: "Status") {
                 ... on ProjectV2ItemFieldSingleSelectValue {
@@ -129,7 +131,25 @@ async function fetchBoardAndComments(): Promise<{
           }
         }
       }
-      repository(owner: $owner, name: "${REPO}") {
+    }
+  `;
+
+  // Fetch all project items with pagination
+  let allProjectItems: any[] = [];
+  let cursor: string | null = null;
+  let hasNextPage = true;
+  while (hasNextPage) {
+    const result = await graphql(itemsQuery, { owner: OWNER, number: PROJECT_NUMBER, cursor });
+    const connection = result.data.user.projectV2.items;
+    allProjectItems.push(...connection.nodes);
+    hasNextPage = connection.pageInfo.hasNextPage;
+    cursor = connection.pageInfo.endCursor;
+  }
+
+  // Separate query for PRs (no pagination needed — 50 open PRs is unlikely)
+  const prQuery = `
+    query($owner: String!, $repo: String!) {
+      repository(owner: $owner, name: $repo) {
         pullRequests(states: OPEN, first: 50, orderBy: {field: UPDATED_AT, direction: DESC}) {
           nodes {
             number
@@ -141,10 +161,9 @@ async function fetchBoardAndComments(): Promise<{
       }
     }
   `;
+  const prResult = await graphql(prQuery, { owner: OWNER, repo: REPO });
 
-  const result = await graphql(query, { owner: OWNER, number: PROJECT_NUMBER });
-
-  const projectItems = result.data.user.projectV2.items.nodes;
+  const projectItems = allProjectItems;
   const items: BoardItem[] = [];
   const issueComments: Record<number, string[]> = {};
 
@@ -167,7 +186,7 @@ async function fetchBoardAndComments(): Promise<{
     }
   }
 
-  const prs = (result.data.repository.pullRequests.nodes ?? []).map(
+  const prs = (prResult.data.repository.pullRequests.nodes ?? []).map(
     (pr: any) => ({
       number: pr.number,
       title: pr.title,
@@ -397,12 +416,13 @@ async function moveIssue(issueNum: number, status: string) {
     process.exit(1);
   }
 
-  // Find item ID via GraphQL
+  // Find item ID via paginated GraphQL
   const findQuery = `
-    query($owner: String!, $number: Int!) {
+    query($owner: String!, $number: Int!, $cursor: String) {
       user(login: $owner) {
         projectV2(number: $number) {
-          items(first: 100) {
+          items(first: 100, after: $cursor) {
+            pageInfo { hasNextPage endCursor }
             nodes {
               id
               content { ... on Issue { number } }
@@ -412,13 +432,22 @@ async function moveIssue(issueNum: number, status: string) {
       }
     }
   `;
-  const findResult = await graphql(findQuery, {
-    owner: OWNER,
-    number: PROJECT_NUMBER,
-  });
-  const node = findResult.data.user.projectV2.items.nodes.find(
-    (n: any) => n.content?.number === issueNum
-  );
+  let node: any = null;
+  let findCursor: string | null = null;
+  let findHasNext = true;
+  while (findHasNext && !node) {
+    const findResult = await graphql(findQuery, {
+      owner: OWNER,
+      number: PROJECT_NUMBER,
+      cursor: findCursor,
+    });
+    const connection = findResult.data.user.projectV2.items;
+    node = connection.nodes.find(
+      (n: any) => n.content?.number === issueNum
+    );
+    findHasNext = connection.pageInfo.hasNextPage;
+    findCursor = connection.pageInfo.endCursor;
+  }
   if (!node) {
     console.error(`Issue #${issueNum} not found on project board`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Board exceeded 100 items, causing `items(first: 100)` to miss newer issues (#373-#375)
- Added cursor-based pagination to `fetchBoardAndComments()` — loops until all pages fetched
- Added cursor-based pagination to `moveIssue()` — finds items beyond page 1
- Fixed `result.data.repository` → `prResult.data.repository` reference after query split
- Verified: `--peek`, `--status`, and `--move` all work with #371-#375

## Test plan
- [x] `--peek` returns all Up Next items including #372
- [x] `--status` shows #371 in In Progress
- [x] `--move 373 up-next` succeeds (was failing before fix)
- [x] `--move 374 up-next` succeeds
- [x] `--move 375 up-next` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)