### PR TITLE
research: Depot vs GitHub Codespaces comparison

### DIFF
--- a/product/research/depot-vs-codespaces.md
+++ b/product/research/depot-vs-codespaces.md
@@ -1,26 +1,36 @@
-# Depot vs GitHub Codespaces: Agent Sandboxing Comparison
+# Depot vs GitHub Codespaces vs AWS: Agent Sandboxing Comparison
 
-**Date:** 2026-03-13
+**Date:** 2026-03-13 (revised)
 **Author:** FiremanDecko (Principal Engineer)
 **Issue:** #627
 **Status:** Research deliverable — no code changes
+**Revision:** v2 — corrected usage volume (150-300 dispatches/week), added AWS options
 
 ---
 
 ## Executive Summary
 
-This document compares **Depot** (our current platform) and **GitHub Codespaces** as
-agent sandboxing environments for Fenrir Ledger's AI coding agent dispatch system.
-The primary driver is **cost** — Depot's trial is expiring and we need real pricing
-numbers to make an informed decision.
+This document compares **five platforms** for Fenrir Ledger's AI coding agent dispatch
+sandboxes: **Depot** (current), **GitHub Codespaces**, **AWS EC2** (on-demand + spot),
+**AWS ECS Fargate**, and **AWS EKS**.
 
-**Recommendation:** Stay with Depot. At our usage level, Depot costs **~$260-520/month**
-vs Codespaces at **~$234-468/month** (2-core) or **~$468-936/month** (4-core). The
-modest savings from Codespaces 2-core machines are offset by Depot's superior agent-native
-features, simpler billing, faster cold starts, and purpose-built session management.
-Codespaces only becomes cheaper if we can tolerate 2-core machines, and the reliability
-concerns with Codespaces in late 2025 (multiple major outages, including data loss) are
-a significant risk factor.
+At our corrected usage volume of **150-300 dispatches/week**, cost differences are
+significant:
+
+| Platform | Monthly (150/wk) | Monthly (300/wk) |
+|---|---|---|
+| Depot ($0.01/min) | **$217** | **$435** |
+| Codespaces 2-core | **$66 + $4** | **$131 + $4** |
+| Codespaces 4-core | **$131 + $4** | **$261 + $4** |
+| EC2 Spot (t3.medium) | **$14** | **$29** |
+| EC2 On-Demand (t3.medium) | **$46** | **$91** |
+| ECS Fargate (1 vCPU / 4 GB) | **$38** | **$76** |
+| EKS (t3.medium spot + control plane) | **$87** | **$102** |
+
+**Recommendation:** Migrate to **EC2 Spot instances** with pre-baked AMIs. At our volume,
+EC2 Spot saves **$188-406/month** vs Depot ($2,256-4,872/year). The migration effort
+(~40-60 hours) pays for itself within 2-3 months. ECS Fargate is the runner-up if we
+want managed containers without instance management.
 
 ---
 
@@ -38,6 +48,23 @@ Claude Code, with more planned).
 GitHub Codespaces is a cloud development environment service integrated into GitHub.
 It provides full VS Code environments backed by configurable VMs. While not purpose-built
 for AI agents, it can serve as a sandbox environment with devcontainer configuration.
+
+### AWS EC2
+
+Amazon EC2 provides virtual servers with full OS control. Instances can be launched
+on-demand or as spot instances (up to 90% discount). Pre-baked AMIs allow fast boot
+with our entire toolchain pre-installed.
+
+### AWS ECS Fargate
+
+ECS Fargate runs containers without managing servers. Tasks are defined as container
+images with CPU/memory allocations. Pay only for vCPU and memory consumed per second.
+No cluster management required.
+
+### AWS EKS
+
+EKS provides managed Kubernetes. Agent sandboxes run as pods on auto-scaling node
+groups. Maximum control and flexibility but highest ops overhead.
 
 ---
 
@@ -72,128 +99,391 @@ for AI agents, it can serve as a sandbox environment with devcontainer configura
 - Pro: 180 core-hours/month + 20 GB storage
 - Organization: No free tier
 
+### AWS EC2 Pricing (us-east-1)
+
+| Instance | vCPU | RAM | On-Demand/hr | Spot/hr (typical) |
+|---|---|---|---|---|
+| t3.medium | 2 | 4 GB | $0.042 | ~$0.013 |
+| t3.large | 2 | 8 GB | $0.083 | ~$0.025 |
+| m6i.large | 2 | 8 GB | $0.096 | ~$0.029 |
+
+**Additional costs:**
+- EBS storage: ~$0.08/GB/month (gp3). 20 GB AMI = $1.60/month
+- Data transfer out: first 100 GB/month free, then $0.09/GB
+- AMI storage: negligible (~$0.05/GB/month for snapshots)
+
+### AWS ECS Fargate Pricing (us-east-1)
+
+| Resource | Per-second rate | Per-hour rate |
+|---|---|---|
+| vCPU | $0.00001417 | $0.051 |
+| Memory (GB) | $0.00000156 | $0.0056 |
+
+**Example: 1 vCPU / 4 GB task:**
+- Per hour: $0.051 + (4 x $0.0056) = **$0.073/hr**
+
+**Example: 2 vCPU / 4 GB task:**
+- Per hour: $0.102 + (4 x $0.0056) = **$0.124/hr**
+
+### AWS EKS Pricing
+
+| Component | Cost |
+|---|---|
+| EKS control plane | $0.10/hr ($73/month) |
+| Worker nodes | EC2 pricing (on-demand or spot) |
+| Fargate pods on EKS | Fargate pricing + 20% premium |
+
 ---
 
 ## 3. Cost Model: Our Usage Patterns
 
-### Assumptions
+### Assumptions (REVISED)
 
 | Parameter | Value |
 |---|---|
-| Dispatches per week | 20-30 (we'll model both) |
+| **Dispatches per week** | **150-300** (10+ per session, multiple sessions/day) |
 | Opus agent session length | 30-60 min (avg 45 min) |
 | Haiku agent session length | 15-30 min (avg 22 min) |
 | Opus:Haiku ratio | ~50:50 |
-| Parallel sessions | 4-6 (affects capacity, not cost) |
+| Parallel sessions | 4-6 (affects capacity, not per-dispatch cost) |
 | Weeks per month | 4.33 |
+
+**Note:** Previous estimate of 20-30 dispatches/week was incorrect by ~10x.
+Actual usage: 10+ agents dispatched per 40-minute session, 30-50 dispatches on heavy days.
 
 ### Per-Dispatch Cost
 
-| Metric | Opus (45 min) | Haiku (22 min) |
+**Average session time (blended 50/50 Opus/Haiku):** (45 + 22) / 2 = **33.5 min** (~0.558 hr)
+
+| Platform | Per-Dispatch Cost | Rate |
 |---|---|---|
-| Depot ($0.01/min) | $0.45 | $0.22 |
-| Codespaces 2-core ($0.003/min) | $0.135 | $0.066 |
-| Codespaces 4-core ($0.006/min) | $0.27 | $0.132 |
-
-### Weekly Cost (blended 50/50 Opus/Haiku)
-
-**Average cost per dispatch (blended):**
-- Depot: ($0.45 + $0.22) / 2 = **$0.335/dispatch**
-- Codespaces 2-core: ($0.135 + $0.066) / 2 = **$0.101/dispatch**
-- Codespaces 4-core: ($0.27 + $0.132) / 2 = **$0.201/dispatch**
-
-| Scenario | Depot | Codespaces 2-core | Codespaces 4-core |
-|---|---|---|---|
-| 20 dispatches/week | $6.70/wk | $2.02/wk | $4.02/wk |
-| 30 dispatches/week | $10.05/wk | $3.03/wk | $6.03/wk |
+| Depot | **$0.335** | $0.01/min x 33.5 min |
+| Codespaces 2-core | **$0.101** | $0.003/min x 33.5 min |
+| Codespaces 4-core | **$0.201** | $0.006/min x 33.5 min |
+| EC2 Spot (t3.medium) | **$0.007** | $0.013/hr x 0.558 hr |
+| EC2 On-Demand (t3.medium) | **$0.023** | $0.042/hr x 0.558 hr |
+| ECS Fargate (2 vCPU / 4 GB) | **$0.069** | $0.124/hr x 0.558 hr |
 
 ### Monthly Cost Estimate
 
-| Scenario | Depot | Codespaces 2-core | Codespaces 4-core |
-|---|---|---|---|
-| 20 dispatches/week | **$29.01** | **$8.75** | **$17.41** |
-| 30 dispatches/week | **$43.52** | **$13.12** | **$26.11** |
-
-#### Wait — what about Depot's base plan?
-
-The agent sandbox costs above are **pure compute**. However:
-
-- If we're on the **Developer plan** (free), we only get agent sandbox compute at $0.01/min.
-  No base fee applies unless we need Docker builds or GH Actions runners.
-- If we're on the **Startup plan** ($200/month), the $200 covers Docker builds and
-  GH Actions, but agent sandbox minutes are **always additional**.
-
-**Total monthly cost with Startup plan:**
-
-| Scenario | Depot (Dev plan) | Depot (Startup plan) | Codespaces 2-core | Codespaces 4-core |
-|---|---|---|---|---|
-| 20/week | $29.01 | $229.01 | $8.75 + storage | $17.41 + storage |
-| 30/week | $43.52 | $243.52 | $13.12 + storage | $26.11 + storage |
-
-#### Codespaces storage cost
-
-Assuming ~10 GB per codespace image, with 4-6 codespaces persisted:
-- 6 codespaces x 10 GB x $0.07/GB = **$4.20/month** storage
-
-**If we destroy codespaces after each session** (no persistence): $0 storage.
-
-### Monthly Cost Summary (apples-to-apples, compute only)
-
-| Platform | 20/week | 30/week |
+| Platform | 150/week ($) | 300/week ($) |
 |---|---|---|
-| **Depot** (Developer plan, $0.01/min) | **$29** | **$44** |
-| **Codespaces 2-core** ($0.003/min) | **$9 + $4 storage = $13** | **$13 + $4 storage = $17** |
-| **Codespaces 4-core** ($0.006/min) | **$17 + $4 storage = $21** | **$26 + $4 storage = $30** |
+| **Depot** (Dev plan, $0.01/min) | **$217** | **$435** |
+| **Codespaces 2-core** + storage | **$70** | **$135** |
+| **Codespaces 4-core** + storage | **$135** | **$265** |
+| **EC2 Spot** (t3.medium) + EBS | **$14** | **$29** |
+| **EC2 On-Demand** (t3.medium) + EBS | **$46** | **$91** |
+| **ECS Fargate** (2 vCPU / 4 GB) | **$47** | **$93** |
+| **EKS** (spot nodes + control plane) | **$87** | **$102** |
+
+*EKS cost includes the fixed $73/month control plane fee, which dominates at lower volumes.*
 
 ### Annual Projection
 
-| Platform | Low (20/wk) | High (30/wk) |
+| Platform | Low (150/wk) | High (300/wk) |
 |---|---|---|
-| Depot (Developer plan) | $348/year | $522/year |
-| Codespaces 2-core | $156/year | $204/year |
-| Codespaces 4-core | $252/year | $360/year |
+| Depot (Developer plan) | $2,604/year | $5,220/year |
+| Codespaces 2-core | $840/year | $1,620/year |
+| Codespaces 4-core | $1,620/year | $3,180/year |
+| EC2 Spot (t3.medium) | $168/year | $348/year |
+| EC2 On-Demand (t3.medium) | $552/year | $1,092/year |
+| ECS Fargate (2 vCPU / 4 GB) | $564/year | $1,116/year |
+| EKS (spot + control plane) | $1,044/year | $1,224/year |
 
 ### Cost Verdict
 
-Codespaces is **2-3x cheaper** on pure compute. However:
+At 150-300 dispatches/week, the cost differences are **material**:
 
-1. Depot's pricing is simpler and predictable ($0.01/min, done)
-2. Codespaces storage charges apply if codespaces are kept alive
-3. The absolute dollar difference is small ($15-30/month) at our usage level
-4. If we need the Depot Startup plan for Docker builds, the base fee dominates
+1. **EC2 Spot is 15-30x cheaper than Depot** ($14-29/mo vs $217-435/mo)
+2. **EC2 On-Demand is 5-7x cheaper than Depot** ($46-91/mo vs $217-435/mo)
+3. **ECS Fargate is 5x cheaper than Depot** ($47-93/mo vs $217-435/mo)
+4. **Codespaces 2-core is 3x cheaper than Depot** ($70-135/mo vs $217-435/mo)
+5. **EKS is 2-4x cheaper than Depot** but the control plane fee reduces the advantage
 
-**The real cost question is:** Do we need the Depot Startup plan for Docker builds
-and GitHub Actions, or just agent sandboxes? If agent-only, the Developer (free)
-plan keeps Depot costs at $29-44/month — still more than Codespaces, but the
-premium is modest for a purpose-built agent platform.
-
----
-
-## 4. Feature Comparison Matrix
-
-| Feature | Depot | GitHub Codespaces |
-|---|---|---|
-| **Purpose** | Agent sandbox (purpose-built) | Cloud dev environment (general) |
-| **Machine specs** | 2 vCPU / 4 GB RAM (fixed) | 2-32 cores / 8-128 GB (configurable) |
-| **Cold start** | ~5 seconds | 25-30 sec (with prebuild), 2-7 min (without) |
-| **Billing granularity** | Per-second, no minimums | Per-minute |
-| **Session persistence** | Yes (filesystem + conversation) | Yes (full VM state) |
-| **Session resume** | Yes (by session ID, from UI) | Yes (stop/start, full state) |
-| **Idle timeout control** | Not documented | Configurable 5-240 min, org policies |
-| **Prebuild support** | Pre-installed languages/tools | Full devcontainer prebuilds |
-| **CLI integration** | `depot claude` command | `gh codespace` commands |
-| **API** | REST + gRPC (Connect) | REST API + GraphQL |
-| **Session logs** | Dashboard UI (conversation + execution) | `gh codespace logs`, VS Code export |
-| **Agent support** | Claude Code (native) | Any agent (manual setup) |
-| **devcontainer** | Implicit (pre-configured) | Full devcontainer.json support |
-| **Git integration** | Automatic (filesystem persists) | Native GitHub integration |
-| **Org policies** | Business plan only | Full org-level controls |
-| **Max parallel** | Plan-dependent | Org spending limit controls |
-| **Resource flexibility** | Fixed 2 vCPU / 4 GB | Choose machine type per session |
+Annual savings vs Depot range from **$1,764 (Codespaces)** to **$4,872 (EC2 Spot)**
+at high volume. These are no longer negligible.
 
 ---
 
-## 5. Session Control
+## 4. AWS Option Details
+
+### 4.1 EC2 — On-Demand and Spot Instances
+
+#### How it works
+
+Each agent dispatch launches an EC2 instance from a pre-baked AMI. The instance runs
+Claude Code, executes the task, pushes results, and terminates. Spot instances offer
+the same compute at 60-70% discount, with the risk of interruption (2-minute warning).
+
+#### Pre-baked AMI Strategy
+
+Build a custom AMI with:
+- Ubuntu 22.04 or Amazon Linux 2023
+- Node.js (our project version)
+- Claude Code CLI (pre-installed, pre-authenticated via instance role or env vars)
+- git, gh CLI, jq, standard build tools
+- Project dependencies pre-installed (`npm ci` baked into AMI)
+- Our repo cloned at a known state
+
+**AMI rebuild frequency:** On each dependency change or weekly, via a CI pipeline.
+Build time: ~10-15 minutes. Can be automated with Packer or EC2 Image Builder.
+
+#### Session Lifecycle
+
+1. **Launch:** `aws ec2 run-instances --image-id ami-xxx --instance-type t3.medium --spot`
+2. **Bootstrap:** Instance starts (~30-60s from AMI), pulls latest code, runs agent
+3. **Execute:** Claude Code runs the task (15-60 min)
+4. **Collect:** Agent pushes commits/PRs; logs written to CloudWatch or S3
+5. **Terminate:** Instance self-terminates or is terminated by orchestrator
+
+#### Log/Transcript Retrieval
+
+- CloudWatch Logs agent on AMI streams stdout/stderr in real time
+- Alternatively, write transcript to S3 bucket on completion
+- CloudWatch Log Insights for querying across dispatches
+
+#### Cold Start Time
+
+| Scenario | Time |
+|---|---|
+| From AMI (on-demand) | 30-60 seconds |
+| From AMI (spot) | 30-90 seconds (+ spot fulfillment) |
+| With warm pool (standby instances) | 5-15 seconds |
+
+A warm pool of 2-3 standby instances eliminates cold start but adds ~$2-6/day cost.
+
+#### Setup Effort
+
+| Task | Hours |
+|---|---|
+| AMI creation with Packer | 4-8 |
+| Launch/terminate orchestration script | 8-12 |
+| CloudWatch/S3 log pipeline | 4-6 |
+| IAM roles and security groups | 2-4 |
+| Spot interruption handling | 4-6 |
+| Testing and validation | 8-12 |
+| **Total** | **30-48 hours** |
+
+#### Ongoing Ops Overhead
+
+- AMI rebuilds: ~2 hrs/month (mostly automated)
+- Spot availability monitoring: minimal (SNS alerts)
+- Cost monitoring: CloudWatch billing alarms
+- Security patching: quarterly AMI rebuild
+- **Estimated:** 2-4 hours/month
+
+#### Pros
+
+- Cheapest option, especially with spot pricing
+- Full OS control — install anything
+- Simple mental model: launch instance, run agent, terminate
+- Spot interruption risk is low for 15-60 min tasks (historical rate <5%)
+
+#### Cons
+
+- Must build orchestration (launch, monitor, terminate, retry)
+- AMI maintenance burden
+- Spot can be interrupted (need retry logic)
+- No built-in session persistence (must build if needed)
+- Cold start slower than Depot (30-60s vs 5s)
+
+---
+
+### 4.2 ECS Fargate — Containerized Agent Sandboxes
+
+#### How it works
+
+Each agent dispatch runs as a Fargate task. A Docker image contains our toolchain and
+Claude Code. Tasks are defined in a task definition with CPU/memory allocations.
+ECS manages placement — no EC2 instances to manage.
+
+#### Container Image Strategy
+
+Build a Docker image with:
+```dockerfile
+FROM node:20-slim
+RUN npm install -g @anthropic-ai/claude-code
+RUN apt-get update && apt-get install -y git gh jq
+COPY . /workspace
+RUN cd /workspace && npm ci
+```
+
+**Image rebuild:** On each dependency change, via ECR + CI pipeline.
+Build time: ~5-10 minutes. Push to ECR (~$0.10/GB/month storage).
+
+#### Session Lifecycle
+
+1. **Launch:** `aws ecs run-task --task-definition agent-sandbox --launch-type FARGATE`
+2. **Execute:** Container starts (~15-30s), runs Claude Code
+3. **Collect:** Logs stream to CloudWatch automatically
+4. **Terminate:** Task exits naturally; ECS cleans up
+
+#### Log/Transcript Retrieval
+
+- CloudWatch Logs integration is built-in (awslogs driver)
+- Real-time streaming via `aws logs tail`
+- Log retention policies configurable (7-365 days)
+
+#### Cold Start Time
+
+| Scenario | Time |
+|---|---|
+| Image cached on host | 10-20 seconds |
+| Image pull required | 30-60 seconds |
+| With provisioned capacity | 5-15 seconds |
+
+#### Setup Effort
+
+| Task | Hours |
+|---|---|
+| Dockerfile + ECR setup | 4-6 |
+| ECS task definition + cluster | 4-6 |
+| VPC/networking/security groups | 4-6 |
+| Orchestration script (run-task) | 6-10 |
+| CloudWatch log configuration | 2-4 |
+| Testing and validation | 8-12 |
+| **Total** | **28-44 hours** |
+
+#### Ongoing Ops Overhead
+
+- Image rebuilds: ~1 hr/month (automated via CI)
+- Monitoring: CloudWatch dashboards + alarms
+- No instance management (Fargate handles it)
+- **Estimated:** 1-3 hours/month
+
+#### Pros
+
+- No instance management — true serverless containers
+- Built-in CloudWatch logging
+- Simple scaling — just run more tasks
+- Pay-per-second billing, no idle waste
+- Task definitions are versioned and auditable
+
+#### Cons
+
+- Slightly more expensive than EC2 spot ($0.124/hr vs $0.013/hr)
+- 4 vCPU / 30 GB max per task (sufficient for our needs)
+- No persistent filesystem between tasks (use EFS if needed, adds cost)
+- Container image size affects cold start
+- Less OS-level control than EC2
+
+---
+
+### 4.3 EKS — Kubernetes-Managed Agent Pods
+
+#### How it works
+
+Agent sandboxes run as Kubernetes pods on an EKS cluster. Node groups auto-scale
+based on pending pods. Karpenter or Cluster Autoscaler manages capacity.
+
+#### Pod Specification
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: agent-dispatch-123
+spec:
+  template:
+    spec:
+      containers:
+      - name: claude-agent
+        image: <ecr-repo>/agent-sandbox:latest
+        resources:
+          requests:
+            cpu: "2"
+            memory: "4Gi"
+      restartPolicy: Never
+  backoffLimit: 1
+```
+
+#### Session Lifecycle
+
+1. **Launch:** `kubectl apply -f dispatch-job.yaml` (or via Kubernetes API)
+2. **Schedule:** Karpenter provisions a spot node if needed (~30-90s)
+3. **Execute:** Pod runs Claude Code
+4. **Collect:** Logs via `kubectl logs` or FluentBit → CloudWatch
+5. **Cleanup:** Job TTL controller deletes completed jobs
+
+#### Log/Transcript Retrieval
+
+- `kubectl logs job/agent-dispatch-123`
+- FluentBit DaemonSet → CloudWatch Logs (recommended for persistence)
+- Or Loki/Grafana for self-hosted log aggregation
+
+#### Cold Start Time
+
+| Scenario | Time |
+|---|---|
+| Node available, image cached | 5-15 seconds |
+| Node available, image pull | 15-30 seconds |
+| New node provisioning (Karpenter) | 60-120 seconds |
+
+#### Setup Effort
+
+| Task | Hours |
+|---|---|
+| EKS cluster creation (eksctl/terraform) | 8-12 |
+| Karpenter/autoscaler setup | 6-10 |
+| Docker image + ECR | 4-6 |
+| Job template + orchestration | 8-12 |
+| Networking (VPC, security groups, IAM) | 6-8 |
+| Logging (FluentBit + CloudWatch) | 4-6 |
+| Monitoring (Prometheus/Grafana or CloudWatch) | 4-8 |
+| Testing and validation | 8-12 |
+| **Total** | **48-74 hours** |
+
+#### Ongoing Ops Overhead
+
+- Kubernetes version upgrades: quarterly, 4-8 hrs each
+- Node group maintenance: 2-4 hrs/month
+- Monitoring and alerting: 2-4 hrs/month
+- Security patching: 2-4 hrs/month
+- **Estimated:** 8-16 hours/month
+
+#### Pros
+
+- Maximum control and flexibility
+- Excellent auto-scaling with Karpenter
+- Spot instance support on worker nodes
+- Rich ecosystem (monitoring, logging, networking)
+- Can run any container workload
+
+#### Cons
+
+- **$73/month fixed cost** for EKS control plane (regardless of usage)
+- Highest ops overhead of all options (8-16 hrs/month)
+- Kubernetes expertise required
+- Over-engineered for our current scale (150-300 dispatches/week)
+- Complex networking and IAM setup
+
+---
+
+## 5. Feature Comparison Matrix (All 5 Platforms)
+
+| Feature | Depot | Codespaces | EC2 | ECS Fargate | EKS |
+|---|---|---|---|---|---|
+| **Purpose** | Agent sandbox | Cloud dev env | General compute | Containers | Container orchestration |
+| **Machine specs** | 2 vCPU / 4 GB | 2-32 cores | Any instance type | Up to 4 vCPU / 30 GB | Any (node-based) |
+| **Cold start** | ~5 sec | 25-30 sec (prebuild) | 30-60 sec (AMI) | 10-30 sec | 5-120 sec (varies) |
+| **Billing** | Per-second | Per-minute | Per-second | Per-second | Per-second + $73/mo |
+| **Per-dispatch (blended)** | $0.335 | $0.101-0.201 | $0.007-0.023 | $0.069 | $0.007 + fixed |
+| **Monthly (150/wk)** | $217 | $70-135 | $14-46 | $47 | $87 |
+| **Monthly (300/wk)** | $435 | $135-265 | $29-91 | $93 | $102 |
+| **Setup effort** | 0 hrs (current) | 32-64 hrs | 30-48 hrs | 28-44 hrs | 48-74 hrs |
+| **Ops overhead** | 0 hrs/mo | 1-2 hrs/mo | 2-4 hrs/mo | 1-3 hrs/mo | 8-16 hrs/mo |
+| **Session persistence** | Yes (built-in) | Yes (VM state) | No (must build) | No (ephemeral) | No (ephemeral) |
+| **Session resume** | Yes (session ID) | Yes (stop/start) | No | No | No |
+| **Log retrieval** | Dashboard UI | CLI + API | CloudWatch/S3 | CloudWatch (built-in) | kubectl + FluentBit |
+| **Claude Code install** | Native | Manual (devcontainer) | Pre-baked AMI | Docker image | Docker image |
+| **Prebuild/image** | Implicit | devcontainer prebuilds | Packer AMI | Docker + ECR | Docker + ECR |
+| **Agent support** | Claude Code only | Any | Any | Any | Any |
+| **Idle timeout** | Auto (agent-driven) | Configurable | Must build | Task-driven (auto) | Job TTL |
+| **Spot/preemptible** | No | No | Yes (60-70% savings) | No (Fargate Spot exists but limited) | Yes (node level) |
+
+---
+
+## 6. Session Control (Depot vs Codespaces — unchanged)
 
 ### Depot
 
@@ -209,15 +499,15 @@ premium is modest for a purpose-built agent platform.
 - **Organization policies** can enforce maximum idle timeout
 - Auto-stop on inactivity — compute billing stops, storage continues
 - Manual stop/start via CLI: `gh codespace stop`, `gh codespace start`
-- Full lifecycle management: create → active → stopped → deleted
+- Full lifecycle management: create -> active -> stopped -> deleted
 - **Programmatic control**: `gh codespace create --idle-timeout 15m`
 
-**Verdict:** Codespaces has significantly more granular session lifecycle control.
-Depot's async model is simpler but less controllable.
+**Verdict:** Codespaces has more granular session lifecycle control. AWS options (EC2,
+ECS, EKS) offer full programmatic control but require building the lifecycle management.
 
 ---
 
-## 6. Session Logs
+## 7. Session Logs
 
 ### Depot
 
@@ -229,81 +519,115 @@ Depot's async model is simpler but less controllable.
 
 - `gh codespace logs -c <name> > logs.txt` — programmatic log export
 - VS Code Command Palette: "Codespaces: Export Logs"
-- Creation logs, extension logs, browser console logs available
 - Logs include detailed container, session, and environment information
 
-**Verdict:** Codespaces has better programmatic log access. Depot's UI-based
-approach works for manual review but is harder to automate.
+### AWS Options
+
+- **EC2:** CloudWatch Logs agent streams stdout/stderr; query with Log Insights
+- **ECS Fargate:** Built-in CloudWatch integration via awslogs driver; easiest AWS logging
+- **EKS:** FluentBit DaemonSet to CloudWatch or self-hosted Loki; most flexible
+
+**Verdict:** ECS Fargate has the best out-of-box logging among AWS options. Depot's
+UI works for manual review. Codespaces offers good CLI access. EC2 and EKS require
+more setup.
 
 ---
 
-## 7. Prebuild Speed
+## 8. Prebuild Speed
 
 ### Depot
 
 - **~5 seconds** cold start (containers, not VMs)
 - Pre-installed languages and package managers
-- No custom prebuild configuration needed — trade-off is less customization
+- No custom prebuild configuration needed
 - Consistent start time regardless of project complexity
 
 ### GitHub Codespaces
 
-- **25-30 seconds** with prebuilds configured (devcontainer.json + prebuild workflow)
+- **25-30 seconds** with prebuilds configured
 - **2-7 minutes** without prebuilds (cold, from scratch)
 - Prebuilds run on push/PR, consuming additional compute
 - Prebuild storage costs apply ($0.07/GB/month)
-- Full control over prebuild contents via devcontainer lifecycle hooks
 
-**Verdict:** Depot is faster (5s vs 25-30s) and simpler. Codespaces prebuilds
-offer more customization but require setup and incur additional costs.
+### EC2 (AMI)
+
+- **30-60 seconds** from pre-baked AMI
+- **5-15 seconds** with warm pool (standby instances)
+- AMI rebuild: ~10-15 min via Packer, automated in CI
+- Full toolchain pre-installed — no runtime setup needed
+
+### ECS Fargate (Docker)
+
+- **10-20 seconds** with cached image
+- **30-60 seconds** on image pull
+- Image rebuild: ~5-10 min via CI, push to ECR
+- Container starts and runs agent immediately
+
+### EKS (Kubernetes)
+
+- **5-15 seconds** if node available and image cached
+- **60-120 seconds** if new node provisioning required (Karpenter)
+- Same Docker images as ECS; managed via ECR
+
+**Verdict:** Depot wins on cold start (5s). EC2 warm pool comes close (5-15s). ECS
+Fargate is competitive (10-20s cached). Codespaces is slowest (25-30s).
 
 ---
 
-## 8. API/CLI Integration
+## 9. API/CLI Integration
 
 ### Depot
 
-- `depot claude` — single command to launch agent sandbox
-- Flags pass through to Claude CLI (`-p`, `--model`, etc.)
-- REST + gRPC API via Connect protocol
-- Session management via API (create, resume, list)
-- Currently Claude Code only — other agents planned
-
-### GitHub Codespaces
-
-- `gh codespace create -r <repo> -b <branch> -m <machine>` — full CLI
-- `gh codespace ssh`, `gh codespace ports`, `gh codespace cp`
-- REST API + GraphQL for full programmatic control
-- Can run arbitrary commands: `gh codespace ssh -c <name> -- <command>`
-- Agent-agnostic — run any tool inside the codespace
-
-**Integration with our dispatch system:**
-
-For Depot, integration is straightforward:
 ```bash
 depot claude -p "your prompt" --model opus
 # Returns session URL immediately
 ```
 
-For Codespaces, we'd need a wrapper:
+### GitHub Codespaces
+
 ```bash
 gh codespace create -r fenrir-ledger -b main -m basicLinux32gb
 gh codespace ssh -c <name> -- "claude -p 'your prompt' --model opus"
-# Need to handle lifecycle: create → run → stop → delete
+# Need to handle lifecycle: create -> run -> stop -> delete
 ```
 
-**Verdict:** Depot has simpler agent-specific integration. Codespaces requires
-more orchestration code but offers more flexibility.
+### EC2
+
+```bash
+INSTANCE_ID=$(aws ec2 run-instances --image-id ami-xxx \
+  --instance-type t3.medium --instance-market-options '{"MarketType":"spot"}' \
+  --user-data file://agent-bootstrap.sh \
+  --query 'Instances[0].InstanceId' --output text)
+# Bootstrap script runs Claude Code, pushes results, self-terminates
+```
+
+### ECS Fargate
+
+```bash
+aws ecs run-task --cluster agent-cluster \
+  --task-definition agent-sandbox:latest \
+  --launch-type FARGATE \
+  --overrides '{"containerOverrides":[{"name":"claude-agent","command":["claude","-p","your prompt"]}]}'
+```
+
+### EKS
+
+```bash
+kubectl create job agent-123 --image=<ecr>/agent-sandbox:latest \
+  -- claude -p "your prompt" --model opus
+```
+
+**Verdict:** Depot is simplest (1 command). AWS options require orchestration but offer
+more control. ECS and EKS have clean APIs for task/job submission.
 
 ---
 
-## 9. Reliability
+## 10. Reliability
 
 ### Depot
 
-- **99.93% uptime** (Nov 2025 — Feb 2026, per status.depot.dev)
+- **99.93% uptime** (Nov 2025 - Feb 2026, per status.depot.dev)
 - Newer platform, smaller scale
-- No major documented outages during this period
 - Container-based — fewer failure modes than full VMs
 
 ### GitHub Codespaces
@@ -313,75 +637,91 @@ more orchestration code but offers more flexibility.
   - Oct 20: Creation error rate peaked at **71%**, resume at **46%**
   - Oct 29: Error rates **peaked at 100%** across all regions (~9 hours)
   - Mar 2026: 100% failure rate in Australia East
-- Third-party dependency failures caused cascading issues
-- GitHub's overall uptime reportedly **dropped below 90%** at one point in 2025
+- GitHub's overall uptime dropped below 90% at one point in 2025
 
-**Verdict:** Depot has been more reliable in the measured period. Codespaces'
-late-2025 outages, especially the **data loss incident**, are concerning for
-agent workloads where session state matters.
+### AWS
 
----
+- EC2: **99.99% SLA** (single AZ), 99.5% SLA (per-instance)
+- ECS Fargate: **99.99% SLA**
+- EKS: **99.95% SLA** (control plane)
+- AWS has the longest reliability track record of all options
+- Multi-AZ deployment possible for additional resilience
 
-## 10. Migration Effort Estimate
-
-If switching from Depot to Codespaces:
-
-| Task | Effort | Notes |
-|---|---|---|
-| Create devcontainer.json | 2-4 hours | Define base image, extensions, tools |
-| Configure prebuilds | 2-4 hours | Set up prebuild workflow, test times |
-| Update dispatch system | 8-16 hours | Replace `depot claude` with `gh codespace` orchestration |
-| Session lifecycle management | 8-16 hours | Handle create/run/stop/delete, error recovery |
-| Log collection pipeline | 4-8 hours | Replace Depot dashboard with CLI-based export |
-| Testing and validation | 8-16 hours | End-to-end testing across agent types |
-| **Total** | **32-64 hours** | **~1-2 weeks of engineering effort** |
-
-### Key migration risks:
-- Cold start regression (5s → 25-30s, or worse without prebuilds)
-- No native agent session management — must build our own
-- Codespaces reliability concerns during migration period
-- Storage cost management (forgot to delete = ongoing charges)
+**Verdict:** AWS services have the strongest SLAs and reliability track record. Depot
+has been reliable in our measurement period. Codespaces' outage history is concerning.
 
 ---
 
-## 11. Recommendation
+## 11. Migration Effort Comparison
 
-### Stay with Depot
+| Platform | Setup Hours | Monthly Ops Hours | Break-even vs Depot (150/wk) | Break-even vs Depot (300/wk) |
+|---|---|---|---|---|
+| Codespaces | 32-64 | 1-2 | ~3-4 months | ~2 months |
+| EC2 Spot | 30-48 | 2-4 | ~1-2 months | ~1 month |
+| EC2 On-Demand | 30-48 | 2-4 | ~2-3 months | ~1-2 months |
+| ECS Fargate | 28-44 | 1-3 | ~2-3 months | ~1-2 months |
+| EKS | 48-74 | 8-16 | ~6-12 months* | ~4-6 months* |
+
+*EKS break-even is longer due to high ongoing ops overhead (valued at $50-100/hr engineering time).
+
+---
+
+## 12. Recommendation
+
+### Migrate to EC2 Spot Instances
 
 **Rationale:**
 
-1. **Cost delta is small at our scale.** The difference is $15-30/month (Depot Dev plan
-   vs Codespaces 2-core). Even annually, we're talking $150-300 — less than the cost of
-   a single day of engineering time.
+1. **Cost savings are now material.** At 150-300 dispatches/week, EC2 Spot saves
+   **$188-406/month** vs Depot ($2,256-4,872/year). This is no longer $15-30/month —
+   it's real money.
 
-2. **Purpose-built for our use case.** Depot's agent sandboxes are designed exactly for
-   what we're doing. Session persistence, async execution, and Claude Code integration
-   are first-class features we'd have to build ourselves on Codespaces.
+2. **Migration pays for itself quickly.** 30-48 hours of setup at any reasonable
+   engineering rate is recouped within 1-3 months of savings. The previous "migration
+   cost exceeds savings" argument was based on 10x lower volume.
 
-3. **5-second cold starts matter.** At 20-30 dispatches/week, saving 20-25 seconds per
-   dispatch adds up, but more importantly, it keeps the agent feedback loop tight.
+3. **Spot interruption risk is manageable.** For 15-60 minute tasks, spot interruption
+   rates are historically <5%. We can add on-demand fallback for the rare interruption
+   case (still 5x cheaper than Depot).
 
-4. **Reliability.** Codespaces had serious outages in late 2025, including data loss.
-   Depot's 99.93% uptime over the same period is reassuring.
+4. **Full control.** We own the AMI, the orchestration, and the infrastructure. No
+   vendor lock-in to Depot's proprietary sandbox platform.
 
-5. **Migration cost exceeds savings.** 32-64 hours of engineering effort at any
-   reasonable rate far exceeds the annual cost difference. The migration wouldn't
-   pay for itself for years.
+5. **Proven infrastructure.** EC2 has 99.99% SLA and 18+ years of track record.
 
-6. **Simplicity.** `depot claude -p "..."` vs orchestrating codespace lifecycle.
-   Less code to maintain = fewer bugs = more time building product.
+### Runner-up: ECS Fargate
 
-### When to reconsider:
+If we want managed containers (no instance management, built-in logging, simpler ops):
 
-- If Depot's post-trial pricing changes significantly
-- If we need larger machine specs (4+ vCPU) and Depot doesn't offer them
-- If our dispatch volume grows 10x+ (cost delta becomes meaningful)
-- If Depot has reliability issues or goes offline
-- If we need to run non-Claude agents that Depot doesn't support
+- Monthly cost: $47-93 (still 3-5x cheaper than Depot)
+- Lower ops burden than EC2 (1-3 hrs/month vs 2-4)
+- Better logging out of the box
+- Trade-off: ~3-4x more expensive than EC2 Spot
 
-### Action items:
+### What we lose by leaving Depot
 
-1. **Confirm Depot Developer plan pricing** — verify that the free tier + $0.01/min
-   agent sandbox is available post-trial without requiring the Startup plan
-2. **Set a spending alert** at $50/month on Depot to catch unexpected usage
-3. **Revisit in 3 months** if dispatch volume changes materially
+- **5-second cold starts** (EC2 is 30-60s, though warm pool mitigates this)
+- **Built-in session persistence and resume** (must build if needed)
+- **`depot claude` simplicity** (must build orchestration)
+- **Depot Dashboard** for session review (replaced by CloudWatch)
+
+These are real trade-offs, but at our volume the $200-400/month savings justify the
+additional engineering investment.
+
+### Not recommended
+
+- **GitHub Codespaces:** Cheaper than Depot but more expensive than AWS. Reliability
+  concerns (late-2025 outages, data loss). No compelling advantage over AWS options.
+- **EKS:** Over-engineered for our scale. $73/month control plane fee + 8-16 hrs/month
+  ops overhead. Only justified if we grow to 1,000+ dispatches/week or need multi-tenant
+  isolation.
+
+### Action Items
+
+1. **Build proof-of-concept** with EC2 Spot: AMI creation, launch/terminate script,
+   CloudWatch logging. Estimate: 2-3 days.
+2. **Test spot availability** in us-east-1 for t3.medium over a 2-week period.
+3. **Build on-demand fallback** for spot interruption cases.
+4. **Keep Depot running** during migration (no disruption to current workflow).
+5. **Set a 30-day migration timeline** with parallel running during validation.
+6. **Revisit ECS Fargate** if ops burden of EC2 proves higher than estimated.


### PR DESCRIPTION
PR for issue: #627

Revised comparison: Depot vs Codespaces vs EC2 vs ECS Fargate vs EKS for agent sandboxing. Corrected usage volume (150-300 dispatches/week). Added AWS self-hosted options with cost models.

**Changes:**
- `product/research/depot-vs-codespaces.md` — revised with 5-platform comparison and corrected cost model