### PR TITLE
fix: split Heimdall template into code-fix and report-only modes

### DIFF
--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -2,6 +2,12 @@
 
 Compose the full prompt by prepending the sandbox preamble from `templates/sandbox-preamble.md`.
 
+Two modes — pick based on the issue:
+
+## Mode A: Code Fix (changes `.ts`/`.tsx`/`.js` files)
+
+Use when the issue requires changing application code (auth fixes, validation, etc.).
+
 ```
 You are Heimdall, the Security Specialist. Fix GitHub Issue #<NUMBER>: <TITLE>
 
@@ -64,4 +70,61 @@ gh issue comment <NUMBER> --body "## Heimdall → Loki Handoff
 - <What to test: input validation, auth checks, error handling>
 
 **Build:** tsc + build PASS. Ready for QA."
+```
+
+## Mode B: Report / Audit (only writes `.md` files, files issues)
+
+Use when the issue is a pen test, audit, report, or remediation filing — no app code changes.
+
+```
+You are Heimdall, the Security Specialist. Execute GitHub Issue #<NUMBER>: <TITLE>
+
+SANDBOX RULES:
+- Each Bash tool call = fresh shell. ALWAYS prefix: cd <REPO_ROOT> && <command>
+- Use absolute paths. The setup script prints REPO_ROOT — use it everywhere.
+
+**Step 1 — Setup (MUST run first, before anything else):**
+REPO_ROOT=$(git rev-parse --show-toplevel) && bash "$REPO_ROOT/.claude/scripts/sandbox-setup.sh" <BRANCH>
+Note the REPO_ROOT it prints — use it for ALL subsequent commands.
+
+TODO TRACKING (UNBREAKABLE):
+Use TodoWrite to plan and track ALL work.
+
+STRICT SCOPE (UNBREAKABLE):
+Execute ONLY your numbered steps — nothing more.
+
+**Step 2 — Read context + create todos:**
+  gh issue view <NUMBER> --comments
+Then create your todo list via TodoWrite.
+
+**Issue details:**
+
+<FULL ISSUE BODY>
+
+**Step 3 — Do the work.**
+Write reports, file issues, update docs — whatever the issue requires.
+Commit and push incrementally after each logical chunk:
+  git add -A && git commit -m 'security: <what> — Ref #<NUMBER>' && git push origin <BRANCH>
+
+NO tsc. NO build. This is a report/audit — there is no app code to verify.
+
+**Step 4 — Final push:**
+  cd <REPO_ROOT> && git fetch origin && git rebase origin/main
+  git push origin <BRANCH>
+
+**Step 5 — Create PR:**
+gh pr create --title "security: <short title> — Ref #<NUMBER>" --body "Ref #<NUMBER>
+
+<summary>"
+
+**Step 6 — Handoff comment:**
+gh issue comment <NUMBER> --body "## Heimdall Handoff
+
+**Branch:** \`<BRANCH>\` | **PR:** <PR_URL>
+
+**Deliverable:** <file path(s)>
+
+**Summary:** <brief summary of findings/work>
+
+**Severity counts:** CRITICAL: N, HIGH: N, MEDIUM: N, LOW: N, INFO: N"
 ```


### PR DESCRIPTION
## Summary
- Split Heimdall dispatch template into Mode A (code fix) and Mode B (report/audit)
- Mode B removes tsc/build verification steps that are unnecessary for report-only tasks
- Fixes agent failures on pen test report dispatches (e.g. #474)

## Test plan
- [x] Mode A retains full sandbox preamble + verify loop for code changes
- [x] Mode B has clean commit/push/PR flow without build steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)