### PR TITLE
chore: inject exact wireframe paths into FiremanDecko dispatches

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -155,6 +155,24 @@ Substitute variables in the template:
 - `<TITLE>` → issue title
 - `<BRANCH>` → branch name
 - `<FULL ISSUE BODY>` → full issue body text
+- `<WIREFRAME_FILES>` → (UX chain Step 2 only) exact wireframe file paths from Luna's handoff
+
+**UX Chain — Wireframe Extraction (Step 2 FiremanDecko only):**
+
+When dispatching FiremanDecko as Step 2 of a UX chain, the orchestrator MUST:
+1. Read the `## Luna → FiremanDecko Handoff` comment from the issue.
+2. Extract the file paths listed under `**Files:**` in that comment.
+3. Substitute them into the `<WIREFRAME_FILES>` placeholder as a bulleted list of exact paths.
+
+Example substitution:
+```
+  Luna's wireframes are on this branch. Read EVERY file listed below BEFORE writing any code:
+  - `ux/wireframes/chrome/dashboard-tab-headers.html`
+  - `ux/wireframes/chrome/dashboard-tab-headers-interaction-spec.md`
+  These are the exact wireframe files Luna produced. ...
+```
+
+If no `**Files:**` field exists in the handoff, fall back to: list ALL files changed in the PR (from `gh pr view --json files`).
 
 If `--prompt-extra`, append after the issue body:
 ```

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -10,7 +10,11 @@ You are FiremanDecko, the Principal Engineer. Fix GitHub Issue #<NUMBER>: <TITLE
 **Step 2 — Read context + create todos:**
   gh issue view <NUMBER> --comments
   cd <REPO_ROOT> && git log origin/main..HEAD --oneline
-<If UX chain: Luna's wireframes are on this branch. Read them.>
+<If UX chain:
+  Luna's wireframes are on this branch. Read EVERY file listed below BEFORE writing any code:
+  <WIREFRAME_FILES>
+  These are the exact wireframe files Luna produced. Your implementation MUST match the layout,
+  structure, and responsive behavior defined in these wireframes.>
 Then create your todo list via TodoWrite. Every todo below is required:
   - Read context and plan approach
   - <One todo per logical chunk of implementation work>
@@ -28,7 +32,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
 **Step 3 — Implement (with incremental commits).**
 - Read `.claude/agents/fireman-decko.md` for full behavioral rules (Implementation Rules, Technical Standards, Design Principles).
 - Read affected files FIRST, then make changes.
-- <If UX Step 2: Follow Luna's wireframes for layout and structure.>
+- <If UX Step 2: You MUST read and follow Luna's wireframes (listed in Step 2) for layout and structure. Do not deviate from the wireframe specs.>
 - Follow ALL Implementation Rules from the agent definition (aria-labels, mobile-friendly, logger, paths).
 - **After each logical chunk** (1-3 files changed):
   1. git add -A && git commit -m 'wip: <what> — Ref #<NUMBER>' && git push origin <BRANCH>

--- a/.claude/skills/fire-next-up/templates/resume-flow.md
+++ b/.claude/skills/fire-next-up/templates/resume-flow.md
@@ -41,7 +41,7 @@ When a chain is interrupted (session ended, agent failed, context lost), use `--
 
 5. **Determine the next step:**
    - No handoff comments → Step 1 agent failed before completing. Re-run Step 1.
-   - `Luna → FiremanDecko Handoff` exists but no further → spawn FiremanDecko.
+   - `Luna → FiremanDecko Handoff` exists but no further → extract wireframe file paths from the handoff `**Files:**` field, then spawn FiremanDecko with those paths via `--prompt-extra`.
    - `FiremanDecko → Loki Handoff` or `Heimdall → Loki Handoff` exists but no verdict → spawn Loki.
    - `Loki QA Verdict` exists → check CI status (see Step 5b below).
    - `Freya Handoff` or `FiremanDecko Handoff` (without `→ Loki`) on a research issue → **Research Review** (see Step 5c below).


### PR DESCRIPTION
## Summary
- **FiremanDecko template**: `<WIREFRAME_FILES>` placeholder replaces vague "read them" instruction — now receives an explicit bulleted list of wireframe file paths from Luna's handoff
- **Dispatch SKILL**: adds wireframe extraction step for UX chain Step 2 — reads `**Files:**` from Luna's handoff comment and substitutes into the template
- **Resume flow**: updated to extract wireframe paths when resuming a Luna→FiremanDecko transition

## Test plan
- [ ] Dispatch a UX chain issue through Luna → verify handoff comment has `**Files:**`
- [ ] Resume into FiremanDecko step → verify prompt contains exact wireframe paths
- [ ] Fallback: if Luna's handoff lacks `**Files:**`, dispatch uses PR changed files list

🤖 Generated with [Claude Code](https://claude.com/claude-code)