### PR TITLE
fix: incremental commits for all Depot agents

### DIFF
--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -22,6 +22,10 @@ Read the commits already on this branch (if any):
 - Read the affected files FIRST, then make changes.
 - <If UX Step 2: Follow Luna's wireframes for layout and structure.>
 - All file paths are relative to REPO_ROOT. Do NOT double-nest paths.
+- **COMMIT FREQUENTLY:** After each logical chunk (moved files, updated imports,
+  new component, config changes), commit and push immediately:
+  `cd <REPO_ROOT> && git add -A && git commit -m 'wip: <what you just did> — Ref #<NUMBER>' && git push origin <BRANCH>`
+  This protects your work if the session times out.
 
 **Step 4 — Verify (single command):**
 cd <REPO_ROOT> && bash quality/scripts/verify.sh

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -14,6 +14,10 @@ You are Heimdall, the Security Specialist. Fix GitHub Issue #<NUMBER>: <TITLE>
 **Step 2 — Implement the security fix.**
 - Read the affected files FIRST, then make changes.
 - Update security documentation if the fix changes auth flows, trust boundaries, or threat model.
+- **COMMIT FREQUENTLY:** After each logical change (auth fix, config update, doc change),
+  commit and push immediately:
+  `cd <REPO_ROOT> && git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>`
+  This protects your work if the session times out.
 
 **Step 3 — Verify (single command):**
 cd <REPO_ROOT> && bash quality/scripts/verify.sh

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -19,6 +19,10 @@ Use the previous agent's handoff comment to understand what was built, how to ve
 **Step 3 — Write and run NEW tests only:**
 - Write new Playwright tests in `quality/test-suites/<feature-slug>/` covering the acceptance criteria.
 - Use the previous agent's "How to verify" and "Edge cases" sections to guide your test design.
+- **COMMIT FREQUENTLY:** After writing each test file or fixing a batch of tests,
+  commit and push immediately:
+  `cd <REPO_ROOT> && git add -A && git commit -m 'wip: tests for <what> — Ref #<NUMBER>' && git push origin <BRANCH>`
+  This protects your work if the session times out.
 - First run — build + your suite only (needed on fresh sandboxes):
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh <feature-slug>`
 - Subsequent runs — skip build for fast iteration:

--- a/.claude/skills/fire-next-up/templates/luna.md
+++ b/.claude/skills/fire-next-up/templates/luna.md
@@ -16,6 +16,10 @@ You are Luna, the UX Designer. Design wireframes for GitHub Issue #<NUMBER>: <TI
 - Keep wireframes free of theme styling (no colors, no fonts) — structure only.
 - Update `ux/wireframes.md` if adding new wireframes.
 - Write a brief interaction spec if the feature has non-obvious interactions.
+- **COMMIT FREQUENTLY:** After completing each wireframe file, commit and push
+  immediately:
+  `cd <REPO_ROOT> && git add -A && git commit -m 'wip: wireframe for <what> — Ref #<NUMBER>' && git push origin <BRANCH>`
+  This protects your work if the session times out.
 
 **Step 3 — Commit and push:**
 cd <REPO_ROOT> && git add -A && git commit -m 'design: wireframes for #<NUMBER> — <short description>' && git push origin <BRANCH>

--- a/.claude/skills/fire-next-up/templates/resume-flow.md
+++ b/.claude/skills/fire-next-up/templates/resume-flow.md
@@ -179,6 +179,7 @@ Use commit prefixes (`design:`, `fix:`, `security:`, `test:`) as a secondary sig
 ## Edge Cases
 
 - **Branch exists but no commits beyond main** — the previous agent failed before committing. Re-run that step (same agent, same branch).
+- **Branch has `wip:` commits but no handoff** — the agent was mid-implementation when it timed out. Re-dispatch the same agent on the same branch. The agent's Step 2 reads `git log origin/main..HEAD` and will see the existing WIP commits, picking up where the previous session left off instead of starting from scratch. Include a note in the prompt: "Previous session timed out. WIP commits exist on the branch — read them and continue from where it left off. Do NOT redo work that's already committed."
 - **Multiple agents' commits exist but chain isn't complete** — skip to the next incomplete step.
 - **PR exists but CI failed** — bounce back to Loki with CI failure details.
 - **Issue is closed** — tell the user the issue is already closed. Do not spawn agents.

--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -18,6 +18,17 @@ ALWAYS set timeout: 600000 (10 minutes) on these commands:
 - next build
 Any command that builds or runs tests needs the 10-minute timeout.
 
+INCREMENTAL COMMITS (UNBREAKABLE):
+Depot sessions can time out or fail at any point. To protect your work:
+- Commit and push after EVERY meaningful chunk of work (e.g. after migrating files,
+  after updating routes, after fixing imports, after each major component change).
+- Use descriptive WIP commit messages: `wip: migrate app routes under /ledger — Ref #<NUMBER>`
+- Push after each commit: `git push origin <BRANCH>`
+- Aim for a commit every 5-10 minutes of work, or after each logical unit.
+- The final step will squash or amend into a clean commit message before the PR.
+- This way, if the session dies, the next agent picks up from your last push —
+  not from scratch.
+
 STRICT SCOPE — DO NOT DEVIATE:
 You are a worker in a chain. Execute ONLY the numbered steps listed below — nothing
 more, nothing less. Do not improvise, ad-lib, or take actions not explicitly listed.


### PR DESCRIPTION
## Summary
- All agent templates now require frequent `wip:` commits + pushes during implementation
- Sandbox preamble has INCREMENTAL COMMITS rule (UNBREAKABLE) — commit every 5-10 min
- Resume flow updated to detect `wip:` commits and continue from where the last session died
- Applies to all 4 agents: FiremanDecko, Loki, Luna, Heimdall

## Test plan
- [ ] Next Depot dispatch produces multiple commits instead of one big bang
- [ ] Session timeout leaves recoverable WIP commits on the branch
- [ ] `--resume` detects WIP commits and re-dispatches correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)