### PR TITLE
fix: strip duplicate/unstyled chronicle footers — Ref #486

### DIFF
--- a/development/frontend/content/blog/brain-slug.mdx
+++ b/development/frontend/content/blog/brain-slug.mdx
@@ -126,11 +126,3 @@ slug: "brain-slug"
   </footer>
 
 </div>
-
-<footer className="session-footer">
-    <p className="footer-cipher" aria-hidden="true">ᚠ ᛖ ᚾ ᚱ ᛁ ᚱ</p>
-    <p className="footer-text">The Brain Slug Extraction · Fenrir Ledger Session Chronicle</p>
-    <p className="footer-sub">The wolf remembers everything.</p>
-  </footer>
-
-</div>

--- a/development/frontend/content/blog/lean-wolf.mdx
+++ b/development/frontend/content/blog/lean-wolf.mdx
@@ -268,13 +268,3 @@ slug: "lean-wolf"
   </footer>
 
 </div>
-
-<footer className="session-footer">
-    <div className="footer-cipher" aria-hidden="true">ᛏ ᚢ ᛈ ᚠ ᛁ ᚱ</div>
-    <div className="footer-text">
-      The Lean Wolf · Fenrir Ledger Session Chronicle
-    </div>
-    <p className="footer-sub">The wolf shed its winter coat. Now it runs faster.</p>
-  </footer>
-
-</div>

--- a/development/frontend/content/blog/wireframes-modals.mdx
+++ b/development/frontend/content/blog/wireframes-modals.mdx
@@ -397,13 +397,3 @@ One of the ingredients is "Beard of a Woman"</div>
   </footer>
 
 </div>
-
-<footer className="session-footer">
-    <div className="footer-cipher" aria-hidden="true">ᚠ ᛖ ᚾ ᚱ ᛁ ᚱ</div>
-    <div className="footer-text">
-      Forged by <span className="hl">FiremanDecko</span> · Guarded by <span className="hl">Freya</span> · Shaped by <span className="hl">Luna</span> · Tested by <span className="hl">Loki</span><br />
-      Bound by Seven Impossible Things · Watched by the Wolf · © Fenrir Ledger 2026
-    </div>
-  </footer>
-
-</div>

--- a/development/frontend/src/app/(marketing)/chronicles/[slug]/page.tsx
+++ b/development/frontend/src/app/(marketing)/chronicles/[slug]/page.tsx
@@ -95,6 +95,24 @@ function stripInlineHeader(source: string): string {
   );
 }
 
+/**
+ * Strip ALL `<footer className="session-footer">…</footer>` blocks from MDX content.
+ *
+ * The page layout handles its own footer/back-link, so inline footers in MDX
+ * either duplicate (when inside .chronicle-page) or render as unstyled text
+ * (when outside .chronicle-page where CSS scoping doesn't apply).
+ *
+ * Uses the global flag to catch files with duplicate footer blocks.
+ *
+ * Ref: GitHub Issue #486
+ */
+function stripInlineFooter(source: string): string {
+  return source.replace(
+    /<footer\s+className="session-footer">[\s\S]*?<\/footer>/g,
+    "",
+  );
+}
+
 // ── Page ─────────────────────────────────────────────────────────────────────
 
 export default async function ChronicleDetailPage({
@@ -195,7 +213,7 @@ export default async function ChronicleDetailPage({
           dedentHtml strips leading whitespace so indented HTML isn't treated
           as markdown code blocks.  Ref: Issue #407 */}
       <MDXRemote
-        source={stripInlineHeader(dedentHtml(entry.content))}
+        source={stripInlineFooter(stripInlineHeader(dedentHtml(entry.content)))}
         options={{ mdxOptions: { format: "md", rehypePlugins: [rehypeRaw] } }}
       />
 


### PR DESCRIPTION
## Summary

- Added `stripInlineFooter()` to `[slug]/page.tsx` that removes all `<footer className="session-footer">` blocks from MDX content before rendering — mirrors the existing `stripInlineHeader()` pattern
- Removed duplicate footer blocks from 3 MDX files: `brain-slug.mdx`, `lean-wolf.mdx`, `wireframes-modals.mdx`
- Applied in the render pipeline: `stripInlineFooter(stripInlineHeader(dedentHtml(entry.content)))`

## Test plan

- [ ] Visit each chronicle page and confirm no duplicate footer block appears
- [ ] Confirm no unstyled text block at the bottom of any chronicle page
- [ ] Verify brain-slug, lean-wolf, and wireframes-modals chronicles render cleanly
- [ ] Verify all other chronicle pages still render correctly
- [ ] `tsc --noEmit` passes
- [ ] `next build` passes (33 routes)

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)