### PR TITLE
chore: remove redundant project-add and add --archive=tgz to Vercel deploys

### DIFF
--- a/.claude/commands/plan-w-team.md
+++ b/.claude/commands/plan-w-team.md
@@ -138,10 +138,7 @@ gh issue create \
 EOF
 )"
 
-# Add to project board
-gh project item-add 1 --owner declanshanaghy --url <issue-url>
-
-# MANDATORY: Set status to "Up Next" (otherwise it lands in "No Status")
+# Set status to "Up Next" (auto-add action handles board addition)
 SCRIPT_DIR="$(git rev-parse --show-toplevel)/.claude/skills/fire-next-up/scripts"
 node "$SCRIPT_DIR/pack-status.mjs" --move <issue-number> up-next
 ```

--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Deploy and capture preview URL
         id: deploy
         run: |
-          PREVIEW_URL=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})
+          PREVIEW_URL=$(vercel deploy --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})
           echo "preview_url=$PREVIEW_URL" >> "$GITHUB_OUTPUT"
 
       - name: Install Playwright browsers

--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -34,4 +34,4 @@ jobs:
         run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Deploy
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}

--- a/quality/issue-template.md
+++ b/quality/issue-template.md
@@ -93,11 +93,7 @@ gh issue create \
 EOF
 )"
 
-# 2. Add to project board
-gh project item-add 1 --owner declanshanaghy \
-  --url "https://github.com/declanshanaghy/fenrir-ledger/issues/ISSUE_NUMBER"
-
-# 3. MANDATORY: Set status to "Up Next" (otherwise it lands in "No Status")
+# 2. Set status to "Up Next" (auto-add action handles board addition)
 SCRIPT_DIR="$(git rev-parse --show-toplevel)/.claude/skills/fire-next-up/scripts"
 node "$SCRIPT_DIR/pack-status.mjs" --move ISSUE_NUMBER up-next
 ```


### PR DESCRIPTION
## Summary
- Remove redundant `gh project item-add` from plan-w-team and issue-template (auto-add GH Action handles this)
- Add `--archive=tgz` to Vercel deploy commands in both production and preview workflows to prevent free-tier upload rate limits

## Test plan
- [x] Verified plan-w-team.md updated
- [x] Verified issue-template.md updated
- [x] Verified vercel-production.yml has --archive=tgz
- [x] Verified vercel-preview.yml has --archive=tgz

🤖 Generated with [Claude Code](https://claude.com/claude-code)