### PR TITLE
fix: filter node_modules/.next from combined coverage — 1696 → 309 files

### DIFF
--- a/.claude/skills/coverage-report/SKILL.md
+++ b/.claude/skills/coverage-report/SKILL.md
@@ -5,7 +5,7 @@ description: "Generate code coverage reports. Supports Vitest (--unit-only), Pla
 
 # Coverage Report
 
-Generate code coverage reports via `verify.sh --coverage` or `coverage.mjs` directly.
+Generate code coverage reports via `coverage.mjs` directly.
 
 ## Usage
 
@@ -21,8 +21,6 @@ Runs Vitest unit + integration tests with V8 coverage. Fast, no browser needed.
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
-cd "$REPO_ROOT" && bash quality/scripts/verify.sh --step unit --coverage
-# or
 cd "$REPO_ROOT" && node quality/scripts/coverage.mjs --unit-only
 ```
 
@@ -30,55 +28,78 @@ Reports: `quality/reports/coverage/vitest/` (HTML + LCOV + text-summary)
 
 ### E2E-only mode (default)
 
-Runs Playwright E2E tests with V8 server-side coverage.
+Starts the Next.js production server with `NODE_V8_COVERAGE`, runs Playwright
+tests, then sends SIGTERM for a clean exit that flushes V8 coverage files.
+Uses c8 to process the V8 data — source maps from `.next/server/chunks/ssr/`
+map compiled code back to `src/` automatically.
 
 ```bash
-cd "$REPO_ROOT" && bash quality/scripts/verify.sh --step e2e --coverage
-# or
 cd "$REPO_ROOT" && node quality/scripts/coverage.mjs
 ```
 
-Reports: `quality/reports/coverage/` (HTML + LCOV + text-summary)
+Reports: `quality/reports/coverage/playwright/` (HTML + LCOV + text-summary)
+
+**Note:** `--skip-build` skips the Next.js build if `.next/` already exists.
 
 ### Combined mode (`--combined`)
 
-Runs Vitest + Playwright coverage, then merges into a single combined report.
+Runs Vitest + Playwright coverage, then merges into a single report.
 
 ```bash
-cd "$REPO_ROOT" && node quality/scripts/coverage.mjs --combined
-# or manually:
-cd "$REPO_ROOT" && bash quality/scripts/verify.sh --step test --coverage
+cd "$REPO_ROOT" && node quality/scripts/coverage.mjs --combined [--skip-build]
+# or merge existing reports only:
 cd "$REPO_ROOT" && node quality/scripts/coverage-combine.mjs
 ```
 
 Reports:
 - `quality/reports/coverage/vitest/` — unit/integration coverage
 - `quality/reports/coverage/playwright/` — E2E server-side coverage
-- `quality/reports/coverage/combined/` — merged report (LCOV + HTML if genhtml available)
+- `quality/reports/coverage/combined/` — merged report (HTML via genhtml + LCOV)
 
 ## Execution
 
-Always run from the repo root. The scripts handle dependency installation automatically (including `@vitest/coverage-v8` and the npm rollup native module bug).
+Always run from the repo root. The scripts handle dependency installation
+automatically (`@vitest/coverage-v8`, rollup native module).
+
+Requires `genhtml` for the combined HTML report:
+```bash
+brew install lcov   # macOS
+```
 
 ### Viewing reports
 
 ```bash
-# Unit coverage
-open quality/reports/coverage/vitest/index.html
-
-# E2E coverage
-open quality/reports/coverage/playwright/index.html
-
-# Combined coverage
-open quality/reports/coverage/combined/index.html
+open quality/reports/coverage/vitest/index.html      # Unit
+open quality/reports/coverage/playwright/index.html  # E2E
+open quality/reports/coverage/combined/index.html    # Combined
 ```
+
+## Styling the HTML report
+
+Drop a custom CSS file at `quality/scripts/coverage.css`. It will be picked
+up automatically by `coverage-combine.mjs` and passed to genhtml via
+`--css-file`. The file completely replaces genhtml's default stylesheet.
+
+genhtml's default classes to target: `coverFile`, `coverBar`, `coverPerHi`
+(green), `coverPerMed` (yellow), `coverPerLo` (red), `title`, `tableHead`.
+
+## How E2E coverage works
+
+1. Next.js production build creates `.next/server/chunks/ssr/*.js` files with
+   inline `sourceMappingURL` comments pointing to sibling `.js.map` files.
+2. Server starts with `NODE_V8_COVERAGE` — Node writes raw V8 coverage JSON to
+   `quality/.coverage-tmp/` on clean exit.
+3. SIGTERM → server exits cleanly → coverage files written.
+4. c8 reads V8 JSON, follows source maps to resolve `.next/` paths back to `src/`.
+5. `coverage-combine.mjs` filters `.next/` and `node_modules` entries from the
+   merged LCOV so genhtml only reports on `src/` source files.
 
 ## Notes
 
 - Reports are overwritten on every run (no dated directories)
 - `quality/reports/` is in `.gitignore`
-- The combiner (`coverage-combine.mjs`) merges LCOV files from all available sources
-- If only one source has data, it still generates the combined report from that source
-- E2E coverage is server-side only (API routes, middleware) — client code is bundled/minified
-- `--coverage` flag works with all `verify.sh` step modes: `--step unit`, `--step e2e`, `--step test`
-- `--combined` flag on `coverage.mjs` orchestrates the full pipeline in one command
+- `quality/.coverage-tmp/` is kept after each run for inspection (also gitignored)
+- E2E coverage is server-side only — client-rendered components show 0% unless
+  they also run server-side (RSC, API routes, middleware)
+- `coverage-combine.mjs` can be run standalone to re-merge existing LCOV files
+  without re-running tests

--- a/quality/scripts/coverage-combine.mjs
+++ b/quality/scripts/coverage-combine.mjs
@@ -9,6 +9,12 @@
  * Outputs combined report to:
  *   quality/reports/coverage/combined/  (HTML + LCOV + text-summary)
  *
+ * Filters out .next/ compiled artifacts and node_modules so genhtml only
+ * sees src/ source files.
+ *
+ * Custom CSS: if quality/scripts/coverage.css exists it is passed to genhtml
+ * via --css-file to style the HTML report.
+ *
  * Overwrites previous combined report on every run.
  *
  * Usage:
@@ -24,10 +30,20 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../..");
 const COVERAGE_DIR = path.join(REPO_ROOT, "quality/reports/coverage");
 const COMBINED_DIR = path.join(COVERAGE_DIR, "combined");
+const CUSTOM_CSS = path.join(__dirname, "coverage.css");
 
 const SOURCES = [
   { name: "vitest", lcov: path.join(COVERAGE_DIR, "vitest/lcov.info") },
   { name: "playwright", lcov: path.join(COVERAGE_DIR, "playwright/lcov.info") },
+];
+
+// LCOV entries (SF: ... end_of_record) to exclude from the combined report.
+// Playwright source maps produce both .next/ compiled artifacts and src/ entries
+// for the same code — keep only src/. node_modules slips through source map
+// resolution occasionally.
+const EXCLUDE_PREFIXES = [
+  ".next/",
+  "node_modules/",
 ];
 
 function ts() {
@@ -37,10 +53,27 @@ function log(msg) {
   console.log(`[${ts()}] ${msg}`);
 }
 
+/**
+ * Filter out LCOV records whose SF: path starts with any of EXCLUDE_PREFIXES.
+ * Returns cleaned LCOV string and a count of dropped records.
+ */
+function filterLcov(lcov) {
+  const records = lcov.split("end_of_record");
+  let kept = 0, dropped = 0;
+  const filtered = records.filter((rec) => {
+    const sf = rec.match(/^SF:(.+)$/m)?.[1]?.trim();
+    if (!sf) return false; // empty trailing chunk
+    const exclude = EXCLUDE_PREFIXES.some((p) => sf.startsWith(p));
+    if (exclude) { dropped++; return false; }
+    kept++;
+    return true;
+  });
+  return { lcov: filtered.map((r) => r + "end_of_record").join("\n"), kept, dropped };
+}
+
 function main() {
   log("Combining coverage reports...");
 
-  // Check which sources exist
   const available = SOURCES.filter((s) => existsSync(s.lcov));
   if (available.length === 0) {
     log("ERROR: No coverage data found. Run verify.sh --coverage first.");
@@ -50,41 +83,47 @@ function main() {
 
   log(`Found coverage from: ${available.map((s) => s.name).join(", ")}`);
 
-  // Clean and recreate combined output dir
   if (existsSync(COMBINED_DIR)) rmSync(COMBINED_DIR, { recursive: true });
   mkdirSync(COMBINED_DIR, { recursive: true });
 
-  // Merge LCOV files (simple concatenation — lcov format supports this)
-  const mergedLcov = available.map((s) => readFileSync(s.lcov, "utf-8")).join("\n");
+  // Merge then filter
+  const raw = available.map((s) => readFileSync(s.lcov, "utf-8")).join("\n");
+  const { lcov: filtered, kept, dropped } = filterLcov(raw);
+  log(`LCOV filtered: ${kept} records kept, ${dropped} dropped (.next/ + node_modules)`);
+
   const mergedLcovPath = path.join(COMBINED_DIR, "lcov.info");
-  writeFileSync(mergedLcovPath, mergedLcov);
+  writeFileSync(mergedLcovPath, filtered);
   log(`Merged LCOV written to ${mergedLcovPath}`);
 
-  // Generate HTML + text-summary from merged LCOV using genhtml (if available) or lcov-summary
+  // Build genhtml command
+  const frontendDir = path.join(REPO_ROOT, "development/frontend");
+  const cssFlag = existsSync(CUSTOM_CSS) ? `--css-file "${CUSTOM_CSS}"` : "";
+  if (cssFlag) log(`Custom CSS: ${path.relative(REPO_ROOT, CUSTOM_CSS)}`);
+
+  const genHtmlCmd = [
+    `genhtml "${mergedLcovPath}"`,
+    `--output-directory "${COMBINED_DIR}"`,
+    "--quiet",
+    "--ignore-errors inconsistent,corrupt,source,count,category",
+    "--synthesize-missing",
+    "--rc max_message_count=0",
+    cssFlag,
+  ].filter(Boolean).join(" ");
+
   try {
-    // Try genhtml (from lcov package) for HTML report.
-    // Turbopack bundles produce duplicate function entries and missing source
-    // references — ignore these non-fatal inconsistencies.
-    const frontendDir = path.join(REPO_ROOT, "development/frontend");
-    execSync(
-      `genhtml "${mergedLcovPath}" --output-directory "${COMBINED_DIR}" --quiet --ignore-errors inconsistent,corrupt,source,count,category --synthesize-missing --rc max_message_count=0`,
-      { stdio: ["pipe", "pipe", "pipe"], cwd: frontendDir },
-    );
+    execSync(genHtmlCmd, { stdio: ["pipe", "pipe", "pipe"], cwd: frontendDir });
     log("HTML report generated via genhtml");
   } catch (err) {
-    // genhtml exits non-zero even with --ignore-errors for some warning classes.
-    // Check if it actually produced output despite the exit code.
     if (existsSync(path.join(COMBINED_DIR, "index.html"))) {
       log("HTML report generated via genhtml (with warnings)");
     } else {
       const stderr = err.stderr?.toString() || "";
-      log(`genhtml failed — generating text summary only${stderr ? `: ${stderr.split("\n")[0]}` : ""}`);
-      generateTextSummary(mergedLcov);
+      log(`genhtml failed — text summary only${stderr ? `: ${stderr.split("\n")[0]}` : ""}`);
+      generateTextSummary(filtered);
     }
   }
 
-  // Always print a text summary
-  generateTextSummary(mergedLcov);
+  generateTextSummary(filtered);
 
   log("");
   log("Coverage reports:");
@@ -98,7 +137,6 @@ function main() {
 }
 
 function generateTextSummary(lcovContent) {
-  // Parse LCOV to extract line/function/branch counts
   let linesHit = 0, linesTotal = 0;
   let fnHit = 0, fnTotal = 0;
   let brHit = 0, brTotal = 0;


### PR DESCRIPTION
## Summary
- Strips `.next/` compiled artifacts and `node_modules` from merged LCOV before genhtml. Playwright source maps produce both `.next/server/chunks/ssr/` and `src/` entries for the same code — previously both ended up in the combined report.
- Combined report: **1696 noise files → 309 clean `src/` files**
- Combined coverage: 54.0% lines | 21.2% branches | 20.6% functions
- Adds `--css-file` support: drop a `quality/scripts/coverage.css` to restyle the HTML report
- SKILL.md updated with E2E mechanics, CSS styling docs, `--skip-build` flag, genhtml install

## Test plan
- [x] `node quality/scripts/coverage-combine.mjs` — 309 records, HTML generated, no .next/ entries
- [x] No `node_modules` in report

🤖 Generated with [Claude Code](https://claude.com/claude-code)