### PR TITLE
fix: resolve REPO_ROOT via git rev-parse in sandbox preamble

### DIFF
--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -8,8 +8,8 @@ SANDBOX RULES:
 - Use absolute paths. The setup script prints REPO_ROOT — use it everywhere.
 - Set timeout: 600000 (10 min) on: npm ci, verify.sh, playwright test, next build.
 
-**Step 1 — Setup:**
-bash <REPO_ROOT>/.claude/scripts/sandbox-setup.sh <BRANCH>
+**Step 1 — Setup (MUST run first, before anything else):**
+REPO_ROOT=$(git rev-parse --show-toplevel) && bash "$REPO_ROOT/.claude/scripts/sandbox-setup.sh" <BRANCH>
 Note the REPO_ROOT it prints — use it for ALL subsequent commands.
 
 TODO TRACKING (UNBREAKABLE):


### PR DESCRIPTION
## Summary
- Agents in Depot sandboxes were skipping `sandbox-setup.sh` because Step 1 used `<REPO_ROOT>` — a placeholder the agent hadn't resolved yet (chicken-and-egg)
- Now uses `git rev-parse --show-toplevel` to resolve the path before invoking the script
- Added "MUST run first" emphasis to prevent agents skipping setup

## Test plan
- [ ] Next Depot dispatch runs sandbox-setup.sh successfully
- [ ] Playwright browsers install correctly in sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)