### PR TITLE
fix: add verify budget (3-strike rule) and --skip-tests flag

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -31,6 +31,7 @@ Pulls the next "Up Next" item from the GitHub Project board and runs the full ag
 | `--status` | Full status dashboard. Do NOT dispatch anything. |
 | `--batch N` | Pull top N **unblocked** items from "Up Next", start chains in parallel. Max 5. |
 | `--local` | Force local worktree execution instead of Depot. |
+| `--skip-tests` | Skip `verify.sh --step test` in agent prompt. tsc+build still required. Use with `--resume` after repeated test failures. Handoff gets "⚠️ Tests skipped by Odin" marker. |
 | `#N` | Start a fresh chain for a specific issue number (skip priority selection). |
 | *(no flag)* | Default: pick the top item and start the agent chain via Depot. |
 

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -44,6 +44,8 @@ Then create your todo list via TodoWrite. Every todo below is required:
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x
 On failure: fix, commit+push, re-run that step. Repeat until green.
 ALL test failures (including pre-existing) are YOUR responsibility — they block CI.
+**3-strike rule:** If test fails 3 times after fixes, commit what you have and proceed
+to handoff with "⚠️ VERIFY INCOMPLETE" note. tsc+build are never skippable.
 Update each verify todo as you complete it.
 
 **Step 5 — Rebase + final push:**

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -40,6 +40,8 @@ Then create your todo list via TodoWrite. Every todo below is required:
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x
 On failure: fix, commit+push, re-run that step. Repeat until green.
+**3-strike rule:** If test fails 3 times after fixes, commit what you have and proceed
+to handoff with "⚠️ VERIFY INCOMPLETE" note. tsc+build are never skippable.
 Update each verify todo as you complete it.
 
 **Step 5 — Rebase + final push:**

--- a/.claude/skills/fire-next-up/templates/resume-flow.md
+++ b/.claude/skills/fire-next-up/templates/resume-flow.md
@@ -176,6 +176,20 @@ git log origin/main..origin/<BRANCH> --oneline
 ```
 Use commit prefixes (`design:`, `fix:`, `security:`, `test:`) as a secondary signal.
 
+## `--skip-tests` Flag
+
+When `--resume #N --skip-tests` is used, the orchestrator modifies the agent prompt:
+
+1. **Remove** `bash quality/scripts/verify.sh --step test -x` from the full verify step.
+2. **Replace** with: `# Tests skipped by Odin — tsc+build only`
+3. **Remove** the "Full verify: test" todo from the required todo list.
+4. **Add** to the handoff comment template: `"⚠️ Tests skipped by Odin — Loki must run full verify."`
+5. tsc and build remain **mandatory** — only tests are skippable.
+
+The Loki step still runs full verify including tests. Loki is the safety net.
+
+---
+
 ## Edge Cases
 
 - **Branch exists but no commits beyond main** — the previous agent failed before committing. Re-run that step (same agent, same branch).

--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -34,6 +34,14 @@ At the end, run each verify step as its own Bash tool call:
   bash quality/scripts/verify.sh --step test -x
 On failure: fix, commit+push, re-run that step. Repeat until green.
 
+VERIFY BUDGET (3-STRIKE RULE):
+If you fail the SAME verify step 3 times (3 fix attempts, still failing):
+  1. Commit+push your current state: git add -A && git commit -m 'wip: verify incomplete — Ref #<NUMBER>' && git push origin <BRANCH>
+  2. Stop trying to fix that step. Proceed to PR/handoff.
+  3. In the handoff comment, add: "⚠️ VERIFY INCOMPLETE: <step> failed after 3 attempts. Failures: <summary>"
+  4. tsc and build are NEVER skippable — only test can be abandoned after 3 strikes.
+This prevents burning the entire session on pre-existing or intractable test failures.
+
 STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,
 declare things "done", or add commentary beyond your handoff step.


### PR DESCRIPTION
## Summary
- **3-strike rule** in sandbox preamble: agents auto-abandon test step after 3 failed fix attempts, proceed to handoff with warning
- **`--skip-tests` flag** on `/fire-next-up --resume`: explicitly skips `verify.sh --step test` in agent prompt
- tsc+build remain mandatory — only tests are skippable
- Loki still runs full verify — he's the safety net

## Test plan
- [ ] Dispatch agent, verify 3-strike rule triggers on repeated test failures
- [ ] Use `--resume #N --skip-tests` and verify prompt omits test step

🤖 Generated with [Claude Code](https://claude.com/claude-code)