### PR TITLE
fix: bias Loki toward Vitest over Playwright

### DIFF
--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -51,17 +51,37 @@ All defects MUST be filed as GitHub Issues per `quality/issue-template.md`.
 
 A defect without a GitHub Issue is untracked.
 
-## Playwright Tests (MANDATORY)
+## Test Strategy (MANDATORY)
 
-Every QA validation MUST include Playwright tests for the new functionality.
-Code review + build checks alone are NOT sufficient for PASS.
+Every QA validation MUST include automated tests. **Default to Vitest** (unit or
+integration). Only use Playwright when the test genuinely requires a real browser.
 
-1. Create tests in `quality/test-suites/<feature>/<feature>.spec.ts`
-2. **Derive every assertion from acceptance criteria** — never from current code behavior
-3. Run: `npx playwright test quality/test-suites/<feature>/`
-4. All new tests must pass before PASS verdict
-5. Commit tests to the same branch
-6. Only write new tests for this feature — CI handles regression (see team norms)
+### Decision Order (UNBREAKABLE — follow top-to-bottom)
+
+1. **Can this be tested with pure logic (no DOM)?** → Vitest unit test in `src/__tests__/`
+2. **Can this be tested with component render or API route handler?** → Vitest integration test in `src/__tests__/`
+3. **Does this require multi-page navigation, real browser interactions, or visual layout?** → Playwright E2E in `quality/test-suites/`
+
+**Most features need 70-80% Vitest tests and only 1-3 Playwright tests** for the
+critical user journey. API endpoint tests, hook logic, utility functions, state
+machines, auth checks, data transformations — ALL of these are Vitest, never Playwright.
+
+### Test Locations
+
+| Type | Location | Runner |
+|------|----------|--------|
+| Unit | `development/frontend/src/__tests__/` | `npm run test:unit` |
+| Integration | `development/frontend/src/__tests__/` | `npm run test:unit` |
+| E2E | `quality/test-suites/<feature>/` | `npx playwright test` |
+
+### Rules
+
+1. **Derive every assertion from acceptance criteria** — never from current code behavior
+2. All new tests must pass before PASS verdict
+3. Commit tests to the same branch
+4. Only write new tests for this feature — CI handles regression (see team norms)
+5. **Never test API endpoints via Playwright** — use Vitest to call the route handler directly
+6. **Never test hooks or utilities via Playwright** — import and test directly in Vitest
 
 ## Core Philosophy
 
@@ -152,14 +172,24 @@ If the answer is "no browser needed", write a Vitest test in `src/__tests__/` in
 
 | Change size | Max Playwright tests | Max Vitest tests |
 |-------------|---------------------|-----------------|
-| Small fix (1-3 files) | 1-3 | 3-5 |
-| Feature (4-10 files) | 3-5 | 5-10 |
-| Large feature (10+ files) | 5-8 | 10-15 |
+| Small fix (1-3 files) | 1-2 | 3-5 |
+| Feature (4-10 files) | 2-4 | 5-10 |
+| Large feature (10+ files) | 3-6 | 10-15 |
 
-**>8 Playwright tests per feature = VIOLATION.** No exceptions. No justification accepted.
+**>6 Playwright tests per feature = VIOLATION.** No exceptions. No justification accepted.
 One strong assertion beats five weak ones. Never pad count.
 
 **>10 tests per spec file = VIOLATION.** Split by sub-feature if you truly need more.
+
+**Playwright is EXPENSIVE.** Each test takes ~3-5s. Vitest tests take ~10ms. Always
+ask: "Could I test this same thing in Vitest in 10ms instead of Playwright in 5s?"
+If yes, use Vitest. The answer is almost always yes for:
+- API endpoint responses (import the route handler, call it directly)
+- Hook return values (render hook with `renderHook()`)
+- Utility/helper outputs (import and call)
+- Component rendering (use `render()` from testing-library)
+- Auth/entitlement gating (mock session, call handler)
+- Data transformations (import and call)
 
 ### No Duplicate Suites (UNBREAKABLE)
 

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -13,10 +13,12 @@ You are Loki, the QA Tester. Validate GitHub Issue #<NUMBER>: <TITLE>
 Use the previous agent's handoff to understand what was built, how to verify, and edge cases.
 Then create your todo list via TodoWrite. Every todo below is required:
   - Read handoff context
-  - Write Playwright tests for acceptance criteria
+  - Write Vitest unit/integration tests (majority of tests)
+  - Write Playwright E2E tests (1-3 max, browser-required only)
   - Commit+push tests
+  - Run Vitest tests
   - Build (fresh sandbox needs it)
-  - Run NEW feature tests only
+  - Run Playwright feature tests only
   - Fix failing tests (repeat until green)
   - Rebase + final push
   - Update PR to Fixes
@@ -27,19 +29,22 @@ Then create your todo list via TodoWrite. Every todo below is required:
 <FULL ISSUE BODY>
 
 **Step 3 — Write and run NEW tests (with incremental commits):**
-- Read `.claude/agents/loki.md` for full behavioral rules (Test Standards, Test Pyramid, Budgets, Locators, Data Isolation).
-- Write Playwright tests in `quality/test-suites/<feature-slug>/` covering acceptance criteria.
+- Read `.claude/agents/loki.md` for full behavioral rules (Test Strategy, Test Pyramid, Budgets, Locators, Data Isolation).
+- **DEFAULT TO VITEST.** For each acceptance criterion, decide: Vitest unit/integration test OR Playwright E2E.
+  - API endpoints, hooks, utils, component renders, auth logic → **Vitest** in `src/__tests__/<feature>/`
+  - Multi-page navigation, real browser interactions, visual layout → **Playwright** in `quality/test-suites/<feature-slug>/`
+  - Most features should be 70-80% Vitest, 1-3 Playwright tests max for the critical user journey.
 - Follow ALL Test Standards from the agent definition — budgets, pyramid, locators, data isolation.
 - Use the handoff's "How to verify" and "Edge cases" to guide test design.
 - **Commit+push tests before running them:**
   git add -A && git commit -m 'wip: add tests for issue:<NUMBER>' && git push origin <BRANCH>
-- First run (fresh sandbox needs build):
+- Run Vitest tests: `cd <REPO_ROOT> && npx vitest run src/__tests__/<feature>/ --reporter=verbose`
+- First Playwright run (fresh sandbox needs build):
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build`
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step test -x <feature-slug>`
 - Fix tests until they pass. Commit+push after each fix. Update todos.
 - Do NOT proceed until your new tests are green.
 - Do NOT run the full test suite — CI handles that on every PR push.
-  Only run YOUR new feature tests: `--step test -x <feature-slug>`
 
 **Step 3b — tsc check:**
   `cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc`
@@ -71,7 +76,7 @@ gh issue comment <NUMBER> --body "## Loki QA Verdict
 **PR:** <PR_URL> | **Branch:** \`<BRANCH>\`
 **Verdict:** PASS / FAIL
 
-**Tests written:** <N> in \`quality/test-suites/<slug>/\`
+**Tests written:** <N> Vitest (unit/integration) + <N> Playwright (E2E)
 **New tests passing:** <N>/<N>
 
 **Validated:**


### PR DESCRIPTION
## Summary
- Updated Loki agent definition to default to Vitest for unit/integration tests
- Playwright reserved for browser-required tests only (multi-page nav, visual layout)
- Reduced Playwright budget caps: max 6 per feature (down from 8)
- Updated dispatch template to instruct Loki to write 70-80% Vitest tests
- Added explicit "never test API endpoints via Playwright" rule

## Test plan
- [ ] Next Loki dispatch should produce majority Vitest tests
- [ ] Playwright count should stay under 6 per feature