### PR TITLE
fix: E2E coverage resolves source maps — 0% → 69% lines

### DIFF
--- a/quality/scripts/coverage-combine.mjs
+++ b/quality/scripts/coverage-combine.mjs
@@ -62,16 +62,25 @@ function main() {
 
   // Generate HTML + text-summary from merged LCOV using genhtml (if available) or lcov-summary
   try {
-    // Try genhtml (from lcov package) for HTML report
+    // Try genhtml (from lcov package) for HTML report.
+    // Turbopack bundles produce duplicate function entries and missing source
+    // references — ignore these non-fatal inconsistencies.
+    const frontendDir = path.join(REPO_ROOT, "development/frontend");
     execSync(
-      `genhtml "${mergedLcovPath}" --output-directory "${COMBINED_DIR}" --quiet`,
-      { stdio: "pipe" },
+      `genhtml "${mergedLcovPath}" --output-directory "${COMBINED_DIR}" --quiet --ignore-errors inconsistent,corrupt,source,count,category --synthesize-missing --rc max_message_count=0`,
+      { stdio: ["pipe", "pipe", "pipe"], cwd: frontendDir },
     );
     log("HTML report generated via genhtml");
-  } catch {
-    // Fall back: just report the LCOV stats manually
-    log("genhtml not available — generating text summary only");
-    generateTextSummary(mergedLcov);
+  } catch (err) {
+    // genhtml exits non-zero even with --ignore-errors for some warning classes.
+    // Check if it actually produced output despite the exit code.
+    if (existsSync(path.join(COMBINED_DIR, "index.html"))) {
+      log("HTML report generated via genhtml (with warnings)");
+    } else {
+      const stderr = err.stderr?.toString() || "";
+      log(`genhtml failed — generating text summary only${stderr ? `: ${stderr.split("\n")[0]}` : ""}`);
+      generateTextSummary(mergedLcov);
+    }
   }
 
   // Always print a text summary

--- a/quality/scripts/coverage.mjs
+++ b/quality/scripts/coverage.mjs
@@ -73,10 +73,12 @@ function startServer() {
   log("Starting Next.js production server with V8 coverage enabled...");
 
   // NODE_V8_COVERAGE tells Node.js to write V8 coverage JSON files to this
-  // directory when the process exits. No wrapper tool needed.
+  // directory when the process exits cleanly. Use node directly (not npx) so
+  // SIGTERM reaches the actual Node process for a clean exit + coverage write.
+  const nextBin = path.join(FRONTEND_DIR, "node_modules", ".bin", "next");
   const serverProc = spawn(
-    "npx",
-    ["next", "start", "-p", "9653"],
+    "node",
+    [nextBin, "start", "-p", "9653"],
     {
       cwd: FRONTEND_DIR,
       stdio: ["ignore", "pipe", "pipe"],
@@ -173,7 +175,10 @@ function generateReports() {
 
   log("Generating Playwright coverage reports via c8...");
 
-  // c8 report reads NODE_V8_COVERAGE data and generates Istanbul-format reports
+  // c8 reads V8 coverage JSON and resolves source maps from .next/server/chunks/
+  // back to src/. Do NOT use --all/--src/--include as they prevent source map
+  // resolution — the compiled chunks live under .next/ not src/.
+  // Instead, exclude non-app code and let source maps handle the mapping.
   const c8Args = [
     "c8", "report",
     "--temp-directory", V8_COVERAGE_DIR,
@@ -182,12 +187,6 @@ function generateReports() {
     "--reporter", "html",
     "--reporter", "lcov",
     "--reports-dir", reportsDir,
-    "--all",
-    "--src", path.join(FRONTEND_DIR, "src"),
-    "--include", "src/**/*.ts",
-    "--include", "src/**/*.tsx",
-    "--exclude", "src/**/*.test.*",
-    "--exclude", "src/**/*.spec.*",
     "--exclude", "node_modules/**",
   ];
 


### PR DESCRIPTION
## Summary
- **coverage.mjs**: Removed `--all`/`--src`/`--include` c8 args that blocked source map resolution. V8 coverage data references `.next/server/chunks/ssr/` paths — c8 needs to follow `sourceMappingURL` comments back to `src/`. The old filter prevented this entirely.
- **coverage.mjs**: Spawn `node` directly instead of `npx` for clean SIGTERM → V8 coverage write.
- **coverage-combine.mjs**: genhtml runs from `development/frontend/` (where `.next/` lives) with `--ignore-errors` for Turbopack duplicate functions, missing sources, and unknown categories.
- E2E server-side coverage: **0% → 69.3% lines** (164K/237K statements)
- Combined (unit + E2E): **22.6% → 68.6% lines** (165K/241K)

## Test plan
- [x] `node quality/scripts/coverage.mjs --combined --skip-build` produces reports
- [x] `quality/reports/coverage/playwright/index.html` — real coverage data
- [x] `quality/reports/coverage/combined/index.html` — genhtml HTML report generated
- [x] All 371 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)