### PR TITLE
chore: add on-hold status to pack-status

### DIFF
--- a/.claude/skills/fire-next-up/scripts/pack-status.mjs
+++ b/.claude/skills/fire-next-up/scripts/pack-status.mjs
@@ -8,9 +8,10 @@ var PROJECT_NUMBER = 1;
 var PROJECT_ID = "PVT_kwHOAAW5PM4BQ7LP";
 var FIELD_ID = "PVTSSF_lAHOAAW5PM4BQ7LPzg-54RA";
 var STATUS_OPTIONS = {
-  "up-next": "6e492bcc",
-  "in-progress": "1d9139d4",
-  done: "c5fe053a"
+  "up-next": "9e642425",
+  "in-progress": "46217103",
+  "on-hold": "15f834b7",
+  done: "2cda5d40"
 };
 var GH_API = "https://api.github.com";
 var GH_GQL = "https://api.github.com/graphql";
@@ -312,7 +313,7 @@ async function chainStatus(issueNum) {
 async function moveIssue(issueNum, status) {
   const optionId = STATUS_OPTIONS[status];
   if (!optionId) {
-    console.error(`Invalid status: ${status} (use up-next, in-progress, done)`);
+    console.error(`Invalid status: ${status} (use up-next, in-progress, on-hold, done)`);
     process.exit(1);
   }
   const findQuery = `

--- a/.claude/skills/fire-next-up/scripts/pack-status.ts
+++ b/.claude/skills/fire-next-up/scripts/pack-status.ts
@@ -2,7 +2,7 @@
 /**
  * pack-status.ts — Full pack status dashboard via GraphQL
  *
- * Usage: npx tsx pack-status.ts [--status] [--chain-status <N>] [--move <N> <up-next|in-progress|done>]
+ * Usage: npx tsx pack-status.ts [--status] [--chain-status <N>] [--move <N> <up-next|in-progress|on-hold|done>]
  *
  * Uses native fetch + GitHub GraphQL API directly (no child process spawning).
  * Auth token obtained from `gh auth token` once at startup.
@@ -15,9 +15,10 @@ const PROJECT_NUMBER = 1;
 const PROJECT_ID = "PVT_kwHOAAW5PM4BQ7LP";
 const FIELD_ID = "PVTSSF_lAHOAAW5PM4BQ7LPzg-54RA";
 const STATUS_OPTIONS: Record<string, string> = {
-  "up-next": "6e492bcc",
-  "in-progress": "1d9139d4",
-  done: "c5fe053a",
+  "up-next": "9e642425",
+  "in-progress": "46217103",
+  "on-hold": "15f834b7",
+  done: "2cda5d40",
 };
 
 const GH_API = "https://api.github.com";
@@ -419,7 +420,7 @@ async function chainStatus(issueNum: number) {
 async function moveIssue(issueNum: number, status: string) {
   const optionId = STATUS_OPTIONS[status];
   if (!optionId) {
-    console.error(`Invalid status: ${status} (use up-next, in-progress, done)`);
+    console.error(`Invalid status: ${status} (use up-next, in-progress, on-hold, done)`);
     process.exit(1);
   }
 


### PR DESCRIPTION
## Summary
- Adds "On Hold" status column support to pack-status board management script
- Updates all status option IDs to match new GraphQL field values after board field update

## Test plan
- [x] `pack-status.mjs` rebuilt successfully
- [ ] Verify `--move N on-hold` works via `/fire-next-up --resume`

🤖 Generated with [Claude Code](https://claude.com/claude-code)