### PR TITLE
design: About page dual-realm agent profiles

### DIFF
--- a/development/frontend/src/__tests__/pages/about.test.tsx
+++ b/development/frontend/src/__tests__/pages/about.test.tsx
@@ -1,0 +1,283 @@
+/**
+ * About Page — Component render tests
+ *
+ * Validates the redesigned About page (Issue #633):
+ *   - Dual-realm agent profiles with alternating layout
+ *   - Portrait crossfade driven by theme
+ *   - Realm badges and lore text switch with theme
+ *   - All 5 agents rendered with correct aria-labels
+ *   - Hover overlay class mapping
+ *   - Section landmarks present
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+// ── Theme mock state ────────────────────────────────────────────────────────
+
+let mockResolvedTheme = "light";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: mockResolvedTheme,
+    resolvedTheme: mockResolvedTheme,
+    setTheme: vi.fn(),
+  }),
+}));
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("next/image", () => ({
+  __esModule: true,
+  default: ({
+    src,
+    alt,
+    style,
+    className,
+    ...props
+  }: {
+    src: string;
+    alt: string;
+    style?: Record<string, unknown>;
+    className?: string;
+    [key: string]: unknown;
+  }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} style={style} className={className} {...props} />
+  ),
+}));
+
+// Mock framer-motion to render static elements
+vi.mock("framer-motion", () => ({
+  motion: new Proxy(
+    {},
+    {
+      get: (_target, prop: string) => {
+        // Return a component that renders the HTML element with all props
+        const MotionComponent = ({
+          children,
+          variants: _variants,
+          initial: _initial,
+          animate: _animate,
+          whileHover: _whileHover,
+          ...rest
+        }: Record<string, unknown> & { children?: React.ReactNode }) => {
+          const Tag = prop as keyof JSX.IntrinsicElements;
+          return <Tag {...(rest as Record<string, string>)}>{children}</Tag>;
+        };
+        MotionComponent.displayName = `motion.${prop}`;
+        return MotionComponent;
+      },
+    },
+  ),
+  useInView: () => true,
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+import AboutPage from "@/app/(marketing)/about/page";
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("About Page — Section Landmarks", () => {
+  beforeEach(() => {
+    mockResolvedTheme = "light";
+  });
+
+  it("renders Origin story section", () => {
+    render(<AboutPage />);
+    const section = screen.getByLabelText("Origin story");
+    expect(section).toBeDefined();
+  });
+
+  it("renders The founding myth section", () => {
+    render(<AboutPage />);
+    const section = screen.getByLabelText("The founding myth");
+    expect(section).toBeDefined();
+  });
+
+  it("renders The agents of Asgard section", () => {
+    render(<AboutPage />);
+    const section = screen.getByLabelText("The agents of Asgard");
+    expect(section).toBeDefined();
+  });
+
+  it("renders The Forge section", () => {
+    render(<AboutPage />);
+    const section = screen.getByLabelText("The Forge");
+    expect(section).toBeDefined();
+  });
+
+  it("renders Call to action section", () => {
+    render(<AboutPage />);
+    const section = screen.getByLabelText("Call to action");
+    expect(section).toBeDefined();
+  });
+});
+
+describe("About Page — Agent Myth Rows (#633)", () => {
+  beforeEach(() => {
+    mockResolvedTheme = "light";
+  });
+
+  it("renders all 5 agent articles with correct aria-labels", () => {
+    render(<AboutPage />);
+    const agents = [
+      "Freya \u2014 Product Owner",
+      "Luna \u2014 UX Designer",
+      "FiremanDecko \u2014 Principal Engineer",
+      "Loki \u2014 QA Tester",
+      "Heimdall \u2014 Security Guardian",
+    ];
+    for (const label of agents) {
+      const article = screen.getByLabelText(label);
+      expect(article).toBeDefined();
+      expect(article.tagName.toLowerCase()).toBe("article");
+    }
+  });
+
+  it("renders dual portraits (light + dark) for each agent", () => {
+    render(<AboutPage />);
+    // Check Freya has both light and dark portrait images
+    const lightPortrait = screen.getByAltText("Freya \u2014 light realm portrait");
+    const darkPortrait = screen.getByAltText("Freya \u2014 dark realm portrait");
+    expect(lightPortrait).toBeDefined();
+    expect(darkPortrait).toBeDefined();
+  });
+
+  it("shows light portrait opaque in light theme", () => {
+    mockResolvedTheme = "light";
+    render(<AboutPage />);
+    const lightPortrait = screen.getByAltText("Freya \u2014 light realm portrait") as HTMLImageElement;
+    const darkPortrait = screen.getByAltText("Freya \u2014 dark realm portrait") as HTMLImageElement;
+    expect(lightPortrait.style.opacity).toBe("1");
+    expect(darkPortrait.style.opacity).toBe("0");
+  });
+
+  it("shows dark portrait opaque in dark theme", () => {
+    mockResolvedTheme = "dark";
+    render(<AboutPage />);
+    const lightPortrait = screen.getByAltText("Freya \u2014 light realm portrait") as HTMLImageElement;
+    const darkPortrait = screen.getByAltText("Freya \u2014 dark realm portrait") as HTMLImageElement;
+    expect(lightPortrait.style.opacity).toBe("0");
+    expect(darkPortrait.style.opacity).toBe("1");
+  });
+
+  it("renders agent names as h3 headings", () => {
+    render(<AboutPage />);
+    const headings = screen.getAllByRole("heading", { level: 3 });
+    const names = headings.map((h) => h.textContent);
+    expect(names).toContain("Freya");
+    expect(names).toContain("Luna");
+    expect(names).toContain("FiremanDecko");
+    expect(names).toContain("Loki");
+    expect(names).toContain("Heimdall");
+  });
+
+  it("renders realm badge with aria-live='polite'", () => {
+    render(<AboutPage />);
+    const badges = document.querySelectorAll("[aria-live='polite']");
+    // Each agent gets a realm badge — 5 agents
+    expect(badges.length).toBe(5);
+  });
+
+  it("renders light realm lore visible in light theme", () => {
+    mockResolvedTheme = "light";
+    render(<AboutPage />);
+    // Light lore should not be aria-hidden
+    const lightLoreElements = document.querySelectorAll("[aria-hidden='false']");
+    expect(lightLoreElements.length).toBeGreaterThan(0);
+  });
+});
+
+describe("About Page — Hover Overlay Effects (#633)", () => {
+  beforeEach(() => {
+    mockResolvedTheme = "light";
+  });
+
+  it("renders scan hover overlay for Heimdall", () => {
+    render(<AboutPage />);
+    const scanOverlay = document.querySelector(".about-hover-scan");
+    expect(scanOverlay).not.toBeNull();
+  });
+
+  it("renders glow hover overlay for Freya", () => {
+    render(<AboutPage />);
+    const glowOverlay = document.querySelector(".about-hover-glow");
+    expect(glowOverlay).not.toBeNull();
+  });
+
+  it("renders shimmer hover overlay for Luna", () => {
+    render(<AboutPage />);
+    const shimmerOverlay = document.querySelector(".about-hover-shimmer");
+    expect(shimmerOverlay).not.toBeNull();
+  });
+
+  it("renders fire hover overlay for FiremanDecko", () => {
+    render(<AboutPage />);
+    const fireOverlay = document.querySelector(".about-hover-fire");
+    expect(fireOverlay).not.toBeNull();
+  });
+
+  it("renders glitch hover overlay for Loki", () => {
+    render(<AboutPage />);
+    const glitchOverlay = document.querySelector(".about-hover-glitch");
+    expect(glitchOverlay).not.toBeNull();
+  });
+
+  it("all hover overlays have aria-hidden='true'", () => {
+    render(<AboutPage />);
+    const overlays = [
+      ".about-hover-glow",
+      ".about-hover-shimmer",
+      ".about-hover-fire",
+      ".about-hover-glitch",
+      ".about-hover-scan",
+    ];
+    for (const selector of overlays) {
+      const el = document.querySelector(selector);
+      expect(el?.getAttribute("aria-hidden")).toBe("true");
+    }
+  });
+});
+
+describe("About Page — Alternating Layout (#633)", () => {
+  beforeEach(() => {
+    mockResolvedTheme = "light";
+  });
+
+  it("even-index agents have flex-row, odd-index have flex-row-reverse", () => {
+    render(<AboutPage />);
+    const agents = [
+      "Freya \u2014 Product Owner",
+      "Luna \u2014 UX Designer",
+      "FiremanDecko \u2014 Principal Engineer",
+      "Loki \u2014 QA Tester",
+      "Heimdall \u2014 Security Guardian",
+    ];
+    for (let i = 0; i < agents.length; i++) {
+      const article = screen.getByLabelText(agents[i]);
+      const classes = article.className;
+      if (i % 2 === 0) {
+        expect(classes).toContain("flex-row");
+        expect(classes).not.toContain("flex-row-reverse");
+      } else {
+        expect(classes).toContain("flex-row-reverse");
+      }
+    }
+  });
+});

--- a/development/frontend/src/app/(marketing)/about/page.tsx
+++ b/development/frontend/src/app/(marketing)/about/page.tsx
@@ -3,14 +3,19 @@
 /**
  * About Page — /about
  *
- * The showpiece. Origin story, team showcase, agent chain visualization,
- * and the Norse mythology that drives Fenrir Ledger.
+ * The showpiece. Origin story, team showcase woven into the mythology,
+ * agent chain visualization, and the Norse mythology that drives Fenrir Ledger.
  *
  * Sections:
  *   1. Origin Story Hero — mythic opening, Gleipnir metaphor
  *   2. Why the Wolf — two-column founding myth detail
- *   3. The Pack — 5 agent profile cards + future placeholder
+ *   3. The Myth with Agents — dual-realm agent profiles flanking myth narrative
  *   4. The Forge — agent chain visualization
+ *   5. Final CTA
+ *
+ * Issue #633: Agents woven into The Myth section with alternating L/R layout,
+ * dual-realm (Ljosalfar/Svartalfar) lore per agent, crossfade portraits on
+ * theme toggle, and personality-specific hover overlays.
  *
  * Uses Framer Motion for scroll-triggered stagger animations.
  * Agent portraits load from /images/team/{slug}-{dark|light}.png when
@@ -31,23 +36,30 @@ import Link from "next/link";
 
 /** Rune characters (Elder Futhark). */
 const RUNE = {
-  fehu: "ᚠ",
-  ehwaz: "ᛖ",
-  naudiz: "ᚾ",
-  raidho: "ᚱ",
-  isa: "ᛁ",
-  laguz: "ᛚ",
-  tiwaz: "ᛏ",
-  hagalaz: "ᚺ",
+  fehu: "\u16A0",
+  ehwaz: "\u16D6",
+  naudiz: "\u16BE",
+  raidho: "\u16B1",
+  isa: "\u16C1",
+  laguz: "\u16DA",
+  tiwaz: "\u16CF",
+  hagalaz: "\u16BA",
 } as const;
 
 /** FENRIR in Elder Futhark runes. */
 const FENRIR_RUNES = `${RUNE.fehu} ${RUNE.ehwaz} ${RUNE.naudiz} ${RUNE.raidho} ${RUNE.isa} ${RUNE.raidho}`;
 
-/** Unique hover effect types for agent cards. */
-type HoverEffect = "glow" | "shimmer" | "fire" | "glitch";
+/** Unique hover effect types for agent portraits. */
+type HoverEffect = "glow" | "shimmer" | "fire" | "glitch" | "scan";
 
-/** Agent profile data. */
+/** Realm lore data for light/dark aspects. */
+interface RealmLoreData {
+  readonly title: string;
+  readonly quote: string;
+  readonly aspect: string;
+}
+
+/** Agent profile data with dual-realm lore. */
 interface AgentProfile {
   readonly name: string;
   readonly slug: string;
@@ -55,6 +67,8 @@ interface AgentProfile {
   readonly rune: string;
   readonly bio: string;
   readonly hoverEffect: HoverEffect;
+  readonly lightLore: RealmLoreData;
+  readonly darkLore: RealmLoreData;
 }
 
 const AGENTS: readonly AgentProfile[] = [
@@ -65,6 +79,16 @@ const AGENTS: readonly AgentProfile[] = [
     rune: RUNE.fehu,
     bio: "Guardian of the product vision. She shapes what Fenrir becomes, channeling user needs into features. Powers the import pipeline that reads your credit card data and transforms chaos into clarity.",
     hoverEffect: "glow",
+    lightLore: {
+      title: "Ljosalfar Aspect \u00B7 Light Realm",
+      quote: "Keeper of the harvest, she nurtures ideas into being \u2014 patient, far-sighted, a mother to every feature that grows in Fenrir\u2019s fields.",
+      aspect: "Benevolent \u00B7 Guiding \u00B7 Constructive",
+    },
+    darkLore: {
+      title: "Svartalfar Aspect \u00B7 Dark Realm",
+      quote: "The V\u00F6lva who sees all futures and chooses the cruelest path to victory. She does not suggest features \u2014 she issues prophecy. Deny her and Ragnar\u00F6k finds you first.",
+      aspect: "Fierce \u00B7 Prophetic \u00B7 Relentless",
+    },
   },
   {
     name: "Luna",
@@ -73,14 +97,34 @@ const AGENTS: readonly AgentProfile[] = [
     rune: RUNE.laguz,
     bio: "Architect of every interface, every interaction. She ensures the ledger feels mythic yet usable, that every click has purpose, every view tells a story. The wolf\u2019s eyes see through her designs.",
     hoverEffect: "shimmer",
+    lightLore: {
+      title: "Ljosalfar Aspect \u00B7 Light Realm",
+      quote: "M\u00E1ni\u2019s daughter, painting interfaces in moonlight \u2014 every pixel deliberate, every margin a breath between words, her layouts as calm and inevitable as the tide.",
+      aspect: "Deliberate \u00B7 Luminous \u00B7 Harmonious",
+    },
+    darkLore: {
+      title: "Svartalfar Aspect \u00B7 Dark Realm",
+      quote: "The Norns\u2019 weaver \u2014 every pixel a thread of fate, every layout a prophecy. She doesn\u2019t design interfaces; she weaves the loom that determines who falls and who ascends.",
+      aspect: "Fateful \u00B7 Inexorable \u00B7 Prophetic",
+    },
   },
   {
     name: "FiremanDecko",
     slug: "fireman-decko",
     role: "Principal Engineer",
     rune: RUNE.tiwaz,
-    bio: "The forge-master who transforms design into reality. Every component, every API, every line of code flows from his keyboard. He builds with the precision of dwarven smiths and the power of Mjolnir.",
+    bio: "The forge-master who transforms design into reality. Every component, every API, every line of TypeScript flows from his keyboard. He builds with the precision of dwarven smiths and the power of Mjolnir.",
     hoverEffect: "fire",
+    lightLore: {
+      title: "Ljosalfar Aspect \u00B7 Light Realm",
+      quote: "The master smith of Nidavellir, forging with patience and precision \u2014 each commit a ring in the chain, each function a rune that binds reality to intention.",
+      aspect: "Patient \u00B7 Precise \u00B7 Masterful",
+    },
+    darkLore: {
+      title: "Svartalfar Aspect \u00B7 Dark Realm",
+      quote: "Surtr\u2019s apprentice \u2014 he doesn\u2019t build, he conjures from the flames. The codebase is his pyre; what rises from it is either legend or ash. There is no middle outcome.",
+      aspect: "Incendiary \u00B7 Absolute \u00B7 Uncompromising",
+    },
   },
   {
     name: "Loki",
@@ -89,6 +133,16 @@ const AGENTS: readonly AgentProfile[] = [
     rune: RUNE.laguz,
     bio: "Son of the wolf, breaker of things. He tests with chaos and cunning, finding bugs before users do. Every edge case is his playground, every error his trophy. If it can break, Loki will break it first.",
     hoverEffect: "glitch",
+    lightLore: {
+      title: "Ljosalfar Aspect \u00B7 Light Realm",
+      quote: "The trickster who finds flaws before they become wounds \u2014 his mischief is medicine, his pranks preventative, each test a gentle probe that saves the pack from greater harm.",
+      aspect: "Curious \u00B7 Preventive \u00B7 Cleverly Protective",
+    },
+    darkLore: {
+      title: "Svartalfar Aspect \u00B7 Dark Realm",
+      quote: "Chaos incarnate \u2014 he doesn\u2019t find bugs, he breeds them to hunt their parents. He is the wolf inside the wolf, the test that tears the code apart to prove whether it deserved to live.",
+      aspect: "Chaotic \u00B7 Relentless \u00B7 Merciless",
+    },
   },
   {
     name: "Heimdall",
@@ -96,9 +150,27 @@ const AGENTS: readonly AgentProfile[] = [
     role: "Security Guardian",
     rune: RUNE.hagalaz,
     bio: "Watcher of the Rainbow Bridge, guardian of your data. He sees all threats, blocks all intrusions. Your financial data is his sacred charge. Not even Loki\u2019s tricks can bypass his vigilance.",
-    hoverEffect: "glow",
+    hoverEffect: "scan",
+    lightLore: {
+      title: "Ljosalfar Aspect \u00B7 Light Realm",
+      quote: "The watchman who guards all nine realms \u2014 patient as stone at the Bifr\u00F6st\u2019s edge, his eye ever open, his horn Gjallarhorn poised but silent so long as the realms are safe.",
+      aspect: "Vigilant \u00B7 Patient \u00B7 Protective",
+    },
+    darkLore: {
+      title: "Svartalfar Aspect \u00B7 Dark Realm",
+      quote: "He who hears the grass grow and the wool stretch on sheep across the nine realms \u2014 nothing escapes, nothing is forgiven. He does not warn; he terminates. The audit log is his axe.",
+      aspect: "Omniscient \u00B7 Merciless \u00B7 Zero-Tolerance",
+    },
   },
 ] as const;
+
+/** Rune dividers between agent rows. */
+const AGENT_DIVIDERS: readonly string[] = [
+  `${RUNE.fehu} \u00B7 \u00B7 \u00B7 ${RUNE.laguz}`,
+  `${RUNE.laguz} \u00B7 \u00B7 \u00B7 ${RUNE.tiwaz}`,
+  `${RUNE.tiwaz} \u00B7 \u00B7 \u00B7 ${RUNE.laguz}`,
+  `${RUNE.laguz} \u00B7 \u00B7 \u00B7 ${RUNE.hagalaz}`,
+];
 
 /** Agent chain nodes for the forge visualization. */
 const CHAIN_NODES = [
@@ -120,14 +192,27 @@ const STAGGER: Variants = {
   visible: { transition: { staggerChildren: 0.1 } },
 };
 
-const CARD_VARIANT: Variants = {
-  hidden: { opacity: 0, y: 32, scale: 0.97 },
-  visible: {
-    opacity: 1,
-    y: 0,
-    scale: 1,
-    transition: { duration: 0.5, ease: "easeOut" as const },
-  },
+/** Agent row slides in from left (even-index: portrait on left). */
+const ROW_FROM_LEFT: Variants = {
+  hidden: { opacity: 0, x: -32 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.5, ease: "easeOut" as const } },
+};
+
+/** Agent row slides in from right (odd-index: portrait on right). */
+const ROW_FROM_RIGHT: Variants = {
+  hidden: { opacity: 0, x: 32 },
+  visible: { opacity: 1, x: 0, transition: { duration: 0.5, ease: "easeOut" as const } },
+};
+
+/** Stagger children within an agent row. */
+const ROW_STAGGER: Variants = {
+  hidden: {},
+  visible: { transition: { staggerChildren: 0.15 } },
+};
+
+const CHILD_FADE: Variants = {
+  hidden: { opacity: 0, y: 16 },
+  visible: { opacity: 1, y: 0, transition: { duration: 0.4, ease: "easeOut" as const } },
 };
 
 const CHAIN_NODE_VARIANT: Variants = {
@@ -200,23 +285,25 @@ function SectionHeading({
   );
 }
 
-// ── Agent portrait with image fallback ────────────────────────────────────────
+// ── Dual-realm portrait with crossfade ──────────────────────────────────────
 
-function AgentPortrait({
+/** Portrait with light/dark crossfade on theme toggle. Both images always in DOM. */
+function DualRealmPortrait({
   agent,
 }: {
   agent: AgentProfile;
 }): React.ReactElement {
   const { resolvedTheme } = useTheme();
-  const variant = resolvedTheme === "dark" ? "dark" : "light";
-  const [imgError, setImgError] = useState(false);
+  const isDark = resolvedTheme === "dark";
+  const [lightError, setLightError] = useState(false);
+  const [darkError, setDarkError] = useState(false);
 
-  const handleError = useCallback((): void => {
-    setImgError(true);
-  }, []);
+  const handleLightError = useCallback((): void => setLightError(true), []);
+  const handleDarkError = useCallback((): void => setDarkError(true), []);
 
-  // Fallback: runic symbol placeholder
-  if (imgError) {
+  const bothFailed = lightError && darkError;
+
+  if (bothFailed) {
     return (
       <div className="flex flex-col items-center justify-center h-full gap-3">
         <span className="text-6xl opacity-40 font-heading text-primary animate-pulse">
@@ -230,15 +317,30 @@ function AgentPortrait({
   }
 
   return (
-    <Image
-      src={`/images/team/${agent.slug}-${variant}.png`}
-      alt={`${agent.name} \u2014 ${agent.role}`}
-      width={512}
-      height={512}
-      className="w-full h-full object-contain transition-transform duration-500 group-hover:scale-105"
-      onError={handleError}
-      unoptimized
-    />
+    <>
+      {/* Light portrait */}
+      <Image
+        src={`/images/team/${agent.slug}-light.png`}
+        alt={`${agent.name} \u2014 light realm portrait`}
+        width={512}
+        height={512}
+        className="absolute inset-0 w-full h-full object-cover transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        style={{ opacity: isDark ? 0 : 1 }}
+        onError={handleLightError}
+        unoptimized
+      />
+      {/* Dark portrait */}
+      <Image
+        src={`/images/team/${agent.slug}-dark.png`}
+        alt={`${agent.name} \u2014 dark realm portrait`}
+        width={512}
+        height={512}
+        className="absolute inset-0 w-full h-full object-cover transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        style={{ opacity: isDark ? 1 : 0 }}
+        onError={handleDarkError}
+        unoptimized
+      />
+    </>
   );
 }
 
@@ -249,6 +351,7 @@ function HoverOverlay({ effect }: { effect: HoverEffect }): React.ReactElement {
     shimmer: "about-hover-shimmer",
     fire: "about-hover-fire",
     glitch: "about-hover-glitch",
+    scan: "about-hover-scan",
   };
 
   return (
@@ -259,43 +362,180 @@ function HoverOverlay({ effect }: { effect: HoverEffect }): React.ReactElement {
   );
 }
 
-// ── Agent card ────────────────────────────────────────────────────────────────
+// ── Realm badge ──────────────────────────────────────────────────────────────
 
-function AgentCard({ agent }: { agent: AgentProfile }): React.ReactElement {
+/** Badge below portrait showing current realm. Crossfades with theme. */
+function RealmBadge(): React.ReactElement {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
   return (
-    <motion.div
-      variants={CARD_VARIANT}
-      whileHover={{ y: -8, scale: 1.02, transition: { type: "spring", stiffness: 300, damping: 20 } }}
-      className="group relative flex flex-col border border-border overflow-hidden
-                 bg-card transition-[box-shadow,border-color] duration-300
-                 hover:shadow-gold-md hover:border-primary/40"
-    >
-      {/* Portrait */}
-      <div className="relative w-full aspect-square border-b border-border overflow-hidden bg-muted/50">
-        <AgentPortrait agent={agent} />
-        <HoverOverlay effect={agent.hoverEffect} />
-        <span
-          className="absolute top-3 right-3 text-xl opacity-20 group-hover:opacity-60
-                     transition-opacity duration-300 font-heading text-primary"
-          aria-hidden="true"
-        >
-          {agent.rune}
+    <div className="relative h-7" aria-live="polite">
+      {/* Light realm badge */}
+      <span
+        className="absolute inset-0 inline-flex items-center justify-center gap-1.5
+                   border border-border px-3 py-1
+                   font-mono text-[10px] font-bold uppercase tracking-[0.12em]
+                   text-foreground/70
+                   transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        style={{ opacity: isDark ? 0 : 1 }}
+        aria-hidden={isDark}
+      >
+        <span aria-hidden="true">{"\u2600"}</span>
+        LJOSALFAR &middot; ALFHEIM
+      </span>
+      {/* Dark realm badge */}
+      <span
+        className="absolute inset-0 inline-flex items-center justify-center gap-1.5
+                   border border-border px-3 py-1
+                   font-mono text-[10px] font-bold uppercase tracking-[0.12em]
+                   text-foreground/70
+                   transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        style={{ opacity: isDark ? 1 : 0 }}
+        aria-hidden={!isDark}
+      >
+        <span aria-hidden="true">{"\u263D"}</span>
+        SVARTALFAR &middot; SVARTALFHEIM
+      </span>
+    </div>
+  );
+}
+
+// ── Realm lore block ─────────────────────────────────────────────────────────
+
+/** Dual-realm lore text with crossfade. Both always rendered, one opacity:0. */
+function RealmLore({
+  lightLore,
+  darkLore,
+}: {
+  lightLore: RealmLoreData;
+  darkLore: RealmLoreData;
+}): React.ReactElement {
+  const { resolvedTheme } = useTheme();
+  const isDark = resolvedTheme === "dark";
+
+  return (
+    <div className="relative min-h-[120px]">
+      {/* Light realm lore */}
+      <div
+        className="border-l-[3px] border-primary/60 pl-5 py-4 flex flex-col gap-2
+                   transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        style={{ opacity: isDark ? 0 : 1 }}
+        aria-hidden={isDark}
+      >
+        <span className="font-mono text-[10px] font-bold uppercase tracking-[0.15em] text-foreground/50">
+          {"\u2600"} {lightLore.title}
+        </span>
+        <p className="font-body text-sm leading-relaxed italic text-muted-foreground">
+          &ldquo;{lightLore.quote}&rdquo;
+        </p>
+        <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-foreground/40">
+          {lightLore.aspect}
         </span>
       </div>
-
-      {/* Info */}
-      <div className="p-6 flex flex-col gap-2">
-        <h3 className="font-heading text-lg font-semibold text-foreground">
-          {agent.name}
-        </h3>
-        <p className="font-mono text-xs tracking-widest text-primary uppercase">
-          {agent.role}
+      {/* Dark realm lore */}
+      <div
+        className="absolute top-0 left-0 w-full
+                   border-l-[3px] border-primary/60 pl-5 py-4 flex flex-col gap-2
+                   transition-opacity duration-500 ease-in-out motion-reduce:transition-none"
+        style={{ opacity: isDark ? 1 : 0 }}
+        aria-hidden={!isDark}
+      >
+        <span className="font-mono text-[10px] font-bold uppercase tracking-[0.15em] text-foreground/50">
+          {"\u263D"} {darkLore.title}
+        </span>
+        <p className="font-body text-sm leading-relaxed italic text-muted-foreground">
+          &ldquo;{darkLore.quote}&rdquo;
         </p>
-        <p className="font-body text-sm text-muted-foreground leading-relaxed mt-1">
-          {agent.bio}
-        </p>
+        <span className="font-mono text-[11px] uppercase tracking-[0.1em] text-foreground/40">
+          {darkLore.aspect}
+        </span>
       </div>
-    </motion.div>
+    </div>
+  );
+}
+
+// ── Agent myth row ───────────────────────────────────────────────────────────
+
+/** Single agent row: portrait flanks text, alternating L/R by index. */
+function AgentMythRow({
+  agent,
+  index,
+}: {
+  agent: AgentProfile;
+  index: number;
+}): React.ReactElement {
+  const ref = useRef<HTMLElement>(null);
+  const inView = useInView(ref, { once: true, margin: "-60px" });
+  const isOdd = index % 2 !== 0;
+
+  return (
+    <motion.article
+      ref={ref}
+      initial="hidden"
+      animate={inView ? "visible" : "hidden"}
+      variants={isOdd ? ROW_FROM_RIGHT : ROW_FROM_LEFT}
+      aria-label={`${agent.name} \u2014 ${agent.role}`}
+      className={`flex gap-12 py-14 border-b border-border last:border-b-0
+                  ${isOdd ? "flex-row-reverse" : "flex-row"}
+                  max-md:!flex-col max-md:items-center max-md:gap-7`}
+    >
+      {/* Portrait column */}
+      <motion.div
+        variants={ROW_STAGGER}
+        className="group flex-shrink-0 flex flex-col items-center gap-4 relative"
+      >
+        <motion.div variants={CHILD_FADE}>
+          <div className="relative w-[340px] h-[340px] max-md:w-[280px] max-md:h-[280px] border-2 border-border overflow-hidden">
+            <DualRealmPortrait agent={agent} />
+
+            {/* Rune badge — top-right corner */}
+            <span
+              className="absolute top-3 right-3 text-[28px] opacity-25
+                         group-hover:opacity-70 transition-opacity duration-300
+                         font-heading text-primary"
+              aria-hidden="true"
+            >
+              {agent.rune}
+            </span>
+
+            {/* Personality-specific hover overlay */}
+            <HoverOverlay effect={agent.hoverEffect} />
+          </div>
+        </motion.div>
+
+        {/* Realm badge */}
+        <motion.div variants={CHILD_FADE}>
+          <RealmBadge />
+        </motion.div>
+      </motion.div>
+
+      {/* Text column */}
+      <motion.div
+        variants={ROW_STAGGER}
+        className="flex-1 flex flex-col gap-5 pt-2 max-md:pt-0"
+      >
+        <motion.div variants={CHILD_FADE}>
+          <h3 className="font-heading text-[32px] font-bold leading-none text-foreground max-md:text-[26px]">
+            {agent.name}
+          </h3>
+          <p className="font-mono text-xs font-bold uppercase tracking-[0.12em] text-foreground/60 mt-2">
+            {agent.role}
+          </p>
+        </motion.div>
+
+        <motion.p
+          variants={CHILD_FADE}
+          className="font-body text-[15px] leading-[1.7] text-muted-foreground"
+        >
+          {agent.bio}
+        </motion.p>
+
+        <motion.div variants={CHILD_FADE}>
+          <RealmLore lightLore={agent.lightLore} darkLore={agent.darkLore} />
+        </motion.div>
+      </motion.div>
+    </motion.article>
   );
 }
 
@@ -489,54 +729,54 @@ function WhyTheWolfSection(): React.ReactElement {
   );
 }
 
-// ── Section: The Pack ─────────────────────────────────────────────────────────
+// ── Section: The Myth with Agents (Issue #633) ──────────────────────────────
 
-function ThePackSection(): React.ReactElement {
+function TheMythWithAgentsSection(): React.ReactElement {
   return (
     <AnimatedSection
       label="The agents of Asgard"
       className="border-b border-border bg-card"
     >
-      <div className="max-w-[1100px] mx-auto px-6 py-14 sm:py-20">
-        <SectionHeading
-          label={RUNE.tiwaz}
-          title="The Agents of Asgard"
-          subtitle="Every member of the pack has their domain, their purpose, their saga."
-        />
-
-        <motion.div
-          variants={STAGGER}
-          className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6"
-        >
-          {AGENTS.map((agent) => (
-            <AgentCard key={agent.slug} agent={agent} />
-          ))}
-
-          {/* Future agent placeholder */}
-          <motion.div
-            variants={CARD_VARIANT}
-            className="flex flex-col border border-dashed border-border/40 overflow-hidden
-                       bg-card/30 opacity-30"
+      <div className="max-w-[1200px] mx-auto px-6 py-14 sm:py-20">
+        {/* Section intro */}
+        <div className="text-center max-w-[700px] mx-auto mb-16">
+          <motion.p
+            variants={FADE_UP}
+            className="font-mono text-xs tracking-[0.3em] text-primary uppercase mb-3"
           >
-            <div className="w-full aspect-square border-b border-border/30 flex items-center justify-center bg-muted/20">
-              <span className="text-6xl opacity-30 font-heading text-muted-foreground">
-                ?
-              </span>
-            </div>
-            <div className="p-6 flex flex-col gap-2">
-              <h3 className="font-heading text-lg font-semibold text-foreground/50">
-                Coming Soon
-              </h3>
-              <p className="font-mono text-xs tracking-widest text-muted-foreground/40 uppercase">
-                The Pack Grows
-              </p>
-              <p className="font-body text-sm text-muted-foreground/30 leading-relaxed mt-1">
-                New agents join when Odin calls. Each brings their skills to
-                strengthen Fenrir.
-              </p>
-            </div>
-          </motion.div>
-        </motion.div>
+            {RUNE.tiwaz} &mdash; The Pack
+          </motion.p>
+          <motion.h2
+            variants={FADE_UP}
+            className="font-display text-2xl sm:text-3xl font-bold uppercase tracking-wide text-foreground mb-4"
+          >
+            The Agents of Asgard
+          </motion.h2>
+          <motion.p
+            variants={FADE_UP}
+            className="font-body text-base text-muted-foreground leading-relaxed"
+          >
+            Fenrir Ledger is built entirely by AI agents. Each carries a dual
+            nature &mdash; a light face for construction, a shadow face for the
+            hunt. The theme toggle doesn&apos;t just change colors. It reveals
+            which realm you&apos;re peering into.
+          </motion.p>
+        </div>
+
+        {/* Agent rows */}
+        {AGENTS.map((agent, i) => (
+          <div key={agent.slug}>
+            <AgentMythRow agent={agent} index={i} />
+            {i < AGENTS.length - 1 && AGENT_DIVIDERS[i] && (
+              <div
+                className="text-center font-heading text-xl tracking-[0.5em] opacity-20 py-6"
+                aria-hidden="true"
+              >
+                {AGENT_DIVIDERS[i]}
+              </div>
+            )}
+          </div>
+        ))}
       </div>
     </AnimatedSection>
   );
@@ -686,7 +926,7 @@ export default function AboutPage(): React.ReactElement {
     <>
       <OriginHeroSection />
       <WhyTheWolfSection />
-      <ThePackSection />
+      <TheMythWithAgentsSection />
       <TheForgeSection />
       <FinalCtaSection />
     </>

--- a/development/frontend/src/app/globals.css
+++ b/development/frontend/src/app/globals.css
@@ -738,12 +738,12 @@ body.konami-shake-mobile {
 
 /* ── About Page — Hover Effects ──────────────────────────────────────────── */
 /*
- * Per-agent hover effects for the About page profile cards.
+ * Per-agent hover effects for the About page agent portraits.
  * Freya = golden glow, Luna = shimmer sweep, FiremanDecko = fire gradient,
- * Loki = glitch distortion, Heimdall = golden glow (shared with Freya).
+ * Loki = glitch distortion, Heimdall = horizontal scan-line sweep.
  */
 
-/* Freya / Heimdall — warm golden glow with pulse */
+/* Freya — warm golden glow with pulse */
 .about-hover-glow {
   background: radial-gradient(
     ellipse at center,
@@ -813,12 +813,34 @@ body.konami-shake-mobile {
   100% { transform: translateX(0); }
 }
 
+/* Heimdall — horizontal scan-line sweep */
+.about-hover-scan {
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 45%,
+    rgba(91, 158, 201, 0.3) 48%,
+    rgba(91, 158, 201, 0.5) 50%,
+    rgba(91, 158, 201, 0.3) 52%,
+    transparent 55%,
+    transparent 100%
+  );
+  background-size: 100% 300%;
+  animation: about-scan-sweep 2s ease-in-out infinite;
+}
+
+@keyframes about-scan-sweep {
+  0%   { background-position: 0 100%; }
+  100% { background-position: 0 -100%; }
+}
+
 /* About page — reduced motion: disable all hover animations */
 @media (prefers-reduced-motion: reduce) {
   .about-hover-glow,
   .about-hover-shimmer,
   .about-hover-fire,
-  .about-hover-glitch {
+  .about-hover-glitch,
+  .about-hover-scan {
     animation: none !important;
     transition: none !important;
   }
@@ -829,7 +851,8 @@ body.konami-shake-mobile {
   .about-hover-glow,
   .about-hover-shimmer,
   .about-hover-fire,
-  .about-hover-glitch {
+  .about-hover-glitch,
+  .about-hover-scan {
     animation: none;
   }
 }

--- a/ux/wireframes.md
+++ b/ux/wireframes.md
@@ -11,6 +11,14 @@ Wireframes are standalone HTML5 documents. They use only structural layout — n
 
 ---
 
+## About Page — Dual-Realm Agent Profiles (Issue #633)
+
+| File | Description |
+|------|-------------|
+| [wireframes/marketing-site/about.html](wireframes/marketing-site/about.html) | About page redesign: alternating agent profiles woven into The Myth section — replaces 3-col card grid with 5 full-width portrait+text rows (portrait alternates left/right by index); dual-realm lore per agent (Ljósálfar/light aspect + Svartálfar/dark aspect); portrait crossfade on theme toggle (transition-opacity 500ms); realm badge beneath each portrait; runic placeholder fallback; personality-specific hover overlays (glow/shimmer/fire/glitch/scan); Framer Motion scroll-triggered slide-in (direction matches portrait side); responsive: portrait-above-text stacked at 768px; full interaction spec in HTML comments (portrait crossfade impl, lore crossfade impl, AgentProfile interface changes, section changes summary, a11y requirements including aria-live realm badge, prefers-reduced-motion) |
+
+---
+
 ## Dashboard Tab Headers, Tooltips, and Empty States
 
 | File | Description |

--- a/ux/wireframes/marketing-site/about.html
+++ b/ux/wireframes/marketing-site/about.html
@@ -3,242 +3,249 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Wireframe: About Page — /about</title>
+  <title>Wireframe: About Page — /about (Issue #633 Dual-Realm Agent Profiles)</title>
   <style>
     /* Layout and structure only.
        No colors, no custom fonts, no shadows, no border-radius.
-       Theme styling is defined in ../../theme-system.md. */
+       Theme styling is defined in ../../theme-system.md.
+       Issue #633: Agents woven into The Myth section, alternating left/right,
+       with dual-realm (Ljósálfar/Svartálfar) lore per agent. */
+
     * { box-sizing: border-box; margin: 0; padding: 0; }
-    body { font-family: sans-serif; font-size: 14px; }
+    body { font-family: sans-serif; font-size: 14px; max-width: 100%; }
 
-    /* ── Section wrappers ────────────────────────────────────────────────── */
-    section { padding: 80px 48px; border-bottom: 1px solid; position: relative; }
+    /* ── Utility ─────────────────────────────────────────────────────────── */
     .section-label { font-size: 11px; font-weight: bold; text-transform: uppercase; letter-spacing: 0.1em; opacity: 0.5; margin-bottom: 8px; }
-    .note { font-size: 11px; font-style: italic; opacity: 0.6; }
+    .note { font-size: 11px; font-style: italic; opacity: 0.6; margin-top: 6px; }
+    .note-block { font-size: 11px; font-style: italic; opacity: 0.6; border: 1px dashed; padding: 8px 12px; margin: 8px 0; }
+    button { border: 1px solid; padding: 7px 16px; cursor: pointer; background: none; font-family: inherit; font-size: 13px; }
 
-    /* ── Nav (reused from marketing site) ─────────────────────────────────── */
+    /* ── Nav ──────────────────────────────────────────────────────────────── */
     nav.site-nav {
-      position: sticky;
-      top: 0;
+      position: sticky; top: 0;
       border-bottom: 1px solid;
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      padding: 12px 48px;
-      z-index: 10;
+      display: flex; justify-content: space-between; align-items: center;
+      padding: 12px 48px; z-index: 10;
     }
     .nav-brand { font-weight: bold; }
     .nav-links { display: flex; gap: 24px; align-items: center; }
     .nav-links a { text-decoration: none; font-size: 13px; }
-    button { border: 1px solid; padding: 7px 16px; cursor: pointer; background: none; font-family: inherit; font-size: 13px; }
+
+    /* ── Sections ─────────────────────────────────────────────────────────── */
+    section { padding: 80px 48px; border-bottom: 1px solid; position: relative; }
 
     /* ── Origin Story Hero ────────────────────────────────────────────────── */
     .origin-hero {
-      min-height: 100vh;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      padding: 80px 48px;
+      min-height: 100vh; display: flex; align-items: center;
+      justify-content: center; text-align: center; padding: 80px 48px;
     }
-    .origin-content {
-      max-width: 800px;
-      display: flex;
-      flex-direction: column;
-      gap: 32px;
-      align-items: center;
-    }
+    .origin-content { max-width: 800px; display: flex; flex-direction: column; gap: 32px; align-items: center; }
     .origin-content h1 { font-size: 48px; font-weight: bold; line-height: 1.1; }
     .origin-content .subtitle { font-size: 20px; font-weight: 300; }
     .origin-myth { max-width: 600px; }
     .origin-myth p { font-size: 16px; line-height: 1.6; margin-bottom: 16px; }
-    .runic-divider {
-      font-size: 24px;
-      letter-spacing: 0.5em;
-      opacity: 0.4;
-      margin: 24px 0;
-    }
+    .runic-divider { font-size: 24px; letter-spacing: 0.5em; opacity: 0.4; margin: 24px 0; }
 
-    /* ── Origin Story Detail ──────────────────────────────────────────────── */
+    /* ── Origin Story Detail (2-col, unchanged) ───────────────────────────── */
     .origin-detail {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 48px;
-      max-width: 1200px;
-      margin: 0 auto;
+      display: grid; grid-template-columns: 1fr 1fr; gap: 48px;
+      max-width: 1200px; margin: 0 auto;
     }
     .origin-column h3 { font-size: 24px; margin-bottom: 16px; font-weight: bold; }
     .origin-column p { font-size: 15px; line-height: 1.6; margin-bottom: 12px; }
     .origin-column blockquote {
-      border-left: 2px solid;
-      padding-left: 16px;
-      font-style: italic;
-      font-size: 14px;
-      margin: 20px 0;
+      border-left: 2px solid; padding-left: 16px; font-style: italic;
+      font-size: 14px; margin: 20px 0;
     }
 
-    /* ── The Pack (Team) ───────────────────────────────────────────────────── */
-    .pack-grid {
-      display: grid;
-      grid-template-columns: repeat(3, 1fr);
-      gap: 32px;
-      max-width: 1200px;
-      margin: 48px auto 0;
-    }
-    .agent-card {
-      border: 2px solid;
-      padding: 0;
-      display: flex;
-      flex-direction: column;
-      position: relative;
-      overflow: hidden;
-      transition: transform 0.3s ease;
-      cursor: pointer;
-    }
-    .agent-card:hover {
-      transform: translateY(-8px);
-    }
-    .agent-portrait {
-      width: 100%;
-      height: 280px;
-      border-bottom: 2px solid;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 12px;
-      position: relative;
-      overflow: hidden;
-    }
-    .agent-portrait img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-    .portrait-overlay {
-      position: absolute;
-      top: 0;
-      left: 0;
-      right: 0;
-      bottom: 0;
-      opacity: 0;
-      transition: opacity 0.3s ease;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-    }
-    .agent-card:hover .portrait-overlay { opacity: 1; }
-    .agent-info {
-      padding: 24px;
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-    .agent-name {
-      font-size: 20px;
-      font-weight: bold;
-    }
-    .agent-role {
-      font-size: 14px;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      opacity: 0.7;
-    }
-    .agent-bio {
-      font-size: 14px;
-      line-height: 1.5;
-    }
-    .agent-rune {
-      position: absolute;
-      top: 12px;
-      right: 12px;
-      font-size: 24px;
-      opacity: 0.3;
-    }
+    /* ════════════════════════════════════════════════════════════════════════
+       ── THE MYTH WITH AGENTS WOVEN IN (Issue #633 NEW DESIGN) ──────────────
+       ════════════════════════════════════════════════════════════════════════
 
-    /* ── Heimdall special case (no portrait yet) ───────────────────────────── */
-    .agent-placeholder {
+       Replaces the separate "The Pack" card grid.
+       Each agent section: portrait flanks myth text, alternating L/R by index.
+       Agent 0 (Freya):      portrait LEFT  | text RIGHT
+       Agent 1 (Luna):       text LEFT      | portrait RIGHT
+       Agent 2 (FiremanDe):  portrait LEFT  | text RIGHT
+       Agent 3 (Loki):       text LEFT      | portrait RIGHT
+       Agent 4 (Heimdall):   portrait LEFT  | text RIGHT
+    */
+
+    /* Section container */
+    .myth-with-agents { max-width: 1200px; margin: 0 auto; }
+    .myth-section-intro { text-align: center; max-width: 700px; margin: 0 auto 64px; }
+    .myth-section-intro h2 { font-size: 36px; font-weight: bold; margin-bottom: 16px; }
+    .myth-section-intro p { font-size: 16px; line-height: 1.6; }
+
+    /* ── Single agent row ───────────────────────────────────────────────────
+       .agent-myth-row is a flex row.
+       Even-index (0,2,4): portrait on left  → flex-direction: row
+       Odd-index (1,3):    portrait on right → flex-direction: row-reverse
+       On mobile: always portrait on top, text below (flex-direction: column)
+    */
+    .agent-myth-row {
+      display: flex;
+      flex-direction: row;          /* default: portrait left */
+      align-items: flex-start;
+      gap: 48px;
+      padding: 56px 0;
+      border-bottom: 1px solid;
+    }
+    .agent-myth-row:last-child { border-bottom: none; }
+
+    /* Odd-index rows reverse the portrait to the right */
+    .agent-myth-row.portrait-right { flex-direction: row-reverse; }
+
+    /* ── Portrait column ─────────────────────────────────────────────────── */
+    .agent-portrait-col {
+      flex: 0 0 340px;
       display: flex;
       flex-direction: column;
       align-items: center;
-      justify-content: center;
       gap: 16px;
-      height: 100%;
-    }
-    .runic-symbol {
-      font-size: 72px;
-      opacity: 0.5;
+      position: relative;
     }
 
-    /* ── Built by AI Section ──────────────────────────────────────────────── */
-    .ai-chain {
-      max-width: 1000px;
-      margin: 48px auto 0;
+    /* Portrait container — square, responsive */
+    .agent-portrait-frame {
+      width: 340px;
+      height: 340px;
+      border: 2px solid;
+      position: relative;
+      overflow: hidden;
     }
-    .chain-visualization {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0;
-      margin: 32px 0;
+
+    /* The actual <img> tag fills the frame */
+    .agent-portrait-frame img {
+      width: 100%; height: 100%; object-fit: cover; display: block;
+      /* Implementation: transition-opacity duration-500 for theme crossfade */
     }
-    .chain-node {
+
+    /* Runic placeholder (shown when image missing / loading) */
+    .portrait-fallback {
+      width: 100%; height: 100%;
+      display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      gap: 12px; border: none;
+    }
+    .portrait-fallback .rune-symbol { font-size: 80px; opacity: 0.4; }
+    .portrait-fallback .fallback-label { font-size: 11px; opacity: 0.5; font-style: italic; }
+
+    /* Rune badge — top-right corner of portrait frame */
+    .portrait-rune-badge {
+      position: absolute; top: 12px; right: 12px;
+      font-size: 28px; opacity: 0.25;
+      /* group-hover: opacity 0.7, transition 300ms */
+    }
+
+    /* Realm badge — shows which realm is active (light/dark) */
+    .realm-badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      border: 1px solid; padding: 4px 12px;
+      font-size: 10px; font-weight: bold; text-transform: uppercase;
+      letter-spacing: 0.12em;
+      /* Implementation: content switches with theme; subtle fade-in */
+    }
+    .realm-badge.light-realm::before { content: '☀ '; }
+    .realm-badge.dark-realm::before { content: '☽ '; }
+
+    /* Hover effect overlay (personality-specific) */
+    .portrait-hover-overlay {
+      position: absolute; inset: 0; opacity: 0; pointer-events: none;
+      /* Implementation: group-hover:opacity-100 transition-opacity 300ms
+         Freya: glow effect | Luna: shimmer | FiremanDecko: fire particles
+         Loki: glitch | Heimdall: scan-line sweep */
+    }
+
+    /* ── Text column ─────────────────────────────────────────────────────── */
+    .agent-text-col {
       flex: 1;
       display: flex;
       flex-direction: column;
-      align-items: center;
-      gap: 12px;
-      padding: 20px;
-      border: 1px solid;
+      gap: 20px;
+      padding-top: 8px;
+    }
+
+    .agent-name { font-size: 32px; font-weight: bold; line-height: 1.1; }
+    .agent-role {
+      font-size: 12px; font-weight: bold; text-transform: uppercase;
+      letter-spacing: 0.12em; opacity: 0.6;
+    }
+    .agent-bio { font-size: 15px; line-height: 1.7; }
+
+    /* ── Dual-realm lore block ──────────────────────────────────────────────
+       This is the new element per #633.
+       Shows ONE lore variant at a time based on current theme.
+       Implementation: useTheme() drives which block shows; crossfade on toggle.
+    */
+    .realm-lore-wrapper {
       position: relative;
+      min-height: 80px;   /* reserve space to prevent layout shift during transition */
+    }
+
+    .realm-lore {
+      border-left: 3px solid;
+      padding: 16px 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+    /* Implementation: one is visible, other is opacity:0 + position:absolute
+       Crossfade: transition-opacity duration-500 ease-in-out */
+
+    .realm-lore .realm-title {
+      font-size: 10px; font-weight: bold; text-transform: uppercase;
+      letter-spacing: 0.15em; opacity: 0.5;
+    }
+    .realm-lore .realm-quote {
+      font-size: 14px; line-height: 1.6; font-style: italic;
+    }
+    .realm-lore .realm-aspect {
+      font-size: 11px; opacity: 0.5; font-style: normal;
+      text-transform: uppercase; letter-spacing: 0.1em;
+    }
+
+    /* Light realm lore (shown in light theme) */
+    .realm-lore.lore-light {
+      /* Implementation: visible when resolvedTheme === 'light' */
+    }
+    /* Dark realm lore (shown in dark theme) */
+    .realm-lore.lore-dark {
+      /* Implementation: visible when resolvedTheme === 'dark' */
+    }
+
+    /* Rune decorative divider between agents */
+    .agent-rune-divider {
+      text-align: center;
+      font-size: 20px;
+      letter-spacing: 0.5em;
+      opacity: 0.2;
+      padding: 24px 0;
+    }
+
+    /* ── Forge section (unchanged) ───────────────────────────────────────── */
+    .ai-chain { max-width: 1000px; margin: 48px auto 0; }
+    .chain-visualization {
+      display: flex; align-items: stretch; justify-content: center;
+      gap: 0; margin: 32px 0;
+    }
+    .chain-node {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; gap: 12px; padding: 20px;
+      border: 1px solid; position: relative;
     }
     .chain-node:not(:last-child)::after {
-      content: '→';
-      position: absolute;
-      right: -20px;
-      top: 50%;
-      transform: translateY(-50%);
-      font-size: 24px;
-      z-index: 1;
+      content: '→'; position: absolute; right: -20px; top: 50%;
+      transform: translateY(-50%); font-size: 24px; z-index: 1;
     }
     .chain-icon {
-      width: 64px;
-      height: 64px;
-      border: 2px solid;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 24px;
+      width: 64px; height: 64px; border: 2px solid;
+      display: flex; align-items: center; justify-content: center; font-size: 24px;
     }
     .chain-label { font-weight: bold; font-size: 14px; }
     .chain-desc { font-size: 12px; text-align: center; opacity: 0.8; }
 
-    /* ── Technology Stack ──────────────────────────────────────────────────── */
-    .tech-stack {
-      display: flex;
-      justify-content: center;
-      gap: 48px;
-      margin-top: 32px;
-      flex-wrap: wrap;
-    }
-    .tech-item {
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      gap: 8px;
-    }
-    .tech-logo {
-      width: 48px;
-      height: 48px;
-      border: 1px solid;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      font-size: 10px;
-    }
-    .tech-name { font-size: 13px; font-weight: bold; }
-
-    /* ── Responsive Mobile (375px) ─────────────────────────────────────────── */
+    /* ── Responsive: Mobile (375px min) ─────────────────────────────────── */
     @media (max-width: 768px) {
       section { padding: 48px 24px; }
       nav.site-nav { padding: 12px 24px; }
@@ -247,48 +254,47 @@
       .origin-content h1 { font-size: 32px; }
       .origin-content .subtitle { font-size: 18px; }
 
-      .origin-detail {
-        grid-template-columns: 1fr;
-        gap: 32px;
+      .origin-detail { grid-template-columns: 1fr; gap: 32px; }
+
+      /* Agent rows: collapse to portrait-above-text stacked layout */
+      .agent-myth-row {
+        flex-direction: column !important; /* force column for ALL rows on mobile */
+        gap: 28px;
+        padding: 40px 0;
+        align-items: center;
       }
 
-      .pack-grid {
-        grid-template-columns: 1fr;
-        gap: 24px;
+      .agent-portrait-col {
+        flex: 0 0 auto;
+        width: 100%;
+        align-items: center;
+      }
+      .agent-portrait-frame {
+        width: 280px; height: 280px;
       }
 
-      .chain-visualization {
-        flex-direction: column;
-        gap: 16px;
-      }
+      .agent-text-col { padding-top: 0; }
+      .agent-name { font-size: 26px; }
+
+      .chain-visualization { flex-direction: column; gap: 16px; }
       .chain-node:not(:last-child)::after {
-        content: '↓';
-        right: 50%;
-        top: auto;
-        bottom: -24px;
+        content: '↓'; right: 50%; top: auto; bottom: -24px;
         transform: translateX(50%);
       }
-
-      .tech-stack {
-        gap: 24px;
-      }
     }
 
-    /* ── Parallax zones (implementation note) ────────────────────────────────── */
-    .parallax-layer {
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      pointer-events: none;
-      opacity: 0.1;
+    /* ── Annotation helpers ───────────────────────────────────────────────── */
+    .annotation-box {
+      border: 1px dashed; padding: 12px 16px; margin: 16px 0;
+      font-size: 11px; font-style: italic; opacity: 0.55;
     }
-    .parallax-layer.back { z-index: -2; }
-    .parallax-layer.mid { z-index: -1; }
+    .label-LIGHT { font-weight: bold; }
+    .label-DARK { font-weight: bold; }
   </style>
 </head>
 <body>
 
-  <!-- ── Sticky nav ────────────────────────────────────────────────────────── -->
+  <!-- ── Sticky Nav (unchanged from current) ──────────────────────────────── -->
   <nav class="site-nav" aria-label="Site navigation">
     <div class="nav-brand">[ᛟ wolf icon] FENRIR LEDGER</div>
     <div class="nav-links">
@@ -298,304 +304,424 @@
       <button>[Enter the Ledger ▶]</button>
     </div>
   </nav>
-  <p class="note" style="padding: 4px 48px;">Nav: glassmorphism backdrop-blur. Active page underlined with rune accent.</p>
+  <p class="note" style="padding: 4px 48px;">Nav: glassmorphism backdrop-blur. Active page underlined with rune accent. Theme toggle button (rotary) in nav.</p>
 
-  <!-- ── Origin Story Hero (100vh) ───────────────────────────────────────────── -->
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       SECTION 1: Origin Story Hero (100vh) — UNCHANGED
+       ═══════════════════════════════════════════════════════════════════════ -->
   <section class="origin-hero">
-    <div class="parallax-layer back">
-      <p class="note">[Parallax BG: Faint runic patterns, slow drift on scroll]</p>
-    </div>
     <div class="origin-content">
       <h1>THE WOLF WAS NOT BOUND.<br/>YOU ARE.</h1>
       <p class="subtitle">Every annual fee is Gleipnir — the impossible chain</p>
-
       <div class="runic-divider">ᚠ ᛖ ᚾ ᚱ ᛁ ᚱ</div>
-
       <div class="origin-myth">
-        <p>
-          In Norse mythology, Fenrir was the wolf prophesied to devour Odin at Ragnarök.
-          The gods feared him, so they bound him with Gleipnir — a chain forged from impossible things:
-          the breath of a fish, the beard of a woman, the roots of a mountain.
-        </p>
-        <p>
-          <strong>Credit card companies are your Gleipnir.</strong> They bind you with things that seem impossible to track:
-          annual fees that strike in silence, sign-up bonuses that expire forgotten, rewards that vanish unclaimed.
-        </p>
-        <p>
-          <strong>Fenrir Ledger breaks the chain.</strong> Built by Odin himself to free you from the bonds
-          of modern finance. The wolf remembers what you forget. The wolf watches what you miss.
-        </p>
+        <p>In Norse mythology, Fenrir was the wolf prophesied to devour Odin at Ragnarök. The gods feared him, so they bound him with Gleipnir — a chain forged from impossible things: the breath of a fish, the beard of a woman, the roots of a mountain.</p>
+        <p><strong>Credit card companies are your Gleipnir.</strong> They bind you with things that seem impossible to track: annual fees that strike in silence, sign-up bonuses that expire forgotten, rewards that vanish unclaimed.</p>
+        <p><strong>Fenrir Ledger breaks the chain.</strong> Built by Odin himself to free you from the bonds of modern finance. The wolf remembers what you forget. The wolf watches what you miss.</p>
       </div>
     </div>
   </section>
+  <!-- Note: Framer Motion scroll-triggered stagger, parallax runic bg opacity 0.03 -->
 
-  <!-- ── Origin Story Detail ──────────────────────────────────────────────── -->
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       SECTION 2: Why the Wolf — 2-col founding myth — UNCHANGED
+       ═══════════════════════════════════════════════════════════════════════ -->
   <section>
-    <div class="section-label">The Founding Myth</div>
+    <div class="section-label">ᚠ — The Founding Myth</div>
     <h2 style="font-size: 36px; text-align: center; margin-bottom: 48px;">WHY THE WOLF?</h2>
-
     <div class="origin-detail">
       <div class="origin-column">
         <h3>The Personal Mission</h3>
-        <p>
-          Odin, the Allfather of this codebase, watched too many warriors fall to forgotten fees.
-          Too many friends missing bonuses. Too many kin paying for cards they don't use.
-        </p>
-        <blockquote>
-          "I built Fenrir because I was tired of being Gleipnir's victim. Now the wolf hunts for us all."
-          <br/>— Odin
-        </blockquote>
-        <p>
-          This isn't corporate software. This is mythology made manifest. Every line of code
-          is a fang. Every notification is a howl. Every saved dollar is plunder from the hoard.
-        </p>
+        <p>Odin, the Allfather of this codebase, watched too many warriors fall to forgotten fees. Too many friends missing bonuses. Too many kin paying for cards they don't use.</p>
+        <blockquote>"I built Fenrir because I was tired of being Gleipnir's victim. Now the wolf hunts for us all." <br/>— Odin</blockquote>
+        <p>This isn't corporate software. This is mythology made manifest. Every line of code is a fang. Every notification is a howl. Every saved dollar is plunder from the hoard.</p>
       </div>
-
       <div class="origin-column">
         <h3>The Norse Connection</h3>
-        <p>
-          We didn't choose Norse mythology for aesthetics. We chose it because it fits.
-          The credit card industry deals in cycles — billing cycles, statement cycles, promo cycles.
-          Norse mythology understands cycles: Ragnarök isn't the end, it's the turning of the wheel.
-        </p>
-        <p>
-          Every card you close breaks a link in Gleipnir. Every fee you dodge weakens the binding.
-          Every bonus you claim is tribute taken back from those who would bind you.
-        </p>
-        <blockquote>
-          "Though it looks like silk ribbon, no chain is stronger."
-          <br/>— Prose Edda, on Gleipnir
-        </blockquote>
+        <p>We didn't choose Norse mythology for aesthetics. We chose it because it fits. The credit card industry deals in cycles — billing, statement, promo. Norse mythology understands cycles: Ragnarök isn't the end, it's the turning of the wheel.</p>
+        <p>Every card you close breaks a link in Gleipnir. Every fee you dodge weakens the binding. Every bonus you claim is tribute taken back from those who would bind you.</p>
+        <blockquote>"Though it looks like silk ribbon, no chain is stronger." <br/>— Prose Edda, on Gleipnir</blockquote>
       </div>
     </div>
-
-    <p class="note" style="text-align: center; margin-top: 32px;">
-      Implementation: Subtle parallax on runic elements. Stone texture overlays on section borders.
-    </p>
   </section>
 
-  <!-- ── The Pack (Team Section) ──────────────────────────────────────────── -->
-  <section style="overflow: visible;">
-    <div class="section-label">Meet the Pack</div>
-    <h2 style="font-size: 36px; text-align: center; margin-bottom: 16px;">THE AGENTS OF ASGARD</h2>
-    <p style="text-align: center; max-width: 600px; margin: 0 auto 48px; font-size: 16px;">
-      Fenrir Ledger is built entirely by AI agents, each with their domain, their purpose, their saga.
-      Click their portraits to hear their howl.
-    </p>
 
-    <div class="pack-grid">
-      <!-- Freya -->
-      <div class="agent-card">
-        <div class="agent-portrait">
-          <img src="[freya-dark.png on dark theme / freya-light.png on light]" alt="Freya portrait" />
-          <div class="portrait-overlay">
-            <p class="note">[Glow effect on hover]</p>
-          </div>
-          <span class="agent-rune">ᚠ</span>
-        </div>
-        <div class="agent-info">
-          <div class="agent-name">Freya</div>
-          <div class="agent-role">Product Owner</div>
-          <div class="agent-bio">
-            Guardian of the product vision. She shapes what Fenrir becomes, channeling user needs into features.
-            Powers the AI import pipeline that reads your credit card PDFs and transforms chaos into clarity.
-          </div>
-        </div>
-      </div>
-
-      <!-- Luna -->
-      <div class="agent-card">
-        <div class="agent-portrait">
-          <img src="[luna-dark.png on dark theme / luna-light.png on light]" alt="Luna portrait" />
-          <div class="portrait-overlay">
-            <p class="note">[Shimmer effect on hover]</p>
-          </div>
-          <span class="agent-rune">ᛚ</span>
-        </div>
-        <div class="agent-info">
-          <div class="agent-name">Luna</div>
-          <div class="agent-role">UX Designer</div>
-          <div class="agent-bio">
-            Architect of every interface, every interaction. She ensures the ledger feels mythic yet usable,
-            that every click has purpose, every view tells a story. The wolf's eyes see through her designs.
-          </div>
-        </div>
-      </div>
-
-      <!-- FiremanDecko -->
-      <div class="agent-card">
-        <div class="agent-portrait">
-          <img src="[fireman-decko-dark.png on dark / fireman-decko-light.png on light]" alt="FiremanDecko portrait" />
-          <div class="portrait-overlay">
-            <p class="note">[Fire particle effect on hover]</p>
-          </div>
-          <span class="agent-rune">ᛏ</span>
-        </div>
-        <div class="agent-info">
-          <div class="agent-name">FiremanDecko</div>
-          <div class="agent-role">Principal Engineer</div>
-          <div class="agent-bio">
-            The forge-master who transforms design into reality. Every component, every API, every line of TypeScript
-            flows from his keyboard. He builds with the precision of dwarven smiths and the power of Mjolnir.
-          </div>
-        </div>
-      </div>
-
-      <!-- Loki -->
-      <div class="agent-card">
-        <div class="agent-portrait">
-          <img src="[loki-dark.png on dark theme / loki-light.png on light]" alt="Loki portrait" />
-          <div class="portrait-overlay">
-            <p class="note">[Glitch effect on hover]</p>
-          </div>
-          <span class="agent-rune">ᛚ</span>
-        </div>
-        <div class="agent-info">
-          <div class="agent-name">Loki</div>
-          <div class="agent-role">QA Tester</div>
-          <div class="agent-bio">
-            Son of the wolf, breaker of things. He tests with chaos and cunning, finding bugs before users do.
-            Every edge case is his playground, every error his trophy. If it can break, Loki will break it first.
-          </div>
-        </div>
-      </div>
-
-      <!-- Heimdall (no portrait yet) -->
-      <div class="agent-card">
-        <div class="agent-portrait">
-          <div class="agent-placeholder">
-            <div class="runic-symbol">ᚺ</div>
-            <p class="note">[Portrait coming soon]</p>
-          </div>
-          <span class="agent-rune">ᚺ</span>
-        </div>
-        <div class="agent-info">
-          <div class="agent-name">Heimdall</div>
-          <div class="agent-role">Security Guardian</div>
-          <div class="agent-bio">
-            Watcher of the Rainbow Bridge, guardian of your data. He sees all threats, blocks all intrusions.
-            Your financial data is his sacred charge. Not even Loki's tricks can bypass his vigilance.
-          </div>
-        </div>
-      </div>
-
-      <!-- Empty slot for future agent -->
-      <div class="agent-card" style="border-style: dashed; opacity: 0.3;">
-        <div class="agent-portrait">
-          <div class="agent-placeholder">
-            <div class="runic-symbol">?</div>
-            <p class="note">[The next saga awaits]</p>
-          </div>
-        </div>
-        <div class="agent-info">
-          <div class="agent-name">Coming Soon</div>
-          <div class="agent-role">The Pack Grows</div>
-          <div class="agent-bio">
-            New agents join when Odin calls. Each brings their skills to strengthen Fenrir.
-          </div>
-        </div>
-      </div>
-    </div>
-
-    <p class="note" style="text-align: center; margin-top: 32px;">
-      Implementation: Framer Motion stagger animations on scroll. Each card has unique hover effect matching personality.
-      Click opens modal with extended agent story. Theme switch animates portrait swap with crossfade.
-    </p>
-  </section>
-
-  <!-- ── Built by AI Section ───────────────────────────────────────────────── -->
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       SECTION 3: THE MYTH — AGENTS WOVEN IN (Issue #633 NEW DESIGN)
+       Replaces: "The Pack" card grid section entirely.
+       Page flow: Hero → Myth Intro → Each agent interwoven as myth progresses
+       ═══════════════════════════════════════════════════════════════════════ -->
   <section>
-    <div class="section-label">The Forge</div>
+    <div class="myth-with-agents">
+
+      <!-- Section intro copy -->
+      <div class="myth-section-intro">
+        <div class="section-label">ᛏ — The Pack</div>
+        <h2>The Agents of Asgard</h2>
+        <p>
+          Fenrir Ledger is built entirely by AI agents. Each carries a dual nature —
+          a light face for construction, a shadow face for the hunt.
+          The theme toggle doesn't just change colors. It reveals which realm you're peering into.
+        </p>
+        <div class="annotation-box">
+          ☀ <span class="label-LIGHT">LIGHT THEME</span> → Ljósálfar realm (Alfheim). Agent in benevolent, constructive form.<br/>
+          ☽ <span class="label-DARK">DARK THEME</span> → Svartálfar realm (Svartalfheim). Agent's shadow nature — fierce, cunning, relentless.<br/>
+          Portrait and lore text both crossfade when theme toggles (transition-opacity 500ms).
+        </div>
+      </div>
+
+      <!-- ───────────────────────────────────────────────────────────────────
+           AGENT 0 — FREYA (index 0 → portrait LEFT, text RIGHT)
+           ─────────────────────────────────────────────────────────────────── -->
+      <article class="agent-myth-row" aria-label="Freya — Product Owner">
+        <!-- Portrait column (left on desktop, top on mobile) -->
+        <div class="agent-portrait-col">
+          <div class="agent-portrait-frame">
+
+            <!-- Light portrait (shown in light theme) -->
+            <img
+              src="/images/team/freya-light.png"
+              alt="Freya — light realm portrait"
+              style="opacity: 1; /* 1 in light, 0 in dark */"
+            />
+            <!--
+              Implementation:
+              Light portrait: opacity: resolvedTheme === 'light' ? 1 : 0
+              Dark portrait: opacity: resolvedTheme === 'dark' ? 1 : 0
+              Both stacked (position: absolute), transition-opacity 500ms
+            -->
+            <img
+              src="/images/team/freya-dark.png"
+              alt="Freya — dark realm portrait"
+              style="position: absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; opacity: 0; /* 0 in light, 1 in dark */"
+            />
+
+            <!-- Runic placeholder fallback (shown if both images error) -->
+            <div class="portrait-fallback" style="display: none; /* shown only on image error */">
+              <div class="rune-symbol">ᚠ</div>
+              <div class="fallback-label">Portrait coming soon</div>
+            </div>
+
+            <!-- Rune badge (always visible) -->
+            <span class="portrait-rune-badge" aria-hidden="true">ᚠ</span>
+
+            <!-- Hover overlay (personality-specific, no structural difference) -->
+            <div class="portrait-hover-overlay" aria-hidden="true">
+              <!-- Implementation: about-hover-glow class (Freya) -->
+            </div>
+          </div>
+
+          <!-- Realm badge — changes content with theme -->
+          <div class="realm-badge light-realm">LJÓSÁLFAR · ALFHEIM</div>
+          <!-- Implementation: shown when light theme; dark realm badge shown when dark theme -->
+          <div class="realm-badge dark-realm" style="display:none;">SVARTÁLFAR · SVARTALFHEIM</div>
+          <p class="note">Realm badge text switches with theme toggle.</p>
+        </div>
+
+        <!-- Text column (right on desktop, bottom on mobile) -->
+        <div class="agent-text-col">
+          <div>
+            <div class="agent-name">Freya</div>
+            <div class="agent-role">Product Owner</div>
+          </div>
+
+          <p class="agent-bio">
+            Guardian of the product vision. She shapes what Fenrir becomes,
+            channeling user needs into features. Powers the import pipeline that
+            reads your credit card data and transforms chaos into clarity.
+          </p>
+
+          <!-- Dual-realm lore block (NEW — #633) -->
+          <div class="realm-lore-wrapper">
+            <!-- Light theme lore (Ljósálfar) -->
+            <div class="realm-lore lore-light">
+              <span class="realm-title">☀ Ljósálfar Aspect · Light Realm</span>
+              <p class="realm-quote">"Keeper of the harvest, she nurtures ideas into being — patient, far-sighted, a mother to every feature that grows in Fenrir's fields."</p>
+              <span class="realm-aspect">Benevolent · Guiding · Constructive</span>
+            </div>
+            <!-- Dark theme lore (Svartálfar) — crossfades in on dark toggle -->
+            <div class="realm-lore lore-dark" style="display:none;">
+              <!-- Implementation: position:absolute, opacity crossfade with light version -->
+              <span class="realm-title">☽ Svartálfar Aspect · Dark Realm</span>
+              <p class="realm-quote">"The Völva who sees all futures and chooses the cruelest path to victory. She does not suggest features — she issues prophecy. Deny her and Ragnarök finds you first."</p>
+              <span class="realm-aspect">Fierce · Prophetic · Relentless</span>
+            </div>
+          </div>
+
+          <p class="note">Implementation: useTheme() drives lore visibility. Crossfade via CSS opacity transition (500ms) not display:none in production — both divs rendered, one opacity:0. The realm-lore-wrapper min-height prevents layout shift.</p>
+        </div>
+      </article>
+
+      <div class="agent-rune-divider" aria-hidden="true">ᚠ · · · ᛚ</div>
+
+      <!-- ───────────────────────────────────────────────────────────────────
+           AGENT 1 — LUNA (index 1 → portrait RIGHT, text LEFT)
+           ─────────────────────────────────────────────────────────────────── -->
+      <article class="agent-myth-row portrait-right" aria-label="Luna — UX Designer">
+        <!-- Portrait column (right on desktop, top on mobile) -->
+        <div class="agent-portrait-col">
+          <div class="agent-portrait-frame">
+            <img src="/images/team/luna-light.png" alt="Luna — light realm portrait" style="opacity: 1;" />
+            <img src="/images/team/luna-dark.png" alt="Luna — dark realm portrait" style="position: absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; opacity: 0;" />
+            <div class="portrait-fallback" style="display: none;">
+              <div class="rune-symbol">ᛚ</div>
+              <div class="fallback-label">Portrait coming soon</div>
+            </div>
+            <span class="portrait-rune-badge" aria-hidden="true">ᛚ</span>
+            <div class="portrait-hover-overlay" aria-hidden="true"><!-- shimmer --></div>
+          </div>
+          <div class="realm-badge light-realm">LJÓSÁLFAR · ALFHEIM</div>
+          <div class="realm-badge dark-realm" style="display:none;">SVARTÁLFAR · SVARTALFHEIM</div>
+        </div>
+
+        <!-- Text column (left on desktop, bottom on mobile) -->
+        <div class="agent-text-col">
+          <div>
+            <div class="agent-name">Luna</div>
+            <div class="agent-role">UX Designer</div>
+          </div>
+          <p class="agent-bio">
+            Architect of every interface, every interaction. She ensures the
+            ledger feels mythic yet usable, that every click has purpose, every
+            view tells a story. The wolf's eyes see through her designs.
+          </p>
+          <div class="realm-lore-wrapper">
+            <div class="realm-lore lore-light">
+              <span class="realm-title">☀ Ljósálfar Aspect · Light Realm</span>
+              <p class="realm-quote">"Máni's daughter, painting interfaces in moonlight — every pixel deliberate, every margin a breath between words, her layouts as calm and inevitable as the tide."</p>
+              <span class="realm-aspect">Deliberate · Luminous · Harmonious</span>
+            </div>
+            <div class="realm-lore lore-dark" style="display:none;">
+              <span class="realm-title">☽ Svartálfar Aspect · Dark Realm</span>
+              <p class="realm-quote">"The Norns' weaver — every pixel a thread of fate, every layout a prophecy. She doesn't design interfaces; she weaves the loom that determines who falls and who ascends."</p>
+              <span class="realm-aspect">Fateful · Inexorable · Prophetic</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <div class="agent-rune-divider" aria-hidden="true">ᛚ · · · ᛏ</div>
+
+      <!-- ───────────────────────────────────────────────────────────────────
+           AGENT 2 — FIREMAN DECKO (index 2 → portrait LEFT, text RIGHT)
+           ─────────────────────────────────────────────────────────────────── -->
+      <article class="agent-myth-row" aria-label="FiremanDecko — Principal Engineer">
+        <div class="agent-portrait-col">
+          <div class="agent-portrait-frame">
+            <img src="/images/team/fireman-decko-light.png" alt="FiremanDecko — light realm portrait" style="opacity: 1;" />
+            <img src="/images/team/fireman-decko-dark.png" alt="FiremanDecko — dark realm portrait" style="position: absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; opacity: 0;" />
+            <div class="portrait-fallback" style="display: none;">
+              <div class="rune-symbol">ᛏ</div>
+              <div class="fallback-label">Portrait coming soon</div>
+            </div>
+            <span class="portrait-rune-badge" aria-hidden="true">ᛏ</span>
+            <div class="portrait-hover-overlay" aria-hidden="true"><!-- fire particles --></div>
+          </div>
+          <div class="realm-badge light-realm">LJÓSÁLFAR · ALFHEIM</div>
+          <div class="realm-badge dark-realm" style="display:none;">SVARTÁLFAR · SVARTALFHEIM</div>
+        </div>
+
+        <div class="agent-text-col">
+          <div>
+            <div class="agent-name">FiremanDecko</div>
+            <div class="agent-role">Principal Engineer</div>
+          </div>
+          <p class="agent-bio">
+            The forge-master who transforms design into reality. Every component,
+            every API, every line of TypeScript flows from his keyboard. He builds
+            with the precision of dwarven smiths and the power of Mjolnir.
+          </p>
+          <div class="realm-lore-wrapper">
+            <div class="realm-lore lore-light">
+              <span class="realm-title">☀ Ljósálfar Aspect · Light Realm</span>
+              <p class="realm-quote">"The master smith of Nidavellir, forging with patience and precision — each commit a ring in the chain, each function a rune that binds reality to intention."</p>
+              <span class="realm-aspect">Patient · Precise · Masterful</span>
+            </div>
+            <div class="realm-lore lore-dark" style="display:none;">
+              <span class="realm-title">☽ Svartálfar Aspect · Dark Realm</span>
+              <p class="realm-quote">"Surtr's apprentice — he doesn't build, he conjures from the flames. The codebase is his pyre; what rises from it is either legend or ash. There is no middle outcome."</p>
+              <span class="realm-aspect">Incendiary · Absolute · Uncompromising</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <div class="agent-rune-divider" aria-hidden="true">ᛏ · · · ᛚ</div>
+
+      <!-- ───────────────────────────────────────────────────────────────────
+           AGENT 3 — LOKI (index 3 → portrait RIGHT, text LEFT)
+           ─────────────────────────────────────────────────────────────────── -->
+      <article class="agent-myth-row portrait-right" aria-label="Loki — QA Tester">
+        <div class="agent-portrait-col">
+          <div class="agent-portrait-frame">
+            <img src="/images/team/loki-light.png" alt="Loki — light realm portrait" style="opacity: 1;" />
+            <img src="/images/team/loki-dark.png" alt="Loki — dark realm portrait" style="position: absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; opacity: 0;" />
+            <div class="portrait-fallback" style="display: none;">
+              <div class="rune-symbol">ᛚ</div>
+              <div class="fallback-label">Portrait coming soon</div>
+            </div>
+            <span class="portrait-rune-badge" aria-hidden="true">ᛚ</span>
+            <div class="portrait-hover-overlay" aria-hidden="true"><!-- glitch --></div>
+          </div>
+          <div class="realm-badge light-realm">LJÓSÁLFAR · ALFHEIM</div>
+          <div class="realm-badge dark-realm" style="display:none;">SVARTÁLFAR · SVARTALFHEIM</div>
+        </div>
+
+        <div class="agent-text-col">
+          <div>
+            <div class="agent-name">Loki</div>
+            <div class="agent-role">QA Tester</div>
+          </div>
+          <p class="agent-bio">
+            Son of the wolf, breaker of things. He tests with chaos and cunning,
+            finding bugs before users do. Every edge case is his playground,
+            every error his trophy. If it can break, Loki will break it first.
+          </p>
+          <div class="realm-lore-wrapper">
+            <div class="realm-lore lore-light">
+              <span class="realm-title">☀ Ljósálfar Aspect · Light Realm</span>
+              <p class="realm-quote">"The trickster who finds flaws before they become wounds — his mischief is medicine, his pranks preventative, each test a gentle probe that saves the pack from greater harm."</p>
+              <span class="realm-aspect">Curious · Preventive · Cleverly Protective</span>
+            </div>
+            <div class="realm-lore lore-dark" style="display:none;">
+              <span class="realm-title">☽ Svartálfar Aspect · Dark Realm</span>
+              <p class="realm-quote">"Chaos incarnate — he doesn't find bugs, he breeds them to hunt their parents. He is the wolf inside the wolf, the test that tears the code apart to prove whether it deserved to live."</p>
+              <span class="realm-aspect">Chaotic · Relentless · Merciless</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+      <div class="agent-rune-divider" aria-hidden="true">ᛚ · · · ᚺ</div>
+
+      <!-- ───────────────────────────────────────────────────────────────────
+           AGENT 4 — HEIMDALL (index 4 → portrait LEFT, text RIGHT)
+           ─────────────────────────────────────────────────────────────────── -->
+      <article class="agent-myth-row" aria-label="Heimdall — Security Guardian">
+        <div class="agent-portrait-col">
+          <div class="agent-portrait-frame">
+            <img src="/images/team/heimdall-light.png" alt="Heimdall — light realm portrait" style="opacity: 1;" />
+            <img src="/images/team/heimdall-dark.png" alt="Heimdall — dark realm portrait" style="position: absolute; top:0; left:0; width:100%; height:100%; object-fit:cover; opacity: 0;" />
+            <div class="portrait-fallback" style="display: none;">
+              <div class="rune-symbol">ᚺ</div>
+              <div class="fallback-label">Portrait coming soon</div>
+            </div>
+            <span class="portrait-rune-badge" aria-hidden="true">ᚺ</span>
+            <div class="portrait-hover-overlay" aria-hidden="true"><!-- scan-line sweep --></div>
+          </div>
+          <div class="realm-badge light-realm">LJÓSÁLFAR · ALFHEIM</div>
+          <div class="realm-badge dark-realm" style="display:none;">SVARTÁLFAR · SVARTALFHEIM</div>
+        </div>
+
+        <div class="agent-text-col">
+          <div>
+            <div class="agent-name">Heimdall</div>
+            <div class="agent-role">Security Guardian</div>
+          </div>
+          <p class="agent-bio">
+            Watcher of the Rainbow Bridge, guardian of your data. He sees all
+            threats, blocks all intrusions. Your financial data is his sacred
+            charge. Not even Loki's tricks can bypass his vigilance.
+          </p>
+          <div class="realm-lore-wrapper">
+            <div class="realm-lore lore-light">
+              <span class="realm-title">☀ Ljósálfar Aspect · Light Realm</span>
+              <p class="realm-quote">"The watchman who guards all nine realms — patient as stone at the Bifröst's edge, his eye ever open, his horn Gjallarhorn poised but silent so long as the realms are safe."</p>
+              <span class="realm-aspect">Vigilant · Patient · Protective</span>
+            </div>
+            <div class="realm-lore lore-dark" style="display:none;">
+              <span class="realm-title">☽ Svartálfar Aspect · Dark Realm</span>
+              <p class="realm-quote">"He who hears the grass grow and the wool stretch on sheep across the nine realms — nothing escapes, nothing is forgiven. He does not warn; he terminates. The audit log is his axe."</p>
+              <span class="realm-aspect">Omniscient · Merciless · Zero-Tolerance</span>
+            </div>
+          </div>
+        </div>
+      </article>
+
+    </div><!-- /myth-with-agents -->
+
+    <!-- Global annotation block -->
+    <div class="annotation-box" style="margin-top: 40px;">
+      <strong>Design decision — Pack card grid removed (#633):</strong><br/>
+      The 3-col agent card grid ("The Pack" section) is replaced by this alternating inline layout.
+      Agents are now narrative participants in The Myth, not a separate directory.
+      The "coming soon" placeholder slot is removed; new agents added to AGENTS array
+      will automatically extend this section with the alternating pattern.
+    </div>
+
+    <p class="note" style="text-align: center; margin-top: 20px;">
+      Implementation: Framer Motion scroll-triggered stagger animations preserved per agent row.
+      Each .agent-myth-row animates in from the side matching its portrait position
+      (left-row: slide from left; right-row: slide from right). Duration 0.5s ease-out.
+    </p>
+  </section>
+
+
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       SECTION 4: The Forge — UNCHANGED
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <section>
+    <div class="section-label">ᚺ — The Forge</div>
     <h2 style="font-size: 36px; text-align: center; margin-bottom: 16px;">BUILT BY AI, FOR HUMANS</h2>
 
     <div class="ai-chain">
       <p style="text-align: center; font-size: 16px; margin-bottom: 32px;">
-        Fenrir Ledger is the first credit card tracker built entirely by AI agents. No human wrote this code.
-        Odin orchestrates the agents, but they do the work. This is how modern software should be built.
+        Fenrir Ledger is the first credit card tracker built entirely by AI agents.
+        Odin orchestrates the pack. The pack delivers.
       </p>
 
       <div class="chain-visualization">
         <div class="chain-node">
           <div class="chain-icon">ᚠ</div>
           <div class="chain-label">Freya Defines</div>
-          <div class="chain-desc">Requirements & user stories</div>
+          <div class="chain-desc">Requirements &amp; user stories</div>
         </div>
-
         <div class="chain-node">
           <div class="chain-icon">ᛚ</div>
           <div class="chain-label">Luna Designs</div>
-          <div class="chain-desc">Wireframes & interactions</div>
+          <div class="chain-desc">Wireframes &amp; interactions</div>
         </div>
-
         <div class="chain-node">
           <div class="chain-icon">ᛏ</div>
           <div class="chain-label">FiremanDecko Builds</div>
-          <div class="chain-desc">Code & implementation</div>
+          <div class="chain-desc">Code &amp; implementation</div>
         </div>
-
         <div class="chain-node">
           <div class="chain-icon">ᛚ</div>
           <div class="chain-label">Loki Validates</div>
-          <div class="chain-desc">Testing & QA</div>
+          <div class="chain-desc">Testing &amp; QA</div>
         </div>
       </div>
 
       <p style="text-align: center; font-size: 15px; margin-top: 32px;">
-        Each agent has autonomy within their domain. They collaborate through shared artifacts:
-        design docs, wireframes, code. The result is software with the consistency of a singular vision
-        but the expertise of specialists.
-      </p>
-
-      <p style="text-align: center; margin-top: 24px;">
-        <strong>This changes everything.</strong> Development velocity unconstrained by human limits.
-        Features shipped at the speed of thought. Bugs fixed before coffee gets cold.
+        Each member of the pack has autonomy within their domain. They collaborate through
+        shared artifacts: design docs, wireframes, code. The result is software with
+        the consistency of a singular vision but the expertise of specialists.
       </p>
     </div>
-
     <p class="note" style="text-align: center; margin-top: 32px;">
-      Implementation: Chain nodes pulse with subtle animation. Arrows animate as energy flow between nodes.
-      Parallax depth with nodes at different z-layers.
+      Implementation: Chain nodes pulse with subtle animation. Arrows animate as energy flow.
+      This section is unchanged by issue #633.
     </p>
   </section>
 
-  <!-- ── Technology Section ────────────────────────────────────────────────── -->
-  <section style="border-bottom: none;">
-    <div class="section-label">The Arsenal</div>
-    <h2 style="font-size: 36px; text-align: center; margin-bottom: 32px;">FORGED WITH MODERN STEEL</h2>
 
-    <div class="tech-stack">
-      <div class="tech-item">
-        <div class="tech-logo">Next.js</div>
-        <div class="tech-name">Next.js 15</div>
-      </div>
-      <div class="tech-item">
-        <div class="tech-logo">TS</div>
-        <div class="tech-name">TypeScript</div>
-      </div>
-      <div class="tech-item">
-        <div class="tech-logo">Vercel</div>
-        <div class="tech-name">Vercel</div>
-      </div>
-      <div class="tech-item">
-        <div class="tech-logo">Claude</div>
-        <div class="tech-name">Anthropic Claude</div>
-      </div>
-      <div class="tech-item">
-        <div class="tech-logo">Tailwind</div>
-        <div class="tech-name">Tailwind CSS</div>
-      </div>
-    </div>
-
-    <p style="text-align: center; margin-top: 32px;">
-      <a href="https://github.com/fenrir-ledger" style="font-size: 14px;">Open Source (source available) →</a>
+  <!-- ═══════════════════════════════════════════════════════════════════════
+       SECTION 5: Final CTA — UNCHANGED
+       ═══════════════════════════════════════════════════════════════════════ -->
+  <section style="border-bottom: none; text-align: center;">
+    <h2 style="font-size: 36px; margin-bottom: 24px;">The wolf waits. The chain weakens.</h2>
+    <p style="font-size: 18px; max-width: 480px; margin: 0 auto 32px; line-height: 1.6;">
+      Every day you delay is another fee that might land, another bonus that might expire.
+      Start tracking before the next deadline passes.
     </p>
-
-    <p class="note" style="text-align: center; margin-top: 16px;">
-      Implementation: Tech logos as SVG icons. Hover reveals brief description tooltip.
-    </p>
+    <button style="padding: 16px 40px; font-size: 14px; font-weight: bold; letter-spacing: 0.1em;">[Open the Ledger ▶]</button>
   </section>
 
-  <!-- ── Footer (reuse from marketing site) ──────────────────────────────────── -->
+
+  <!-- ── Footer (unchanged) ─────────────────────────────────────────────── -->
   <footer style="padding: 32px 48px; border-top: 1px solid;">
     <div style="display: grid; grid-template-columns: 1fr auto; gap: 16px; align-items: end;">
       <div>
@@ -603,9 +729,7 @@
         <em>"Though it looks like silk ribbon…" — Prose Edda</em><br/>
         <small>ᚠ ᛖ ᚾ ᚱ ᛁ ᚱ</small>
       </div>
-      <div>
-        <button>[Enter the Ledger ▶]</button>
-      </div>
+      <div><button>[Enter the Ledger ▶]</button></div>
     </div>
     <nav aria-label="Footer links" style="margin-top: 24px; display: flex; gap: 24px; font-size: 13px;">
       <a href="/">Home</a>
@@ -615,11 +739,91 @@
       <a href="/static/terms.html">Terms</a>
     </nav>
     <p style="margin-top: 16px; font-size: 12px;">
-      <span>&copy; 2026 Fenrir Ledger</span> ·
-      <span>Built by AI Agents</span> ·
-      <span>Orchestrated by Odin</span>
+      © 2026 Fenrir Ledger · Built by AI Agents · Orchestrated by Odin
     </p>
   </footer>
+
+
+  <!--
+  ══════════════════════════════════════════════════════════════════════════════
+  INTERACTION SPEC — Issue #633 Dual-Realm Agent Profiles
+  ══════════════════════════════════════════════════════════════════════════════
+
+  1. PORTRAIT CROSSFADE (theme toggle)
+     ─────────────────────────────────
+     Both portrait <img> tags are always rendered in the DOM.
+     Light portrait: className="... transition-opacity duration-500"
+                     style={{ opacity: resolvedTheme === 'light' ? 1 : 0 }}
+     Dark portrait:  position: absolute inset-0, same crossfade
+                     style={{ opacity: resolvedTheme === 'dark' ? 1 : 0 }}
+     No layout shift — both absolutely positioned within the fixed-size frame.
+
+  2. LORE TEXT CROSSFADE (theme toggle)
+     ─────────────────────────────────
+     Both .lore-light and .lore-dark divs are always in the DOM.
+     .realm-lore-wrapper has position: relative; min-height: [tallest variant].
+     .lore-light: position: relative; opacity controlled by theme
+     .lore-dark:  position: absolute; top: 0; left: 0; width: 100%; opacity controlled
+     Crossfade: transition-opacity duration-500 ease-in-out
+     min-height on wrapper prevents layout jump when switching.
+
+  3. REALM BADGE
+     ─────────────────────────────────
+     Two badges stacked (position: relative / absolute pattern same as portraits).
+     Content: "LJÓSÁLFAR · ALFHEIM" vs "SVARTÁLFAR · SVARTALFHEIM"
+     Consider: single badge with text content swap + transition.
+
+  4. ALTERNATING ROW LAYOUT
+     ─────────────────────────────────
+     AGENTS array index 0,2,4 → .agent-myth-row (portrait left, flex-row)
+     AGENTS array index 1,3   → .agent-myth-row.portrait-right (flex-row-reverse)
+     Mobile (max-width: 768px): ALL rows → flex-direction: column (portrait top)
+     Implementation shortcut: index % 2 === 0 ? '' : 'portrait-right'
+
+  5. SCROLL ANIMATIONS (Framer Motion — preserved)
+     ─────────────────────────────────
+     Each .agent-myth-row wraps in <motion.article> with useInView.
+     Even-index rows: initial={{ opacity:0, x:-32 }} animate={{ opacity:1, x:0 }}
+     Odd-index rows:  initial={{ opacity:0, x:32 }}  animate={{ opacity:1, x:0 }}
+     Stagger the portrait col and text col children with staggerChildren: 0.15
+     Transition: duration 0.5, ease "easeOut", once: true
+
+  6. HOVER EFFECTS (personality-specific — preserved from card design)
+     ─────────────────────────────────
+     Freya: about-hover-glow (radial glow from center)
+     Luna:  about-hover-shimmer (shimmer sweep)
+     FiremanDecko: about-hover-fire (fire particle / heat haze)
+     Loki:  about-hover-glitch (RGB split / jitter)
+     Heimdall: about-hover-scan (horizontal scan line sweep)
+     Applied via .portrait-hover-overlay group-hover:opacity-100
+
+  7. ACCESSIBILITY
+     ─────────────────────────────────
+     - Each .agent-myth-row is <article> with aria-label="[Name] — [Role]"
+     - Portrait <img> alt describes realm: "Freya — light realm portrait"
+     - Realm badge: aria-live="polite" so screen readers announce theme change
+     - Lore text: aria-hidden on the non-active variant (opacity:0 version)
+       Implementation: aria-hidden={resolvedTheme !== 'light'} on lore-light div
+     - Portrait frame min touch-target satisfied by full-width mobile layout
+     - Hover overlays: aria-hidden="true" on all decorative elements
+     - Reduced motion: @media (prefers-reduced-motion): skip crossfade, instant swap
+
+  8. DATA INTERFACE CHANGES (for FiremanDecko)
+     ─────────────────────────────────
+     Add to AgentProfile interface:
+       lightLore: { title: string; quote: string; aspect: string }
+       darkLore:  { title: string; quote: string; aspect: string }
+     Add to each AGENTS entry (see lore text in wireframe above).
+     AgentPortrait component: accept theme prop or use useTheme() internally.
+     Remove: hoverEffect field can stay (repurposed for portrait hover overlay).
+
+  9. SECTION CHANGES SUMMARY
+     ─────────────────────────────────
+     REMOVED: ThePackSection() (3-col card grid + placeholder slot)
+     ADDED:   TheMythWithAgentsSection() (alternating portrait rows)
+     UNCHANGED: OriginHeroSection, WhyTheWolfSection, TheForgeSection, FinalCtaSection
+  ══════════════════════════════════════════════════════════════════════════════
+  -->
 
 </body>
 </html>


### PR DESCRIPTION
PR for issue: #633

Redesign About page: agent profiles flanking The Myth section with dual-realm lore and crossfade animations.

**Changes:**
- `development/frontend/src/app/(marketing)/about/page.tsx` - Replace ThePackSection card grid with TheMythWithAgentsSection alternating layout; extend AgentProfile with lightLore/darkLore; new DualRealmPortrait, RealmBadge, RealmLore, AgentMythRow components
- `development/frontend/src/app/globals.css` - Add about-hover-scan effect for Heimdall; update reduced-motion and touch-device media queries
- `development/frontend/src/__tests__/pages/about.test.tsx` - 19 Vitest tests covering section landmarks, dual portraits, theme crossfade, hover overlays, alternating layout, and accessibility
- `ux/wireframes/marketing-site/about.html` - Luna wireframe (unchanged, reference only)

**Verification:**
- Toggle light/dark theme to see dual-realm portraits crossfade (500ms ease-in-out)
- Check mobile layout (375px) for stacked portrait-above-text
- Verify hover overlays per agent (glow, shimmer, fire, glitch, scan)
- Realm badges switch text between LJOSALFAR/SVARTALFAR with theme
- prefers-reduced-motion disables all animations
- tsc PASS, build PASS (32 routes), 19 Vitest tests PASS