### PR TITLE
ci: auto-add new issues to project board

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -101,9 +101,10 @@ When `--resume` finds actions that are clearly ready, execute them immediately:
 | Completed chain still in "In Progress" | Move to Done |
 | Research handoff + PR merged + issue open | Present research review to Odin |
 
-**Only pause for Odin's approval on:** merges (confirm first), ambiguous situations, or FAIL verdicts.
+**Only pause for Odin's approval on:** ambiguous situations or FAIL verdicts.
 
-Report what was auto-executed in the dashboard output.
+**Do NOT pause for:** merges, Loki dispatches, board moves, or any other obvious action.
+Execute all clear-cut actions immediately and report what was done in the dashboard output.
 
 ---
 

--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -1,0 +1,15 @@
+name: Auto-add issues to project board
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to Fenrir Ledger Triage project
+        uses: actions/add-to-project@v1
+        with:
+          project-url: https://github.com/users/declanshanaghy/projects/1
+          github-token: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically add all new issues to the Fenrir Ledger Triage project board
- Updates fire-next-up auto-advance rules to not pause for merges

## Setup Required
- `PROJECT_TOKEN` secret must be set (PAT with `project` + `repo` scopes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)