### PR TITLE
fix: add seedEntitlement to dashboard-tabs tests

### DIFF
--- a/quality/test-suites/dashboard-tabs/dashboard-tabs.spec.ts
+++ b/quality/test-suites/dashboard-tabs/dashboard-tabs.spec.ts
@@ -18,6 +18,7 @@ import { test, expect } from "@playwright/test";
 import {
   clearAllStorage,
   seedCards,
+  seedEntitlement,
   seedHousehold,
   makeCard,
   makeUrgentCard,
@@ -34,6 +35,7 @@ async function setupDashboard(
   await clearAllStorage(page);
   await seedHousehold(page, ANONYMOUS_HOUSEHOLD_ID);
   await seedCards(page, ANONYMOUS_HOUSEHOLD_ID, cards);
+  await seedEntitlement(page);
   await page.reload({ waitUntil: "load" });
 }
 
@@ -130,13 +132,13 @@ test.describe("Dashboard Tabs QA — Issue #279", () => {
         makeUrgentCard({ cardName: "Urgent" }),
       ]);
 
-      // Tab order: Howl → Hunt → Active → Valhalla → All
-      const howlTab = page.locator('button#tab-howl');
-      const huntTab = page.locator('button#tab-hunt');
+      // Tab order: All → Valhalla → Active → Hunt → Howl
+      const allTab = page.locator('button#tab-all');
+      const valhallaTab = page.locator('button#tab-valhalla');
 
-      await howlTab.focus();
+      await allTab.focus();
       await page.keyboard.press("ArrowRight");
-      await expect(huntTab).toHaveAttribute("aria-selected", "true");
+      await expect(valhallaTab).toHaveAttribute("aria-selected", "true");
     });
   });
 


### PR DESCRIPTION
## Summary
- Missed in PR #606 — `dashboard-tabs/dashboard-tabs.spec.ts` needs Karl entitlement to click Howl/Hunt tabs
- Fixed stale ArrowRight test: tab order is All→Valhalla→Active→Hunt→Howl (reversed from old order)

## Test plan
- [ ] CI green after merge + rebase of PRs #599 and #600

🤖 Generated with [Claude Code](https://claude.com/claude-code)