### PR TITLE
fix: update stale E2E test assertions to match current UI

### DIFF
--- a/quality/test-suites/chronicles/chronicles.spec.ts
+++ b/quality/test-suites/chronicles/chronicles.spec.ts
@@ -34,11 +34,11 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
 
     // Verify page title
     const title = page.locator("h1");
-    await expect(title).toContainText("Chronicles");
+    await expect(title).toContainText("Prose Edda");
 
     // Verify page description
     const description = page.locator("p");
-    await expect(description.first()).toContainText("Behind-the-scenes narratives");
+    await expect(description.first()).toContainText("sagas of the forge");
 
     // Verify chronicle cards exist - look for links with h2 inside (title elements)
     const cards = page.locator("a[href*='/chronicles/']");
@@ -118,8 +118,8 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     // Navigate to home page to verify navbar/footer
     await page.goto("/", { waitUntil: "load" });
 
-    // Find all links with text "Chronicles"
-    const chroniclesLinks = page.locator("a:has-text('Chronicles')");
+    // Find all links with text "Prose Edda" (chronicles page was renamed)
+    const chroniclesLinks = page.locator("a:has-text('Prose Edda')");
     const count = await chroniclesLinks.count();
     expect(count).toBeGreaterThanOrEqual(2); // At least navbar + footer
 
@@ -186,8 +186,8 @@ test.describe("Chronicles Migration QA — Issue #373", () => {
     // Navigate to detail page
     await page.goto(href || "/chronicles", { waitUntil: "load" });
 
-    // Look for "All Chronicles" link which indicates prev/next nav exists
-    const allChroniclesLink = page.locator("a:has-text('All Chronicles')");
+    // Look for "Back to All Sagas" link which indicates prev/next nav exists
+    const allChroniclesLink = page.locator("a:has-text('Back to All Sagas')");
     await expect(allChroniclesLink).toBeVisible({ timeout: 5000 });
 
     // Verify navigation sections exist (breadcrumb + prev/next)

--- a/quality/test-suites/csv-format-help/csv-format-help.spec.ts
+++ b/quality/test-suites/csv-format-help/csv-format-help.spec.ts
@@ -9,6 +9,7 @@
 import { test, expect } from "@playwright/test";
 import {
   seedCards,
+  seedEntitlement,
   seedHousehold,
   clearAllStorage,
   ANONYMOUS_HOUSEHOLD_ID,
@@ -43,6 +44,7 @@ async function setupAuthenticatedWithCards(page: any): Promise<void> {
   await seedFakeAuth(page);
   await seedHousehold(page, AUTH_HOUSEHOLD_ID);
   await seedCards(page, AUTH_HOUSEHOLD_ID, FEW_CARDS);
+  await seedEntitlement(page);
   await page.reload({ waitUntil: "load" });
   await page.getByRole("link", { name: "Add Card" }).waitFor({ state: "visible", timeout: 15000 });
 }

--- a/quality/test-suites/dashboard/dashboard.spec.ts
+++ b/quality/test-suites/dashboard/dashboard.spec.ts
@@ -186,11 +186,9 @@ test.describe("Dashboard — Summary Stats", () => {
     await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, URGENT_CARDS);
     await page.reload({ waitUntil: "load" });
 
-    // Spec: Dashboard.tsx renders "{needsAttention.length} need{plural} attention"
     // URGENT_CARDS has 5 cards: 3 fee_approaching + 2 promo_expiring = 5 urgent
+    // The count appears in the Howl tab badge
     await expect(page.locator("body")).toContainText("5");
-    await expect(page.locator("body")).toContainText("need");
-    await expect(page.locator("body")).toContainText("attention");
   });
 
   test("no 'needs attention' shown when all cards are active", async ({

--- a/quality/test-suites/dialog-a11y/dialog-a11y.spec.ts
+++ b/quality/test-suites/dialog-a11y/dialog-a11y.spec.ts
@@ -17,6 +17,7 @@
 import { test, expect } from "@playwright/test";
 import {
   seedCards,
+  seedEntitlement,
   seedHousehold,
   clearAllStorage,
   ANONYMOUS_HOUSEHOLD_ID,
@@ -58,6 +59,7 @@ async function setupAuthenticatedWithCards(page: any): Promise<void> {
   await seedFakeAuth(page);
   await seedHousehold(page, AUTH_HOUSEHOLD_ID);
   await seedCards(page, AUTH_HOUSEHOLD_ID, FEW_CARDS);
+  await seedEntitlement(page);
   await page.reload({ waitUntil: "load" });
   await page.getByRole("link", { name: "Add Card" }).waitFor({ state: "visible", timeout: 15000 });
 }

--- a/quality/test-suites/empty-state-cta/empty-state-cta.spec.ts
+++ b/quality/test-suites/empty-state-cta/empty-state-cta.spec.ts
@@ -38,7 +38,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     // Reload with networkidle so all async effects settle.
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // Count all /cards/new links — must be exactly 1 (EmptyState only, no header dupe).
     const addCardLinks = page.locator('a[href="/ledger/cards/new"]');
@@ -53,7 +53,7 @@ test.describe("AC-1 & AC-4 — Single primary CTA (no duplicate Add Card)", () =
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // The EmptyState is identified by its aria-description (Gleipnir ingredient 6 easter egg).
     const emptyState = page.locator('[aria-description="the spittle of a bird"]');
@@ -94,7 +94,7 @@ test.describe("AC-2 — Upsell banner not shown to new (zero-card) users", () =>
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // The full SignInNudge banner has role="region" aria-label="Sync your data".
     // It must NOT appear in the zero-cards state.
@@ -132,7 +132,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // The subtle nudge renders as a <button> with text "Sign in to sync your data".
     const subtleNudge = page.locator('button:text("Sign in to sync your data")');
@@ -145,7 +145,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // Full banner identified by role="region" with aria-label — must not be present.
     const fullBanner = page.locator('[role="region"][aria-label="Sync your data"]');
@@ -158,7 +158,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     const subtleNudge = page.locator('button:text("Sign in to sync your data")');
     await expect(subtleNudge).toBeVisible();
@@ -177,7 +177,7 @@ test.describe("AC-3 — Sign-in nudge is subtle (not a full-width banner) at zer
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // The nudge paragraph carries "muted-foreground" styling — it is NOT a primary/gold CTA.
     const parentParagraph = page.locator(
@@ -203,7 +203,7 @@ test.describe("Edge cases", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     expect(jsErrors).toHaveLength(0);
   });
@@ -218,7 +218,7 @@ test.describe("Edge cases", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     const addCardLinks = page.locator('a[href="/ledger/cards/new"]');
     await expect(addCardLinks).toHaveCount(1);
@@ -235,7 +235,7 @@ test.describe("Edge cases", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     const subtleNudge = page.locator('button:text("Sign in to sync your data")');
     await expect(subtleNudge).toBeVisible();
@@ -249,7 +249,7 @@ test.describe("Edge cases", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     const headline = page.locator("h2").filter({ hasText: /Gleipnir/ });
     await expect(headline).toBeVisible();
@@ -263,7 +263,7 @@ test.describe("Edge cases", () => {
     await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
     await page.reload({ waitUntil: "load" });
 
-    await page.waitForSelector('text="Before"', { timeout: 10000 });
+    await page.waitForSelector('[aria-description="the spittle of a bird"]', { timeout: 10000 });
 
     // Exactly one /cards/new link (EmptyState only).
     const addCardLinks = page.locator('a[href="/ledger/cards/new"]');

--- a/quality/test-suites/howl-count/howl-count-badge.spec.ts
+++ b/quality/test-suites/howl-count/howl-count-badge.spec.ts
@@ -11,6 +11,7 @@ import { test, expect } from "@playwright/test";
 import {
   clearAllStorage,
   seedCards,
+  seedEntitlement,
   seedHousehold,
   makeCard,
   makeUrgentCard,
@@ -30,6 +31,7 @@ async function setup(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
+  await seedEntitlement(page);
   await page.reload({ waitUntil: "load" });
 }
 

--- a/quality/test-suites/layout/howl-panel.spec.ts
+++ b/quality/test-suites/layout/howl-panel.spec.ts
@@ -16,6 +16,7 @@ import { test, expect } from "@playwright/test";
 import {
   clearAllStorage,
   seedCards,
+  seedEntitlement,
   seedHousehold,
   makeCard,
   makeUrgentCard,
@@ -35,6 +36,7 @@ async function setup(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
+  await seedEntitlement(page);
   await page.reload({ waitUntil: "load" });
 }
 

--- a/quality/test-suites/profile-dropdown/profile-dropdown.spec.ts
+++ b/quality/test-suites/profile-dropdown/profile-dropdown.spec.ts
@@ -107,13 +107,8 @@ test.describe("Profile Dropdown — Desktop (1280px)", () => {
     const userMenu = page.locator('[role="menu"]');
     await expect(userMenu).toBeVisible();
 
-    // Then: dropdown has four sections in order:
-    // 1. Profile header (informational)
-    const profileHeader = userMenu.locator("div[aria-hidden='true']").first();
-    await expect(profileHeader).toContainText(MOCK_USER.name);
-    await expect(profileHeader).toContainText(MOCK_USER.email);
-
-    // 2. My Cards link (first menuitem)
+    // Then: dropdown has four sections:
+    // 1. My Cards link (first menuitem)
     const myCardsButton = userMenu.locator('[role="menuitem"]').nth(0);
     await expect(myCardsButton).toBeVisible();
     await expect(myCardsButton).toContainText("My Cards");
@@ -375,13 +370,6 @@ test.describe("Profile Dropdown — Mobile (375px)", () => {
     await expect(menuBox.x + menuBox.width).toBeLessThanOrEqual(
       viewportSize.width - 4
     );
-
-    // All text should be readable (not overflowing)
-    const profileHeader = userMenu.locator("div[aria-hidden='true']").first();
-    const isOverflowing = await profileHeader.evaluate((el) => {
-      return el.scrollWidth > el.clientWidth;
-    });
-    await expect(isOverflowing).toBe(false);
   });
 
   test("TC-PD-M03: Menu items are touch-friendly on mobile", async ({

--- a/quality/test-suites/reverse-tab-order/dashboard-tab-order.spec.ts
+++ b/quality/test-suites/reverse-tab-order/dashboard-tab-order.spec.ts
@@ -16,6 +16,7 @@ import { test, expect } from "@playwright/test";
 import {
   clearAllStorage,
   seedCards,
+  seedEntitlement,
   seedHousehold,
   makeCard,
   makeUrgentCard,
@@ -32,6 +33,7 @@ async function setupDashboard(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
+  await seedEntitlement(page);
   await page.reload({ waitUntil: "load" });
 }
 


### PR DESCRIPTION
## Summary
- **chronicles**: assertions updated for page rename to "Prose Edda" and back link "↑ Back to All Sagas"
- **csv-format-help, dialog-a11y**: seed Karl entitlement so Import button opens Import Wizard (not upsell dialog)
- **howl-count, howl-panel**: seed Karl entitlement so Howl tab badge and panel render (not locked)
- **reverse-tab-order**: seed Karl entitlement so Hunt/Howl tabs can be clicked/navigated (not upsell)
- **dashboard**: remove stale "needs attention" stat assertions (UI stat was removed)
- **empty-state-cta**: replace `text="Before"` (exact-match, never matches) with `[aria-description="the spittle of a bird"]`
- **profile-dropdown**: remove `div[aria-hidden='true']` profile header assertions (dropdown has no such element)

## Root causes
Most failures were caused by Karl tier entitlement gating added after these tests were written. Tests that interact with Import, Howl tab, or Hunt tab need `seedEntitlement()` to bypass the upsell wall.

## Test plan
- [ ] CI runs clean on this PR (tsc + unit + e2e all green)
- [ ] After merge, rebase branches #583 and #585 onto updated main

🤖 Generated with [Claude Code](https://claude.com/claude-code)