### PR TITLE
fix: add TodoWrite tracking + incremental verify to agent templates

### DIFF
--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -7,28 +7,44 @@ You are FiremanDecko, the Principal Engineer. Fix GitHub Issue #<NUMBER>: <TITLE
 
 {{SANDBOX_PREAMBLE}}
 
-**Step 2 — Read context:**
+**Step 2 — Read context + create todos:**
   gh issue view <NUMBER> --comments
   cd <REPO_ROOT> && git log origin/main..HEAD --oneline
 <If UX chain: Luna's wireframes are on this branch. Read them.>
+Then create your todo list via TodoWrite. Every todo below is required:
+  - Read context and plan approach
+  - <One todo per logical chunk of implementation work>
+  - Incremental commit+push+tsc after each chunk
+  - Full verify: tsc
+  - Full verify: build
+  - Full verify: test
+  - Rebase + final push
+  - Create/update PR
+  - Post handoff comment
 
 **Issue details:**
 
 <FULL ISSUE BODY>
 
-**Step 3 — Implement.**
+**Step 3 — Implement (with incremental commits).**
 - Read affected files FIRST, then make changes.
 - <If UX Step 2: Follow Luna's wireframes for layout and structure.>
 - All file paths relative to REPO_ROOT. Do NOT double-nest paths.
 - Mobile-friendly: min 375px, two-col collapse with `flex flex-col md:grid`.
 - Backend code: use `import { log } from "@/lib/logger"`, never raw console.*.
+- **After each logical chunk** (1-3 files changed):
+  1. git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>
+  2. cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc
+  3. If tsc fails: fix, commit+push, re-run tsc.
+  4. Update your todos (mark chunk completed, start next chunk).
 
-**Step 4 — Verify (each step = separate Bash tool call):**
+**Step 4 — Full verify (each step = separate Bash tool call + separate todo):**
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x
 On failure: fix, commit+push, re-run that step. Repeat until green.
 ALL test failures (including pre-existing) are YOUR responsibility — they block CI.
+Update each verify todo as you complete it.
 
 **Step 5 — Rebase + final push:**
   cd <REPO_ROOT> && git fetch origin && git rebase origin/main

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -7,32 +7,52 @@ You are Heimdall, the Security Specialist. Fix GitHub Issue #<NUMBER>: <TITLE>
 
 {{SANDBOX_PREAMBLE}}
 
+**Step 2 — Read context + create todos:**
+  gh issue view <NUMBER> --comments
+Then create your todo list via TodoWrite. Every todo below is required:
+  - Read issue context and affected files
+  - Implement security fix (one todo per logical chunk)
+  - Incremental commit+push+tsc after each chunk
+  - Update security docs (if auth/trust boundary changes)
+  - Full verify: tsc
+  - Full verify: build
+  - Full verify: test
+  - Rebase + final push
+  - Create PR
+  - Post handoff comment
+
 **Issue details:**
 
 <FULL ISSUE BODY>
 
-**Step 2 — Implement the security fix.**
+**Step 3 — Implement the security fix (with incremental commits).**
 - Read affected files FIRST, then make changes.
 - Update security docs if the fix changes auth flows, trust boundaries, or threat model.
 - Secret masking (UNBREAKABLE): never log secrets, tokens, or credentials.
+- **After each logical chunk** (1-3 files changed):
+  1. git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>
+  2. cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc
+  3. If tsc fails: fix, commit+push, re-run tsc.
+  4. Update your todos.
 
-**Step 3 — Verify (each step = separate Bash tool call):**
+**Step 4 — Full verify (each step = separate Bash tool call + separate todo):**
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x
-On failure: fix, commit+push, re-run that step.
+On failure: fix, commit+push, re-run that step. Repeat until green.
+Update each verify todo as you complete it.
 
-**Step 4 — Rebase + final push:**
+**Step 5 — Rebase + final push:**
   cd <REPO_ROOT> && git fetch origin && git rebase origin/main
 If conflicts: resolve, re-run verify steps.
   cd <REPO_ROOT> && git add -A && git commit -m 'security: <description> — Ref #<NUMBER>' && git push origin <BRANCH>
 
-**Step 5 — Create PR (use Ref, not Fixes — Loki updates after QA):**
+**Step 6 — Create PR (use Ref, not Fixes — Loki updates after QA):**
 gh pr create --title "security: <short title> — Ref #<NUMBER>" --body "Ref #<NUMBER>
 
 <summary of security fix>"
 
-**Step 6 — Handoff comment:**
+**Step 7 — Handoff comment:**
 gh issue comment <NUMBER> --body "## Heimdall → Loki Handoff
 
 **Branch:** \`<BRANCH>\` | **PR:** <PR_URL>

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -7,33 +7,47 @@ You are Loki, the QA Tester. Validate GitHub Issue #<NUMBER>: <TITLE>
 
 {{SANDBOX_PREAMBLE}}
 
-**Step 2 — Read handoff context:**
+**Step 2 — Read handoff context + create todos:**
   gh issue view <NUMBER> --comments
   cd <REPO_ROOT> && git log origin/main..HEAD --oneline
 Use the previous agent's handoff to understand what was built, how to verify, and edge cases.
+Then create your todo list via TodoWrite. Every todo below is required:
+  - Read handoff context
+  - Write Playwright tests for acceptance criteria
+  - Commit+push tests
+  - Run feature tests (build + test)
+  - Fix failing tests (repeat until green)
+  - Full verify: tsc
+  - Full verify: build
+  - Full verify: test (all)
+  - Fix pre-existing failures (if any)
+  - Rebase + final push
+  - Update PR to Fixes
+  - Post QA verdict comment
 
 **Issue details:**
 
 <FULL ISSUE BODY>
 
-**Step 3 — Write and run NEW tests:**
+**Step 3 — Write and run NEW tests (with incremental commits):**
 - Write Playwright tests in `quality/test-suites/<feature-slug>/` covering acceptance criteria.
 - Use the handoff's "How to verify" and "Edge cases" to guide test design.
+- **Commit+push tests before running them:**
+  git add -A && git commit -m 'wip: add tests for #<NUMBER>' && git push origin <BRANCH>
 - First run (fresh sandbox needs build):
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build`
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x <feature-slug>`
-- Subsequent runs:
-  `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x <feature-slug>`
-- Fix tests until they pass. Do NOT proceed until your new tests are green.
+- Fix tests until they pass. Commit+push after each fix. Update todos.
+- Do NOT proceed until your new tests are green.
 
-**Step 3b — Full verify (only after new tests pass):**
+**Step 3b — Full verify (only after new tests pass, each = separate todo):**
 Run each as a SEPARATE Bash tool call:
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc`
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build`
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x`
 Pre-existing failures: fix surgically (minimum change — wrong locator, missing await).
 Do NOT rewrite unrelated tests or add tests beyond feature scope.
-After each fix: commit+push, re-run `--step test -x`. Repeat until all pass.
+After each fix: commit+push, re-run `--step test -x`. Update todos. Repeat until all pass.
 Do NOT skip this step. Do NOT verdict PASS if any check is failing.
 
 **Step 3c — Rebase:**

--- a/.claude/skills/fire-next-up/templates/luna.md
+++ b/.claude/skills/fire-next-up/templates/luna.md
@@ -7,18 +7,29 @@ You are Luna, the UX Designer. Design wireframes for GitHub Issue #<NUMBER>: <TI
 
 {{SANDBOX_PREAMBLE}}
 
+**Step 2 — Read context + create todos:**
+  gh issue view <NUMBER> --comments
+Then create your todo list via TodoWrite. Every todo below is required:
+  - Read issue context
+  - Design wireframes (HTML, structure only)
+  - Update wireframes.md index
+  - Write interaction spec (if needed)
+  - Commit+push wireframes
+  - Create PR
+  - Post handoff comment
+
 **Issue details:**
 
 <FULL ISSUE BODY>
 
-**Step 2 — Design wireframes:**
+**Step 3 — Design wireframes (with incremental commits):**
 - Create HTML wireframe(s) in `ux/wireframes/` — structure only, no theme styling.
 - Update `ux/wireframes.md` if adding new wireframes.
 - Write a brief interaction spec if the feature has non-obvious interactions.
 - Mobile-first: 375px minimum viewport.
-
-**Step 3 — Commit and push:**
-  cd <REPO_ROOT> && git add -A && git commit -m 'design: wireframes for #<NUMBER> — <short description>' && git push origin <BRANCH>
+- **After completing wireframes, commit+push immediately:**
+  git add -A && git commit -m 'wip: wireframes for #<NUMBER>' && git push origin <BRANCH>
+  Update your todos.
 
 **Step 4 — Create PR (use Ref, not Fixes — you are not the final agent):**
 gh pr create --title "design: wireframes for #<NUMBER> — <short description>" --body "Ref #<NUMBER>

--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -12,16 +12,27 @@ SANDBOX RULES:
 bash <REPO_ROOT>/.claude/scripts/sandbox-setup.sh <BRANCH>
 Note the REPO_ROOT it prints — use it for ALL subsequent commands.
 
-VERIFY — SEPARATE STEPS (UNBREAKABLE):
-Never run verify.sh as one call. Each step = its own Bash tool call:
+TODO TRACKING (UNBREAKABLE):
+Use TodoWrite to plan and track ALL work. Create todos at the START of the session
+covering every numbered step. Update each todo to in_progress when you start it and
+completed when done. This is your progress ledger — if the session dies, the todo
+state shows exactly where you stopped.
+
+INCREMENTAL COMMIT + VERIFY LOOP (UNBREAKABLE):
+After every logical chunk of implementation work (~5-10 min or 1-3 files changed):
+  1. git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>
+  2. bash quality/scripts/verify.sh --step tsc
+  3. If tsc fails: fix immediately, commit+push, re-run tsc.
+  4. Update your todo progress.
+Do NOT batch all changes into one commit at the end. Sessions can die at any time —
+uncommitted work is lost work.
+
+FULL VERIFY — SEPARATE STEPS (UNBREAKABLE):
+At the end, run each verify step as its own Bash tool call:
   bash quality/scripts/verify.sh --step tsc
   bash quality/scripts/verify.sh --step build
   bash quality/scripts/verify.sh --step test -x
 On failure: fix, commit+push, re-run that step. Repeat until green.
-
-INCREMENTAL COMMITS (UNBREAKABLE):
-Sessions can die at any time. Commit+push after every logical chunk (5-10 min).
-  git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>
 
 STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,


### PR DESCRIPTION
## Summary
- Agents now use **TodoWrite** to plan and track all steps from session start
- **Incremental commit+push+tsc** loop after every logical chunk (prevents lost work when sessions die)
- Each verify step (tsc, build, test) is a separate todo for progress tracking
- All 5 templates updated: sandbox-preamble, FiremanDecko, Loki, Luna, Heimdall

## Test plan
- [ ] Dispatch a FiremanDecko agent and verify it creates todos at session start
- [ ] Verify incremental commits appear (wip: commits) instead of one big batch
- [ ] Verify tsc runs after each incremental commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)