### PR TITLE
fix: flaky daysUntil test crossing DST boundary

### DIFF
--- a/development/frontend/src/__tests__/lib/card-utils.test.ts
+++ b/development/frontend/src/__tests__/lib/card-utils.test.ts
@@ -94,13 +94,13 @@ describe("daysUntil", () => {
   });
 
   it("returns positive for future dates", () => {
-    const today = new Date("2025-03-01T00:00:00");
-    expect(daysUntil("2025-03-11T00:00:00.000Z", today)).toBe(10);
+    const today = new Date("2025-01-01T00:00:00.000Z");
+    expect(daysUntil("2025-01-11T00:00:00.000Z", today)).toBe(10);
   });
 
   it("returns negative for past dates", () => {
-    const today = new Date("2025-03-11T00:00:00");
-    expect(daysUntil("2025-03-01T00:00:00.000Z", today)).toBe(-10);
+    const today = new Date("2025-01-11T00:00:00.000Z");
+    expect(daysUntil("2025-01-01T00:00:00.000Z", today)).toBe(-10);
   });
 
   it("returns Infinity for empty string", () => {


### PR DESCRIPTION
## Summary
- Moved `daysUntil` test dates from March (crosses spring DST on Mar 9) to January to avoid timezone-dependent off-by-one (`expected 10, got 9`)

## Test plan
- [x] All 371 unit tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)