### PR TITLE
fix(ci): replace deprecated actions/add-to-project with gh CLI

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -9,7 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add issue to Fenrir Ledger Triage project
-        uses: actions/add-to-project@v1
-        with:
-          project-url: https://github.com/users/declanshanaghy/projects/1
-          github-token: ${{ secrets.PROJECT_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          gh project item-add 1 \
+            --owner declanshanaghy \
+            --url "${{ github.event.issue.html_url }}"


### PR DESCRIPTION
## Summary
- `actions/add-to-project@v1` was removed from GitHub — every new issue has been silently failing to get added to the project board
- Replaced with `gh project item-add` CLI command which uses the Projects V2 API
- Uses the existing `PROJECT_TOKEN` secret

## Test plan
- [ ] Create a test issue and verify it appears on the project board automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)