### PR TITLE
fix: add workflow self-trigger path to production deploy

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'development/frontend/**'
+      - '.github/workflows/vercel-production.yml'
   workflow_dispatch:
 
 env:

--- a/development/frontend/next.config.ts
+++ b/development/frontend/next.config.ts
@@ -1,3 +1,4 @@
+// Next.js configuration for Fenrir Ledger
 import type { NextConfig } from "next";
 
 /**


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/vercel-production.yml` to path triggers so workflow changes redeploy
- Minor `next.config.ts` touch to ensure this merge triggers a production deploy

## Test plan
- [ ] Merge triggers Vercel production deploy (both files match path filters)

🤖 Generated with [Claude Code](https://claude.com/claude-code)