### PR TITLE
feat: add hover animations to About page team characters — Ref #484

### DIFF
--- a/development/frontend/src/app/(marketing)/about/page.tsx
+++ b/development/frontend/src/app/(marketing)/about/page.tsx
@@ -274,9 +274,10 @@ function AgentCard({ agent }: { agent: AgentProfile }): React.ReactElement {
   return (
     <motion.div
       variants={CARD_VARIANT}
+      whileHover={{ y: -8, scale: 1.02, transition: { type: "spring", stiffness: 300, damping: 20 } }}
       className="group relative flex flex-col border border-border overflow-hidden
-                 bg-card transition-all duration-300
-                 hover:-translate-y-2 hover:shadow-gold-md hover:border-primary/40"
+                 bg-card transition-[box-shadow,border-color] duration-300
+                 hover:shadow-gold-md hover:border-primary/40"
     >
       {/* Portrait */}
       <div className="relative w-full aspect-square border-b border-border overflow-hidden bg-muted/50">

--- a/development/frontend/src/app/globals.css
+++ b/development/frontend/src/app/globals.css
@@ -728,13 +728,19 @@ body.konami-shake-mobile {
  * Loki = glitch distortion, Heimdall = golden glow (shared with Freya).
  */
 
-/* Freya / Heimdall — warm golden glow */
+/* Freya / Heimdall — warm golden glow with pulse */
 .about-hover-glow {
   background: radial-gradient(
     ellipse at center,
     rgba(212, 165, 32, 0.25) 0%,
     transparent 70%
   );
+  animation: about-glow-pulse 2s ease-in-out infinite alternate;
+}
+
+@keyframes about-glow-pulse {
+  0%   { opacity: 0.6; }
+  100% { opacity: 1; }
 }
 
 /* Luna — horizontal shimmer sweep */
@@ -790,6 +796,27 @@ body.konami-shake-mobile {
   33%  { transform: translateX(-2px); }
   66%  { transform: translateX(2px); }
   100% { transform: translateX(0); }
+}
+
+/* About page — reduced motion: disable all hover animations */
+@media (prefers-reduced-motion: reduce) {
+  .about-hover-glow,
+  .about-hover-shimmer,
+  .about-hover-fire,
+  .about-hover-glitch {
+    animation: none !important;
+    transition: none !important;
+  }
+}
+
+/* About page — touch devices: rely on tap rather than hover for overlay */
+@media (hover: none) {
+  .about-hover-glow,
+  .about-hover-shimmer,
+  .about-hover-fire,
+  .about-hover-glitch {
+    animation: none;
+  }
 }
 
 /* About page — runic background pattern */


### PR DESCRIPTION
Fixes #484

Adds consistent hover animations to all team member character cards on the About page, matching Luna's existing animation style.

## Changes
- **Framer Motion `whileHover`** — replaced Tailwind `hover:-translate-y-2` with a spring-based lift animation (`y: -8, scale: 1.02`) on all `AgentCard` components for a more polished, consistent feel
- **Glow pulse animation** — Freya and Heimdall's static golden glow now pulses (`about-glow-pulse`) to match Luna's animated shimmer sweep
- **`prefers-reduced-motion`** — all four about-hover effects (glow, shimmer, fire, glitch) are disabled when reduced motion is preferred
- **Touch device handling** — `@media (hover: none)` disables CSS animations on touch devices for graceful degradation

## Verification
- Visit /about and hover over each team member card
- All 6 cards should animate consistently (lift + scale + unique overlay effect)
- Test with `prefers-reduced-motion` enabled — animations should be disabled/simplified
- Check mobile — no broken layout

## QA Validation Results
- ✅ **tsc check**: PASS
- ✅ **Next.js build**: PASS (33 routes)
- ✅ **Branch rebased** on origin/main

CSS animation change — build verification only, no Playwright tests needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>