### PR TITLE
fix: use unsafe-inline for style-src in CSP

### DIFF
--- a/development/frontend/src/lib/csp-headers.ts
+++ b/development/frontend/src/lib/csp-headers.ts
@@ -16,8 +16,6 @@
  */
 export function buildCspDirectives(nonce?: string): string[] {
   const scriptSrcNonce = nonce ? `'nonce-${nonce}'` : "'unsafe-inline'";
-  const styleSrcNonce = nonce ? `'nonce-${nonce}'` : "'unsafe-inline'";
-
   return [
     // Default: only same-origin
     "default-src 'self'",
@@ -26,8 +24,10 @@ export function buildCspDirectives(nonce?: string): string[] {
     // In development, Next.js HMR / React Fast Refresh requires 'unsafe-eval'.
     `script-src 'self' ${scriptSrcNonce}${process.env.NODE_ENV !== "production" ? " 'unsafe-eval'" : ""} https://accounts.google.com https://apis.google.com https://js.stripe.com https://va.vercel-scripts.com https://vercel.live`,
 
-    // Styles: self + nonce (or unsafe-inline fallback) + Google Fonts
-    `style-src 'self' ${styleSrcNonce} https://fonts.googleapis.com https://accounts.google.com`,
+    // Styles: self + unsafe-inline + Google Fonts
+    // unsafe-inline is required for style attributes (React, next-themes, Framer Motion).
+    // CSP nonces only work on <style> tags, not style="" attributes — no practical alternative.
+    `style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://accounts.google.com`,
 
     // Images: self + Google profile pictures + YouTube thumbnails + data: URIs
     "img-src 'self' https://lh3.googleusercontent.com https://img.youtube.com data:",

--- a/quality/test-suites/csp-nonce/csp-nonce.spec.ts
+++ b/quality/test-suites/csp-nonce/csp-nonce.spec.ts
@@ -52,19 +52,13 @@ test.describe("CSP — Nonce Header Present", () => {
     expect(hasNonce || hasUnsafeInline).toBeTruthy();
   });
 
-  test("should have nonce value in style-src directive", async ({ page }) => {
+  test("should have unsafe-inline in style-src directive", async ({ page }) => {
     const response = await page.goto(BASE_URL);
     const headers = response?.headers() || {};
     const cspHeader = headers["content-security-policy"] || "";
 
-    // Verify style-src directive exists
-    expect(cspHeader).toMatch(/style-src\s+/);
-
-    // Verify nonce is present or unsafe-inline fallback (dev mode)
-    const hasNonce = cspHeader.match(/style-src[^;]*'nonce-[a-zA-Z0-9+/=]+'/);
-    const hasUnsafeInline = cspHeader.includes("'unsafe-inline'");
-
-    expect(hasNonce || hasUnsafeInline).toBeTruthy();
+    // style-src uses unsafe-inline (nonces don't work on style="" attributes)
+    expect(cspHeader).toMatch(/style-src[^;]*'unsafe-inline'/);
   });
 
   test("should generate unique nonce per request", async ({ page }) => {


### PR DESCRIPTION
Fixes #531

## Summary
- Replaced nonce with `'unsafe-inline'` in `style-src` CSP directive
- CSP nonces only work on `<style>` tags, not `style=""` attributes — React, next-themes, and Framer Motion all use inline style attributes
- `script-src` nonce remains in place (this is what matters for XSS)
- Updated CSP test to expect `unsafe-inline` instead of nonce for styles

## Test plan
- [ ] No CSP violations for inline styles in browser console
- [ ] Dark/light theme toggle works on all pages
- [ ] Script nonce still present in `script-src`

🤖 Generated with [Claude Code](https://claude.com/claude-code)