### PR TITLE
perf: optimize Playwright CI + test performance

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -28,6 +28,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
+          cache-dependency-path: development/frontend/package-lock.json
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('development/frontend/package-lock.json') }}
 
       - name: Resolve preview URL
         id: url
@@ -40,10 +49,22 @@ jobs:
             echo "branch=${{ github.event.deployment.ref }}" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install dependencies
+        working-directory: development/frontend
+        run: npm ci
+        timeout-minutes: 5
+
       - name: Install Playwright browsers
         working-directory: development/frontend
-        run: npm ci && npx playwright install --with-deps chromium
-        timeout-minutes: 10
+        run: npx playwright install --with-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        timeout-minutes: 5
+
+      - name: Install Playwright browser deps (cached)
+        working-directory: development/frontend
+        run: npx playwright install-deps chromium
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        timeout-minutes: 2
 
       - name: Run Playwright tests against preview
         id: playwright

--- a/development/frontend/playwright.config.ts
+++ b/development/frontend/playwright.config.ts
@@ -7,13 +7,13 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: false,
   retries: 0,
-  workers: 2,
+  workers: process.env.CI ? 2 : (process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : 4),
   reporter: process.env.CI
     ? [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]]
     : "list",
   use: {
     baseURL: process.env.SERVER_URL || "http://localhost:9653",
-    trace: "on-first-retry",
+    trace: "off",
     // Pass Vercel's automation bypass secret as a header so tests can reach
     // preview deployments that are behind deployment protection.
     extraHTTPHeaders: process.env.VERCEL_BYPASS_SECRET

--- a/quality/test-suites/accessibility/a11y.spec.ts
+++ b/quality/test-suites/accessibility/a11y.spec.ts
@@ -39,7 +39,7 @@ test.describe("Page Landmarks", () => {
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
   });
 
   test("TC-A01: main landmark exists on dashboard", async ({ page }) => {
@@ -88,7 +88,7 @@ test.describe("Heading Hierarchy", () => {
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     const h1 = page.locator("h1").first();
     await expect(h1).toBeVisible();
@@ -118,7 +118,7 @@ test.describe("Heading Hierarchy", () => {
     await page.goto("/ledger/cards/new");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Wait for the form to render — it's gated behind status !== "loading"
     const heading = page.locator("h1, h2, h3").first();
@@ -137,7 +137,7 @@ test.describe("Form Accessibility", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
     // Navigate to the add card form
     await page.goto("/ledger/cards/new");
     // Wait for the form to appear (gated behind auth status resolution)
@@ -237,7 +237,7 @@ test.describe("Keyboard Navigation", () => {
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     const focusedElements = new Set<string>();
 
@@ -272,7 +272,7 @@ test.describe("Keyboard Navigation", () => {
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Find a card tile link — each card wraps in <Link href="/ledger/cards/{id}/edit">
     const cardLinks = page.locator('a[href*="/cards/"][href*="/edit"]');
@@ -319,7 +319,7 @@ test.describe("Screen Reader Support", () => {
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, URGENT_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Badges are <span> elements inside the card tile header area with
     // aria-label="Card status: {label}"
@@ -354,7 +354,7 @@ test.describe("Screen Reader Support", () => {
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // At least one aria-live region must be present in the page
     const liveRegions = page.locator(
@@ -374,7 +374,7 @@ test.describe("Screen Reader Support", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // TopBar renders the anonymous avatar button when not authenticated
     const avatarButton = page.locator(
@@ -390,7 +390,7 @@ test.describe("Screen Reader Support", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // In expanded state the button has aria-label="Collapse sidebar"
     const collapseButton = page.locator(

--- a/quality/test-suites/auth-returnto/auth-returnto.spec.ts
+++ b/quality/test-suites/auth-returnto/auth-returnto.spec.ts
@@ -48,10 +48,10 @@ test.describe("Auth returnTo — Query Param Validation", () => {
   }) => {
     // Spec: buildSignInUrl("/ledger") should include returnTo=/ledger
     // even though "/" is the default, the feature still works for base ledger path
-    await page.goto("/ledger", { waitUntil: "networkidle" });
+    await page.goto("/ledger", { waitUntil: "load" });
 
     // Navigate to sign-in (simulating the upsell flow)
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     // Verify the page loaded
     await expect(page).toHaveURL(/\/ledger\/sign-in/);
@@ -63,7 +63,7 @@ test.describe("Auth returnTo — Query Param Validation", () => {
     // Spec: when user navigates to /ledger/sign-in?returnTo=/ledger/settings,
     // they should return to /ledger/settings after sign-in
     await page.goto("/ledger/sign-in?returnTo=/ledger/settings", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Verify returnTo param is in the URL
@@ -78,7 +78,7 @@ test.describe("Auth returnTo — Query Param Validation", () => {
     // Spec: when user navigates to /ledger/sign-in?returnTo=/ledger/valhalla,
     // they should return to /ledger/valhalla after sign-in
     await page.goto("/ledger/sign-in?returnTo=/ledger/valhalla", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Verify returnTo param is in the URL
@@ -89,7 +89,7 @@ test.describe("Auth returnTo — Query Param Validation", () => {
 
   test("sign-in with no returnTo defaults to /ledger", async ({ page }) => {
     // Spec: /ledger/sign-in without returnTo param should default to /ledger
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     // Verify no returnTo param in URL
     await expect(page).toHaveURL(/\/ledger\/sign-in$/);
@@ -101,7 +101,7 @@ test.describe("Auth returnTo — Query Param Validation", () => {
     // Spec: validateReturnTo should reject "https://evil.com" and fall back to /ledger
     // This is validated in the sign-in page's handleSignIn method
     await page.goto("/ledger/sign-in?returnTo=https://evil.com", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // The page should still load (validateReturnTo prevents the attack)
@@ -115,7 +115,7 @@ test.describe("Auth returnTo — Query Param Validation", () => {
   test("protocol-relative URLs in returnTo are rejected", async ({ page }) => {
     // Spec: validateReturnTo should reject "//evil.com"
     await page.goto("/ledger/sign-in?returnTo=//evil.com", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // The page should still load
@@ -134,7 +134,7 @@ test.describe("Auth returnTo — sessionStorage Management", () => {
     // Spec: when user clicks "Sign in to Google", handleSignIn stores
     // { verifier, state, callbackUrl: validatedReturnTo } in sessionStorage
     await page.goto("/ledger/sign-in?returnTo=/ledger/settings", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Get the initial sessionStorage state
@@ -156,7 +156,6 @@ test.describe("Auth returnTo — sessionStorage Management", () => {
     await signInButton.click();
 
     // Wait for a short delay to allow sessionStorage to be written
-    await page.waitForTimeout(500);
 
     // Verify PKCE data was stored with the correct callbackUrl
     const sessionAfter = await page.evaluate(() => {
@@ -174,7 +173,7 @@ test.describe("Auth returnTo — sessionStorage Management", () => {
     page,
   }) => {
     // Spec: when returnTo is missing, validateReturnTo returns "/ledger"
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     // Intercept the redirect to Google
     await page.route("https://accounts.google.com/**", (route) => {
@@ -185,7 +184,6 @@ test.describe("Auth returnTo — sessionStorage Management", () => {
     const signInButton = page.locator('button:has-text("Sign in to Google")');
     await signInButton.click();
 
-    await page.waitForTimeout(500);
 
     // Verify PKCE data was stored with /ledger as default
     const sessionData = await page.evaluate(() => {
@@ -201,7 +199,7 @@ test.describe("Auth returnTo — sessionStorage Management", () => {
   }) => {
     // Spec: validateReturnTo rejects https://evil.com and falls back to /ledger
     await page.goto("/ledger/sign-in?returnTo=https://evil.com", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Intercept the redirect
@@ -213,7 +211,6 @@ test.describe("Auth returnTo — sessionStorage Management", () => {
     const signInButton = page.locator('button:has-text("Sign in to Google")');
     await signInButton.click();
 
-    await page.waitForTimeout(500);
 
     // Verify the external URL was rejected and /ledger is used instead
     const sessionData = await page.evaluate(() => {
@@ -244,8 +241,7 @@ test.describe("Auth returnTo — Graceful Degradation", () => {
     ];
 
     for (const url of malformedUrls) {
-      await page.goto(url, { waitUntil: "networkidle" });
-      await page.waitForTimeout(200);
+      await page.goto(url, { waitUntil: "load" });
     }
 
     // Filter out benign Next.js HMR noise
@@ -265,7 +261,7 @@ test.describe("Auth returnTo — Graceful Degradation", () => {
     page.on("pageerror", (err) => errors.push(err.message));
 
     await page.goto("/ledger/sign-in?returnTo=/ledger/sign-in", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Intercept the redirect
@@ -277,7 +273,6 @@ test.describe("Auth returnTo — Graceful Degradation", () => {
     const signInButton = page.locator('button:has-text("Sign in to Google")');
     await signInButton.click();
 
-    await page.waitForTimeout(500);
 
     // Verify the loop is prevented by checking sessionStorage
     const sessionData = await page.evaluate(() => {

--- a/quality/test-suites/auth/auth-callback.spec.ts
+++ b/quality/test-suites/auth/auth-callback.spec.ts
@@ -53,7 +53,7 @@ test.describe("Auth Callback — Missing Params", () => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "load" });
 
     const fatal = errors.filter(
       (e) => !e.includes("hydration") && !e.includes("HMR")
@@ -65,7 +65,7 @@ test.describe("Auth Callback — Missing Params", () => {
     page,
   }) => {
     // Spec: auth/callback/page.tsx — !code || !stateParam → "Missing code or state in callback URL."
-    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "load" });
 
     await expect(
       page.locator("text=Missing code or state in callback URL.")
@@ -76,7 +76,7 @@ test.describe("Auth Callback — Missing Params", () => {
     page,
   }) => {
     // Spec: auth/callback/page.tsx — error state renders destructive heading "The Bifrost trembled"
-    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "load" });
 
     // The heading uses the Norse name with ö — match either variant for robustness
     const heading = page.locator("text=The Bifr");
@@ -87,7 +87,7 @@ test.describe("Auth Callback — Missing Params", () => {
     page,
   }) => {
     // Spec: auth/callback/page.tsx — error state renders <a href="/ledger/sign-in">Return to the gate</a>
-    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "load" });
 
     const link = page.locator("a:has-text('Return to the gate')");
     await expect(link).toBeVisible({ timeout: 5000 });
@@ -105,7 +105,7 @@ test.describe("Auth Callback — Google Error Param", () => {
   }) => {
     // Spec: auth/callback/page.tsx — errorParam → `Google returned: ${errorParam}`
     await page.goto("/ledger/auth/callback?error=access_denied", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     await expect(
@@ -116,7 +116,7 @@ test.describe("Auth Callback — Google Error Param", () => {
   test("shows error heading when Google returns an error", async ({ page }) => {
     // Spec: auth/callback/page.tsx — error state renders destructive heading
     await page.goto("/ledger/auth/callback?error=access_denied", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     const heading = page.locator("text=The Bifr");
@@ -129,7 +129,7 @@ test.describe("Auth Callback — Google Error Param", () => {
     // Edge case: arbitrary error string from Google should not crash
     await page.goto(
       "/auth/callback?error=server_error",
-      { waitUntil: "networkidle" }
+      { waitUntil: "load" }
     );
 
     await expect(
@@ -151,7 +151,7 @@ test.describe("Auth Callback — PKCE Session Data Missing", () => {
     // Note: callback page has a 100ms delay to prevent race conditions with React StrictMode
     // Navigate with valid-looking code + state but no PKCE session data
     await page.goto("/ledger/auth/callback?code=fake_code&state=fake_state", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Wait for the error message to appear (100ms delay + React render time)
@@ -167,7 +167,7 @@ test.describe("Auth Callback — PKCE Session Data Missing", () => {
     // Spec: error state always renders the sign-in recovery link
     // Note: callback page has a 100ms delay to prevent race conditions with React StrictMode
     await page.goto("/ledger/auth/callback?code=fake_code&state=fake_state", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     // Wait for the error state to render with a longer timeout
@@ -201,7 +201,7 @@ test.describe("Auth Callback — CSRF State Mismatch", () => {
 
     // Navigate with a DIFFERENT state in the URL — triggers CSRF check
     await page.goto("/ledger/auth/callback?code=fake_code&state=different-state-xyz", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     await expect(
@@ -270,7 +270,7 @@ test.describe("Auth Callback — Corrupt PKCE Data", () => {
     });
 
     await page.goto("/ledger/auth/callback?code=fake_code&state=any-state", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     await expect(
@@ -287,7 +287,7 @@ test.describe("Auth Callback — Responsive (375px)", () => {
   test("error state is readable at 375px viewport", async ({ page }) => {
     // Spec: team norms — minimum 375px. Callback error card uses max-w-xs.
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/ledger/auth/callback", { waitUntil: "networkidle" });
+    await page.goto("/ledger/auth/callback", { waitUntil: "load" });
 
     // Error message must not overflow — it uses max-w-xs
     const errorMsg = page.locator("text=Missing code or state in callback URL.");

--- a/quality/test-suites/auth/sign-in.spec.ts
+++ b/quality/test-suites/auth/sign-in.spec.ts
@@ -27,7 +27,7 @@ import { clearAllStorage } from "../helpers/test-fixtures";
 test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
-  await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+  await page.goto("/ledger/sign-in", { waitUntil: "load" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -40,7 +40,7 @@ test.describe("Sign-In Page — Rendering", () => {
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
 
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     // Filter out known benign Next.js HMR noise in dev
     const fatal = errors.filter(
@@ -51,7 +51,7 @@ test.describe("Sign-In Page — Rendering", () => {
 
   test("page returns HTTP 200", async ({ page }) => {
     // Spec: /sign-in must be a valid, reachable route
-    const response = await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    const response = await page.goto("/ledger/sign-in", { waitUntil: "load" });
     expect(response?.status()).toBe(200);
   });
 
@@ -182,7 +182,7 @@ test.describe("Sign-In Page — Responsive (375px)", () => {
   test("page is usable at 375px viewport width", async ({ page }) => {
     // Spec: team norms — minimum 375px. Sign-in card uses w-full max-w-[400px]
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     const heading = page.locator("h1#signin-heading");
     await expect(heading).toBeVisible();
@@ -199,7 +199,7 @@ test.describe("Sign-In Page — Responsive (375px)", () => {
   test("sign-in card does not overflow viewport at 375px", async ({ page }) => {
     // Spec: sign-in/page.tsx — w-full max-w-[400px], px-4 on the outer div
     await page.setViewportSize({ width: 375, height: 812 });
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     const main = page.locator("main[aria-labelledby='signin-heading']");
     const box = await main.boundingBox();
@@ -252,7 +252,7 @@ test.describe("Sign-In Page — Variant B (has local cards)", () => {
       localStorage.setItem("fenrir:household", householdId);
     });
 
-    await page.goto("/ledger/sign-in", { waitUntil: "networkidle" });
+    await page.goto("/ledger/sign-in", { waitUntil: "load" });
 
     // If the anon household key matches, heading must switch to Variant B
     // The spec says cardCount > 0 produces: "Your chains are already here."

--- a/quality/test-suites/card-lifecycle/add-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/add-card.spec.ts
@@ -22,7 +22,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "load" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/card-lifecycle/close-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/close-card.spec.ts
@@ -35,9 +35,9 @@ test.describe("Close Card — Confirmation Dialog", () => {
     const card = makeCard({ cardName: "Dialog Test Card" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Close Card")').first().click();
 
@@ -50,9 +50,9 @@ test.describe("Close Card — Confirmation Dialog", () => {
     const card = makeCard({ cardName: "Cancel Close Test" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Close Card")').first().click();
     await expect(page.locator("text=Close this card?")).toBeVisible();
@@ -76,9 +76,9 @@ test.describe("Close Card — Confirm Action", () => {
     const card = makeCard({ cardName: "Card To Close" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Close Card")').first().click();
     await expect(page.locator("text=Close this card?")).toBeVisible();
@@ -98,9 +98,9 @@ test.describe("Close Card — Confirm Action", () => {
     const card = makeCard({ cardName: "Soon To Be Closed" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Close Card")').first().click();
     await expect(page.locator("text=Close this card?")).toBeVisible();

--- a/quality/test-suites/card-lifecycle/delete-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/delete-card.spec.ts
@@ -35,9 +35,9 @@ test.describe("Delete Card — Confirmation Dialog", () => {
     const card = makeCard({ cardName: "Dialog Delete Test" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Delete card")').first().click();
 
@@ -48,9 +48,9 @@ test.describe("Delete Card — Confirmation Dialog", () => {
     const card = makeCard({ cardName: "Cancel Delete Test" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Delete card")').first().click();
     await expect(page.locator("text=Delete this card?")).toBeVisible();
@@ -74,9 +74,9 @@ test.describe("Delete Card — Confirm Action", () => {
     const card = makeCard({ cardName: "Card To Delete" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Delete card")').first().click();
     await expect(page.locator("text=Delete this card?")).toBeVisible();
@@ -94,9 +94,9 @@ test.describe("Delete Card — Confirm Action", () => {
     const card = makeCard({ cardName: "Permanently Gone Card" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Delete card")').first().click();
     await expect(page.locator("text=Delete this card?")).toBeVisible();
@@ -117,9 +117,9 @@ test.describe("Delete Card — Confirm Action", () => {
     const cardToKeep = makeCard({ cardName: "Keep This One" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [cardToDelete, cardToKeep]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${cardToDelete.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${cardToDelete.id}/edit`, { waitUntil: "load" });
 
     await page.locator('button:has-text("Delete card")').first().click();
     await expect(page.locator("text=Delete this card?")).toBeVisible();

--- a/quality/test-suites/card-lifecycle/edit-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/edit-card.spec.ts
@@ -35,9 +35,9 @@ test.describe("Edit Card — Pre-populated Fields", () => {
     const card = makeCard({ cardName: "Freya's Folly" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     const cardNameInput = page.locator("#cardName");
     await expect(cardNameInput).toHaveValue("Freya's Folly");
@@ -45,10 +45,10 @@ test.describe("Edit Card — Pre-populated Fields", () => {
 
   test("unknown card ID redirects to dashboard", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.goto("/ledger/cards/nonexistent-id-that-does-not-exist/edit", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     await page.waitForURL("**/", { timeout: 5000 });
@@ -67,9 +67,9 @@ test.describe("Edit Card — Save Changes", () => {
     const card = makeCard({ cardName: "Original Name" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator("#cardName").fill("Updated Name");
     await page.locator('button[type="submit"]').click();
@@ -84,9 +84,9 @@ test.describe("Edit Card — Save Changes", () => {
     const card = makeCard({ cardName: "Before Update" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     const newName = `After Update ${Date.now()}`;
     await page.locator("#cardName").fill(newName);
@@ -110,9 +110,9 @@ test.describe("Edit Card — Cancel Without Saving", () => {
     const card = makeCard({ cardName: "Do Not Change Me" });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator("#cardName").fill("Changed But Cancelled");
 
@@ -130,16 +130,16 @@ test.describe("Edit Card — Cancel Without Saving", () => {
     const card = makeCard({ cardName: originalName });
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
 
     await page.locator("#cardName").fill("This Should Not Save");
     await page.locator('button:has-text("Cancel")').click();
 
     await page.waitForURL("**/", { timeout: 5000 });
 
-    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "networkidle" });
+    await page.goto(`/cards/${card.id}/edit`, { waitUntil: "load" });
     const cardNameInput = page.locator("#cardName");
     await expect(cardNameInput).toHaveValue(originalName);
   });

--- a/quality/test-suites/chronicles/chronicles.spec.ts
+++ b/quality/test-suites/chronicles/chronicles.spec.ts
@@ -29,7 +29,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // Navigate to chronicles index
-    const response = await page.goto("/chronicles", { waitUntil: "networkidle" });
+    const response = await page.goto("/chronicles", { waitUntil: "load" });
     expect(response?.status()).toBe(200);
 
     // Verify page title
@@ -60,7 +60,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // First get the list of chronicles
-    await page.goto("/chronicles", { waitUntil: "networkidle" });
+    await page.goto("/chronicles", { waitUntil: "load" });
 
     // Get first chronicle card
     const firstCard = page.locator("a[href*='/chronicles/']").first();
@@ -68,7 +68,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     expect(href).toBeTruthy();
 
     // Navigate to the detail page
-    const response = await page.goto(href || "/chronicles", { waitUntil: "networkidle" });
+    const response = await page.goto(href || "/chronicles", { waitUntil: "load" });
     expect(response?.status()).toBe(200);
 
     // Verify breadcrumb navigation exists - look for link to /chronicles in breadcrumb
@@ -93,7 +93,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // Navigate to chronicles index
-    await page.goto("/chronicles", { waitUntil: "networkidle" });
+    await page.goto("/chronicles", { waitUntil: "load" });
 
     // Verify navbar exists with navigation - check for home link
     const homeLink = page.locator("a[href='/']").first();
@@ -116,7 +116,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // Navigate to home page to verify navbar/footer
-    await page.goto("/", { waitUntil: "networkidle" });
+    await page.goto("/", { waitUntil: "load" });
 
     // Find all links with text "Chronicles"
     const chroniclesLinks = page.locator("a:has-text('Chronicles')");
@@ -141,7 +141,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // Navigate to old /blog route
-    const response = await page.goto("/blog", { waitUntil: "networkidle" });
+    const response = await page.goto("/blog", { waitUntil: "load" });
     expect(response?.status()).toBe(404);
   });
 
@@ -153,7 +153,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     // Set mobile viewport
     await page.setViewportSize({ width: 375, height: 812 });
 
-    await page.goto("/chronicles", { waitUntil: "networkidle" });
+    await page.goto("/chronicles", { waitUntil: "load" });
 
     // Verify cards are visible and stacked on mobile
     const cards = page.locator("a[href*='/chronicles/']");
@@ -177,14 +177,14 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // Navigate to chronicles index
-    await page.goto("/chronicles", { waitUntil: "networkidle" });
+    await page.goto("/chronicles", { waitUntil: "load" });
 
     // Get first chronicle link
     const firstCard = page.locator("a[href*='/chronicles/']").first();
     const href = await firstCard.getAttribute("href");
 
     // Navigate to detail page
-    await page.goto(href || "/chronicles", { waitUntil: "networkidle" });
+    await page.goto(href || "/chronicles", { waitUntil: "load" });
 
     // Look for "All Chronicles" link which indicates prev/next nav exists
     const allChroniclesLink = page.locator("a:has-text('All Chronicles')");
@@ -203,7 +203,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     page,
   }) => {
     // Get all chronicle cards
-    await page.goto("/chronicles", { waitUntil: "networkidle" });
+    await page.goto("/chronicles", { waitUntil: "load" });
 
     // Test first 2 chronicles (budget test, 30s timeout is tight)
     for (let i = 0; i < 2; i++) {
@@ -212,7 +212,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
       expect(href).toMatch(/^\/chronicles\/[a-z0-9-]+$/);
 
       // Navigate and verify 200 status
-      const response = await page.goto(href || "/chronicles", { waitUntil: "networkidle" });
+      const response = await page.goto(href || "/chronicles", { waitUntil: "load" });
       expect(response?.status()).toBe(200);
 
       // Verify we're on a detail page (not index)
@@ -220,7 +220,7 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
       await expect(breadcrumb).toBeVisible();
 
       // Go back to index for next iteration
-      await page.goto("/chronicles", { waitUntil: "networkidle" });
+      await page.goto("/chronicles", { waitUntil: "load" });
     }
   });
 });

--- a/quality/test-suites/credit-limit-step2/credit-limit-step2.spec.ts
+++ b/quality/test-suites/credit-limit-step2/credit-limit-step2.spec.ts
@@ -20,7 +20,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "load" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/dashboard-tabs/dashboard-tabs.spec.ts
+++ b/quality/test-suites/dashboard-tabs/dashboard-tabs.spec.ts
@@ -34,7 +34,7 @@ async function setupDashboard(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 }
 
 test.describe("Dashboard Tabs QA — Issue #279", () => {

--- a/quality/test-suites/dashboard/dashboard.spec.ts
+++ b/quality/test-suites/dashboard/dashboard.spec.ts
@@ -54,7 +54,7 @@ test.describe("Dashboard — Empty State", () => {
     // Seed household only — no cards
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, EMPTY_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: EmptyState.tsx h2 begins "Before" and contains "Gleipnir was forged"
     // The heading includes two myth-link anchors (Gleipnir, Fenrir) so we
@@ -70,7 +70,7 @@ test.describe("Dashboard — Empty State", () => {
   }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, EMPTY_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: EmptyState.tsx renders <Link href="/ledger/cards/new">Add Card</Link>
     const addCardLink = page.locator('a[href="/ledger/cards/new"]').first();
@@ -83,7 +83,7 @@ test.describe("Dashboard — Empty State", () => {
   }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, EMPTY_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Dashboard renders EmptyState when cards.length === 0 — no card links
     // to /cards/{id}/edit should exist
@@ -102,7 +102,7 @@ test.describe("Dashboard — Card Grid", () => {
   }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: CardTile.tsx renders <CardTitle>{card.cardName}</CardTitle>
     // FEW_CARDS = [Sapphire Preferred, Platinum, Venture Rewards]
@@ -114,7 +114,7 @@ test.describe("Dashboard — Card Grid", () => {
   test("renders exactly 3 card tiles for FEW_CARDS", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Each CardTile is wrapped in a Link to /cards/{id}/edit
     // Cards appear in "All" tab + status tab; scope to the "All" tabpanel
@@ -126,7 +126,7 @@ test.describe("Dashboard — Card Grid", () => {
   test("renders MANY_CARDS (10 cards) — no empty state", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, MANY_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // When cards exist, EmptyState is not rendered — no h2 with "Gleipnir"
     // should be present. Use count check (instant) rather than textContent()
@@ -151,7 +151,7 @@ test.describe("Dashboard — Summary Stats", () => {
   }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, MANY_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: Dashboard.tsx renders "{cards.length} cards" in the summary header
     // MANY_CARDS has 10 entries
@@ -169,7 +169,7 @@ test.describe("Dashboard — Summary Stats", () => {
     const oneCard = [FEW_CARDS[0]!];
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, oneCard);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: Dashboard.tsx uses ternary → cards.length === 1 ? "card" : "cards"
     // Must be "1 card" not "1 cards"
@@ -184,7 +184,7 @@ test.describe("Dashboard — Summary Stats", () => {
   test("shows 'needs attention' count for URGENT_CARDS", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, URGENT_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: Dashboard.tsx renders "{needsAttention.length} need{plural} attention"
     // URGENT_CARDS has 5 cards: 3 fee_approaching + 2 promo_expiring = 5 urgent
@@ -199,7 +199,7 @@ test.describe("Dashboard — Summary Stats", () => {
     // FEW_CARDS are all status: "active" — no urgent entries
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: needsAttention.length > 0 guard before rendering the attention span
     const body = await page.locator("body").innerText();
@@ -217,7 +217,7 @@ test.describe("Dashboard — Status Badges", () => {
     // FEW_CARDS are all status: "active"
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: STATUS_LABELS.active = "Active" (constants.ts, authoritative)
     // StatusBadge renders <Badge>{label}</Badge> where label = STATUS_LABELS[status]
@@ -232,7 +232,7 @@ test.describe("Dashboard — Status Badges", () => {
   test("fee_approaching cards show 'Fee Due Soon' badge", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, URGENT_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: STATUS_LABELS.fee_approaching = "Fee Due Soon" (constants.ts)
     // Scope to "All" tab to avoid 5-tab duplication
@@ -246,7 +246,7 @@ test.describe("Dashboard — Status Badges", () => {
   test("promo_expiring cards show 'Promo Expiring' badge", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, URGENT_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: STATUS_LABELS.promo_expiring = "Promo Expiring" (constants.ts)
     // Scope to "All" tab to avoid 5-tab duplication
@@ -267,7 +267,7 @@ test.describe("Dashboard — Card Tile Links", () => {
   test("each card tile links to /cards/{id}/edit", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: CardTile.tsx wraps content in <Link href={`/cards/${card.id}/edit`}>
     // Each FEW_CARDS entry has a unique ID — verify the link pattern exists
@@ -285,7 +285,7 @@ test.describe("Dashboard — Card Tile Links", () => {
   }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     const firstCard = FEW_CARDS[0]!;
     const tileLink = page.locator(`a[href="/ledger/cards/${firstCard.id}/edit"]`).first();
@@ -299,7 +299,7 @@ test.describe("Dashboard — Card Tile Links", () => {
   test("Add Card button in header navigates to /cards/new", async ({ page }) => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, FEW_CARDS);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // Spec: page.tsx renders <Link href="/ledger/cards/new">Add Card</Link> in the header
     const addCardBtn = page.locator('a[href="/ledger/cards/new"]').first();

--- a/quality/test-suites/empty-state-cta/empty-state-cta.spec.ts
+++ b/quality/test-suites/empty-state-cta/empty-state-cta.spec.ts
@@ -36,7 +36,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     // Reload with networkidle so all async effects settle.
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -51,7 +51,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -72,7 +72,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [makeCard()]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     // With cards present the summary header is shown (e.g. "1 card").
     await page.waitForSelector('text=/\\d+ card/', { timeout: 10000 });
@@ -92,7 +92,7 @@ test.describe("AC-2 — Upsell banner not shown to new (zero-card) users", () =>
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -111,7 +111,7 @@ test.describe("AC-2 — Upsell banner not shown to new (zero-card) users", () =>
     await page.evaluate(() => localStorage.removeItem("fenrir:upsell_dismissed"));
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [makeCard()]);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text=/\\d+ card/', { timeout: 10000 });
 
@@ -130,7 +130,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -143,7 +143,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -156,7 +156,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -175,7 +175,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -201,7 +201,7 @@ test.describe("Edge cases", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -216,7 +216,7 @@ test.describe("Edge cases", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -233,7 +233,7 @@ test.describe("Edge cases", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -247,7 +247,7 @@ test.describe("Edge cases", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 
@@ -261,7 +261,7 @@ test.describe("Edge cases", () => {
     await page.goto("/");
     await clearAllStorage(page);
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-    await page.reload({ waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
 
     await page.waitForSelector('text="Before"', { timeout: 10000 });
 

--- a/quality/test-suites/feature-flags/feature-flags.spec.ts
+++ b/quality/test-suites/feature-flags/feature-flags.spec.ts
@@ -36,14 +36,14 @@ test.describe("Settings page structure", () => {
   test("TC-FF-101: /settings page loads with HTTP 200", async ({ page }) => {
     await clearEntitlementState(page);
     const response = await page.goto(`${BASE_URL}/settings`, {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
     expect(response?.status()).toBe(200);
   });
 
   test("TC-FF-102: Settings page renders the page heading", async ({ page }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     const heading = page.getByRole("heading", { level: 1, name: /Settings/i });
     await expect(heading).toBeVisible();
   });
@@ -52,7 +52,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     const stripeSection = page.locator('[role="region"][aria-label="Subscription"]');
     await expect(stripeSection).toBeVisible();
   });
@@ -61,7 +61,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     // SubscriptionGate renders a locked upsell card (aria-label ends with "(locked)")
     // instead of children for Thrall users
     const cloudSyncLocked = page.locator('[aria-label="Cloud Sync (locked)"]');
@@ -72,7 +72,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     // All three SubscriptionGate instances render locked upsell cards with
     // aria-label="<Feature Name> (locked)" when the user is a Thrall
     const cloudSyncLocked = page.locator('[aria-label="Cloud Sync (locked)"]');
@@ -87,7 +87,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     // Locked upsell cards render an "Unlock with Karl" CTA button
     const unlockButtons = page.getByRole("button", { name: /unlock with karl/i });
     const count = await unlockButtons.count();
@@ -98,7 +98,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     // The actual feature sections (Cloud Sync, Multi-Household, Data Export)
     // Soft gate: children are always rendered alongside the upsell card
     const cloudSync = page.locator('[aria-label="Cloud Sync"]');
@@ -111,7 +111,7 @@ test.describe("Settings page structure", () => {
 
   test("TC-FF-108: Settings page header tagline is visible", async ({ page }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     const tagline = page.getByText("Forge your preferences. Shape the ledger to your will.");
     await expect(tagline).toBeVisible();
   });
@@ -120,7 +120,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     // "Coming soon to Karl supporters" is inside gated children -- Thrall users
     // Soft gate: children always render, so "Coming soon" text is visible
     const comingSoonText = page.getByText("Coming soon to Karl supporters.");
@@ -131,7 +131,7 @@ test.describe("Settings page structure", () => {
     page,
   }) => {
     await clearEntitlementState(page);
-    const response = await page.goto(`${BASE_URL}/`, { waitUntil: "networkidle" });
+    const response = await page.goto(`${BASE_URL}/`, { waitUntil: "load" });
     expect(response?.status()).toBe(200);
   });
 
@@ -140,7 +140,7 @@ test.describe("Settings page structure", () => {
   }) => {
     await page.setViewportSize({ width: 375, height: 812 });
     await clearEntitlementState(page);
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     const heading = page.getByRole("heading", { level: 1, name: /Settings/i });
     await expect(heading).toBeVisible();
     const stripeSection = page.locator('[role="region"][aria-label="Subscription"]');
@@ -151,8 +151,7 @@ test.describe("Settings page structure", () => {
     await clearEntitlementState(page);
     const errors: string[] = [];
     page.on("pageerror", (err) => errors.push(err.message));
-    await page.goto(`${BASE_URL}/settings`, { waitUntil: "networkidle" });
-    await page.waitForTimeout(500);
+    await page.goto(`${BASE_URL}/settings`, { waitUntil: "load" });
     expect(
       errors.filter((e) => !e.includes("hydration") && !e.includes("Warning:")),
     ).toHaveLength(0);

--- a/quality/test-suites/fee-bonus-step2/fee-bonus-step2.spec.ts
+++ b/quality/test-suites/fee-bonus-step2/fee-bonus-step2.spec.ts
@@ -35,7 +35,7 @@ test.beforeEach(async ({ page }) => {
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   // Navigate to new card form
-  await page.goto("/ledger/cards/new", { waitUntil: "networkidle" });
+  await page.goto("/ledger/cards/new", { waitUntil: "load" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/howl-count/howl-count-badge.spec.ts
+++ b/quality/test-suites/howl-count/howl-count-badge.spec.ts
@@ -30,7 +30,7 @@ async function setup(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 }
 
 function makeOverdueCard(overrides: Record<string, unknown> = {}) {

--- a/quality/test-suites/import/import-wizard.spec.ts
+++ b/quality/test-suites/import/import-wizard.spec.ts
@@ -24,7 +24,7 @@
  *   2. seed auth session → householdId === "test-household-id"
  *   3. seed household → "fenrir:household" = "test-household-id"
  *   4. seed cards → at least 1 active card under that household
- *   5. reload({ waitUntil: "networkidle" }) — causes React to re-read localStorage
+ *   5. reload({ waitUntil: "load" }) — causes React to re-read localStorage
  *
  * NOTE: baseURL is provided by Playwright config (playwright.config.ts).
  * Tests use page.goto(path) — no hardcoded port or BASE_URL constant.

--- a/quality/test-suites/layout/howl-panel.spec.ts
+++ b/quality/test-suites/layout/howl-panel.spec.ts
@@ -35,7 +35,7 @@ async function setup(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 }
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/layout/sidebar.spec.ts
+++ b/quality/test-suites/layout/sidebar.spec.ts
@@ -29,7 +29,7 @@ test.beforeEach(async ({ page }) => {
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [makeCard({ cardName: "Test Card" })]);
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════
@@ -95,7 +95,6 @@ test.describe("SideNav — Collapse toggle", () => {
     // Collapse
     const collapseBtn = page.locator('aside button[aria-label="Collapse sidebar"]');
     await collapseBtn.click();
-    await page.waitForTimeout(300);
 
     // Label span should not be rendered (not just hidden)
     await expect(cardsLabel).not.toBeAttached();

--- a/quality/test-suites/layout/topbar.spec.ts
+++ b/quality/test-suites/layout/topbar.spec.ts
@@ -27,7 +27,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/");
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 });
 
 // ════════════════════════════════════════════════════════════════════════════

--- a/quality/test-suites/profile-dropdown/profile-dropdown.spec.ts
+++ b/quality/test-suites/profile-dropdown/profile-dropdown.spec.ts
@@ -75,12 +75,12 @@ test.describe("Profile Dropdown — Desktop (1280px)", () => {
   test.beforeEach(async ({ page }) => {
     page.setViewportSize({ width: 1280, height: 720 });
     // Navigate to "/" first to establish browser context
-    await page.goto("/", { waitUntil: "networkidle" });
+    await page.goto("/", { waitUntil: "load" });
     // Clear storage and seed auth session
     await clearAllStorage(page);
     await seedAuthSession(page);
     // Navigate to /ledger
-    await page.goto("/ledger", { waitUntil: "networkidle" });
+    await page.goto("/ledger", { waitUntil: "load" });
   });
 
   test("TC-PD01: Dropdown opens when avatar button is clicked", async ({
@@ -198,7 +198,6 @@ test.describe("Profile Dropdown — Desktop (1280px)", () => {
 
     // Click to cycle
     await themeButton.click();
-    await page.waitForTimeout(100); // Wait for state update
 
     // Button should still be visible after click
     await expect(themeButton).toBeVisible();
@@ -234,7 +233,7 @@ test.describe("Profile Dropdown — Desktop (1280px)", () => {
 
     // Then: user should be redirected to sign-in or home
     // and dropdown should close
-    await page.waitForNavigation({ waitUntil: "networkidle" });
+    await page.waitForNavigation({ waitUntil: "load" });
     const userMenuAfter = page.locator('[role="menu"]');
     await expect(userMenuAfter).not.toBeVisible();
   });
@@ -339,12 +338,12 @@ test.describe("Profile Dropdown — Mobile (375px)", () => {
   test.beforeEach(async ({ page }) => {
     page.setViewportSize({ width: 375, height: 667 });
     // Navigate to "/" first to establish browser context
-    await page.goto("/", { waitUntil: "networkidle" });
+    await page.goto("/", { waitUntil: "load" });
     // Clear storage and seed auth session
     await clearAllStorage(page);
     await seedAuthSession(page);
     // Navigate to /ledger
-    await page.goto("/ledger", { waitUntil: "networkidle" });
+    await page.goto("/ledger", { waitUntil: "load" });
   });
 
   test("TC-PD-M01: Dropdown opens on mobile", async ({ page }) => {
@@ -475,12 +474,12 @@ test.describe("Profile Dropdown — Accessibility", () => {
   test.beforeEach(async ({ page }) => {
     page.setViewportSize({ width: 1280, height: 720 });
     // Navigate to "/" first to establish browser context
-    await page.goto("/", { waitUntil: "networkidle" });
+    await page.goto("/", { waitUntil: "load" });
     // Clear storage and seed auth session
     await clearAllStorage(page);
     await seedAuthSession(page);
     // Navigate to /ledger
-    await page.goto("/ledger", { waitUntil: "networkidle" });
+    await page.goto("/ledger", { waitUntil: "load" });
   });
 
   test("TC-PD-A01: Dropdown has proper ARIA roles and labels", async ({

--- a/quality/test-suites/reverse-tab-order/dashboard-tab-order.spec.ts
+++ b/quality/test-suites/reverse-tab-order/dashboard-tab-order.spec.ts
@@ -32,7 +32,7 @@ async function setupDashboard(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 }
 
 test.describe("Dashboard Tab Order (Issue #399)", () => {

--- a/quality/test-suites/select-reset/select-reset.spec.ts
+++ b/quality/test-suites/select-reset/select-reset.spec.ts
@@ -27,7 +27,7 @@ test.beforeEach(async ({ page }) => {
   // Seed household so the form loads properly
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   // Navigate to the new card form
-  await page.goto('/cards/new', { waitUntil: 'networkidle' });
+  await page.goto('/cards/new', { waitUntil: 'load' });
   // Wait for the form to be visible
   await page.waitForSelector('#issuerId');
 });
@@ -37,7 +37,6 @@ test('Issuer select preserves value after Back from Step 2', async ({ page }) =>
   await page.locator('#issuerId').click();
   const issuerOption = page.locator('[role="option"]:has-text("American Express")').first();
   await issuerOption.click();
-  await page.waitForTimeout(200);
 
   // Fill Step 1 required fields
   await page.locator('#cardName').fill('Test Card');
@@ -45,14 +44,12 @@ test('Issuer select preserves value after Back from Step 2', async ({ page }) =>
 
   // Advance to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Verify we're on Step 2 (Back button is visible)
   await expect(page.locator('button:has-text("Back")')).toBeVisible();
 
   // Click Back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Verify we're back on Step 1
   await expect(page.locator('button:has-text("More Details")')).toBeVisible();
@@ -60,7 +57,6 @@ test('Issuer select preserves value after Back from Step 2', async ({ page }) =>
   // Verify the Issuer select trigger shows a value (not placeholder)
   // Click the select to open it and see if the option is marked as selected
   await page.locator('#issuerId').click();
-  await page.waitForTimeout(300);
 
   // Find the American Express option and check if it's marked as selected
   const amexOption = page.locator('[role="option"]:has-text("American Express")').first();
@@ -76,7 +72,6 @@ test('Bonus Type select preserves value after Back from Step 2', async ({ page }
   // Fill Step 1 fields
   await page.locator('#issuerId').click();
   await page.locator('[role="option"]').first().click();
-  await page.waitForTimeout(200);
 
   await page.locator('#cardName').fill('Bonus Card');
   await page.locator('#openDate').fill('2026-01-10');
@@ -85,25 +80,21 @@ test('Bonus Type select preserves value after Back from Step 2', async ({ page }
   await page.locator('#bonusType').click();
   const bonusOption = page.locator('[role="option"]:has-text("Points")').first();
   await bonusOption.click();
-  await page.waitForTimeout(200);
 
   // Advance to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Verify we're on Step 2
   await expect(page.locator('button:has-text("Back")')).toBeVisible();
 
   // Click Back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Verify we're back on Step 1
   await expect(page.locator('button:has-text("More Details")')).toBeVisible();
 
   // Verify the Bonus Type select still shows Points (not placeholder)
   await page.locator('#bonusType').click();
-  await page.waitForTimeout(300);
 
   // Check if Points option is marked as selected
   const pointsOption = page.locator('[role="option"]:has-text("Points")').first();
@@ -119,7 +110,6 @@ test('All three selects preserve values simultaneously after Back', async ({ pag
   // Select Issuer
   await page.locator('#issuerId').click();
   await page.locator('[role="option"]').first().click();
-  await page.waitForTimeout(200);
 
   // Fill Card Name and Date
   await page.locator('#cardName').fill('Multi-Select Card');
@@ -128,18 +118,15 @@ test('All three selects preserve values simultaneously after Back', async ({ pag
   // Select Bonus Type
   await page.locator('#bonusType').click();
   await page.locator('[role="option"]:has-text("Miles")').first().click();
-  await page.waitForTimeout(200);
 
   // Advance to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Verify we're on Step 2
   await expect(page.locator('button:has-text("Back")')).toBeVisible();
 
   // Click Back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Verify Card Name and Date (text inputs) are preserved
   await expect(page.locator('#cardName')).toHaveValue('Multi-Select Card');
@@ -147,7 +134,6 @@ test('All three selects preserve values simultaneously after Back', async ({ pag
 
   // Verify Issuer select has a value selected by opening and checking
   await page.locator('#issuerId').click();
-  await page.waitForTimeout(200);
   const issuerFirstOption = page.locator('[role="option"]').first();
   const issuerSelected = await issuerFirstOption.evaluate((el: Element) =>
     el.getAttribute('aria-selected') === 'true' || el.classList.contains('bg-accent')
@@ -157,9 +143,7 @@ test('All three selects preserve values simultaneously after Back', async ({ pag
   // Verify Bonus Type select has Miles selected
   // Click elsewhere to close issuer dropdown
   await page.click('body');
-  await page.waitForTimeout(200);
   await page.locator('#bonusType').click();
-  await page.waitForTimeout(200);
   const milesOption = page.locator('[role="option"]:has-text("Miles")').first();
   const bonusSelected = await milesOption.evaluate((el: Element) =>
     el.getAttribute('aria-selected') === 'true' || el.classList.contains('bg-accent')
@@ -171,36 +155,29 @@ test('Clearing a select and going Back preserves the cleared state', async ({ pa
   // Select an issuer
   await page.locator('#issuerId').click();
   await page.locator('[role="option"]').first().click();
-  await page.waitForTimeout(200);
 
   await page.locator('#cardName').fill('Test Card');
   await page.locator('#openDate').fill('2026-01-15');
 
   // Advance to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Go back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Now change the issuer selection to a different option
   await page.locator('#issuerId').click();
   const secondOption = page.locator('[role="option"]').nth(1);
   await secondOption.click();
-  await page.waitForTimeout(200);
 
   // Advance to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Go back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // The second selection should be preserved
   await page.locator('#issuerId').click();
-  await page.waitForTimeout(200);
   const secondOptionVerify = page.locator('[role="option"]').nth(1);
   const isSelected = await secondOptionVerify.evaluate((el: Element) =>
     el.getAttribute('aria-selected') === 'true' || el.classList.contains('bg-accent')
@@ -214,7 +191,6 @@ test('Changing bonus type selection preserves new value after Back navigation', 
   // Select initial issuer and bonus type
   await page.locator('#issuerId').click();
   await page.locator('[role="option"]').first().click();
-  await page.waitForTimeout(200);
 
   await page.locator('#cardName').fill('Type Change Test');
   await page.locator('#openDate').fill('2026-01-10');
@@ -222,34 +198,26 @@ test('Changing bonus type selection preserves new value after Back navigation', 
   // Select Points initially
   await page.locator('#bonusType').click();
   await page.locator('[role="option"]:has-text("Points")').first().click();
-  await page.waitForTimeout(200);
 
   // Go to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Go back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Now change the bonus type to Miles
   await page.locator('#bonusType').click();
-  await page.waitForTimeout(300);
   const milesOption = page.locator('[role="option"]:has-text("Miles")').first();
   await milesOption.click();
-  await page.waitForTimeout(200);
 
   // Go to Step 2 again
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Go back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Verify the new selection (Miles) is preserved
   await page.locator('#bonusType').click();
-  await page.waitForTimeout(300);
   const milesVerify = page.locator('[role="option"]:has-text("Miles")').first();
   const isSelected = await milesVerify.evaluate((el: Element) =>
     el.getAttribute('aria-selected') === 'true' || el.classList.contains('bg-accent')
@@ -267,7 +235,6 @@ test('Form submission still works correctly with controlled selects', async ({ p
 
   // Advance to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   // Fill Step 2 fields
   const creditLimitTrigger = page.locator('#creditLimit');
@@ -294,7 +261,6 @@ test('Issuer select reflects correct value in form state on Back navigation', as
   // Select an issuer
   await page.locator('#issuerId').click();
   await page.locator('[role="option"]').first().click();
-  await page.waitForTimeout(200);
 
   // Fill other required fields
   await page.locator('#cardName').fill('Form State Card');
@@ -302,15 +268,12 @@ test('Issuer select reflects correct value in form state on Back navigation', as
 
   // Go to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Go back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Verify the issuer select retained its value by clicking and checking selection
   await page.locator('#issuerId').click();
-  await page.waitForTimeout(200);
   const firstOption = page.locator('[role="option"]').first();
   const isSelected = await firstOption.evaluate((el: Element) =>
     el.getAttribute('aria-selected') === 'true' || el.classList.contains('bg-accent')
@@ -324,7 +287,6 @@ test('Bonus Type select shows correct option after selecting and navigating back
   // Fill Step 1 fields
   await page.locator('#issuerId').click();
   await page.locator('[role="option"]').first().click();
-  await page.waitForTimeout(200);
 
   await page.locator('#cardName').fill('Bonus Option Card');
   await page.locator('#openDate').fill('2026-02-10');
@@ -333,19 +295,15 @@ test('Bonus Type select shows correct option after selecting and navigating back
   await page.locator('#bonusType').click();
   const milesOption = page.locator('[role="option"]:has-text("Miles")').first();
   await milesOption.click();
-  await page.waitForTimeout(200);
 
   // Go to Step 2
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(500);
 
   // Go back
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(500);
 
   // Click on bonus type select to verify it shows the selected option
   await page.locator('#bonusType').click();
-  await page.waitForTimeout(300);
 
   // The Miles option should be highlighted/selected
   const milesOptionInDropdown = page.locator('[role="option"]:has-text("Miles")').first();

--- a/quality/test-suites/stale-auth-nudge/stale-auth-nudge.spec.ts
+++ b/quality/test-suites/stale-auth-nudge/stale-auth-nudge.spec.ts
@@ -135,7 +135,6 @@ test.describe("AC-2: Nudge is dismissible", () => {
     await expect(getBanner(page)).toBeVisible({ timeout: 5000 });
 
     await getDesktopDismissBtn(page).click();
-    await page.waitForTimeout(400);
 
     const cacheValue = await getEntitlementCacheValue(page);
     expect(cacheValue).toBeNull();
@@ -151,7 +150,6 @@ test.describe("AC-2: Nudge is dismissible", () => {
     await expect(getBanner(page)).toBeVisible({ timeout: 5000 });
 
     await getDesktopDismissBtn(page).click();
-    await page.waitForTimeout(400);
 
     const flag = await getDismissFlag(page);
     expect(flag).toBe("true");
@@ -167,7 +165,6 @@ test.describe("AC-3: No nudge for genuinely anonymous users", () => {
     page,
   }) => {
     await page.reload({ waitUntil: "domcontentloaded" });
-    await page.waitForTimeout(500);
 
     await expect(getBanner(page)).not.toBeVisible();
   });
@@ -182,7 +179,6 @@ test.describe("AC-3: No nudge for genuinely anonymous users", () => {
     }, NUDGE_DISMISSED_KEY);
 
     await page.reload({ waitUntil: "domcontentloaded" });
-    await page.waitForTimeout(500);
 
     await expect(getBanner(page)).not.toBeVisible();
   });

--- a/quality/test-suites/theme-toggle/theme-toggle-ui.spec.ts
+++ b/quality/test-suites/theme-toggle/theme-toggle-ui.spec.ts
@@ -117,7 +117,7 @@ test("Dark theme persists after page reload via localStorage key fenrir-theme", 
   expect(stored).toBe("dark");
 
   // Reload and verify dark theme persists
-  await page.reload({ waitUntil: "networkidle" });
+  await page.reload({ waitUntil: "load" });
 
   classes = await getHtmlClasses(page);
   expect(classes).toContain(DARK_CLASS);
@@ -137,7 +137,6 @@ test("First load detects OS dark preference and pins to dark", async ({
 
   // ThemeToggle effect should resolve "system" → "dark" and persist it
   // Allow a moment for the effect to fire (uses a useEffect hook)
-  await page.waitForTimeout(1000);
 
   // The CSS class should be applied immediately
   const classes = await getHtmlClasses(page);

--- a/quality/test-suites/valhalla/valhalla-net-gain.spec.ts
+++ b/quality/test-suites/valhalla/valhalla-net-gain.spec.ts
@@ -61,8 +61,8 @@ test.describe("Valhalla — Net gain (positive, with earned cashback)", () => {
       },
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Profitable Card"]');
     // Spec: net gain displays with positive value
@@ -84,8 +84,8 @@ test.describe("Valhalla — Net gain (positive, with earned cashback)", () => {
       signUpBonus: null, // No bonus
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Fee Card"]');
     // Spec: "Net gain:" label is always present in plunder section
@@ -109,8 +109,8 @@ test.describe("Valhalla — Net gain (positive, with earned cashback)", () => {
       },
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: High Cashback Card"]');
     // Spec: earned cashback is summed into net gain
@@ -142,8 +142,8 @@ test.describe("Valhalla — Net gain (forfeited bonuses, zero contribution)", ()
       },
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator(
       'article[aria-label="Closed card: Forfeited Cashback Card"]'
@@ -169,8 +169,8 @@ test.describe("Valhalla — Net gain (forfeited bonuses, zero contribution)", ()
       },
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Forfeited Points Card"]');
     // Spec: points have no monetary value, only fee avoided counts
@@ -199,8 +199,8 @@ test.describe("Valhalla — Net gain (no-fee cards)", () => {
       },
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: No-Fee Premium Card"]');
     // Spec: no-fee card shows explicit "$0 (no-fee card)" message
@@ -218,8 +218,8 @@ test.describe("Valhalla — Net gain (no-fee cards)", () => {
       signUpBonus: null,
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Zero Gain Card"]');
     // Spec: zero net gain displays in muted-foreground color
@@ -241,8 +241,8 @@ test.describe("Valhalla — Net gain (zero and neutral scenarios)", () => {
       signUpBonus: null,
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Neutral Card"]');
     // Spec: zero net gain displays in muted-foreground color
@@ -268,8 +268,8 @@ test.describe("Valhalla — Net gain (zero and neutral scenarios)", () => {
       },
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Formatted Card"]');
     // Spec: currency displayed with proper formatting
@@ -316,8 +316,8 @@ test.describe("Valhalla — Net gain (multiple cards, mixed scenarios)", () => {
       }),
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     // Card 1: $150 + $300 = $450
     const card1 = page.locator('article[aria-label="Closed card: High Gain Card"]');
@@ -364,8 +364,8 @@ test.describe("Valhalla — Net gain (miles bonuses, zero contribution)", () => 
     };
 
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Mixed Bonus Card"]');
     // Net gain: $100 fee + $50 cashback = $150

--- a/quality/test-suites/valhalla/valhalla.spec.ts
+++ b/quality/test-suites/valhalla/valhalla.spec.ts
@@ -42,8 +42,8 @@ async function setupAndGotoValhalla(page: Parameters<typeof clearAllStorage>[0])
 test.describe("Valhalla — Page heading", () => {
   test("displays 'Valhalla' heading", async ({ page }) => {
     await setupAndGotoValhalla(page);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const heading = page.locator("h1").first();
     await expect(heading).toContainText("Valhalla");
@@ -64,8 +64,8 @@ test.describe("Valhalla — Closed cards display", () => {
       makeClosedCard({ cardName: "Honored Card Beta" }),
     ];
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, closedCards);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await expect(
       page.locator('article[aria-label="Closed card: Honored Card Alpha"]')
@@ -79,8 +79,8 @@ test.describe("Valhalla — Closed cards display", () => {
     await setupAndGotoValhalla(page);
     const card = makeClosedCard({ cardName: "Linkable Tombstone" });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [card]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const tombstone = page.locator('article[aria-label="Closed card: Linkable Tombstone"]');
     const viewLink = tombstone.locator('a[href*="/cards/"]');
@@ -92,8 +92,8 @@ test.describe("Valhalla — Closed cards display", () => {
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [
       makeClosedCard({ cardName: "Filter Test Card" }),
     ]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const issuerFilter = page.locator('select[aria-label="Filter by issuer"]');
     const sortFilter = page.locator('select[aria-label="Sort order"]');
@@ -104,8 +104,8 @@ test.describe("Valhalla — Closed cards display", () => {
   test("filter bar is hidden when Valhalla is empty", async ({ page }) => {
     await setupAndGotoValhalla(page);
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, []);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     const issuerFilter = page.locator('select[aria-label="Filter by issuer"]');
     await expect(issuerFilter).not.toBeVisible();
@@ -123,8 +123,8 @@ test.describe("Valhalla — Active cards excluded", () => {
       makeCard({ cardName: "Still Active Card" }),
       makeUrgentCard({ cardName: "Urgent Active Card" }),
     ]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await expect(page.locator('article[aria-label^="Closed card:"]')).toHaveCount(0);
     await expect(page.locator('[aria-label="Valhalla is empty"]')).toBeVisible();
@@ -147,8 +147,8 @@ test.describe("Valhalla — Deleted cards excluded", () => {
     const honestClosedCard = makeClosedCard({ cardName: "Honored Dead" });
 
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [deletedClosedCard, honestClosedCard]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await expect(
       page.locator('article[aria-label="Closed card: Erased From Memory"]')
@@ -166,8 +166,8 @@ test.describe("Valhalla — Deleted cards excluded", () => {
       deletedAt: new Date().toISOString(),
     });
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, [deletedCard]);
-    await page.reload({ waitUntil: "networkidle" });
-    await page.goto("/ledger/valhalla", { waitUntil: "networkidle" });
+    await page.reload({ waitUntil: "load" });
+    await page.goto("/ledger/valhalla", { waitUntil: "load" });
 
     await expect(page.locator('[aria-label="Valhalla is empty"]')).toBeVisible();
     await expect(page.locator('article[aria-label^="Closed card:"]')).toHaveCount(0);

--- a/quality/test-suites/wizard-back-button/wizard-back-button.spec.ts
+++ b/quality/test-suites/wizard-back-button/wizard-back-button.spec.ts
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto('/');
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
-  await page.goto('/cards/new', { waitUntil: 'networkidle' });
+  await page.goto('/cards/new', { waitUntil: 'load' });
   await page.waitForSelector('#issuerId');
 });
 
@@ -26,13 +26,11 @@ test('Clicking Back returns to Step 1', async ({ page }) => {
   await page.locator('#openDate').fill('2026-01-15');
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   const backButton = page.locator('button:has-text("Back")');
   await expect(backButton).toBeVisible();
 
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(300);
 
   await expect(page.locator('button:has-text("More Details")')).toBeVisible();
   await expect(page.locator('button:has-text("Back")')).not.toBeVisible();
@@ -50,10 +48,8 @@ test('All Step 1 values are preserved after clicking Back', async ({ page }) => 
   await page.locator('#openDate').fill(openDate);
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(300);
 
   const cardNameInput = page.locator('#cardName');
   const openDateInput = page.locator('#openDate');
@@ -70,7 +66,6 @@ test('Notes field is preserved through Step 2 navigation', async ({ page }) => {
   await page.locator('#openDate').fill('2026-01-10');
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   const notesArea = page.locator('#notes');
   if (await notesArea.isVisible()) {
@@ -78,10 +73,8 @@ test('Notes field is preserved through Step 2 navigation', async ({ page }) => {
   }
 
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(300);
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   const notesAfter = page.locator('#notes');
   if (await notesAfter.isVisible()) {
@@ -97,16 +90,13 @@ test('Multiple back-and-forth cycles preserve all data', async ({ page }) => {
   await page.locator('#openDate').fill('2026-02-01');
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(300);
 
   await expect(page.locator('#cardName')).toHaveValue('Multi-Cycle Card');
   await expect(page.locator('#openDate')).toHaveValue('2026-02-01');
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   const notesArea = page.locator('#notes');
   if (await notesArea.isVisible()) {
@@ -114,12 +104,10 @@ test('Multiple back-and-forth cycles preserve all data', async ({ page }) => {
   }
 
   await page.click('button:has-text("Back")');
-  await page.waitForTimeout(300);
 
   await expect(page.locator('#cardName')).toHaveValue('Multi-Cycle Card');
 
   await page.click('button:has-text("More Details")');
-  await page.waitForTimeout(300);
 
   const notesAfter = page.locator('#notes');
   if (await notesAfter.isVisible()) {

--- a/quality/test-suites/wizard-step2/wizard-step2.spec.ts
+++ b/quality/test-suites/wizard-step2/wizard-step2.spec.ts
@@ -19,7 +19,7 @@ import {
 // ─── Shared helpers ────────────────────────────────────────────────────────────
 
 async function goToNewCard(page: import("@playwright/test").Page) {
-  await page.goto("/", { waitUntil: "networkidle" });
+  await page.goto("/", { waitUntil: "load" });
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await page.goto("/ledger/cards/new", { waitUntil: "domcontentloaded" });
   await page.locator("#cardName").waitFor({ state: "visible", timeout: 15000 });


### PR DESCRIPTION
## Summary
- **CI caching**: Add npm dependency caching (`setup-node` cache) + Playwright browser caching (`actions/cache`). Saves 2-4 min per CI run by avoiding cold `npm ci` + `npx playwright install` on every push.
- **Kill `networkidle`**: Replace 184 `waitUntil: "networkidle"` with `"load"` across 26 spec files. `networkidle` adds ~500ms idle wait per call — ~100s total across the suite.
- **Remove hard sleeps**: Delete 67 `waitForTimeout` calls across 8 spec files. These were polling for UI transitions that Playwright's auto-waiting handles natively.
- **Dynamic workers**: 4 locally (was hardcoded at 2), 2 in CI, configurable via `PW_WORKERS` env var.
- **Trace off**: Was `on-first-retry` with `retries: 0` — trace was never collected.

## Impact
| Optimization | Estimated Savings |
|---|---|
| CI caching (npm + browsers) | 2-4 min per run |
| networkidle → load (184 calls × ~500ms) | ~100s total |
| Remove hard sleeps (67 calls) | ~30s total |
| 4 workers locally (was 2) | ~50% faster local runs |

## Test plan
- [ ] CI workflow runs with cache miss (first run), then cache hit (second push)
- [ ] Playwright tests pass against Vercel preview (no flakes from removed sleeps)
- [ ] Local `bash quality/scripts/verify.sh --step tsc` passes
- [ ] Local `bash quality/scripts/verify.sh --step build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)