### PR TITLE
fix: strip duplicate header from chronicle pages

### DIFF
--- a/development/frontend/src/app/(marketing)/chronicles/[slug]/page.tsx
+++ b/development/frontend/src/app/(marketing)/chronicles/[slug]/page.tsx
@@ -80,6 +80,21 @@ function dedentHtml(source: string): string {
     .join("\n");
 }
 
+/**
+ * Strip the `<header class="session-header">…</header>` block from MDX content.
+ *
+ * The page component already renders a compact header from frontmatter, so the
+ * inline header in the MDX body creates a duplicate. This regex removes it.
+ *
+ * Ref: GitHub Issue #469 follow-up
+ */
+function stripInlineHeader(source: string): string {
+  return source.replace(
+    /<header\s+className="session-header">[\s\S]*?<\/header>/,
+    "",
+  );
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default async function ChronicleDetailPage({
@@ -180,7 +195,7 @@ export default async function ChronicleDetailPage({
           dedentHtml strips leading whitespace so indented HTML isn't treated
           as markdown code blocks.  Ref: Issue #407 */}
       <MDXRemote
-        source={dedentHtml(entry.content)}
+        source={stripInlineHeader(dedentHtml(entry.content))}
         options={{ mdxOptions: { format: "md", rehypePlugins: [rehypeRaw] } }}
       />
 


### PR DESCRIPTION
Fixes the double header visible on every chronicle page.

## Summary
- The page component renders a compact header from MDX frontmatter (title, date, excerpt)
- The MDX body also contains a `<header class="session-header">` block with the same info
- Added `stripInlineHeader()` to remove the inline header before passing to MDXRemote
- Affects all 15 existing chronicles + any future ones generated by brandify

## Test plan
- [ ] Visit any chronicle page (e.g. `/chronicles/brain-slug`) — single header only
- [ ] Verify content below the header still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)