### PR TITLE
chore: fix stale designs/ references in plan-w-team

### DIFF
--- a/.claude/commands/plan-w-team.md
+++ b/.claude/commands/plan-w-team.md
@@ -103,11 +103,11 @@ commit them before filing issues. Implementers need these artifacts on `main`.
 
 ```bash
 # Check for uncommitted design artifacts
-git status --short -- ux/ designs/
+git status --short -- ux/ product/
 
 # If there are changes:
 git checkout -b ux/<feature-slug>-wireframes
-git add ux/ designs/
+git add ux/ product/
 git commit -m "feat(ux): add <feature> wireframes and interaction spec
 
 Refs #<issue numbers if known>


### PR DESCRIPTION
## Summary
- Updated `plan-w-team.md` to reference `ux/` and `product/` instead of `designs/`
- Closed PR #595 (moved files wrong direction — ux/ is canonical, not designs/ux-design/)
- Updated auto-memory with correct directory structure

Directory ownership:
| Role | Directory |
|------|-----------|
| Luna (UX) | `ux/` |
| Freya (Product) | `product/` |
| Heimdall (Security) | `security/` |
| Loki (QA) | `quality/` |

`designs/` is deprecated — only contains gitignored sync report artifacts.

## Test plan
- [x] No code changes, only markdown path references

🤖 Generated with [Claude Code](https://claude.com/claude-code)