### PR TITLE
fix: eliminate light theme white flash on card hover — Ref #298

### DIFF
--- a/development/frontend/src/app/(marketing)/about/page.tsx
+++ b/development/frontend/src/app/(marketing)/about/page.tsx
@@ -564,8 +564,8 @@ function TheForgeSection(): React.ReactElement {
               key={node.label}
               variants={CHAIN_NODE_VARIANT}
               className="relative flex-1 flex flex-col items-center gap-3 p-5
-                         border border-border bg-card
-                         transition-colors duration-300 hover:bg-accent/30"
+                         border border-border bg-card card-interactive
+                         hover:bg-card-hover"
             >
               <div
                 className="w-14 h-14 border-2 border-primary/30 flex items-center justify-center

--- a/development/frontend/src/app/globals.css
+++ b/development/frontend/src/app/globals.css
@@ -51,6 +51,12 @@
     --ring:                 38  80% 28%;    /* dark burnt gold focus ring */
     --radius:               0.25rem;        /* sharp, angular — not pill */
 
+    /* ── Card Hover (Issue #298) ──────────────────────────── */
+    /* Opaque equivalents of semi-transparent hover overlays.
+     * Avoids white flash from transitioning opaque → transparent colors.
+     * Computed: gold @ 5% over card white #ffffff ≈ #fefcf6 */
+    --card-hover:           40 50% 98%;     /* #fefcf6 — opaque gold/5-on-white */
+
     /* ── Charts (thunder palette for white backgrounds) ───────── */
     --chart-1:              38  80% 28%;    /* dark burnt gold */
     --chart-2:              163 70% 22%;    /* deep forest green */
@@ -136,6 +142,9 @@
   --border:               22  8%  20%;    /* #3a3530 — stone seam */
   --input:                20  7%  27%;    /* #4a4540 */
   --ring:                 42  75% 48%;    /* gold focus ring */
+
+  /* ── Card Hover (Issue #298) ──────────────────────────── */
+  --card-hover:           30 18% 11%;     /* #211d17 — opaque gold/5-on-forge */
 
   /* ── Charts (Norse palette) ─────────────────────────────── */
   --chart-1:              42  75% 48%;    /* gold */
@@ -259,16 +268,22 @@
  * Background changes are applied instantly (no interpolation = no flash).
  * Use this class INSTEAD of `transition-colors` on any card/tile element
  * that has a bg-card resting state with a hover bg change.
+ *
+ * The !important on transition-property is intentional: it must override
+ * any Tailwind transition utility that might be composed on the same element
+ * (e.g. transition-colors, transition-all). Without it, a higher-specificity
+ * or later-in-source utility can re-add background-color to the transition
+ * list, reintroducing the flash.
  */
 .card-interactive {
-  transition-property: border-color, box-shadow;
+  transition-property: border-color, box-shadow !important;
   transition-duration: 150ms;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 @media (prefers-reduced-motion: reduce) {
   .card-interactive {
-    transition: none;
+    transition: none !important;
   }
 }
 

--- a/development/frontend/src/components/sheets/MethodSelection.tsx
+++ b/development/frontend/src/components/sheets/MethodSelection.tsx
@@ -223,7 +223,7 @@ export function MethodSelection({ onSelectMethod, pickerApiKey = null }: MethodS
               "focus:outline-none focus:ring-2 focus:ring-gold/50",
               method.disabled
                 ? "border-border bg-card/50 opacity-50 cursor-not-allowed"
-                : "border-border bg-card hover:border-gold/40 hover:bg-gold/5",
+                : "border-border bg-card hover:border-gold/40 hover:bg-card-hover",
             ].join(" ")}
           >
             {method.disabledLabel && (

--- a/development/frontend/tailwind.config.ts
+++ b/development/frontend/tailwind.config.ts
@@ -17,6 +17,7 @@ const config: Config = {
         card: {
           DEFAULT:    "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
+          hover:      "hsl(var(--card-hover))",
         },
         popover: {
           DEFAULT:    "hsl(var(--popover))",


### PR DESCRIPTION
Ref #298

Eliminates the white flash when hovering over import method cards (and other card surfaces) in Light theme. The flash was caused by CSS color interpolation between opaque `bg-card` (#ffffff) and semi-transparent `hover:bg-gold/5`.

**Changes:**
- `globals.css` — Added `--card-hover` CSS custom property (light: `#fefcf6`, dark: `#211d17`) as opaque equivalents of the semi-transparent hover overlays; hardened `.card-interactive` with `!important` on `transition-property` to prevent any Tailwind utility from re-adding `background-color` to the transition list
- `tailwind.config.ts` — Added `card.hover` color token mapped to `--card-hover`
- `MethodSelection.tsx` — Replaced `hover:bg-gold/5` with `hover:bg-card-hover` (opaque)
- `about/page.tsx` — Replaced `transition-colors hover:bg-accent/30` with `card-interactive hover:bg-card-hover` on chain node cards

**Verification:**
- Open the app in Light theme
- Click "Import Cards" → hover over all 3 method cards — no white flash
- Switch to Dark theme → verify hover still works with subtle gold tint
- Visit /about → hover over the chain node cards — no flash