### PR TITLE
fix: remove sessions copy step from CI workflows

### DIFF
--- a/.claude/skills/fire-next-up/scripts/pack-status.mjs
+++ b/.claude/skills/fire-next-up/scripts/pack-status.mjs
@@ -15,6 +15,7 @@ var STATUS_OPTIONS = {
 var GH_API = "https://api.github.com";
 var GH_GQL = "https://api.github.com/graphql";
 var TOKEN = execSync("gh auth token", { encoding: "utf-8" }).trim();
+var EXCLUDED_LABELS = ["marketing"];
 var HEADERS = {
   Authorization: `bearer ${TOKEN}`,
   "Content-Type": "application/json",
@@ -260,7 +261,9 @@ function analyzeChain(item, comments, prs) {
 async function statusDashboard() {
   const { items, issueComments, pullRequests } = await fetchBoardAndComments();
   const inProgress = items.filter((i) => i.status === "In Progress");
-  const upNext = items.filter((i) => i.status === "Up Next");
+  const upNext = items.filter(
+    (i) => i.status === "Up Next" && !i.labels.some((l) => EXCLUDED_LABELS.includes(l))
+  );
   const chains = inProgress.map(
     (item) => analyzeChain(item, issueComments[item.num] ?? [], pullRequests)
   );
@@ -508,7 +511,9 @@ async function resumeDetect(issueNum) {
 }
 async function peek() {
   const { items } = await fetchBoardAndComments();
-  const upNext = items.filter((i) => i.status === "Up Next");
+  const upNext = items.filter(
+    (i) => i.status === "Up Next" && !i.labels.some((l) => EXCLUDED_LABELS.includes(l))
+  );
   const priorityOrder = {
     critical: 0,
     high: 1,

--- a/.claude/skills/fire-next-up/scripts/pack-status.ts
+++ b/.claude/skills/fire-next-up/scripts/pack-status.ts
@@ -26,6 +26,9 @@ const GH_GQL = "https://api.github.com/graphql";
 // Get token once at startup (only execSync we keep)
 const TOKEN = execSync("gh auth token", { encoding: "utf-8" }).trim();
 
+// Labels to exclude from the Up Next queue (these issues are manually managed)
+const EXCLUDED_LABELS = ["marketing"];
+
 const HEADERS = {
   Authorization: `bearer ${TOKEN}`,
   "Content-Type": "application/json",
@@ -350,7 +353,11 @@ async function statusDashboard() {
   const { items, issueComments, pullRequests } = await fetchBoardAndComments();
 
   const inProgress = items.filter((i) => i.status === "In Progress");
-  const upNext = items.filter((i) => i.status === "Up Next");
+  const upNext = items.filter(
+    (i) =>
+      i.status === "Up Next" &&
+      !i.labels.some((l) => EXCLUDED_LABELS.includes(l))
+  );
 
   const chains: ChainStatus[] = inProgress.map((item) =>
     analyzeChain(item, issueComments[item.num] ?? [], pullRequests)
@@ -639,7 +646,11 @@ async function resumeDetect(issueNum: number) {
 
 async function peek() {
   const { items } = await fetchBoardAndComments();
-  const upNext = items.filter((i) => i.status === "Up Next");
+  const upNext = items.filter(
+    (i) =>
+      i.status === "Up Next" &&
+      !i.labels.some((l) => EXCLUDED_LABELS.includes(l))
+  );
 
   const priorityOrder: Record<string, number> = {
     critical: 0,

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -42,12 +42,6 @@ jobs:
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Copy sessions into Next.js public/
-        run: |
-          rm -rf development/frontend/public/sessions
-          mkdir -p development/frontend/public/sessions
-          cp -r sessions/. development/frontend/public/sessions/
-
       - name: Build
         run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
 

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - 'development/frontend/**'
-      - 'sessions/**'
   workflow_dispatch:
 
 env:
@@ -29,12 +28,6 @@ jobs:
 
       - name: Pull Vercel environment
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Copy sessions into Next.js public/
-        run: |
-          rm -rf development/frontend/public/sessions
-          mkdir -p development/frontend/public/sessions
-          cp -r sessions/. development/frontend/public/sessions/
 
       - name: Build
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## Summary
- Removed the `Copy sessions into Next.js public/` step from both `vercel-production.yml` and `vercel-preview.yml` — the `sessions/` directory was deleted but CI still tried to copy it, breaking production deploys
- Removed `sessions/**` from production workflow path triggers
- Excluded `marketing`-labeled issues from the fire-next-up Up Next queue (pack-status script)

## Test plan
- [ ] Verify production deploy succeeds (no more `cp: cannot stat 'sessions/.'` error)
- [ ] Verify `/fire-next-up --peek` no longer shows marketing issues (#306, #307, #308)

🤖 Generated with [Claude Code](https://claude.com/claude-code)