### PR TITLE
fix: restore Elder Futhark runes in dashboard tabs — Ref #616

### DIFF
--- a/development/frontend/src/app/(marketing)/about/page.tsx
+++ b/development/frontend/src/app/(marketing)/about/page.tsx
@@ -31,14 +31,14 @@ import Link from "next/link";
 
 /** Rune characters (Elder Futhark). */
 const RUNE = {
-  fehu: "\u16A0",
-  ehwaz: "\u16D6",
-  naudiz: "\u16BE",
-  raidho: "\u16B1",
-  isa: "\u16C1",
-  laguz: "\u16DA",
-  tiwaz: "\u16CF",
-  hagalaz: "\u16BA",
+  fehu: "ᚠ",
+  ehwaz: "ᛖ",
+  naudiz: "ᚾ",
+  raidho: "ᚱ",
+  isa: "ᛁ",
+  laguz: "ᛚ",
+  tiwaz: "ᛏ",
+  hagalaz: "ᚺ",
 } as const;
 
 /** FENRIR in Elder Futhark runes. */

--- a/development/frontend/src/components/dashboard/Dashboard.tsx
+++ b/development/frontend/src/components/dashboard/Dashboard.tsx
@@ -629,7 +629,7 @@ export function Dashboard({ cards, initialTab }: DashboardProps) {
         <TabSummary tabId="howl" cards={displayHowlCards} />
         <div tabIndex={-1} className="outline-none pt-5">
           {displayHowlCards.length === 0 ? (
-            <TabEmptyState tabId="howl" rune="\u16B2" />
+            <TabEmptyState tabId="howl" rune="ᚲ" />
           ) : (
             <AnimatedCardGrid
               cards={displayHowlCards}
@@ -656,7 +656,7 @@ export function Dashboard({ cards, initialTab }: DashboardProps) {
         <TabSummary tabId="hunt" cards={displayHuntCards} />
         <div tabIndex={-1} className="outline-none pt-5">
           {displayHuntCards.length === 0 ? (
-            <TabEmptyState tabId="hunt" rune="\u16DC" />
+            <TabEmptyState tabId="hunt" rune="ᛜ" />
           ) : (
             <AnimatedCardGrid
               cards={displayHuntCards}
@@ -683,7 +683,7 @@ export function Dashboard({ cards, initialTab }: DashboardProps) {
         <TabSummary tabId="active" cards={displayActiveCards} />
         <div tabIndex={-1} className="outline-none pt-5">
           {displayActiveCards.length === 0 ? (
-            <TabEmptyState tabId="active" rune="\u16C9" />
+            <TabEmptyState tabId="active" rune="ᛉ" />
           ) : (
             <AnimatedCardGrid
               cards={displayActiveCards}
@@ -710,7 +710,7 @@ export function Dashboard({ cards, initialTab }: DashboardProps) {
         <TabSummary tabId="valhalla" cards={displayValhallaCards} />
         <div tabIndex={-1} className="outline-none pt-5">
           {displayValhallaCards.length === 0 ? (
-            <TabEmptyState tabId="valhalla" rune="\u2191" />
+            <TabEmptyState tabId="valhalla" rune="↑" />
           ) : (
             <AnimatedCardGrid
               cards={displayValhallaCards}
@@ -737,7 +737,7 @@ export function Dashboard({ cards, initialTab }: DashboardProps) {
         <TabSummary tabId="all" cards={displayCards} />
         <div tabIndex={-1} className="outline-none pt-5">
           {displayCards.length === 0 ? (
-            <TabEmptyState tabId="all" rune="\u16DF" />
+            <TabEmptyState tabId="all" rune="ᛟ" />
           ) : (
             <AnimatedCardGrid
               cards={displayCards}

--- a/development/frontend/src/components/dashboard/DashboardTabs.tsx
+++ b/development/frontend/src/components/dashboard/DashboardTabs.tsx
@@ -145,7 +145,7 @@ export function DashboardTabs({ cards, children }: DashboardTabsProps) {
             )}
             style={{ fontFamily: "serif" }}
           >
-            {ragnarokActive ? "\u16A0" : "\u16B2"}
+            {ragnarokActive ? "ᚠ" : "ᚲ"}
           </span>
           {ragnarokActive ? "Ragnarok Approaches" : "The Howl"}
           {/* Badge */}
@@ -190,7 +190,7 @@ export function DashboardTabs({ cards, children }: DashboardTabsProps) {
             className="text-base leading-none select-none"
             style={{ fontFamily: "serif" }}
           >
-            {"\u16C9"}
+            {"ᛉ"}
           </span>
           Active
           <span

--- a/development/frontend/src/components/dashboard/HowlTeaserState.tsx
+++ b/development/frontend/src/components/dashboard/HowlTeaserState.tsx
@@ -35,7 +35,7 @@ const SAMPLE_ALERTS: SampleAlert[] = [
   {
     id: "sample-1",
     urgencyLabel: "ANNUAL FEE \u00B7 7 DAYS REMAINING",
-    rune: "\u16A6",
+    rune: "ᚦ",
     issuer: "CHASE SAPPHIRE",
     cardName: "Preferred Reserve",
     amount: "$95 annual fee due Mar 15",
@@ -44,7 +44,7 @@ const SAMPLE_ALERTS: SampleAlert[] = [
   {
     id: "sample-2",
     urgencyLabel: "PROMO EXPIRING \u00B7 14 DAYS REMAINING",
-    rune: "\u16B7",
+    rune: "ᚷ",
     issuer: "AMEX GOLD",
     cardName: "Spend $4,000 by Apr 1",
     amount: "$2,100 remaining to unlock 75,000 pts",
@@ -53,7 +53,7 @@ const SAMPLE_ALERTS: SampleAlert[] = [
   {
     id: "sample-3",
     urgencyLabel: "ANNUAL FEE \u00B7 30 DAYS REMAINING",
-    rune: "\u16B9",
+    rune: "ᚹ",
     issuer: "CAPITAL ONE",
     cardName: "Venture X Rewards",
     amount: "$395 annual fee due Apr 2",

--- a/development/frontend/src/components/entitlement/KarlUpsellDialog.tsx
+++ b/development/frontend/src/components/entitlement/KarlUpsellDialog.tsx
@@ -265,7 +265,7 @@ export function KarlUpsellDialog({
  * Usage: <KarlUpsellDialog {...KARL_UPSELL_VALHALLA} open={...} onDismiss={...} />
  */
 export const KARL_UPSELL_VALHALLA = {
-  featureIcon: "\u16CF", // ᛏ Tiwaz rune
+  featureIcon: "ᛏ", // Tiwaz rune
   featureName: "Valhalla",
   featureTagline: "Hall of the Honored Dead",
   featureTeaser:
@@ -284,7 +284,7 @@ export const KARL_UPSELL_VALHALLA = {
  * Usage: <KarlUpsellDialog {...KARL_UPSELL_HOWL} open={...} onDismiss={...} />
  */
 export const KARL_UPSELL_HOWL = {
-  featureIcon: "\u16B2", // ᚲ Kenaz rune
+  featureIcon: "ᚲ", // Kenaz rune
   featureName: "The Howl",
   featureTagline: "The Wolf Cries Before the Chain Breaks",
   featureTeaser:
@@ -303,7 +303,7 @@ export const KARL_UPSELL_HOWL = {
  * Usage: <KarlUpsellDialog {...KARL_UPSELL_VELOCITY} open={...} onDismiss={...} />
  */
 export const KARL_UPSELL_VELOCITY = {
-  featureIcon: "\u16CA", // ᛊ Sowilo rune
+  featureIcon: "ᛊ", // Sowilo rune
   featureName: "Velocity",
   featureTagline: "How Fast Does Your Plunder Flow?",
   featureTeaser:
@@ -322,7 +322,7 @@ export const KARL_UPSELL_VELOCITY = {
  * Usage: <KarlUpsellDialog {...KARL_UPSELL_IMPORT} open={...} onDismiss={...} />
  */
 export const KARL_UPSELL_IMPORT = {
-  featureIcon: "\u16DA", // ᛚ Laguz rune (flow, water — data flowing in)
+  featureIcon: "ᛚ", // Laguz rune (flow, water — data flowing in)
   featureName: "Import",
   featureTagline: "The Runes Inscribed Afar Shall Be Read Here",
   featureTeaser:

--- a/development/frontend/src/lib/constants.ts
+++ b/development/frontend/src/lib/constants.ts
@@ -99,38 +99,38 @@ export const TAB_HEADER_CONTENT: Record<
   { title: string; description: string; statuses: string }
 > = {
   all: {
-    title: "\u16DF All Cards \u2014 The Full Ledger",
+    title: "ᛟ All Cards — The Full Ledger",
     description:
       "Every card in your portfolio, regardless of status. The complete record of every chain forged, every hunt begun, every warrior that earned its place in the hall.",
     statuses:
       "All status labels appear here: Active | Fee Due Soon | Promo Expiring | Overdue | Bonus Open | Closed | Graduated",
   },
   valhalla: {
-    title: "\u2191 Valhalla \u2014 Hall of the Honored Dead",
+    title: "↑ Valhalla — Hall of the Honored Dead",
     description:
       "Cards that have completed their journey. Closed cards and cards that graduated after earning their sign-up bonus rest here. Their rewards were harvested. Their chains were broken.",
     statuses: "Status labels in this tab: Closed | Graduated",
   },
   active: {
-    title: "\u16C9 Active Cards \u2014 Asgard\u2019s Warriors",
+    title: "ᛉ Active Cards — Asgard\u2019s Warriors",
     description:
-      "Cards in good standing with no urgent deadlines. These are your reliable earners \u2014 rewards are flowing and no fees are imminent.",
+      "Cards in good standing with no urgent deadlines. These are your reliable earners — rewards are flowing and no fees are imminent.",
     statuses:
-      "Status label in this tab: Active \u2014 card is open, no bonus window, no approaching fee",
+      "Status label in this tab: Active — card is open, no bonus window, no approaching fee",
   },
   hunt: {
-    title: "\u16DC The Hunt \u2014 Pursue the Plunder",
+    title: "ᛜ The Hunt — Pursue the Plunder",
     description:
-      "Cards with open sign-up bonus windows. You are actively hunting the welcome mead \u2014 track your spending progress and hit the threshold before the deadline.",
+      "Cards with open sign-up bonus windows. You are actively hunting the welcome mead — track your spending progress and hit the threshold before the deadline.",
     statuses:
-      "Status label in this tab: Bonus Open \u2014 sign-up bonus spending window is active",
+      "Status label in this tab: Bonus Open — sign-up bonus spending window is active",
   },
   howl: {
-    title: "\u16B2 The Howl \u2014 Where Chains Tighten",
+    title: "ᚲ The Howl — Where Chains Tighten",
     description:
       "Cards shown here demand your attention. Annual fees are approaching, promotional rates are expiring, or deadlines have already passed. These are the chains that will tighten if ignored.",
     statuses:
-      "Status labels in this tab: Fee Due Soon \u2014 annual fee due within 30 days | Promo Expiring \u2014 promotional rate ending soon | Overdue \u2014 a deadline has passed",
+      "Status labels in this tab: Fee Due Soon — annual fee due within 30 days | Promo Expiring — promotional rate ending soon | Overdue — a deadline has passed",
   },
 };
 

--- a/development/frontend/src/lib/issuer-utils.ts
+++ b/development/frontend/src/lib/issuer-utils.ts
@@ -39,70 +39,70 @@ export interface IssuerMeta {
  */
 const ISSUER_META: Record<string, IssuerMeta> = {
   chase: {
-    rune: "\u16B1",       // Raidho
+    rune: "ᚱ",       // Raidho
     runeName: "Raidho",
     runeConnection: "Journeys, movement (sapphire travel cards)",
     logoPath: "/static/logos/issuers/chase.svg",
     brandColor: "#0060A9",
   },
   bank_of_america: {
-    rune: "\u16A0",       // Fehu
+    rune: "ᚠ",       // Fehu
     runeName: "Fehu",
     runeConnection: "Wealth, cattle (America's bank)",
     logoPath: "/static/logos/issuers/bank-of-america.svg",
     brandColor: "#E31837",
   },
   capital_one: {
-    rune: "\u16A6",       // Thurisaz
+    rune: "ᚦ",       // Thurisaz
     runeName: "Thurisaz",
     runeConnection: "Power, force (what's in your wallet)",
     logoPath: "/static/logos/issuers/capital-one.svg",
     brandColor: "#D03027",
   },
   wells_fargo: {
-    rune: "\u16B9",       // Wunjo
+    rune: "ᚹ",       // Wunjo
     runeName: "Wunjo",
     runeConnection: "Joy, prosperity (stagecoach)",
     logoPath: "/static/logos/issuers/wells-fargo.svg",
     brandColor: "#D71E28",
   },
   amex: {
-    rune: "\u16CA",       // Sowilo
+    rune: "ᛊ",       // Sowilo
     runeName: "Sowilo",
     runeConnection: "Sun, success (premium)",
     logoPath: "/static/logos/issuers/amex.svg",
     brandColor: "#006FCF",
   },
   citibank: {
-    rune: "\u16C1",       // Isa
+    rune: "ᛁ",       // Isa
     runeName: "Isa",
     runeConnection: "Ice, focus (global reach)",
     logoPath: "/static/logos/issuers/citi.svg",
     brandColor: "#003B70",
   },
   discover: {
-    rune: "\u16BE",       // Naudiz
+    rune: "ᚾ",       // Naudiz
     runeName: "Naudiz",
     runeConnection: "Need, discovery",
     logoPath: "/static/logos/issuers/discover.svg",
     brandColor: "#FF6600",
   },
   us_bank: {
-    rune: "\u16A2",       // Uruz
+    rune: "ᚢ",       // Uruz
     runeName: "Uruz",
     runeConnection: "Strength, endurance",
     logoPath: "/static/logos/issuers/us-bank.svg",
     brandColor: "#D50032",
   },
   barclays: {
-    rune: "\u16B7",       // Gebo
+    rune: "ᚷ",       // Gebo
     runeName: "Gebo",
     runeConnection: "Gift, partnership (global banking)",
     logoPath: "/static/logos/issuers/barclays.svg",
     brandColor: "#00AEEF",
   },
   hsbc: {
-    rune: "\u16C7",       // Ehwaz
+    rune: "ᛇ",       // Ehwaz
     runeName: "Ehwaz",
     runeConnection: "Horse, movement (worldwide presence)",
     logoPath: "/static/logos/issuers/hsbc.svg",


### PR DESCRIPTION
Ref #616

Replace literal Unicode escape sequences with actual Elder Futhark rune characters across the dashboard. Fixes rendering of tab headers from escaped text (`\u16C9`) to proper glyphs (ᛉ).

**Changes:**
- `development/frontend/src/lib/constants.ts` — Replace `\u####` escape sequences with literal rune glyphs in TAB_HEADER_CONTENT (all 5 tabs)
- `development/frontend/src/components/dashboard/Dashboard.tsx` — Literal runes in TabEmptyState props
- `development/frontend/src/components/dashboard/DashboardTabs.tsx` — Literal runes in tab button labels
- `development/frontend/src/components/dashboard/HowlTeaserState.tsx` — Literal runes in sample alert data
- `development/frontend/src/lib/issuer-utils.ts` — Literal runes in issuer metadata (10 issuers)
- `development/frontend/src/components/entitlement/KarlUpsellDialog.tsx` — Literal runes in upsell feature icons
- `development/frontend/src/app/(marketing)/about/page.tsx` — Literal runes in FENRIR spelling

**Verification:**
- All 5 dashboard tabs display proper Elder Futhark rune characters in headers and empty states
- Tab headers render as glyphs, not escape sequences
- Runes are visually distinct across browsers
- tsc PASS, build PASS (30 routes)