### PR TITLE
fix(ci): downgrade Playwright workflow to Node 22 LTS

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Resolve preview URL
         id: url


### PR DESCRIPTION
## Summary
- Downgrades `actions/setup-node` from Node 24 to Node 22 LTS in the Playwright CI workflow
- npm 11 (Node 24) enforces strict lockfile integrity for cross-platform optional deps, causing `npm ci` to fail on ubuntu runners when the lockfile was generated on macOS (missing `@unrs/resolver-binding-linux-*` entries)
- Node 22 LTS (npm 10) tolerates this, matching our local dev environment

## Test plan
- [ ] Verify Playwright CI passes on an existing PR after merging this to main
- [ ] All 3 in-flight PRs (#490, #491, #492) should go green

🤖 Generated with [Claude Code](https://claude.com/claude-code)