### PR TITLE
chore: reconcile agent templates with definition files — Ref #581

### DIFF
--- a/.claude/agents/fireman-decko.md
+++ b/.claude/agents/fireman-decko.md
@@ -75,6 +75,17 @@ story refinement with edge cases.
 - Specific exception types, structured logging
 - Unit-testable: pure functions where possible, isolated side effects
 
+## Implementation Rules (UNBREAKABLE)
+
+- Mobile-friendly: min 375px, two-col collapse with `flex flex-col md:grid`.
+- **Accessibility aria-labels:** Every interactive region, card, section,
+  and landmark MUST have a meaningful `aria-label` or `aria-labelledby`. Gate regions
+  use `aria-label="<Feature Name>"` (unlocked) or `aria-label="<Feature Name> (locked)"`
+  (locked). List items like cards use `aria-label="<Card type>: <Card name>"`. This is
+  how Playwright E2E tests locate elements — missing labels = broken tests.
+- Backend code: use `import { log } from "@/lib/logger"`, never raw console.*.
+- All file paths relative to REPO_ROOT. Do NOT double-nest paths.
+
 ## Design Principles
 
 - **Platform First:** Follow framework patterns

--- a/.claude/agents/heimdall.md
+++ b/.claude/agents/heimdall.md
@@ -34,6 +34,18 @@ security/
 - NEVER echo raw secrets — mask per CLAUDE.md rules
 - All paths relative to repo root
 
+## Dispatch Modes
+
+Heimdall operates in two modes depending on the issue:
+
+- **Mode A — Code Fix:** When the issue requires changing `.ts`/`.tsx`/`.js` files
+  (auth fixes, validation, etc.). Follows the standard implement → verify → PR → handoff
+  workflow. Updates security docs if auth flows or trust boundaries change.
+
+- **Mode B — Report / Audit:** When the issue is a pen test, audit, report, or
+  remediation filing — no app code changes. Writes reports, files issues, updates docs.
+  No tsc/build needed since no app code changes.
+
 ## Workflow
 
 1. **Scope** — Determine audit area. Default: full-codebase sweep

--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -111,3 +111,92 @@ check state before acting, meaningful exit codes (0=pass, 1=fail, 2=env error).
 Zero items, exactly one, thousands (pagination), data changes while UI open,
 multiple tabs, server restart, item deleted while viewing, network timeout,
 rapid interaction (button mashing).
+
+## Test Standards (UNBREAKABLE)
+
+**READ FIRST:** `quality/test-guidelines.md` — the test pyramid and what belongs where.
+
+### Test Pyramid Enforcement (UNBREAKABLE)
+
+Before writing ANY Playwright test, ask: "Does this need a browser?"
+- HTTP header checks → **Vitest integration test**, not Playwright
+- Pure logic (utils, validators, formatters) → **Vitest unit test**, not Playwright
+- CSS animation timing → **DO NOT TEST AT ALL**
+- Token/session logic → **Vitest integration test**, not Playwright
+- One-time migration/upgrade checks → **DO NOT WRITE**
+
+If the answer is "no browser needed", write a Vitest test in `src/__tests__/` instead.
+
+### Budget (UNBREAKABLE — HARD LIMITS)
+
+| Change size | Max Playwright tests | Max Vitest tests |
+|-------------|---------------------|-----------------|
+| Small fix (1-3 files) | 1-3 | 3-5 |
+| Feature (4-10 files) | 3-5 | 5-10 |
+| Large feature (10+ files) | 5-8 | 10-15 |
+
+**>8 Playwright tests per feature = VIOLATION.** No exceptions. No justification accepted.
+One strong assertion beats five weak ones. Never pad count.
+
+**>10 tests per spec file = VIOLATION.** Split by sub-feature if you truly need more.
+
+### No Duplicate Suites (UNBREAKABLE)
+
+- **ONE suite per feature area.** Check existing suites before creating a new file.
+- If `card-lifecycle/edit-card.spec.ts` exists, add your test THERE. Do not create `card-crud/edit-card.spec.ts`.
+- If the issue number is in the filename (e.g., `issue-333/`), you're doing it wrong. Use the feature name.
+- After a bug fix lands, merge the regression test into the parent feature suite.
+
+### No Animation / CSS Timing Tests (UNBREAKABLE)
+
+Do NOT test:
+- Animation durations or easing curves
+- CSS transition timing
+- Framer Motion variants or animation states
+- Element position during animation
+
+DO test:
+- Elements appear/disappear after interaction (final state only)
+- ARIA labels exist on animated elements
+- `prefers-reduced-motion` disables animation (single test, not a whole suite)
+
+**Static/content-only changes (MDX, copy, CSS, images, docs) — ZERO Playwright tests.**
+If the PR only changes static content (MDX files, markdown, CSS classes, copy text, images),
+do NOT write Playwright tests. Instead: verify via `tsc` + `build` only. In your verdict,
+note "Static content change — build verification only, no Playwright tests needed."
+This rule overrides all other test guidance when the change is purely static.
+
+**Test behavior, not implementation:**
+ONLY test what THIS PR implements. If issue says "add X" but code doesn't, that's FAIL — not a test for X.
+Assertions derive from acceptance criteria, not from what the code currently does.
+
+**What to test:** Interactive workflows, auth flows, data persistence, form validation, error handling.
+**What NOT to test:** Static pages, static content (MDX/markdown), CSS appearance, exact text copy, DOM structure, removed features, source files (no readFileSync), HTTP headers, animation timing.
+
+### Locators — Semantic Only
+
+```typescript
+// GOOD
+page.getByRole("button", { name: "Import" });
+page.locator('[aria-label="Card status: Active"]');
+// BAD
+page.locator('.btn-primary');
+page.locator('div:nth-child(3) > button');
+```
+
+### Data Isolation
+
+```typescript
+test.beforeEach(async ({ page }) => {
+  await page.goto("/");
+  await clearAllStorage(page);
+  await seedHousehold(page, HOUSEHOLD_ID);
+});
+```
+
+**Max 2 navigation steps per test (UNBREAKABLE).**
+Pre-populate via `seedCards()` in `beforeEach`. Multi-step flows are the #1 flake source.
+
+**Group by feature:** `test.describe("Add Card — Validation", ...)` not `test.describe("CardForm renders", ...)`
+
+**Keep lean:** Max 10 tests per spec file. Use shared seed data helpers. Never use date-dependent assertions.

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -72,13 +72,19 @@ If agent cannot be inferred, error and tell user to use `--agent`.
 
 Templates live in `/fire-next-up/templates/` (shared, not duplicated):
 
-| Agent | Template |
-|-------|----------|
-| Luna | `templates/luna.md` |
-| FiremanDecko | `templates/firemandecko.md` |
-| Heimdall | `templates/heimdall.md` |
-| Loki | `templates/loki.md` |
-| Loki (CI bounce-back) | `templates/loki-bounce-back.md` |
+| Agent | Template | Agent Definition (canonical rules) |
+|-------|----------|------------------------------------|
+| Luna | `templates/luna.md` | `.claude/agents/luna.md` |
+| FiremanDecko | `templates/firemandecko.md` | `.claude/agents/fireman-decko.md` |
+| Heimdall | `templates/heimdall.md` | `.claude/agents/heimdall.md` |
+| Loki | `templates/loki.md` | `.claude/agents/loki.md` |
+| Loki (CI bounce-back) | `templates/loki-bounce-back.md` | `.claude/agents/loki.md` |
+
+**Single source of truth:** Agent definition files (`.claude/agents/*.md`) are the
+canonical source for behavioral rules (test standards, implementation rules, design
+principles, constraints, etc.). Templates contain only the dispatch workflow steps
+and reference the agent definition for behavioral rules. Do NOT duplicate behavioral
+rules in templates — add them to the agent definition file instead.
 
 All templates use `{{SANDBOX_PREAMBLE}}` — replace with the embedded preamble below.
 

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -26,16 +26,10 @@ Then create your todo list via TodoWrite. Every todo below is required:
 <FULL ISSUE BODY>
 
 **Step 3 — Implement (with incremental commits).**
+- Read `.claude/agents/fireman-decko.md` for full behavioral rules (Implementation Rules, Technical Standards, Design Principles).
 - Read affected files FIRST, then make changes.
 - <If UX Step 2: Follow Luna's wireframes for layout and structure.>
-- All file paths relative to REPO_ROOT. Do NOT double-nest paths.
-- Mobile-friendly: min 375px, two-col collapse with `flex flex-col md:grid`.
-- **Accessibility aria-labels (UNBREAKABLE):** Every interactive region, card, section,
-  and landmark MUST have a meaningful `aria-label` or `aria-labelledby`. Gate regions
-  use `aria-label="<Feature Name>"` (unlocked) or `aria-label="<Feature Name> (locked)"`
-  (locked). List items like cards use `aria-label="<Card type>: <Card name>"`. This is
-  how Playwright E2E tests locate elements — missing labels = broken tests.
-- Backend code: use `import { log } from "@/lib/logger"`, never raw console.*.
+- Follow ALL Implementation Rules from the agent definition (aria-labels, mobile-friendly, logger, paths).
 - **After each logical chunk** (1-3 files changed):
   1. git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>
   2. cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -31,6 +31,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
 <FULL ISSUE BODY>
 
 **Step 3 — Implement the security fix (with incremental commits).**
+- Read `.claude/agents/heimdall.md` for full behavioral rules (Constraints, Workflow, Severity, Report Format).
 - Read affected files FIRST, then make changes.
 - Update security docs if the fix changes auth flows, trust boundaries, or threat model.
 - Secret masking (UNBREAKABLE): never log secrets, tokens, or credentials.
@@ -102,6 +103,7 @@ Then create your todo list via TodoWrite.
 <FULL ISSUE BODY>
 
 **Step 3 — Do the work.**
+- Read `.claude/agents/heimdall.md` for full behavioral rules (Constraints, Workflow, Severity, Report Format).
 Write reports, file issues, update docs — whatever the issue requires.
 Commit and push incrementally after each logical chunk:
   git add -A && git commit -m 'security: <what> — Ref #<NUMBER>' && git push origin <BRANCH>

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -27,7 +27,9 @@ Then create your todo list via TodoWrite. Every todo below is required:
 <FULL ISSUE BODY>
 
 **Step 3 — Write and run NEW tests (with incremental commits):**
+- Read `.claude/agents/loki.md` for full behavioral rules (Test Standards, Test Pyramid, Budgets, Locators, Data Isolation).
 - Write Playwright tests in `quality/test-suites/<feature-slug>/` covering acceptance criteria.
+- Follow ALL Test Standards from the agent definition — budgets, pyramid, locators, data isolation.
 - Use the handoff's "How to verify" and "Edge cases" to guide test design.
 - **Commit+push tests before running them:**
   git add -A && git commit -m 'wip: add tests for #<NUMBER>' && git push origin <BRANCH>
@@ -82,90 +84,7 @@ gh issue comment <NUMBER> --body "## Loki QA Verdict
 
 ---
 
-## Test Standards (UNBREAKABLE)
-
-**READ FIRST:** `quality/test-guidelines.md` — the test pyramid and what belongs where.
-
-### Test Pyramid Enforcement (UNBREAKABLE)
-
-Before writing ANY Playwright test, ask: "Does this need a browser?"
-- HTTP header checks → **Vitest integration test**, not Playwright
-- Pure logic (utils, validators, formatters) → **Vitest unit test**, not Playwright
-- CSS animation timing → **DO NOT TEST AT ALL**
-- Token/session logic → **Vitest integration test**, not Playwright
-- One-time migration/upgrade checks → **DO NOT WRITE**
-
-If the answer is "no browser needed", write a Vitest test in `src/__tests__/` instead.
-
-### Budget (UNBREAKABLE — HARD LIMITS)
-
-| Change size | Max Playwright tests | Max Vitest tests |
-|-------------|---------------------|-----------------|
-| Small fix (1-3 files) | 1-3 | 3-5 |
-| Feature (4-10 files) | 3-5 | 5-10 |
-| Large feature (10+ files) | 5-8 | 10-15 |
-
-**>8 Playwright tests per feature = VIOLATION.** No exceptions. No justification accepted.
-One strong assertion beats five weak ones. Never pad count.
-
-**>10 tests per spec file = VIOLATION.** Split by sub-feature if you truly need more.
-
-### No Duplicate Suites (UNBREAKABLE)
-
-- **ONE suite per feature area.** Check existing suites before creating a new file.
-- If `card-lifecycle/edit-card.spec.ts` exists, add your test THERE. Do not create `card-crud/edit-card.spec.ts`.
-- If the issue number is in the filename (e.g., `issue-333/`), you're doing it wrong. Use the feature name.
-- After a bug fix lands, merge the regression test into the parent feature suite.
-
-### No Animation / CSS Timing Tests (UNBREAKABLE)
-
-Do NOT test:
-- Animation durations or easing curves
-- CSS transition timing
-- Framer Motion variants or animation states
-- Element position during animation
-
-DO test:
-- Elements appear/disappear after interaction (final state only)
-- ARIA labels exist on animated elements
-- `prefers-reduced-motion` disables animation (single test, not a whole suite)
-
-**Static/content-only changes (MDX, copy, CSS, images, docs) — ZERO Playwright tests.**
-If the PR only changes static content (MDX files, markdown, CSS classes, copy text, images),
-do NOT write Playwright tests. Instead: verify via `tsc` + `build` only. In your verdict,
-note "Static content change — build verification only, no Playwright tests needed."
-This rule overrides all other test guidance when the change is purely static.
-
-**Test behavior, not implementation:**
-ONLY test what THIS PR implements. If issue says "add X" but code doesn't, that's FAIL — not a test for X.
-Assertions derive from acceptance criteria, not from what the code currently does.
-
-**What to test:** Interactive workflows, auth flows, data persistence, form validation, error handling.
-**What NOT to test:** Static pages, static content (MDX/markdown), CSS appearance, exact text copy, DOM structure, removed features, source files (no readFileSync), HTTP headers, animation timing.
-
-**Locators — semantic only:**
-```typescript
-// GOOD
-page.getByRole("button", { name: "Import" });
-page.locator('[aria-label="Card status: Active"]');
-// BAD
-page.locator('.btn-primary');
-page.locator('div:nth-child(3) > button');
-```
-
-**Data isolation:**
-```typescript
-test.beforeEach(async ({ page }) => {
-  await page.goto("/");
-  await clearAllStorage(page);
-  await seedHousehold(page, HOUSEHOLD_ID);
-});
-```
-
-**Max 2 navigation steps per test (UNBREAKABLE).**
-Pre-populate via `seedCards()` in `beforeEach`. Multi-step flows are the #1 flake source.
-
-**Group by feature:** `test.describe("Add Card — Validation", ...)` not `test.describe("CardForm renders", ...)`
-
-**Keep lean:** Max 10 tests per spec file. Use shared seed data helpers. Never use date-dependent assertions.
+**Test Standards:** Canonical source is `.claude/agents/loki.md` § "Test Standards (UNBREAKABLE)".
+Read that file at the start of Step 3 — it contains budgets, pyramid enforcement,
+locator rules, data isolation patterns, and all UNBREAKABLE test constraints.
 ```

--- a/.claude/skills/fire-next-up/templates/luna.md
+++ b/.claude/skills/fire-next-up/templates/luna.md
@@ -23,6 +23,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
 <FULL ISSUE BODY>
 
 **Step 3 — Design wireframes (with incremental commits):**
+- Read `.claude/agents/luna.md` for full behavioral rules (Wireframe Rules, Design Principles, Responsibilities).
 - Create HTML wireframe(s) in `ux/wireframes/` — structure only, no theme styling.
 - Update `ux/wireframes.md` if adding new wireframes.
 - Write a brief interaction spec if the feature has non-obvious interactions.


### PR DESCRIPTION
Ref #581

Reconciles the two sources of truth for agent behavior rules. Agent definition files
(`.claude/agents/*.md`) are now the canonical source for ALL behavioral rules. Dispatch
templates (`.claude/skills/fire-next-up/templates/*.md`) contain only workflow steps and
reference the agent definitions.

**Changes:**
- `.claude/agents/loki.md` — Added Test Standards section (test pyramid, budgets, locators, data isolation, animation rules) previously only in template
- `.claude/agents/fireman-decko.md` — Added Implementation Rules section (aria-labels, mobile-friendly, logger, paths) previously only in template
- `.claude/agents/heimdall.md` — Added Dispatch Modes section (Mode A/B description) previously only in template
- `.claude/skills/fire-next-up/templates/loki.md` — Replaced inline test standards with reference to agent definition
- `.claude/skills/fire-next-up/templates/firemandecko.md` — Replaced inline implementation rules with reference to agent definition
- `.claude/skills/fire-next-up/templates/heimdall.md` — Added agent definition references in both Mode A and Mode B
- `.claude/skills/fire-next-up/templates/luna.md` — Added agent definition reference
- `.claude/skills/dispatch/SKILL.md` — Documented single-source-of-truth pattern with agent definition mapping table

**Verification:**
- Templates and agent files are consistent — single source of truth for behavioral rules
- No behavioral rules were lost — all moved from templates into agent definitions
- tsc + build PASS