### PR TITLE
fix: use --session-id instead of --title for Depot sessions

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -164,7 +164,7 @@ If `--prompt-extra`, append after the issue body:
 ```bash
 source <repo-root>/.env && depot claude create \
   --org "$DEPOT_ORG_ID" \
-  --title "issue-<N>-step<S>-<agent>-$(uuidgen | cut -c1-8 | tr A-Z a-z)" \
+  --session-id "issue-<N>-step<S>-<agent>-$(uuidgen | cut -c1-8 | tr A-Z a-z)" \
   --repository "https://github.com/declanshanaghy/fenrir-ledger" \
   --branch "main" \
   --model "<MODEL>" \


### PR DESCRIPTION
## Summary
- `--title` is not a valid flag for `depot claude` or `claude` CLI
- Unrecognized flags pass through to claude which rejects them, killing the session on startup
- All 3 dispatches from this session (#527 Loki, #536 FiremanDecko, #537 FiremanDecko) failed silently because of this
- Fix: `--title` → `--session-id`

## Test plan
- [ ] Re-dispatch with `--session-id` and verify session starts and gets human-readable name

🤖 Generated with [Claude Code](https://claude.com/claude-code)