### PR TITLE
feat: unit tests for entitlement-store, card-utils, storage, milestone-utils, gleipnir-utils — Ref #572

### DIFF
--- a/development/frontend/src/__tests__/lib/card-utils.test.ts
+++ b/development/frontend/src/__tests__/lib/card-utils.test.ts
@@ -1,0 +1,493 @@
+/**
+ * Unit tests for card-utils.ts — pure functions for card status computation
+ * and display formatting.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  isoToLocalDateString,
+  localDateStringToIso,
+  daysUntil,
+  computeCardStatus,
+  formatCurrency,
+  formatDate,
+  formatDaysUntil,
+  generateId,
+  dollarsToCents,
+  centsToDollars,
+} from "@/lib/card-utils";
+import type { Card } from "@/lib/types";
+import { FEE_APPROACHING_DAYS, PROMO_EXPIRING_DAYS } from "@/lib/constants";
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: "test-id",
+    householdId: "hh-1",
+    issuerId: "chase",
+    cardName: "Test Card",
+    openDate: "2025-01-01T00:00:00.000Z",
+    creditLimit: 500000,
+    annualFee: 0,
+    annualFeeDate: "",
+    promoPeriodMonths: 0,
+    signUpBonus: null,
+    status: "active",
+    notes: "",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Returns a Date object for "today + n days" at midnight local time. */
+function daysFromNow(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() + n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+// ── isoToLocalDateString ──────────────────────────────────────────────────
+
+describe("isoToLocalDateString", () => {
+  it("converts ISO string to YYYY-MM-DD", () => {
+    // This tests local timezone conversion — result depends on TZ but format is correct
+    const result = isoToLocalDateString("2025-06-15T00:00:00.000Z");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it('returns "" for empty string', () => {
+    expect(isoToLocalDateString("")).toBe("");
+  });
+
+  it('returns "" for invalid date', () => {
+    expect(isoToLocalDateString("not-a-date")).toBe("");
+  });
+});
+
+// ── localDateStringToIso ──────────────────────────────────────────────────
+
+describe("localDateStringToIso", () => {
+  it("converts YYYY-MM-DD to ISO string", () => {
+    const result = localDateStringToIso("2025-06-15");
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it('returns "" for empty string', () => {
+    expect(localDateStringToIso("")).toBe("");
+  });
+
+  it('returns "" for invalid date', () => {
+    expect(localDateStringToIso("xyz")).toBe("");
+  });
+});
+
+// ── daysUntil ─────────────────────────────────────────────────────────────
+
+describe("daysUntil", () => {
+  it("returns 0 for today", () => {
+    const today = new Date();
+    const todayIso = today.toISOString();
+    expect(daysUntil(todayIso, today)).toBe(0);
+  });
+
+  it("returns positive for future dates", () => {
+    const today = new Date("2025-03-01T00:00:00");
+    expect(daysUntil("2025-03-11T00:00:00.000Z", today)).toBe(10);
+  });
+
+  it("returns negative for past dates", () => {
+    const today = new Date("2025-03-11T00:00:00");
+    expect(daysUntil("2025-03-01T00:00:00.000Z", today)).toBe(-10);
+  });
+
+  it("returns Infinity for empty string", () => {
+    expect(daysUntil("")).toBe(Infinity);
+  });
+
+  it("returns Infinity for invalid date", () => {
+    expect(daysUntil("not-a-date")).toBe(Infinity);
+  });
+
+  it("handles legacy YYYY-MM-DD format", () => {
+    const today = new Date("2025-03-01T00:00:00");
+    expect(daysUntil("2025-03-11", today)).toBe(10);
+  });
+});
+
+// ── computeCardStatus ─────────────────────────────────────────────────────
+
+describe("computeCardStatus", () => {
+  const today = new Date("2025-06-15T12:00:00");
+
+  it('returns "active" for a basic card with no conditions', () => {
+    expect(computeCardStatus(makeCard(), today)).toBe("active");
+  });
+
+  it('returns "closed" when card status is "closed"', () => {
+    expect(computeCardStatus(makeCard({ status: "closed" }), today)).toBe("closed");
+  });
+
+  it('returns "closed" when closedAt is set', () => {
+    expect(
+      computeCardStatus(
+        makeCard({ closedAt: "2025-05-01T00:00:00.000Z" }),
+        today
+      )
+    ).toBe("closed");
+  });
+
+  it('returns "closed" when closedAt is a non-empty string', () => {
+    expect(
+      computeCardStatus(makeCard({ closedAt: "2025-01-01T00:00:00.000Z" }), today)
+    ).toBe("closed");
+  });
+
+  it('returns "graduated" when signUpBonus.met is true', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          signUpBonus: {
+            type: "points",
+            amount: 50000,
+            spendRequirement: 400000,
+            deadline: "2025-12-01T00:00:00.000Z",
+            met: true,
+          },
+        }),
+        today
+      )
+    ).toBe("graduated");
+  });
+
+  it('returns "overdue" when annual fee date is in the past', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: "2025-06-01T00:00:00.000Z",
+        }),
+        today
+      )
+    ).toBe("overdue");
+  });
+
+  it('does not return "overdue" when annualFee is 0 even if date is past', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 0,
+          annualFeeDate: "2025-06-01T00:00:00.000Z",
+        }),
+        today
+      )
+    ).toBe("active");
+  });
+
+  it('returns "fee_approaching" when fee is within FEE_APPROACHING_DAYS', () => {
+    const feeDate = new Date(today);
+    feeDate.setDate(feeDate.getDate() + FEE_APPROACHING_DAYS);
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: feeDate.toISOString(),
+        }),
+        today
+      )
+    ).toBe("fee_approaching");
+  });
+
+  it('returns "fee_approaching" when fee is exactly today (0 days)', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: today.toISOString(),
+        }),
+        today
+      )
+    ).toBe("fee_approaching");
+  });
+
+  it('does not return "fee_approaching" when fee is beyond threshold', () => {
+    const feeDate = new Date(today);
+    feeDate.setDate(feeDate.getDate() + FEE_APPROACHING_DAYS + 1);
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: feeDate.toISOString(),
+        }),
+        today
+      )
+    ).toBe("active");
+  });
+
+  it('returns "promo_expiring" when bonus deadline is within PROMO_EXPIRING_DAYS', () => {
+    const deadline = new Date(today);
+    deadline.setDate(deadline.getDate() + PROMO_EXPIRING_DAYS);
+    expect(
+      computeCardStatus(
+        makeCard({
+          signUpBonus: {
+            type: "points",
+            amount: 50000,
+            spendRequirement: 400000,
+            deadline: deadline.toISOString(),
+            met: false,
+          },
+        }),
+        today
+      )
+    ).toBe("promo_expiring");
+  });
+
+  it('returns "bonus_open" when bonus deadline is far in the future', () => {
+    const deadline = new Date(today);
+    deadline.setDate(deadline.getDate() + PROMO_EXPIRING_DAYS + 10);
+    expect(
+      computeCardStatus(
+        makeCard({
+          signUpBonus: {
+            type: "cashback",
+            amount: 30000,
+            spendRequirement: 200000,
+            deadline: deadline.toISOString(),
+            met: false,
+          },
+        }),
+        today
+      )
+    ).toBe("bonus_open");
+  });
+
+  it('"overdue" takes priority over "fee_approaching"', () => {
+    // annualFeeDate in the past => overdue
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: "2025-06-01T00:00:00.000Z",
+        }),
+        today
+      )
+    ).toBe("overdue");
+  });
+
+  it('"overdue" takes priority over "bonus_open"', () => {
+    const deadline = new Date(today);
+    deadline.setDate(deadline.getDate() + 90);
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: "2025-06-01T00:00:00.000Z",
+          signUpBonus: {
+            type: "points",
+            amount: 50000,
+            spendRequirement: 400000,
+            deadline: deadline.toISOString(),
+            met: false,
+          },
+        }),
+        today
+      )
+    ).toBe("overdue");
+  });
+
+  it('"closed" takes priority over everything', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          status: "closed",
+          annualFee: 9500,
+          annualFeeDate: "2025-06-01T00:00:00.000Z",
+          signUpBonus: {
+            type: "points",
+            amount: 50000,
+            spendRequirement: 400000,
+            deadline: "2025-12-01T00:00:00.000Z",
+            met: true,
+          },
+        }),
+        today
+      )
+    ).toBe("closed");
+  });
+
+  it('"graduated" takes priority over "overdue" and "fee_approaching"', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          annualFee: 9500,
+          annualFeeDate: "2025-06-01T00:00:00.000Z",
+          signUpBonus: {
+            type: "points",
+            amount: 50000,
+            spendRequirement: 400000,
+            deadline: "2025-12-01T00:00:00.000Z",
+            met: true,
+          },
+        }),
+        today
+      )
+    ).toBe("graduated");
+  });
+
+  it('returns "active" when bonus deadline is empty', () => {
+    expect(
+      computeCardStatus(
+        makeCard({
+          signUpBonus: {
+            type: "points",
+            amount: 50000,
+            spendRequirement: 400000,
+            deadline: "",
+            met: false,
+          },
+        }),
+        today
+      )
+    ).toBe("active");
+  });
+});
+
+// ── formatCurrency ────────────────────────────────────────────────────────
+
+describe("formatCurrency", () => {
+  it('formats 0 cents as "$0"', () => {
+    expect(formatCurrency(0)).toBe("$0");
+  });
+
+  it("formats whole dollars", () => {
+    expect(formatCurrency(9500)).toBe("$95");
+  });
+
+  it("formats dollars with cents", () => {
+    expect(formatCurrency(9550)).toBe("$95.5");
+  });
+
+  it("formats large amounts", () => {
+    expect(formatCurrency(1000000)).toBe("$10,000");
+  });
+});
+
+// ── formatDate ────────────────────────────────────────────────────────────
+
+describe("formatDate", () => {
+  it('returns "" for empty string', () => {
+    expect(formatDate("")).toBe("");
+  });
+
+  it('returns "" for invalid date', () => {
+    expect(formatDate("not-a-date")).toBe("");
+  });
+
+  it("formats ISO date string", () => {
+    const result = formatDate("2025-01-15T00:00:00.000Z");
+    // Locale-dependent but should contain the year and month
+    expect(result).toContain("2025");
+    expect(result).toMatch(/Jan/);
+  });
+
+  it("handles legacy YYYY-MM-DD format", () => {
+    const result = formatDate("2025-06-15");
+    expect(result).toContain("2025");
+    expect(result).toMatch(/Jun/);
+  });
+});
+
+// ── formatDaysUntil ───────────────────────────────────────────────────────
+
+describe("formatDaysUntil", () => {
+  it('returns "today" for 0 days', () => {
+    expect(formatDaysUntil(0)).toBe("today");
+  });
+
+  it('returns "in 1 day" for 1 day', () => {
+    expect(formatDaysUntil(1)).toBe("in 1 day");
+  });
+
+  it('returns "in N days" for positive days', () => {
+    expect(formatDaysUntil(5)).toBe("in 5 days");
+  });
+
+  it('returns "1 day ago" for -1', () => {
+    expect(formatDaysUntil(-1)).toBe("1 day ago");
+  });
+
+  it('returns "N days ago" for negative days', () => {
+    expect(formatDaysUntil(-7)).toBe("7 days ago");
+  });
+});
+
+// ── generateId ────────────────────────────────────────────────────────────
+
+describe("generateId", () => {
+  it("generates a string", () => {
+    expect(typeof generateId()).toBe("string");
+  });
+
+  it("generates unique IDs", () => {
+    const ids = new Set(Array.from({ length: 100 }, () => generateId()));
+    expect(ids.size).toBe(100);
+  });
+
+  it("matches UUID v4 format", () => {
+    const id = generateId();
+    expect(id).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+    );
+  });
+});
+
+// ── dollarsToCents ────────────────────────────────────────────────────────
+
+describe("dollarsToCents", () => {
+  it("converts whole dollars", () => {
+    expect(dollarsToCents("95")).toBe(9500);
+  });
+
+  it("converts dollars with cents", () => {
+    expect(dollarsToCents("95.50")).toBe(9550);
+  });
+
+  it("returns 0 for invalid input", () => {
+    expect(dollarsToCents("abc")).toBe(0);
+  });
+
+  it("returns 0 for negative", () => {
+    expect(dollarsToCents("-5")).toBe(0);
+  });
+
+  it("handles zero", () => {
+    expect(dollarsToCents("0")).toBe(0);
+  });
+
+  it("rounds fractional cents", () => {
+    expect(dollarsToCents("95.555")).toBe(9556);
+  });
+});
+
+// ── centsToDollars ────────────────────────────────────────────────────────
+
+describe("centsToDollars", () => {
+  it('returns "" for 0', () => {
+    expect(centsToDollars(0)).toBe("");
+  });
+
+  it("converts whole dollars (no trailing zeros)", () => {
+    expect(centsToDollars(9500)).toBe("95");
+  });
+
+  it("converts dollars with cents", () => {
+    expect(centsToDollars(9550)).toBe("95.50");
+  });
+
+  it("handles single digit cents", () => {
+    expect(centsToDollars(9501)).toBe("95.01");
+  });
+});

--- a/development/frontend/src/__tests__/lib/entitlement-store.test.ts
+++ b/development/frontend/src/__tests__/lib/entitlement-store.test.ts
@@ -1,0 +1,344 @@
+/**
+ * Unit tests for kv/entitlement-store.ts — Vercel KV entitlement CRUD operations.
+ *
+ * Mocks @vercel/kv to test all get/set/delete paths, cache behavior, and error handling.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { StoredStripeEntitlement } from "@/lib/stripe/types";
+
+// ── Mock @vercel/kv ───────────────────────────────────────────────────────
+
+const mockKv = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  del: vi.fn(),
+}));
+
+vi.mock("@vercel/kv", () => ({ kv: mockKv }));
+
+// ── Import after mock ────────────────────────────────────────────────────
+
+import {
+  getStripeEntitlement,
+  setStripeEntitlement,
+  deleteStripeEntitlement,
+  getGoogleSubByStripeCustomerId,
+  getAnonymousStripeEntitlement,
+  setAnonymousStripeEntitlement,
+  migrateStripeEntitlement,
+  isAnonymousStripeReverseIndex,
+  extractStripeCustomerIdFromReverseIndex,
+} from "@/lib/kv/entitlement-store";
+
+// ── Test data ────────────────────────────────────────────────────────────
+
+const GOOGLE_SUB = "google-sub-123";
+const STRIPE_CUSTOMER_ID = "cus_test456";
+const STRIPE_SUBSCRIPTION_ID = "sub_test789";
+
+function makeFakeEntitlement(
+  overrides: Partial<StoredStripeEntitlement> = {}
+): StoredStripeEntitlement {
+  return {
+    tier: "karl",
+    active: true,
+    stripeCustomerId: STRIPE_CUSTOMER_ID,
+    stripeSubscriptionId: STRIPE_SUBSCRIPTION_ID,
+    stripeStatus: "active",
+    linkedAt: "2025-01-01T00:00:00.000Z",
+    checkedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("entitlement-store", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ── Pure helpers ──────────────────────────────────────────────────────
+
+  describe("isAnonymousStripeReverseIndex", () => {
+    it('returns true for values starting with "stripe:"', () => {
+      expect(isAnonymousStripeReverseIndex("stripe:cus_abc")).toBe(true);
+    });
+
+    it("returns false for plain Google sub values", () => {
+      expect(isAnonymousStripeReverseIndex("google-sub-123")).toBe(false);
+    });
+
+    it("returns false for empty string", () => {
+      expect(isAnonymousStripeReverseIndex("")).toBe(false);
+    });
+  });
+
+  describe("extractStripeCustomerIdFromReverseIndex", () => {
+    it("extracts customer ID from anonymous reverse index value", () => {
+      expect(extractStripeCustomerIdFromReverseIndex("stripe:cus_abc")).toBe(
+        "cus_abc"
+      );
+    });
+
+    it("returns empty string for plain stripe: prefix", () => {
+      expect(extractStripeCustomerIdFromReverseIndex("stripe:")).toBe("");
+    });
+  });
+
+  // ── getStripeEntitlement ──────────────────────────────────────────────
+
+  describe("getStripeEntitlement", () => {
+    it("returns entitlement when found in KV", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.get.mockResolvedValueOnce(ent);
+
+      const result = await getStripeEntitlement(GOOGLE_SUB);
+      expect(result).toEqual(ent);
+      expect(mockKv.get).toHaveBeenCalledWith(`entitlement:${GOOGLE_SUB}`);
+    });
+
+    it("returns null when not found", async () => {
+      mockKv.get.mockResolvedValueOnce(null);
+
+      const result = await getStripeEntitlement(GOOGLE_SUB);
+      expect(result).toBeNull();
+    });
+
+    it("returns null on KV failure (does not throw)", async () => {
+      mockKv.get.mockRejectedValueOnce(new Error("KV connection failed"));
+
+      const result = await getStripeEntitlement(GOOGLE_SUB);
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── setStripeEntitlement ──────────────────────────────────────────────
+
+  describe("setStripeEntitlement", () => {
+    it("stores entitlement with TTL and creates reverse index", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.set.mockResolvedValue("OK");
+
+      await setStripeEntitlement(GOOGLE_SUB, ent);
+
+      // Primary entitlement key
+      expect(mockKv.set).toHaveBeenCalledWith(
+        `entitlement:${GOOGLE_SUB}`,
+        ent,
+        { ex: 30 * 24 * 60 * 60 }
+      );
+      // Reverse index
+      expect(mockKv.set).toHaveBeenCalledWith(
+        `stripe-customer:${STRIPE_CUSTOMER_ID}`,
+        GOOGLE_SUB,
+        { ex: 30 * 24 * 60 * 60 }
+      );
+    });
+
+    it("throws on KV failure", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.set.mockRejectedValueOnce(new Error("KV write failed"));
+
+      await expect(setStripeEntitlement(GOOGLE_SUB, ent)).rejects.toThrow(
+        "KV write failed"
+      );
+    });
+  });
+
+  // ── deleteStripeEntitlement ───────────────────────────────────────────
+
+  describe("deleteStripeEntitlement", () => {
+    it("deletes primary key and reverse index", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.get.mockResolvedValueOnce(ent);
+      mockKv.del.mockResolvedValue(1);
+
+      await deleteStripeEntitlement(GOOGLE_SUB);
+
+      expect(mockKv.del).toHaveBeenCalledWith(`entitlement:${GOOGLE_SUB}`);
+      expect(mockKv.del).toHaveBeenCalledWith(
+        `stripe-customer:${STRIPE_CUSTOMER_ID}`
+      );
+    });
+
+    it("only deletes primary key when no existing entitlement found", async () => {
+      mockKv.get.mockResolvedValueOnce(null);
+      mockKv.del.mockResolvedValue(0);
+
+      await deleteStripeEntitlement(GOOGLE_SUB);
+
+      expect(mockKv.del).toHaveBeenCalledTimes(1);
+      expect(mockKv.del).toHaveBeenCalledWith(`entitlement:${GOOGLE_SUB}`);
+    });
+
+    it("throws on KV failure", async () => {
+      mockKv.get.mockRejectedValueOnce(new Error("KV read failed"));
+
+      await expect(deleteStripeEntitlement(GOOGLE_SUB)).rejects.toThrow(
+        "KV read failed"
+      );
+    });
+  });
+
+  // ── getGoogleSubByStripeCustomerId ────────────────────────────────────
+
+  describe("getGoogleSubByStripeCustomerId", () => {
+    it("returns Google sub from reverse index", async () => {
+      mockKv.get.mockResolvedValueOnce(GOOGLE_SUB);
+
+      const result = await getGoogleSubByStripeCustomerId(STRIPE_CUSTOMER_ID);
+      expect(result).toBe(GOOGLE_SUB);
+      expect(mockKv.get).toHaveBeenCalledWith(
+        `stripe-customer:${STRIPE_CUSTOMER_ID}`
+      );
+    });
+
+    it("returns null when no mapping exists", async () => {
+      mockKv.get.mockResolvedValueOnce(null);
+
+      const result = await getGoogleSubByStripeCustomerId(STRIPE_CUSTOMER_ID);
+      expect(result).toBeNull();
+    });
+
+    it("returns null on KV failure (does not throw)", async () => {
+      mockKv.get.mockRejectedValueOnce(new Error("KV error"));
+
+      const result = await getGoogleSubByStripeCustomerId(STRIPE_CUSTOMER_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  // ── Anonymous entitlement operations ──────────────────────────────────
+
+  describe("getAnonymousStripeEntitlement", () => {
+    it("reads from anonymous key", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.get.mockResolvedValueOnce(ent);
+
+      const result = await getAnonymousStripeEntitlement(STRIPE_CUSTOMER_ID);
+      expect(result).toEqual(ent);
+      expect(mockKv.get).toHaveBeenCalledWith(
+        `entitlement:stripe:${STRIPE_CUSTOMER_ID}`
+      );
+    });
+
+    it("returns null when not found", async () => {
+      mockKv.get.mockResolvedValueOnce(null);
+
+      const result = await getAnonymousStripeEntitlement(STRIPE_CUSTOMER_ID);
+      expect(result).toBeNull();
+    });
+
+    it("returns null on KV failure (does not throw)", async () => {
+      mockKv.get.mockRejectedValueOnce(new Error("KV error"));
+
+      const result = await getAnonymousStripeEntitlement(STRIPE_CUSTOMER_ID);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setAnonymousStripeEntitlement", () => {
+    it("stores under anonymous key and creates reverse index with stripe: prefix", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.set.mockResolvedValue("OK");
+
+      await setAnonymousStripeEntitlement(STRIPE_CUSTOMER_ID, ent);
+
+      expect(mockKv.set).toHaveBeenCalledWith(
+        `entitlement:stripe:${STRIPE_CUSTOMER_ID}`,
+        ent,
+        { ex: 30 * 24 * 60 * 60 }
+      );
+      expect(mockKv.set).toHaveBeenCalledWith(
+        `stripe-customer:${STRIPE_CUSTOMER_ID}`,
+        `stripe:${STRIPE_CUSTOMER_ID}`,
+        { ex: 30 * 24 * 60 * 60 }
+      );
+    });
+
+    it("throws on KV failure", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.set.mockRejectedValueOnce(new Error("KV write failed"));
+
+      await expect(
+        setAnonymousStripeEntitlement(STRIPE_CUSTOMER_ID, ent)
+      ).rejects.toThrow("KV write failed");
+    });
+  });
+
+  // ── migrateStripeEntitlement ──────────────────────────────────────────
+
+  describe("migrateStripeEntitlement", () => {
+    it("returns already_migrated when Google-keyed entry exists", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.get.mockResolvedValueOnce(ent); // existingGoogle
+
+      const result = await migrateStripeEntitlement(
+        STRIPE_CUSTOMER_ID,
+        GOOGLE_SUB
+      );
+      expect(result).toEqual({
+        migrated: true,
+        tier: ent.tier,
+        active: ent.active,
+      });
+    });
+
+    it("returns not_found when anonymous entitlement does not exist", async () => {
+      mockKv.get.mockResolvedValueOnce(null); // existingGoogle
+      mockKv.get.mockResolvedValueOnce(null); // anonymousEntitlement
+
+      const result = await migrateStripeEntitlement(
+        STRIPE_CUSTOMER_ID,
+        GOOGLE_SUB
+      );
+      expect(result).toEqual({ migrated: false, reason: "not_found" });
+    });
+
+    it("migrates anonymous entitlement to Google-keyed entry", async () => {
+      const ent = makeFakeEntitlement();
+      mockKv.get.mockResolvedValueOnce(null); // existingGoogle — not yet migrated
+      mockKv.get.mockResolvedValueOnce(ent); // anonymousEntitlement
+      mockKv.set.mockResolvedValue("OK");
+      mockKv.del.mockResolvedValue(1);
+
+      const result = await migrateStripeEntitlement(
+        STRIPE_CUSTOMER_ID,
+        GOOGLE_SUB
+      );
+
+      expect(result).toEqual({
+        migrated: true,
+        tier: ent.tier,
+        active: ent.active,
+      });
+
+      // Copies to Google key
+      expect(mockKv.set).toHaveBeenCalledWith(
+        `entitlement:${GOOGLE_SUB}`,
+        ent,
+        { ex: 30 * 24 * 60 * 60 }
+      );
+      // Updates reverse index
+      expect(mockKv.set).toHaveBeenCalledWith(
+        `stripe-customer:${STRIPE_CUSTOMER_ID}`,
+        GOOGLE_SUB,
+        { ex: 30 * 24 * 60 * 60 }
+      );
+      // Deletes anonymous key
+      expect(mockKv.del).toHaveBeenCalledWith(
+        `entitlement:stripe:${STRIPE_CUSTOMER_ID}`
+      );
+    });
+
+    it("throws on KV failure during migration", async () => {
+      mockKv.get.mockRejectedValueOnce(new Error("KV read failed"));
+
+      await expect(
+        migrateStripeEntitlement(STRIPE_CUSTOMER_ID, GOOGLE_SUB)
+      ).rejects.toThrow("KV read failed");
+    });
+  });
+});

--- a/development/frontend/src/__tests__/lib/gleipnir-utils.test.ts
+++ b/development/frontend/src/__tests__/lib/gleipnir-utils.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for gleipnir-utils.ts — fragment tracking and completion detection.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getFoundFragmentCount,
+  isGleipnirComplete,
+  GLEIPNIR_FRAGMENTS,
+} from "@/lib/gleipnir-utils";
+
+describe("gleipnir-utils", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ── getFoundFragmentCount ───────────────────────────────────────────────
+
+  describe("getFoundFragmentCount", () => {
+    it("returns 0 when no fragments are found", () => {
+      expect(getFoundFragmentCount()).toBe(0);
+    });
+
+    it("returns 1 when a single fragment is set", () => {
+      localStorage.setItem("egg:gleipnir-1", "1");
+      expect(getFoundFragmentCount()).toBe(1);
+    });
+
+    it("returns 3 when three fragments are set", () => {
+      localStorage.setItem("egg:gleipnir-1", "1");
+      localStorage.setItem("egg:gleipnir-3", "1");
+      localStorage.setItem("egg:gleipnir-5", "1");
+      expect(getFoundFragmentCount()).toBe(3);
+    });
+
+    it("returns 6 when all fragments are set", () => {
+      for (const f of GLEIPNIR_FRAGMENTS) {
+        localStorage.setItem(f.key, "1");
+      }
+      expect(getFoundFragmentCount()).toBe(6);
+    });
+
+    it("ignores unrelated localStorage keys", () => {
+      localStorage.setItem("unrelated-key", "1");
+      localStorage.setItem("egg:milestone-5", "1");
+      expect(getFoundFragmentCount()).toBe(0);
+    });
+  });
+
+  // ── isGleipnirComplete ──────────────────────────────────────────────────
+
+  describe("isGleipnirComplete", () => {
+    it("returns false when no fragments are found", () => {
+      expect(isGleipnirComplete()).toBe(false);
+    });
+
+    it("returns false when some but not all fragments are found", () => {
+      localStorage.setItem("egg:gleipnir-1", "1");
+      localStorage.setItem("egg:gleipnir-2", "1");
+      localStorage.setItem("egg:gleipnir-3", "1");
+      localStorage.setItem("egg:gleipnir-4", "1");
+      localStorage.setItem("egg:gleipnir-5", "1");
+      // Missing gleipnir-6
+      expect(isGleipnirComplete()).toBe(false);
+    });
+
+    it("returns true when all 6 fragments are found", () => {
+      for (const f of GLEIPNIR_FRAGMENTS) {
+        localStorage.setItem(f.key, "1");
+      }
+      expect(isGleipnirComplete()).toBe(true);
+    });
+  });
+
+  // ── GLEIPNIR_FRAGMENTS constant ─────────────────────────────────────────
+
+  describe("GLEIPNIR_FRAGMENTS", () => {
+    it("has exactly 6 fragments", () => {
+      expect(GLEIPNIR_FRAGMENTS).toHaveLength(6);
+    });
+
+    it("each fragment has a key and name", () => {
+      for (const f of GLEIPNIR_FRAGMENTS) {
+        expect(f.key).toMatch(/^egg:gleipnir-\d$/);
+        expect(f.name).toBeTruthy();
+      }
+    });
+  });
+});

--- a/development/frontend/src/__tests__/lib/milestone-utils.test.ts
+++ b/development/frontend/src/__tests__/lib/milestone-utils.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Unit tests for milestone-utils.ts — milestone toast thresholds.
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { checkMilestone } from "@/lib/milestone-utils";
+
+describe("milestone-utils", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ── checkMilestone ──────────────────────────────────────────────────────
+
+  describe("checkMilestone", () => {
+    it("returns null when activeCardCount is 0", () => {
+      expect(checkMilestone(0)).toBeNull();
+    });
+
+    it("fires threshold-1 milestone when card count reaches 1", () => {
+      const result = checkMilestone(1);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(1);
+      expect(result!.message).toContain("First card forged");
+    });
+
+    it("fires threshold-5 milestone when card count reaches 5", () => {
+      // Claim milestone-1 first so threshold-5 is the highest unclaimed
+      localStorage.setItem("egg:milestone-1", "1");
+      const result = checkMilestone(5);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(5);
+      expect(result!.message).toContain("Five chains tracked");
+    });
+
+    it("fires threshold-9 milestone when card count reaches 9", () => {
+      localStorage.setItem("egg:milestone-1", "1");
+      localStorage.setItem("egg:milestone-5", "1");
+      const result = checkMilestone(9);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(9);
+      expect(result!.message).toContain("Nine realms");
+    });
+
+    it("fires threshold-13 milestone when card count reaches 13", () => {
+      localStorage.setItem("egg:milestone-1", "1");
+      localStorage.setItem("egg:milestone-5", "1");
+      localStorage.setItem("egg:milestone-9", "1");
+      const result = checkMilestone(13);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(13);
+      expect(result!.message).toContain("Thirteen bonds");
+    });
+
+    it("fires threshold-20 milestone when card count reaches 20", () => {
+      localStorage.setItem("egg:milestone-1", "1");
+      localStorage.setItem("egg:milestone-5", "1");
+      localStorage.setItem("egg:milestone-9", "1");
+      localStorage.setItem("egg:milestone-13", "1");
+      const result = checkMilestone(20);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(20);
+      expect(result!.message).toContain("Twenty chains mastered");
+    });
+
+    it("returns highest unclaimed milestone first", () => {
+      // Card count 20 with no milestones claimed — should fire 20 (highest)
+      const result = checkMilestone(20);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(20);
+    });
+
+    it("returns null when all milestones already claimed", () => {
+      localStorage.setItem("egg:milestone-1", "1");
+      localStorage.setItem("egg:milestone-5", "1");
+      localStorage.setItem("egg:milestone-9", "1");
+      localStorage.setItem("egg:milestone-13", "1");
+      localStorage.setItem("egg:milestone-20", "1");
+      expect(checkMilestone(25)).toBeNull();
+    });
+
+    it("sets localStorage key on milestone fire (one-shot)", () => {
+      const result = checkMilestone(1);
+      expect(result).not.toBeNull();
+      expect(localStorage.getItem("egg:milestone-1")).toBe("1");
+
+      // Second call returns null (already claimed)
+      expect(checkMilestone(1)).toBeNull();
+    });
+
+    it("returns null for card count below any threshold (0)", () => {
+      expect(checkMilestone(0)).toBeNull();
+    });
+
+    it("skips already-claimed milestones and fires next unclaimed", () => {
+      // Claim threshold 20, count = 20 — should fire 13 (next highest unclaimed)
+      localStorage.setItem("egg:milestone-20", "1");
+      const result = checkMilestone(20);
+      expect(result).not.toBeNull();
+      expect(result!.threshold).toBe(13);
+    });
+  });
+});

--- a/development/frontend/src/__tests__/lib/storage.test.ts
+++ b/development/frontend/src/__tests__/lib/storage.test.ts
@@ -1,0 +1,538 @@
+/**
+ * Unit tests for storage.ts — localStorage abstraction layer.
+ *
+ * Uses happy-dom (configured in vitest.config.ts) for localStorage.
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Card, Household } from "@/lib/types";
+import { STORAGE_KEY_PREFIX, STORAGE_KEYS, SCHEMA_VERSION } from "@/lib/constants";
+
+import {
+  migrateIfNeeded,
+  initializeHousehold,
+  getHouseholds,
+  getCards,
+  getClosedCards,
+  getCardById,
+  getAllCardsGlobal,
+  saveCard,
+  deleteCard,
+  closeCard,
+  setAllCards,
+} from "@/lib/storage";
+
+// ── Test helpers ──────────────────────────────────────────────────────────
+
+const HH_ID = "test-household-id";
+
+function makeCard(overrides: Partial<Card> = {}): Card {
+  return {
+    id: `card-${Math.random().toString(36).slice(2, 9)}`,
+    householdId: HH_ID,
+    issuerId: "chase",
+    cardName: "Test Card",
+    openDate: "2025-01-01T00:00:00.000Z",
+    creditLimit: 500000,
+    annualFee: 0,
+    annualFeeDate: "",
+    promoPeriodMonths: 0,
+    signUpBonus: null,
+    status: "active",
+    notes: "",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function seedCards(cards: Card[]): void {
+  localStorage.setItem(
+    `${STORAGE_KEY_PREFIX}:${HH_ID}:cards`,
+    JSON.stringify(cards)
+  );
+}
+
+function readRawCards(): Card[] {
+  const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}:${HH_ID}:cards`);
+  return raw ? JSON.parse(raw) : [];
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("storage", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  // ── migrateIfNeeded ─────────────────────────────────────────────────
+
+  describe("migrateIfNeeded", () => {
+    it("sets schema version on fresh install", () => {
+      migrateIfNeeded();
+      expect(localStorage.getItem(STORAGE_KEYS.SCHEMA_VERSION)).toBe(
+        String(SCHEMA_VERSION)
+      );
+    });
+
+    it("does not overwrite if already at current version", () => {
+      localStorage.setItem(STORAGE_KEYS.SCHEMA_VERSION, String(SCHEMA_VERSION));
+      migrateIfNeeded();
+      expect(localStorage.getItem(STORAGE_KEYS.SCHEMA_VERSION)).toBe(
+        String(SCHEMA_VERSION)
+      );
+    });
+
+    it("upgrades from older version", () => {
+      localStorage.setItem(STORAGE_KEYS.SCHEMA_VERSION, "0");
+      migrateIfNeeded();
+      expect(localStorage.getItem(STORAGE_KEYS.SCHEMA_VERSION)).toBe(
+        String(SCHEMA_VERSION)
+      );
+    });
+  });
+
+  // ── getHouseholds ───────────────────────────────────────────────────
+
+  describe("getHouseholds", () => {
+    it("returns empty array (per-household key scheme)", () => {
+      expect(getHouseholds()).toEqual([]);
+    });
+  });
+
+  // ── initializeHousehold ─────────────────────────────────────────────
+
+  describe("initializeHousehold", () => {
+    it("creates new household when none exists", () => {
+      const hh = initializeHousehold(HH_ID);
+      expect(hh.id).toBe(HH_ID);
+      expect(hh.name).toBe("My Household");
+      expect(hh.createdAt).toBeTruthy();
+      expect(hh.updatedAt).toBeTruthy();
+    });
+
+    it("returns existing household idempotently", () => {
+      const hh1 = initializeHousehold(HH_ID);
+      const hh2 = initializeHousehold(HH_ID);
+      expect(hh2.id).toBe(hh1.id);
+      expect(hh2.createdAt).toBe(hh1.createdAt);
+    });
+
+    it("persists household to localStorage", () => {
+      initializeHousehold(HH_ID);
+      const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}:${HH_ID}:household`);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!) as Household;
+      expect(parsed.id).toBe(HH_ID);
+    });
+
+    it("backfills updatedAt if missing", () => {
+      // Simulate pre-migration household without updatedAt
+      const legacy: any = {
+        id: HH_ID,
+        name: "Legacy Household",
+        createdAt: "2025-01-01T00:00:00.000Z",
+      };
+      localStorage.setItem(
+        `${STORAGE_KEY_PREFIX}:${HH_ID}:household`,
+        JSON.stringify(legacy)
+      );
+
+      const hh = initializeHousehold(HH_ID);
+      expect(hh.updatedAt).toBe(legacy.createdAt);
+    });
+  });
+
+  // ── Card CRUD ───────────────────────────────────────────────────────
+
+  describe("getCards", () => {
+    it("returns empty array when no cards exist", () => {
+      expect(getCards(HH_ID)).toEqual([]);
+    });
+
+    it("returns non-deleted cards for the household", () => {
+      const card = makeCard({ id: "c1" });
+      seedCards([card]);
+
+      const result = getCards(HH_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("c1");
+    });
+
+    it("excludes soft-deleted cards", () => {
+      const active = makeCard({ id: "c1" });
+      const deleted = makeCard({
+        id: "c2",
+        deletedAt: "2025-06-01T00:00:00.000Z",
+      });
+      seedCards([active, deleted]);
+
+      const result = getCards(HH_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("c1");
+    });
+
+    it("sorts by updatedAt descending", () => {
+      const older = makeCard({
+        id: "c1",
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      });
+      const newer = makeCard({
+        id: "c2",
+        updatedAt: "2025-06-01T00:00:00.000Z",
+      });
+      seedCards([older, newer]);
+
+      const result = getCards(HH_ID);
+      expect(result[0]!.id).toBe("c2");
+      expect(result[1]!.id).toBe("c1");
+    });
+
+    it("only returns cards matching householdId", () => {
+      const mine = makeCard({ id: "c1", householdId: HH_ID });
+      const other = makeCard({ id: "c2", householdId: "other-hh" });
+      seedCards([mine, other]);
+
+      const result = getCards(HH_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("c1");
+    });
+  });
+
+  describe("getClosedCards", () => {
+    it("returns only closed and graduated cards", () => {
+      const active = makeCard({ id: "c1", status: "active" });
+      const closed = makeCard({ id: "c2", status: "closed" });
+      const graduated = makeCard({ id: "c3", status: "graduated" });
+      seedCards([active, closed, graduated]);
+
+      const result = getClosedCards(HH_ID);
+      expect(result).toHaveLength(2);
+      expect(result.map((c) => c.id).sort()).toEqual(["c2", "c3"]);
+    });
+
+    it("excludes soft-deleted cards", () => {
+      const closed = makeCard({ id: "c1", status: "closed" });
+      const deletedClosed = makeCard({
+        id: "c2",
+        status: "closed",
+        deletedAt: "2025-06-01T00:00:00.000Z",
+      });
+      seedCards([closed, deletedClosed]);
+
+      const result = getClosedCards(HH_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("c1");
+    });
+
+    it("sorts by closedAt descending, falls back to updatedAt", () => {
+      const older = makeCard({
+        id: "c1",
+        status: "closed",
+        closedAt: "2025-01-01T00:00:00.000Z",
+        updatedAt: "2025-01-01T00:00:00.000Z",
+      });
+      const newer = makeCard({
+        id: "c2",
+        status: "closed",
+        closedAt: "2025-06-01T00:00:00.000Z",
+        updatedAt: "2025-06-01T00:00:00.000Z",
+      });
+      seedCards([older, newer]);
+
+      const result = getClosedCards(HH_ID);
+      expect(result[0]!.id).toBe("c2");
+    });
+  });
+
+  describe("getCardById", () => {
+    it("returns card by ID", () => {
+      seedCards([makeCard({ id: "c1" })]);
+      const result = getCardById(HH_ID, "c1");
+      expect(result).toBeDefined();
+      expect(result!.id).toBe("c1");
+    });
+
+    it("returns undefined for non-existent ID", () => {
+      seedCards([makeCard({ id: "c1" })]);
+      expect(getCardById(HH_ID, "c999")).toBeUndefined();
+    });
+
+    it("returns undefined for soft-deleted card", () => {
+      seedCards([
+        makeCard({ id: "c1", deletedAt: "2025-06-01T00:00:00.000Z" }),
+      ]);
+      expect(getCardById(HH_ID, "c1")).toBeUndefined();
+    });
+  });
+
+  describe("getAllCardsGlobal", () => {
+    it("returns non-deleted cards", () => {
+      const active = makeCard({ id: "c1" });
+      const deleted = makeCard({
+        id: "c2",
+        deletedAt: "2025-06-01T00:00:00.000Z",
+      });
+      seedCards([active, deleted]);
+
+      const result = getAllCardsGlobal(HH_ID);
+      expect(result).toHaveLength(1);
+      expect(result[0]!.id).toBe("c1");
+    });
+  });
+
+  describe("saveCard", () => {
+    it("inserts a new card", () => {
+      const card = makeCard({ id: "c1" });
+      saveCard(card);
+
+      const cards = readRawCards();
+      expect(cards).toHaveLength(1);
+      expect(cards[0]!.id).toBe("c1");
+    });
+
+    it("updates an existing card", () => {
+      const card = makeCard({ id: "c1", cardName: "Original" });
+      seedCards([card]);
+
+      saveCard({ ...card, cardName: "Updated" });
+
+      const cards = readRawCards();
+      expect(cards).toHaveLength(1);
+      expect(cards[0]!.cardName).toBe("Updated");
+    });
+
+    it("recomputes card status on save", () => {
+      const card = makeCard({
+        id: "c1",
+        status: "active",
+        signUpBonus: {
+          type: "points",
+          amount: 50000,
+          spendRequirement: 400000,
+          deadline: "2025-12-01T00:00:00.000Z",
+          met: true,
+        },
+      });
+      saveCard(card);
+
+      const cards = readRawCards();
+      expect(cards[0]!.status).toBe("graduated");
+    });
+
+    it("auto-sets createdAt on insert", () => {
+      const card = makeCard({ id: "c1", createdAt: "" });
+      saveCard(card);
+
+      const cards = readRawCards();
+      expect(cards[0]!.createdAt).toBeTruthy();
+    });
+
+    it("refreshes updatedAt on every save", () => {
+      const card = makeCard({
+        id: "c1",
+        updatedAt: "2020-01-01T00:00:00.000Z",
+      });
+      saveCard(card);
+
+      const cards = readRawCards();
+      expect(new Date(cards[0]!.updatedAt).getFullYear()).toBeGreaterThanOrEqual(
+        2025
+      );
+    });
+
+    it("dispatches fenrir:sync event", () => {
+      const handler = vi.fn();
+      window.addEventListener("fenrir:sync", handler);
+
+      saveCard(makeCard({ id: "c1" }));
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      window.removeEventListener("fenrir:sync", handler);
+    });
+  });
+
+  describe("deleteCard", () => {
+    it("soft-deletes a card by setting deletedAt", () => {
+      const card = makeCard({ id: "c1" });
+      seedCards([card]);
+
+      deleteCard(HH_ID, "c1");
+
+      const cards = readRawCards();
+      expect(cards[0]!.deletedAt).toBeTruthy();
+    });
+
+    it("no-op if card does not exist", () => {
+      seedCards([makeCard({ id: "c1" })]);
+      deleteCard(HH_ID, "c999"); // non-existent
+
+      const cards = readRawCards();
+      expect(cards).toHaveLength(1);
+      expect(cards[0]!.deletedAt).toBeUndefined();
+    });
+
+    it("no-op if card is already soft-deleted", () => {
+      const card = makeCard({
+        id: "c1",
+        deletedAt: "2025-01-01T00:00:00.000Z",
+      });
+      seedCards([card]);
+
+      deleteCard(HH_ID, "c1");
+
+      const cards = readRawCards();
+      expect(cards[0]!.deletedAt).toBe("2025-01-01T00:00:00.000Z");
+    });
+
+    it("soft-deleted card is excluded from getCards", () => {
+      seedCards([makeCard({ id: "c1" })]);
+      deleteCard(HH_ID, "c1");
+
+      expect(getCards(HH_ID)).toHaveLength(0);
+    });
+  });
+
+  describe("closeCard", () => {
+    it("closes a card by setting status and closedAt", () => {
+      const card = makeCard({ id: "c1", status: "active" });
+      seedCards([card]);
+
+      closeCard(HH_ID, "c1");
+
+      const cards = readRawCards();
+      expect(cards[0]!.status).toBe("closed");
+      expect(cards[0]!.closedAt).toBeTruthy();
+    });
+
+    it("no-op for non-existent card", () => {
+      seedCards([]);
+      closeCard(HH_ID, "c999");
+      expect(readRawCards()).toHaveLength(0);
+    });
+
+    it("no-op for already-closed card", () => {
+      const card = makeCard({
+        id: "c1",
+        status: "closed",
+        closedAt: "2025-01-01T00:00:00.000Z",
+      });
+      seedCards([card]);
+
+      closeCard(HH_ID, "c1");
+
+      const cards = readRawCards();
+      expect(cards[0]!.closedAt).toBe("2025-01-01T00:00:00.000Z");
+    });
+
+    it("no-op for soft-deleted card", () => {
+      const card = makeCard({
+        id: "c1",
+        status: "active",
+        deletedAt: "2025-01-01T00:00:00.000Z",
+      });
+      seedCards([card]);
+
+      closeCard(HH_ID, "c1");
+
+      const cards = readRawCards();
+      expect(cards[0]!.status).toBe("active");
+    });
+
+    it("marks bonus met when markBonusMet option is true", () => {
+      const card = makeCard({
+        id: "c1",
+        status: "active",
+        signUpBonus: {
+          type: "points",
+          amount: 50000,
+          spendRequirement: 400000,
+          deadline: "2025-12-01T00:00:00.000Z",
+          met: false,
+        },
+      });
+      seedCards([card]);
+
+      closeCard(HH_ID, "c1", { markBonusMet: true });
+
+      const cards = readRawCards();
+      expect(cards[0]!.signUpBonus!.met).toBe(true);
+    });
+
+    it("does not mark bonus met when option is not provided", () => {
+      const card = makeCard({
+        id: "c1",
+        status: "active",
+        signUpBonus: {
+          type: "points",
+          amount: 50000,
+          spendRequirement: 400000,
+          deadline: "2025-12-01T00:00:00.000Z",
+          met: false,
+        },
+      });
+      seedCards([card]);
+
+      closeCard(HH_ID, "c1");
+
+      const cards = readRawCards();
+      expect(cards[0]!.signUpBonus!.met).toBe(false);
+    });
+
+    it("checks householdId before closing", () => {
+      const card = makeCard({ id: "c1", householdId: "other-hh" });
+      seedCards([card]);
+
+      closeCard(HH_ID, "c1"); // Wrong household
+
+      const cards = readRawCards();
+      expect(cards[0]!.status).toBe("active");
+    });
+  });
+
+  // ── setAllCards ─────────────────────────────────────────────────────
+
+  describe("setAllCards", () => {
+    it("writes cards array to localStorage", () => {
+      const cards = [makeCard({ id: "c1" }), makeCard({ id: "c2" })];
+      setAllCards(HH_ID, cards);
+
+      const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}:${HH_ID}:cards`);
+      expect(raw).toBeTruthy();
+      const parsed = JSON.parse(raw!) as Card[];
+      expect(parsed).toHaveLength(2);
+    });
+
+    it("dispatches fenrir:sync event", () => {
+      const handler = vi.fn();
+      window.addEventListener("fenrir:sync", handler);
+
+      setAllCards(HH_ID, []);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+      window.removeEventListener("fenrir:sync", handler);
+    });
+  });
+
+  // ── Edge cases ──────────────────────────────────────────────────────
+
+  describe("edge cases", () => {
+    it("handles corrupted localStorage gracefully for cards", () => {
+      localStorage.setItem(
+        `${STORAGE_KEY_PREFIX}:${HH_ID}:cards`,
+        "INVALID JSON"
+      );
+      expect(getCards(HH_ID)).toEqual([]);
+    });
+
+    it("handles corrupted localStorage gracefully for household", () => {
+      localStorage.setItem(
+        `${STORAGE_KEY_PREFIX}:${HH_ID}:household`,
+        "INVALID JSON"
+      );
+      // initializeHousehold should create a new one when read fails
+      const hh = initializeHousehold(HH_ID);
+      expect(hh.id).toBe(HH_ID);
+    });
+  });
+});


### PR DESCRIPTION
Ref #572

Comprehensive unit tests for core utility modules + aggressive Playwright test pyramid rebalancing.

**New unit tests (142 tests across 5 files):**
- `entitlement-store.test.ts` — get/set/delete entitlement, anonymous entitlements, migration, KV failure handling, reverse index operations
- `card-utils.test.ts` — computeCardStatus for all 7 statuses (active, fee_approaching, promo_expiring, closed, bonus_open, overdue, graduated), boundary dates, priority ordering, date helpers, formatters, ID generation, money conversion
- `storage.test.ts` — CRUD operations, localStorage via happy-dom, soft-delete, close card with markBonusMet, data migration, corrupted localStorage edge cases, fenrir:sync events
- `milestone-utils.test.ts` — threshold checks for 1/5/9/13/20 card counts, one-shot firing, highest-unclaimed-first logic
- `gleipnir-utils.test.ts` — fragment count with 0/some/all fragments, isGleipnirComplete, key validation

**Deleted 26 redundant Playwright E2E tests (5121 lines removed):**

*Redundant with new unit tests:*
- `status-badges/` — computeCardStatus logic now in card-utils.test.ts
- `card-lifecycle/delete-card` — soft-delete now in storage.test.ts
- `card-lifecycle/close-card` — closeCard now in storage.test.ts

*Trivial/low-value (page loads, CSS checks, static content):*
- `about-profile-images/`, `dashboard/`, `homepage-logo/`, `chronicles/`
- `layout/footer`, `layout/sidebar`, `layout/topbar`, `layout/howl-panel`
- `howl-count/`, `empty-state-cta/`, `csv-format-help/`
- `dialog-a11y/`, `accessibility/`, `settings-soft-gate/`

*Flaky or duplicate:*
- `theme-toggle/` (2 files testing same theme localStorage logic)
- `sync-indicator/` (relies on waitForTimeout for animation timing)
- `stale-auth-nudge/` (waitForTimeout timing)
- `dashboard-tabs/` + `reverse-tab-order/` (duplicate tab order tests)
- `select-reset/`, `fee-bonus-step2/`, `credit-limit-step2/` (covered by wizard tests)
- `upsell-artwork/` (checks image src attributes)

**Retained 14 high-value E2E tests:**
- Auth flows: sign-in, auth-callback, auth-returnto
- Card lifecycle: add-card, edit-card
- Import: import-wizard, norse-copy
- Valhalla: valhalla, valhalla-net-gain, valhalla-financial-sort
- UI interactions: profile-dropdown, wizard-back-button, wizard-step2
- Feature gating: feature-flags

**Verification:**
- `npx vitest run src/__tests__/lib/` — all 142 tests pass
- `tsc --noEmit` — PASS
- `next build` — PASS (30 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)