### PR TITLE
chore: PR body template — Fixes → PR for issue

### DIFF
--- a/.claude/skills/fire-next-up/SKILL.md
+++ b/.claude/skills/fire-next-up/SKILL.md
@@ -19,7 +19,7 @@ Pulls the next "Up Next" item from the GitHub Project board and runs the full ag
 
 **Research:** Technical → FiremanDecko, Product → Freya. Sole agent, posts findings and creates PR. No Loki step. After PR merges, orchestrator presents findings to Odin for **Review** (plan into issues, shelve, or drop).
 
-**Chain rules:** Same branch throughout. First agent creates PR with `Fixes #<NUMBER>` in the body (clean title, no issue ref). Loki adds tests on the same PR. If any agent fails, chain stops and orchestrator reports.
+**Chain rules:** Same branch throughout. First agent creates PR with `PR for issue: #<NUMBER>` in the body (clean title, no issue ref). Loki adds tests on the same PR. If any agent fails, chain stops and orchestrator reports.
 
 ## Flags
 

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -53,7 +53,7 @@ If conflicts: resolve, re-run verify steps.
   cd <REPO_ROOT> && git add -A && git commit -m 'feat: <description> — issue:<NUMBER>' && git push origin <BRANCH>
 
 **Step 6 — Create PR:**
-gh pr create --title "feat: <short title>" --body "Fixes #<NUMBER>
+gh pr create --title "feat: <short title>" --body "PR for issue: #<NUMBER>
 
 <1-3 line summary>
 

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -54,7 +54,7 @@ If conflicts: resolve, re-run verify steps.
   cd <REPO_ROOT> && git add -A && git commit -m 'security: <description> — issue:<NUMBER>' && git push origin <BRANCH>
 
 **Step 6 — Create PR:**
-gh pr create --title "security: <short title>" --body "Fixes #<NUMBER>
+gh pr create --title "security: <short title>" --body "PR for issue: #<NUMBER>
 
 <summary of security fix>"
 
@@ -115,7 +115,7 @@ NO tsc. NO build. This is a report/audit — there is no app code to verify.
   git push origin <BRANCH>
 
 **Step 5 — Create PR:**
-gh pr create --title "security: <short title>" --body "Fixes #<NUMBER>
+gh pr create --title "security: <short title>" --body "PR for issue: #<NUMBER>
 
 <summary>"
 

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -62,11 +62,11 @@ If conflicts: resolve, re-run feature tests.
 
 **Step 5 — Update PR to close issue:**
   gh pr view <BRANCH> --json number --jq '.number'
-  gh pr edit <PR_NUMBER> --body "Fixes #<NUMBER>
+  gh pr edit <PR_NUMBER> --body "PR for issue: #<NUMBER>
 
 <keep existing summary, add test results>"
 
-If no PR exists (sole agent): `gh pr create --title "<title>" --body "Fixes #<NUMBER>\n\n<summary>"`
+If no PR exists (sole agent): `gh pr create --title "<title>" --body "PR for issue: #<NUMBER>\n\n<summary>"`
 
 **DO NOT MERGE.** Only the orchestrator merges. Your job ends at the verdict comment.
 

--- a/.claude/skills/fire-next-up/templates/luna.md
+++ b/.claude/skills/fire-next-up/templates/luna.md
@@ -33,7 +33,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
   Update your todos.
 
 **Step 4 — Create PR:**
-gh pr create --title "design: <short description>" --body "Fixes #<NUMBER>
+gh pr create --title "design: <short description>" --body "PR for issue: #<NUMBER>
 
 <summary of wireframes>"
 


### PR DESCRIPTION
## Summary
- Changed all agent PR templates from `Fixes #<NUMBER>` to `PR for issue: #<NUMBER>`
- Prevents GitHub from auto-closing issues when PRs merge
- Orchestrator retains control over issue lifecycle

## Test plan
- [ ] Next agent dispatch uses new template