### PR TITLE
fix: add tool timeout guidance to sandbox preamble

### DIFF
--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -9,6 +9,15 @@ Shell state (cd, env vars, aliases) does NOT persist between tool calls.
 ALWAYS prefix commands with: cd <REPO_ROOT> && <command>
 Use absolute paths for everything. The setup script prints REPO_ROOT — use it.
 
+TOOL TIMEOUTS:
+The Bash tool defaults to 2 minutes. Long-running commands WILL time out.
+ALWAYS set timeout: 600000 (10 minutes) on these commands:
+- npm ci / npm install
+- bash quality/scripts/verify.sh (any variant)
+- npx playwright test
+- next build
+Any command that builds or runs tests needs the 10-minute timeout.
+
 STRICT SCOPE — DO NOT DEVIATE:
 You are a worker in a chain. Execute ONLY the numbered steps listed below — nothing
 more, nothing less. Do not improvise, ad-lib, or take actions not explicitly listed.


### PR DESCRIPTION
## Summary
- Agents in Depot sandboxes were timing out on `verify.sh` (default 2min, agents guessing 5min)
- Added explicit timeout guidance to sandbox preamble: `timeout: 600000` (10min max) for npm ci, verify.sh, playwright, next build

## Test plan
- [ ] Next Depot agent dispatch uses 10-min timeout on build/test commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)