### PR TITLE
fix: migrate Playwright tests to /ledger/ route prefix

### DIFF
--- a/quality/test-suites/accessibility/a11y.spec.ts
+++ b/quality/test-suites/accessibility/a11y.spec.ts
@@ -104,7 +104,7 @@ test.describe("Heading Hierarchy", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.goto("/valhalla");
+    await page.goto("/ledger/valhalla");
     await page.waitForURL(/\//);
 
     const h1 = page.locator("h1").first();
@@ -115,7 +115,7 @@ test.describe("Heading Hierarchy", () => {
   test("TC-A07: add card page has a heading", async ({ page }) => {
     // Spec (cards/new/page.tsx): the new card page renders an h1 "Forge a New Chain".
     // Per WCAG 2.4.6 (AA), a descriptive heading must be present.
-    await page.goto("/cards/new");
+    await page.goto("/ledger/cards/new");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "networkidle" });
@@ -139,7 +139,7 @@ test.describe("Form Accessibility", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "networkidle" });
     // Navigate to the add card form
-    await page.goto("/cards/new");
+    await page.goto("/ledger/cards/new");
     // Wait for the form to appear (gated behind auth status resolution)
     await page.waitForSelector("form", { timeout: 5000 });
   });
@@ -274,7 +274,7 @@ test.describe("Keyboard Navigation", () => {
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
     await page.reload({ waitUntil: "networkidle" });
 
-    // Find a card tile link — each card wraps in <Link href="/cards/{id}/edit">
+    // Find a card tile link — each card wraps in <Link href="/ledger/cards/{id}/edit">
     const cardLinks = page.locator('a[href*="/cards/"][href*="/edit"]');
     await expect(cardLinks.first()).toBeAttached();
 

--- a/quality/test-suites/auth/auth-callback.spec.ts
+++ b/quality/test-suites/auth/auth-callback.spec.ts
@@ -13,7 +13,7 @@
  *   - auth/callback/page.tsx: PKCE session missing → setErrorMessage("PKCE session data missing...")
  *   - auth/callback/page.tsx: CSRF mismatch → setErrorMessage("State mismatch — possible CSRF attack...")
  *   - auth/callback/page.tsx: error state → h-class "The Bifrost trembled" (destructive)
- *   - auth/callback/page.tsx: error state → link "Return to the gate" href="/sign-in"
+ *   - auth/callback/page.tsx: error state → link "Return to the gate" href="/ledger/sign-in"
  *   - auth/callback/page.tsx: exchanging state → "Binding the oath..."
  *   - auth/callback/page.tsx: page wraps content in Suspense fallback "Binding the oath..."
  *   - ADR-005: PKCE flow — /auth/callback is the redirect_uri for the OAuth round-trip
@@ -53,7 +53,7 @@ test.describe("Auth Callback — Missing Params", () => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto("/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
 
     const fatal = errors.filter(
       (e) => !e.includes("hydration") && !e.includes("HMR")
@@ -65,7 +65,7 @@ test.describe("Auth Callback — Missing Params", () => {
     page,
   }) => {
     // Spec: auth/callback/page.tsx — !code || !stateParam → "Missing code or state in callback URL."
-    await page.goto("/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
 
     await expect(
       page.locator("text=Missing code or state in callback URL.")
@@ -76,7 +76,7 @@ test.describe("Auth Callback — Missing Params", () => {
     page,
   }) => {
     // Spec: auth/callback/page.tsx — error state renders destructive heading "The Bifrost trembled"
-    await page.goto("/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
 
     // The heading uses the Norse name with ö — match either variant for robustness
     const heading = page.locator("text=The Bifr");
@@ -86,12 +86,12 @@ test.describe("Auth Callback — Missing Params", () => {
   test("'Return to the gate' link is visible and points to /sign-in", async ({
     page,
   }) => {
-    // Spec: auth/callback/page.tsx — error state renders <a href="/sign-in">Return to the gate</a>
-    await page.goto("/auth/callback", { waitUntil: "networkidle" });
+    // Spec: auth/callback/page.tsx — error state renders <a href="/ledger/sign-in">Return to the gate</a>
+    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
 
     const link = page.locator("a:has-text('Return to the gate')");
     await expect(link).toBeVisible({ timeout: 5000 });
-    await expect(link).toHaveAttribute("href", "/sign-in");
+    await expect(link).toHaveAttribute("href", "/ledger/sign-in");
   });
 });
 
@@ -104,7 +104,7 @@ test.describe("Auth Callback — Google Error Param", () => {
     page,
   }) => {
     // Spec: auth/callback/page.tsx — errorParam → `Google returned: ${errorParam}`
-    await page.goto("/auth/callback?error=access_denied", {
+    await page.goto("/ledger/auth/callback?error=access_denied", {
       waitUntil: "networkidle",
     });
 
@@ -115,7 +115,7 @@ test.describe("Auth Callback — Google Error Param", () => {
 
   test("shows error heading when Google returns an error", async ({ page }) => {
     // Spec: auth/callback/page.tsx — error state renders destructive heading
-    await page.goto("/auth/callback?error=access_denied", {
+    await page.goto("/ledger/auth/callback?error=access_denied", {
       waitUntil: "networkidle",
     });
 
@@ -150,7 +150,7 @@ test.describe("Auth Callback — PKCE Session Data Missing", () => {
     //       if (!raw) → "PKCE session data missing. Please try signing in again."
     // Note: callback page has a 100ms delay to prevent race conditions with React StrictMode
     // Navigate with valid-looking code + state but no PKCE session data
-    await page.goto("/auth/callback?code=fake_code&state=fake_state", {
+    await page.goto("/ledger/auth/callback?code=fake_code&state=fake_state", {
       waitUntil: "networkidle",
     });
 
@@ -166,7 +166,7 @@ test.describe("Auth Callback — PKCE Session Data Missing", () => {
   }) => {
     // Spec: error state always renders the sign-in recovery link
     // Note: callback page has a 100ms delay to prevent race conditions with React StrictMode
-    await page.goto("/auth/callback?code=fake_code&state=fake_state", {
+    await page.goto("/ledger/auth/callback?code=fake_code&state=fake_state", {
       waitUntil: "networkidle",
     });
 
@@ -200,7 +200,7 @@ test.describe("Auth Callback — CSRF State Mismatch", () => {
     });
 
     // Navigate with a DIFFERENT state in the URL — triggers CSRF check
-    await page.goto("/auth/callback?code=fake_code&state=different-state-xyz", {
+    await page.goto("/ledger/auth/callback?code=fake_code&state=different-state-xyz", {
       waitUntil: "networkidle",
     });
 
@@ -269,7 +269,7 @@ test.describe("Auth Callback — Corrupt PKCE Data", () => {
       sessionStorage.setItem("fenrir:pkce", "this-is-not-valid-json{{{{");
     });
 
-    await page.goto("/auth/callback?code=fake_code&state=any-state", {
+    await page.goto("/ledger/auth/callback?code=fake_code&state=any-state", {
       waitUntil: "networkidle",
     });
 
@@ -287,7 +287,7 @@ test.describe("Auth Callback — Responsive (375px)", () => {
   test("error state is readable at 375px viewport", async ({ page }) => {
     // Spec: team norms — minimum 375px. Callback error card uses max-w-xs.
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
 
     // Error message must not overflow — it uses max-w-xs
     const errorMsg = page.locator("text=Missing code or state in callback URL.");

--- a/quality/test-suites/auth/sign-in.spec.ts
+++ b/quality/test-suites/auth/sign-in.spec.ts
@@ -27,7 +27,7 @@ import { clearAllStorage } from "../helpers/test-fixtures";
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
-  await page.goto("/sign-in", { waitUntil: "networkidle" });
+  await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -40,7 +40,7 @@ test.describe("Sign-In Page — Rendering", () => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto("/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
 
     // Filter out known benign Next.js HMR noise in dev
     const fatal = errors.filter(
@@ -51,7 +51,7 @@ test.describe("Sign-In Page — Rendering", () => {
 
   test("page returns HTTP 200", async ({ page }) => {
     // Spec: /sign-in must be a valid, reachable route
-    const response = await page.goto("/sign-in", { waitUntil: "networkidle" });
+    const response = await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
     expect(response?.status()).toBe(200);
   });
 
@@ -136,7 +136,7 @@ test.describe("Sign-In Page — Continue Without Signing In", () => {
     const btn = page.locator('button:has-text("Continue without signing in")');
     await btn.click();
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/sign-in");
+    expect(page.url()).not.toContain("/ledger/sign-in");
   });
 
   test("'Continue without signing in' button meets minimum touch target height (46px)", async ({
@@ -182,7 +182,7 @@ test.describe("Sign-In Page — Responsive (375px)", () => {
   test("page is usable at 375px viewport width", async ({ page }) => {
     // Spec: team norms — minimum 375px. Sign-in card uses w-full max-w-[400px]
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
 
     const heading = page.locator("h1#signin-heading");
     await expect(heading).toBeVisible();
@@ -199,7 +199,7 @@ test.describe("Sign-In Page — Responsive (375px)", () => {
   test("sign-in card does not overflow viewport at 375px", async ({ page }) => {
     // Spec: sign-in/page.tsx — w-full max-w-[400px], px-4 on the outer div
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
 
     const main = page.locator("main[aria-labelledby='signin-heading']");
     const box = await main.boundingBox();
@@ -252,7 +252,7 @@ test.describe("Sign-In Page — Variant B (has local cards)", () => {
       localStorage.setItem("fenrir:household", householdId);
     });
 
-    await page.goto("/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
 
     // If the anon household key matches, heading must switch to Variant B
     // The spec says cardCount > 0 produces: "Your chains are already here."

--- a/quality/test-suites/card-crud/edit-card.spec.ts
+++ b/quality/test-suites/card-crud/edit-card.spec.ts
@@ -175,7 +175,7 @@ test.describe("Edit Card (card-crud) — Save", () => {
     await page.locator('button[type="submit"]').click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 
   test("updated card name persists and appears on dashboard", async ({
@@ -290,12 +290,12 @@ test.describe("Edit Card (card-crud) — Edge Cases", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "networkidle" });
 
-    await page.goto("/cards/totally-nonexistent-card-id-xyz/edit", {
+    await page.goto("/ledger/cards/totally-nonexistent-card-id-xyz/edit", {
       waitUntil: "networkidle",
     });
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 
   test("edit form is responsive at 375px viewport", async ({ page }) => {

--- a/quality/test-suites/card-lifecycle/add-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/add-card.spec.ts
@@ -22,7 +22,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -64,7 +64,7 @@ test.describe("Add Card — Validation Errors", () => {
     await submitBtn.click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/new");
+    expect(page.url()).not.toContain("/ledger/cards/new");
   });
 });
 
@@ -83,7 +83,7 @@ test.describe("Add Card — Successful Creation", () => {
     await page.locator('button[type="submit"]').click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/new");
+    expect(page.url()).not.toContain("/ledger/cards/new");
   });
 
   test("new card appears on dashboard after creation", async ({ page }) => {
@@ -115,6 +115,6 @@ test.describe("Add Card — Cancel Navigation", () => {
     await cancelBtn.click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/new");
+    expect(page.url()).not.toContain("/ledger/cards/new");
   });
 });

--- a/quality/test-suites/card-lifecycle/close-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/close-card.spec.ts
@@ -89,7 +89,7 @@ test.describe("Close Card — Confirm Action", () => {
     await confirmBtn.click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 
   test("closed card no longer appears in active dashboard grid", async ({

--- a/quality/test-suites/card-lifecycle/delete-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/delete-card.spec.ts
@@ -87,7 +87,7 @@ test.describe("Delete Card — Confirm Action", () => {
     await confirmBtn.click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 
   test("deleted card no longer appears on dashboard", async ({ page }) => {

--- a/quality/test-suites/card-lifecycle/edit-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/edit-card.spec.ts
@@ -47,12 +47,12 @@ test.describe("Edit Card — Pre-populated Fields", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "networkidle" });
 
-    await page.goto("/cards/nonexistent-id-that-does-not-exist/edit", {
+    await page.goto("/ledger/cards/nonexistent-id-that-does-not-exist/edit", {
       waitUntil: "networkidle",
     });
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 });
 
@@ -75,7 +75,7 @@ test.describe("Edit Card — Save Changes", () => {
     await page.locator('button[type="submit"]').click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 
   test("updated card name is visible on dashboard after save", async ({

--- a/quality/test-suites/credit-limit-step2/credit-limit-step2.spec.ts
+++ b/quality/test-suites/credit-limit-step2/credit-limit-step2.spec.ts
@@ -20,7 +20,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/dashboard-5-tabs/dashboard-5-tabs.spec.ts
+++ b/quality/test-suites/dashboard-5-tabs/dashboard-5-tabs.spec.ts
@@ -171,7 +171,7 @@ test.describe("Dashboard 5-Tabs QA — Issue #352", () => {
     await setupDashboard(page, testCards);
 
     // Navigate to the old /valhalla route
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     // Should redirect to the dashboard with ?tab=valhalla in URL
     expect(page.url()).toContain("/?tab=valhalla");

--- a/quality/test-suites/dashboard/dashboard.spec.ts
+++ b/quality/test-suites/dashboard/dashboard.spec.ts
@@ -10,7 +10,7 @@
  * Spec references:
  *   - EmptyState.tsx: heading "Before Gleipnir was forged" + "Add Card" link
  *   - Dashboard.tsx:  summary header "{N} cards" / "{N} need attention"
- *   - CardTile.tsx:   Link href="/cards/{id}/edit", cardName, issuerName
+ *   - CardTile.tsx:   Link href="/ledger/cards/{id}/edit", cardName, issuerName
  *   - StatusBadge.tsx: STATUS_LABELS = { active: "Active", fee_approaching: "Fee Due Soon", … }
  *   - constants.ts:   STATUS_LABELS record (authoritative badge text source)
  *
@@ -72,8 +72,8 @@ test.describe("Dashboard — Empty State", () => {
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, EMPTY_CARDS);
     await page.reload({ waitUntil: "networkidle" });
 
-    // Spec: EmptyState.tsx renders <Link href="/cards/new">Add Card</Link>
-    const addCardLink = page.locator('a[href="/cards/new"]').first();
+    // Spec: EmptyState.tsx renders <Link href="/ledger/cards/new">Add Card</Link>
+    const addCardLink = page.locator('a[href="/ledger/cards/new"]').first();
     await expect(addCardLink).toBeVisible();
     await expect(addCardLink).toContainText("Add Card");
   });
@@ -275,7 +275,7 @@ test.describe("Dashboard — Card Tile Links", () => {
     await page.locator('#tab-all').click();
     const allPanel = page.locator('[aria-labelledby="tab-all"]');
     for (const card of FEW_CARDS) {
-      const tileLink = allPanel.locator(`a[href="/cards/${card.id}/edit"]`);
+      const tileLink = allPanel.locator(`a[href="/ledger/cards/${card.id}/edit"]`);
       await expect(tileLink).toBeVisible();
     }
   });
@@ -288,7 +288,7 @@ test.describe("Dashboard — Card Tile Links", () => {
     await page.reload({ waitUntil: "networkidle" });
 
     const firstCard = FEW_CARDS[0]!;
-    const tileLink = page.locator(`a[href="/cards/${firstCard.id}/edit"]`).first();
+    const tileLink = page.locator(`a[href="/ledger/cards/${firstCard.id}/edit"]`).first();
     await tileLink.click();
 
     // After click, URL must be the edit page for that specific card
@@ -301,12 +301,12 @@ test.describe("Dashboard — Card Tile Links", () => {
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
     await page.reload({ waitUntil: "networkidle" });
 
-    // Spec: page.tsx renders <Link href="/cards/new">Add Card</Link> in the header
-    const addCardBtn = page.locator('a[href="/cards/new"]').first();
+    // Spec: page.tsx renders <Link href="/ledger/cards/new">Add Card</Link> in the header
+    const addCardBtn = page.locator('a[href="/ledger/cards/new"]').first();
     await expect(addCardBtn).toBeVisible();
     await addCardBtn.click();
 
     await page.waitForURL("**/cards/new");
-    expect(page.url()).toContain("/cards/new");
+    expect(page.url()).toContain("/ledger/cards/new");
   });
 });

--- a/quality/test-suites/empty-state-cta/empty-state-cta.spec.ts
+++ b/quality/test-suites/empty-state-cta/empty-state-cta.spec.ts
@@ -41,7 +41,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
     // Count all /cards/new links — must be exactly 1 (EmptyState only, no header dupe).
-    const addCardLinks = page.locator('a[href="/cards/new"]');
+    const addCardLinks = page.locator('a[href="/ledger/cards/new"]');
     await expect(addCardLinks).toHaveCount(1);
   });
 
@@ -60,7 +60,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await expect(emptyState).toBeVisible();
 
     // Add Card link lives inside the EmptyState.
-    const emptyStateAddCard = emptyState.locator('a[href="/cards/new"]');
+    const emptyStateAddCard = emptyState.locator('a[href="/ledger/cards/new"]');
     await expect(emptyStateAddCard).toBeVisible();
     await expect(emptyStateAddCard).toContainText("Add Card");
   });
@@ -78,7 +78,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await page.waitForSelector('text=/\\d+ card/', { timeout: 10000 });
 
     // The header Add Card link must now be visible.
-    const headerAddCard = page.locator('a[href="/cards/new"]');
+    const headerAddCard = page.locator('a[href="/ledger/cards/new"]');
     await expect(headerAddCard).toBeVisible();
   });
 });
@@ -166,7 +166,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
 
     // Navigation to /sign-in must happen.
     await page.waitForURL(/\/sign-in/, { timeout: 10000 });
-    expect(page.url()).toContain("/sign-in");
+    expect(page.url()).toContain("/ledger/sign-in");
   });
 
   test("subtle nudge is wrapped in a muted-foreground paragraph (not a gold CTA)", async ({
@@ -220,7 +220,7 @@ test.describe("Edge cases", () => {
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
-    const addCardLinks = page.locator('a[href="/cards/new"]');
+    const addCardLinks = page.locator('a[href="/ledger/cards/new"]');
     await expect(addCardLinks).toHaveCount(1);
 
     const addCardLink = addCardLinks.first();
@@ -266,7 +266,7 @@ test.describe("Edge cases", () => {
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
     // Exactly one /cards/new link (EmptyState only).
-    const addCardLinks = page.locator('a[href="/cards/new"]');
+    const addCardLinks = page.locator('a[href="/ledger/cards/new"]');
     await expect(addCardLinks).toHaveCount(1);
 
     // Gold-bordered "Sign in to sync" button from the full banner must not be visible.

--- a/quality/test-suites/fee-bonus-step2/fee-bonus-step2.spec.ts
+++ b/quality/test-suites/fee-bonus-step2/fee-bonus-step2.spec.ts
@@ -35,7 +35,7 @@ test.beforeEach(async ({ page }) => {
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   // Navigate to new card form
-  await page.goto("/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/google-session-refresh/google-session-refresh.spec.ts
+++ b/quality/test-suites/google-session-refresh/google-session-refresh.spec.ts
@@ -432,7 +432,7 @@ test.describe("AC6: Session Persistence Across Page Refresh", () => {
 
     // Should not redirect to /sign-in
     expect(page.url()).toContain("/ledger");
-    expect(page.url()).not.toContain("/sign-in");
+    expect(page.url()).not.toContain("/ledger/sign-in");
   });
 });
 

--- a/quality/test-suites/issue-333/duplicate-sections-step2.spec.ts
+++ b/quality/test-suites/issue-333/duplicate-sections-step2.spec.ts
@@ -27,7 +27,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
 });
 
 test.describe("Issue #333 — No Duplicate AF/SUB on Step 2", () => {

--- a/quality/test-suites/layout/topbar.spec.ts
+++ b/quality/test-suites/layout/topbar.spec.ts
@@ -38,7 +38,7 @@ test.describe("TopBar — Logo link", () => {
   test("header contains a link with href='/static' that opens in a new tab", async ({
     page,
   }) => {
-    const logoLink = page.locator('header a[href="/static"]').first();
+    const logoLink = page.locator('header a[href="/"]').first();
     await expect(logoLink).toBeAttached();
     await expect(logoLink).toHaveAttribute("target", "_blank");
   });

--- a/quality/test-suites/nextjs-upgrade/nextjs-16-core.spec.ts
+++ b/quality/test-suites/nextjs-upgrade/nextjs-16-core.spec.ts
@@ -123,7 +123,7 @@ test.describe("Next.js 16 — Client-Side Navigation", () => {
     if (await signInLink.isVisible({ timeout: 1000 }).catch(() => false)) {
       await signInLink.click();
       await page.waitForURL("**/sign-in", { timeout: 5000 });
-      expect(page.url()).toContain("/sign-in");
+      expect(page.url()).toContain("/ledger/sign-in");
       expect(page.url()).not.toEqual(initialUrl);
     }
   });

--- a/quality/test-suites/persistent-auth/persistent-auth.spec.ts
+++ b/quality/test-suites/persistent-auth/persistent-auth.spec.ts
@@ -239,10 +239,10 @@ test.describe("Auth Session Persistence", () => {
     await seedSession(page, VALID_SESSION_WITH_REFRESH);
 
     // WHEN the user navigates to a protected page
-    await page.goto("/dashboard");
+    await page.goto("/ledger");
 
     // THEN they remain on the dashboard (no redirect to /sign-in)
-    expect(page.url()).toContain("/dashboard");
+    expect(page.url()).toContain("/ledger");
 
     // AND the session is still stored
     const stored = await getStoredSession(page);
@@ -268,7 +268,7 @@ test.describe("Auth Session Persistence", () => {
       if (await signOutButton.isVisible().catch(() => false)) {
         await signOutButton.click();
         // Wait for sign-out to complete
-        await page.waitForURL("/sign-in", { timeout: 5000 }).catch(() => {});
+        await page.waitForURL("/ledger/sign-in", { timeout: 5000 }).catch(() => {});
       }
     } else {
       // If menu isn't available, manually clear the session
@@ -447,7 +447,7 @@ test.describe("Auth Session Persistence", () => {
     const originalSession = await getStoredSession(page);
 
     // WHEN the user navigates to different routes
-    const routes = ["/dashboard", "/settings", "/"];
+    const routes = ["/ledger", "/ledger/settings", "/"];
     for (const route of routes) {
       await page.goto(route);
 

--- a/quality/test-suites/sign-in-transitions/sign-in-flow.spec.ts
+++ b/quality/test-suites/sign-in-transitions/sign-in-flow.spec.ts
@@ -18,7 +18,7 @@ test.describe("Sign-In State Transitions — Issue #148", () => {
   test("Auth callback does not show removed success state flash", async ({
     page,
   }) => {
-    await page.goto("/auth/callback");
+    await page.goto("/ledger/auth/callback");
     await page.waitForLoadState("networkidle");
 
     const successMessage = page.locator('text="The wolf is named"');
@@ -27,21 +27,21 @@ test.describe("Sign-In State Transitions — Issue #148", () => {
   });
 
   test("Auth callback error state shows correctly", async ({ page }) => {
-    await page.goto("/auth/callback?error=access_denied");
+    await page.goto("/ledger/auth/callback?error=access_denied");
     await page.waitForTimeout(200);
 
     const errorHeading = page.locator('text="The Bifröst trembled"');
     await expect(errorHeading).toBeVisible({ timeout: 5000 });
 
-    const returnLink = page.locator('a[href="/sign-in"]');
+    const returnLink = page.locator('a[href="/ledger/sign-in"]');
     await expect(returnLink).toBeVisible();
   });
 
   test("Auth callback error provides return link to sign-in", async ({ page }) => {
-    await page.goto("/auth/callback?error=access_denied");
+    await page.goto("/ledger/auth/callback?error=access_denied");
     await page.waitForTimeout(200);
 
-    const returnLink = page.locator('a[href="/sign-in"]');
+    const returnLink = page.locator('a[href="/ledger/sign-in"]');
     await expect(returnLink).toBeVisible();
     await expect(returnLink).toHaveText("Return to the gate");
   });

--- a/quality/test-suites/stale-auth-nudge/stale-auth-nudge.spec.ts
+++ b/quality/test-suites/stale-auth-nudge/stale-auth-nudge.spec.ts
@@ -205,6 +205,6 @@ test.describe("AC-4: Sign-in navigation", () => {
     await getDesktopSignInBtn(page).click();
     await page.waitForURL("**/sign-in**", { timeout: 5000 });
 
-    expect(page.url()).toContain("/sign-in");
+    expect(page.url()).toContain("/ledger/sign-in");
   });
 });

--- a/quality/test-suites/stripe-direct/stripe-direct.spec.ts
+++ b/quality/test-suites/stripe-direct/stripe-direct.spec.ts
@@ -262,7 +262,7 @@ test.describe("AnonymousCheckoutModal -- must not exist", () => {
 
   test("TC-STR-021: 'Enter your email' heading does not appear on any subscription surface", async ({ page }) => {
     await clearSubscriptionState(page);
-    for (const path of ["/", "/settings"]) {
+    for (const path of ["/", "/ledger/settings"]) {
       await page.goto(`${BASE_URL}${path}`);
       await page.waitForLoadState("networkidle");
       const emailHeading = page.getByRole("heading", { name: /enter your email/i });

--- a/quality/test-suites/valhalla-financial-sort/valhalla-financial-sort.spec.ts
+++ b/quality/test-suites/valhalla-financial-sort/valhalla-financial-sort.spec.ts
@@ -51,7 +51,7 @@ test.describe("Valhalla Financial Sort — fee avoided descending (AC1)", () => 
       makeClosedCard({ cardName: "Mid Fee Card", annualFee: 9500 }),
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-    await page.goto("/valhalla", { waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await page.locator('select[aria-label="Sort order"]').selectOption("fee_avoided_desc");
 
@@ -110,7 +110,7 @@ test.describe("Valhalla Financial Sort — rewards earned descending (AC2)", () 
       }),
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-    await page.goto("/valhalla", { waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await page.locator('select[aria-label="Sort order"]').selectOption("rewards_desc");
 
@@ -157,7 +157,7 @@ test.describe("Valhalla Financial Sort — net gain descending (AC3)", () => {
       }),
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-    await page.goto("/valhalla", { waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await page.locator('select[aria-label="Sort order"]').selectOption("net_gain_desc");
 
@@ -183,7 +183,7 @@ test.describe("Valhalla Financial Sort — sort persists during session (AC4)", 
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [
       makeClosedCard({ cardName: "Test Card", annualFee: 9500 }),
     ]);
-    await page.goto("/valhalla", { waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const sortSelect = page.locator('select[aria-label="Sort order"]');
 
@@ -207,7 +207,7 @@ test.describe("Valhalla Financial Sort — sort persists during session (AC4)", 
       makeClosedCard({ cardName: "Amex Card", issuerId: "amex", annualFee: 55000 }),
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-    await page.goto("/valhalla", { waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const sortSelect = page.locator('select[aria-label="Sort order"]');
     await sortSelect.selectOption("fee_avoided_desc");

--- a/quality/test-suites/valhalla/valhalla-net-gain.spec.ts
+++ b/quality/test-suites/valhalla/valhalla-net-gain.spec.ts
@@ -62,7 +62,7 @@ test.describe("Valhalla — Net gain (positive, with earned cashback)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Profitable Card"]');
     // Spec: net gain displays with positive value
@@ -85,7 +85,7 @@ test.describe("Valhalla — Net gain (positive, with earned cashback)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Fee Card"]');
     // Spec: "Net gain:" label is always present in plunder section
@@ -110,7 +110,7 @@ test.describe("Valhalla — Net gain (positive, with earned cashback)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: High Cashback Card"]');
     // Spec: earned cashback is summed into net gain
@@ -143,7 +143,7 @@ test.describe("Valhalla — Net gain (forfeited bonuses, zero contribution)", ()
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator(
       'article[aria-label="Closed card: Forfeited Cashback Card"]'
@@ -170,7 +170,7 @@ test.describe("Valhalla — Net gain (forfeited bonuses, zero contribution)", ()
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Forfeited Points Card"]');
     // Spec: points have no monetary value, only fee avoided counts
@@ -200,7 +200,7 @@ test.describe("Valhalla — Net gain (no-fee cards)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: No-Fee Premium Card"]');
     // Spec: no-fee card shows explicit "$0 (no-fee card)" message
@@ -219,7 +219,7 @@ test.describe("Valhalla — Net gain (no-fee cards)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Zero Gain Card"]');
     // Spec: zero net gain displays in muted-foreground color
@@ -242,7 +242,7 @@ test.describe("Valhalla — Net gain (zero and neutral scenarios)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Neutral Card"]');
     // Spec: zero net gain displays in muted-foreground color
@@ -269,7 +269,7 @@ test.describe("Valhalla — Net gain (zero and neutral scenarios)", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Formatted Card"]');
     // Spec: currency displayed with proper formatting
@@ -317,7 +317,7 @@ test.describe("Valhalla — Net gain (multiple cards, mixed scenarios)", () => {
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     // Card 1: $150 + $300 = $450
     const card1 = page.locator('article[aria-label="Closed card: High Gain Card"]');
@@ -365,7 +365,7 @@ test.describe("Valhalla — Net gain (miles bonuses, zero contribution)", () => 
 
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Mixed Bonus Card"]');
     // Net gain: $100 fee + $50 cashback = $150

--- a/quality/test-suites/valhalla/valhalla.spec.ts
+++ b/quality/test-suites/valhalla/valhalla.spec.ts
@@ -43,7 +43,7 @@ test.describe("Valhalla — Page heading", () => {
   test("displays 'Valhalla' heading", async ({ page }) => {
     await setupAndGotoValhalla(page);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const heading = page.locator("h1").first();
     await expect(heading).toContainText("Valhalla");
@@ -65,7 +65,7 @@ test.describe("Valhalla — Closed cards display", () => {
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, closedCards);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     await expect(
       page.locator('article[aria-label="Closed card: Honored Card Alpha"]')
@@ -80,7 +80,7 @@ test.describe("Valhalla — Closed cards display", () => {
     const card = makeClosedCard({ cardName: "Linkable Tombstone" });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Linkable Tombstone"]');
     const viewLink = tombstone.locator('a[href*="/cards/"]');
@@ -93,7 +93,7 @@ test.describe("Valhalla — Closed cards display", () => {
       makeClosedCard({ cardName: "Filter Test Card" }),
     ]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const issuerFilter = page.locator('select[aria-label="Filter by issuer"]');
     const sortFilter = page.locator('select[aria-label="Sort order"]');
@@ -105,7 +105,7 @@ test.describe("Valhalla — Closed cards display", () => {
     await setupAndGotoValhalla(page);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, []);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     const issuerFilter = page.locator('select[aria-label="Filter by issuer"]');
     await expect(issuerFilter).not.toBeVisible();
@@ -124,7 +124,7 @@ test.describe("Valhalla — Active cards excluded", () => {
       makeUrgentCard({ cardName: "Urgent Active Card" }),
     ]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     await expect(page.locator('article[aria-label^="Closed card:"]')).toHaveCount(0);
     await expect(page.locator('[aria-label="Valhalla is empty"]')).toBeVisible();
@@ -148,7 +148,7 @@ test.describe("Valhalla — Deleted cards excluded", () => {
 
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [deletedClosedCard, honestClosedCard]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     await expect(
       page.locator('article[aria-label="Closed card: Erased From Memory"]')
@@ -167,7 +167,7 @@ test.describe("Valhalla — Deleted cards excluded", () => {
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [deletedCard]);
     await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/valhalla", { waitUntil: "networkidle" });
+    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
 
     await expect(page.locator('[aria-label="Valhalla is empty"]')).toBeVisible();
     await expect(page.locator('article[aria-label^="Closed card:"]')).toHaveCount(0);

--- a/quality/test-suites/wizard-animations/wizard-animations.spec.ts
+++ b/quality/test-suites/wizard-animations/wizard-animations.spec.ts
@@ -40,7 +40,7 @@ import {
 async function goToNewCard(page: import("@playwright/test").Page) {
   await page.goto("/", { waitUntil: "networkidle" });
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/cards/new", { waitUntil: "domcontentloaded" });
+  await page.goto("/ledger/cards/new", { waitUntil: "domcontentloaded" });
   await page.locator("#cardName").waitFor({ state: "visible", timeout: 15000 });
 }
 

--- a/quality/test-suites/wizard-step2/wizard-step2.spec.ts
+++ b/quality/test-suites/wizard-step2/wizard-step2.spec.ts
@@ -21,7 +21,7 @@ import {
 async function goToNewCard(page: import("@playwright/test").Page) {
   await page.goto("/", { waitUntil: "networkidle" });
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/cards/new", { waitUntil: "domcontentloaded" });
+  await page.goto("/ledger/cards/new", { waitUntil: "domcontentloaded" });
   await page.locator("#cardName").waitFor({ state: "visible", timeout: 15000 });
 }
 
@@ -75,7 +75,7 @@ test.describe("Wizard Step 2 — Validation", () => {
     await page.locator('button:has-text("Cancel")').click();
 
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
     const bodyText = await page.locator("body").innerText();
     expect(bodyText).not.toContain("Should Not Be Saved");
   });
@@ -115,7 +115,7 @@ test.describe("Wizard Step 2 — Save Card", () => {
 
     await page.locator('button[type="submit"]').click();
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 
   test("Save Card from Step 2 persists card to dashboard", async ({ page }) => {
@@ -141,7 +141,7 @@ test.describe("Wizard Step 2 — Save Card", () => {
     await goToStep2(page);
     await page.locator('button:has-text("Cancel")').click();
     await page.waitForURL("**/", { timeout: 5000 });
-    expect(page.url()).not.toContain("/cards/");
+    expect(page.url()).not.toContain("/ledger/cards/");
   });
 });
 


### PR DESCRIPTION
## Summary
- Migrated 26 Playwright test files from old route paths to `/ledger/` prefixed routes
- Root cause of 537/1148 (47%) CI test failures: PR #371 moved app routes under `/ledger/` but test suites still referenced old paths (`/cards/new`, `/sign-in`, `/valhalla`, `/auth/callback`, `/dashboard`, `/static`)
- All `page.goto()`, `href` locators, `toContain()` assertions, and `waitForURL()` calls updated

### Route Mapping
| Old Route | New Route |
|-----------|-----------|
| `/cards/new` | `/ledger/cards/new` |
| `/cards/{id}/edit` | `/ledger/cards/{id}/edit` |
| `/sign-in` | `/ledger/sign-in` |
| `/valhalla` | `/ledger/valhalla` |
| `/auth/callback` | `/ledger/auth/callback` |
| `/dashboard` | `/ledger` |
| `/settings` | `/ledger/settings` |
| `/static` | `/` |

Fixes #554

## Test plan
- [ ] CI Playwright suite passes (this IS the test — the 537 failures should drop to near-zero)
- [ ] Verify no double `/ledger/ledger/` prefixes in test files
- [ ] Spot-check a few test files to confirm correct route references

🤖 Generated with [Claude Code](https://claude.com/claude-code)