### PR TITLE
fix: skip Vercel preview deploys for branches without PRs

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,1 +1,3 @@
-{}
+{
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"main\" ]; then exit 1; fi; if [ -n \"$VERCEL_GIT_PULL_REQUEST_ID\" ]; then exit 1; fi; exit 0"
+}


### PR DESCRIPTION
## Summary
- Adds `ignoreCommand` to `vercel.json` so only `main` and branches with open PRs get deployed
- Agent branches (pushed by Depot sandboxes) no longer trigger preview deploys
- Eliminates the flood of cancelled/failed Playwright workflow runs

## How it works
Vercel runs the ignore command before each build:
- `main` → always build (exit 1)
- Branch with PR (`VERCEL_GIT_PULL_REQUEST_ID` set) → build (exit 1)  
- Branch without PR → skip (exit 0)

## Test plan
- [x] `main` pushes still trigger production deploy
- [x] PR branches still get preview deploys + Playwright tests
- [x] Agent branches without PRs are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)