### PR TITLE
fix: prevent duplicate Stripe subscriptions — Ref #460

### DIFF
--- a/development/frontend/src/components/entitlement/StripeSettings.tsx
+++ b/development/frontend/src/components/entitlement/StripeSettings.tsx
@@ -118,7 +118,9 @@ export function StripeSettings() {
     setIsSubscribing(true);
     try {
       await subscribeStripe();
-      // If successful, user is redirected -- loading persists until navigation
+      // For redirects (new checkout), loading persists until navigation.
+      // For revives (inline toast), reset loading since we stay on page.
+      setIsSubscribing(false);
     } catch {
       toast.error("Could not start checkout. Please try again.");
       setIsSubscribing(false);

--- a/development/frontend/src/contexts/EntitlementContext.tsx
+++ b/development/frontend/src/contexts/EntitlementContext.tsx
@@ -26,6 +26,7 @@ import {
   useRef,
   type ReactNode,
 } from "react";
+import { toast } from "sonner";
 import { useAuthContext } from "@/contexts/AuthContext";
 import { ensureFreshToken } from "@/lib/auth/refresh-session";
 import {
@@ -272,10 +273,12 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
         throw new Error((err as { error_description?: string }).error_description ?? "Checkout failed");
       }
 
-      const data = (await response.json()) as { url?: string; revived?: boolean };
+      const data = (await response.json()) as { url?: string; revived?: boolean; message?: string };
       if (data.revived) {
-        // Subscription was revived (un-canceled) — redirect to success page
-        window.location.href = "/ledger/settings?stripe=success";
+        // Subscription was revived (un-canceled) — show toast + refresh state inline
+        console.debug("[Fenrir] Subscription revived — refreshing entitlement");
+        toast.success(data.message ?? "Your subscription has been reactivated.");
+        await refreshEntitlement();
       } else if (data.url) {
         window.location.href = data.url;
       }
@@ -286,7 +289,7 @@ export function EntitlementProvider({ children }: EntitlementProviderProps) {
       );
       throw err;
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, refreshEntitlement]);
 
   // -- Stripe: Open Customer Portal ------------------------------------------
 


### PR DESCRIPTION
Ref #460

Prevents duplicate Stripe subscriptions when users cancel and re-subscribe. The backend (already merged in #463) revives canceling subscriptions instead of creating new ones, and reuses existing Stripe Customer IDs for new checkouts. This PR completes the frontend handling.

**Changes:**
- `EntitlementContext.tsx` — Handle `{ revived: true }` response with sonner success toast + inline membership refresh instead of page redirect
- `StripeSettings.tsx` — Reset subscribe loading state after revive (no redirect = stays on page)

**Verification:**
- Cancel a subscription, then re-subscribe — should revive (not create new sub), show toast
- Fully cancel, then re-subscribe — should reuse same Stripe Customer
- Check Stripe dashboard: exactly 1 subscription per user after cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)