### PR TITLE
chore: populate CI status in pack-status dashboard

### DIFF
--- a/.claude/skills/fire-next-up/scripts/pack-status.mjs
+++ b/.claude/skills/fire-next-up/scripts/pack-status.mjs
@@ -134,6 +134,35 @@ async function fetchBoardAndComments() {
   );
   return { items, issueComments, pullRequests: prs };
 }
+async function fetchCIStatus(prs) {
+  const ciMap = {};
+  await Promise.all(
+    prs.map(async (pr) => {
+      try {
+        const data = await restGet(
+          `/repos/${OWNER}/${REPO}/commits/${pr.headRefName}/check-runs`
+        );
+        const runs = data.check_runs ?? [];
+        if (runs.length === 0) {
+          ciMap[pr.number] = "pending";
+          return;
+        }
+        const hasFail = runs.some((r) => r.conclusion === "failure");
+        const allComplete = runs.every((r) => r.status === "completed");
+        if (hasFail) {
+          ciMap[pr.number] = "fail";
+        } else if (allComplete) {
+          ciMap[pr.number] = "pass";
+        } else {
+          ciMap[pr.number] = "pending";
+        }
+      } catch {
+        ciMap[pr.number] = "unknown";
+      }
+    })
+  );
+  return ciMap;
+}
 function detectType(labels) {
   if (labels.includes("bug")) return "bug";
   if (labels.includes("security")) return "security";
@@ -163,13 +192,14 @@ function chainForType(type) {
       return "unknown";
   }
 }
-function analyzeChain(item, comments, prs) {
+function analyzeChain(item, comments, prs, ciMap) {
   const type = detectType(item.labels);
   const priority = detectPriority(item.labels);
   const chain = chainForType(type);
   const matchingPR = prs.find(
     (pr) => pr.headRefName.includes(`issue-${item.num}`)
   );
+  const ci = matchingPR && ciMap ? ciMap[matchingPR.number] ?? null : null;
   const hasLokiPass = comments.some(
     (c) => c.includes("## Loki QA Verdict") && /Verdict.*PASS/.test(c)
   );
@@ -206,7 +236,7 @@ function analyzeChain(item, comments, prs) {
       pr: matchingPR?.number ?? null,
       branch: matchingPR?.headRefName ?? "",
       verdict: null,
-      ci: null,
+      ci,
       next_action,
       command
     };
@@ -254,19 +284,20 @@ function analyzeChain(item, comments, prs) {
     pr: matchingPR?.number ?? null,
     branch: matchingPR?.headRefName ?? "",
     verdict,
-    ci: null,
+    ci,
     next_action,
     command
   };
 }
 async function statusDashboard() {
   const { items, issueComments, pullRequests } = await fetchBoardAndComments();
+  const ciMap = await fetchCIStatus(pullRequests);
   const inProgress = items.filter((i) => i.status === "In Progress");
   const upNext = items.filter(
     (i) => i.status === "Up Next" && !i.labels.some((l) => EXCLUDED_LABELS.includes(l))
   );
   const chains = inProgress.map(
-    (item) => analyzeChain(item, issueComments[item.num] ?? [], pullRequests)
+    (item) => analyzeChain(item, issueComments[item.num] ?? [], pullRequests, ciMap)
   );
   const result = {
     in_flight: chains,

--- a/.claude/skills/fire-next-up/scripts/pack-status.ts
+++ b/.claude/skills/fire-next-up/scripts/pack-status.ts
@@ -202,6 +202,42 @@ async function fetchBoardAndComments(): Promise<{
   return { items, issueComments, pullRequests: prs };
 }
 
+// --- CI Check Status ---
+
+async function fetchCIStatus(
+  prs: Array<{ number: number; headRefName: string }>
+): Promise<Record<number, string>> {
+  // Returns a map of PR number → "pass" | "fail" | "pending"
+  const ciMap: Record<number, string> = {};
+  await Promise.all(
+    prs.map(async (pr) => {
+      try {
+        const data = await restGet(
+          `/repos/${OWNER}/${REPO}/commits/${pr.headRefName}/check-runs`
+        );
+        const runs: Array<{ status: string; conclusion: string | null }> =
+          data.check_runs ?? [];
+        if (runs.length === 0) {
+          ciMap[pr.number] = "pending";
+          return;
+        }
+        const hasFail = runs.some((r) => r.conclusion === "failure");
+        const allComplete = runs.every((r) => r.status === "completed");
+        if (hasFail) {
+          ciMap[pr.number] = "fail";
+        } else if (allComplete) {
+          ciMap[pr.number] = "pass";
+        } else {
+          ciMap[pr.number] = "pending";
+        }
+      } catch {
+        ciMap[pr.number] = "unknown";
+      }
+    })
+  );
+  return ciMap;
+}
+
 // --- Chain Status Detection ---
 
 function detectType(labels: string[]): string {
@@ -239,7 +275,8 @@ function chainForType(type: string): string {
 function analyzeChain(
   item: BoardItem,
   comments: string[],
-  prs: Array<{ number: number; headRefName: string }>
+  prs: Array<{ number: number; headRefName: string }>,
+  ciMap?: Record<number, string>
 ): ChainStatus {
   const type = detectType(item.labels);
   const priority = detectPriority(item.labels);
@@ -248,6 +285,7 @@ function analyzeChain(
   const matchingPR = prs.find((pr) =>
     pr.headRefName.includes(`issue-${item.num}`)
   );
+  const ci = matchingPR && ciMap ? (ciMap[matchingPR.number] ?? null) : null;
 
   const hasLokiPass = comments.some(
     (c) => c.includes("## Loki QA Verdict") && /Verdict.*PASS/.test(c)
@@ -292,7 +330,7 @@ function analyzeChain(
       pr: matchingPR?.number ?? null,
       branch: matchingPR?.headRefName ?? "",
       verdict: null,
-      ci: null,
+      ci,
       next_action,
       command,
     };
@@ -342,7 +380,7 @@ function analyzeChain(
     pr: matchingPR?.number ?? null,
     branch: matchingPR?.headRefName ?? "",
     verdict,
-    ci: null,
+    ci,
     next_action,
     command,
   };
@@ -352,6 +390,7 @@ function analyzeChain(
 
 async function statusDashboard() {
   const { items, issueComments, pullRequests } = await fetchBoardAndComments();
+  const ciMap = await fetchCIStatus(pullRequests);
 
   const inProgress = items.filter((i) => i.status === "In Progress");
   const upNext = items.filter(
@@ -361,7 +400,7 @@ async function statusDashboard() {
   );
 
   const chains: ChainStatus[] = inProgress.map((item) =>
-    analyzeChain(item, issueComments[item.num] ?? [], pullRequests)
+    analyzeChain(item, issueComments[item.num] ?? [], pullRequests, ciMap)
   );
 
   const result = {


### PR DESCRIPTION
## Summary
- Added `fetchCIStatus()` to pack-status script that queries GitHub Check Runs API
- The `ci` field in `--status` output now returns `"pass"`, `"fail"`, `"pending"`, or `"unknown"` instead of always `null`
- Eliminates the need to run `gh pr checks` separately (which exits non-zero on pending, showing red errors in Claude Code output)

## Test plan
- [x] `node pack-status.mjs --status` returns populated `ci` field for open PRs
- [x] No more `gh pr checks` calls needed in orchestrator flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)