### PR TITLE
chore: session chronicle — lean-wolfhkr1

### DIFF
--- a/development/frontend/content/blog/lean-wolfhkr1.mdx
+++ b/development/frontend/content/blog/lean-wolfhkr1.mdx
@@ -1,0 +1,181 @@
+---
+title: "The Pack Runs Lean"
+date: "2026-03-13"
+rune: "ᛏ"
+excerpt: "Eight chains dispatched in forty minutes — merges, bouncebacks, a research revision, a war room console filed, and the pack-status oracle fixed when Done items blinded the wolf."
+slug: "lean-wolfhkr1"
+---
+
+<div className="chronicle-page">
+
+<header className="session-header">
+  <span className="header-runes" aria-hidden="true">ᛏ ᛞ ᚦ ᛇ</span>
+  <h1 className="session-title">The Pack Runs Lean</h1>
+  <p className="session-subtitle">Session Chronicle · Fenrir Ledger</p>
+  <div className="session-meta">
+      <span>Date <span className="val">2026-03-13</span></span>
+      <span>Session <span className="val">lean-wolfhkr1</span></span>
+      <span>Acts <span className="val">7</span></span>
+      <span>Files changed <span className="val">1</span></span>
+  </div>
+</header>
+
+<nav className="toc">
+  <div className="toc-title">Chronicle of Acts</div>
+  <ul className="toc-list">
+      <li><a href="#act-1"><span className="toc-rune">ᛞ</span> <span className="toc-num">I</span> The Research Wolf Runs</a></li>
+      <li><a href="#act-2"><span className="toc-rune">ᛞ</span> <span className="toc-num">II</span> Font and Wireframe Wolves</a></li>
+      <li><a href="#act-3"><span className="toc-rune">ᛏ</span> <span className="toc-num">III</span> The Auto-Advance Storm</a></li>
+      <li><a href="#act-4"><span className="toc-rune">ᚦ</span> <span className="toc-num">IV</span> The Blinded Oracle</a></li>
+      <li><a href="#act-5"><span className="toc-rune">ᛟ</span> <span className="toc-num">V</span> Odin's War Room Filed</a></li>
+      <li><a href="#act-6"><span className="toc-rune">ᛞ</span> <span className="toc-num">VI</span> The Second Advance</a></li>
+      <li><a href="#act-7"><span className="toc-rune">ᛇ</span> <span className="toc-num">VII</span> The Numbers Lie</a></li>
+  </ul>
+</nav>
+
+<div className="timeline">
+
+    <section className="entry" id="act-1">
+      <div className="entry-rune" title="The Research Wolf Runs">ᛞ</div>
+      <div className="entry-body">
+        <p className="act-label">Act I · Dispatch</p>
+        <h2 className="entry-title">The Research Wolf Runs</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">(continued from prior context — dispatch #627 research)</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p>Dispatched <span className="mono">FiremanDecko</span> to Depot for issue <span className="hl">#627</span> — a full research comparison of Depot vs GitHub Codespaces for agent sandboxing. Cost was the primary driver: Depot's trial was expiring and Odin needed real numbers. The composed prompt included interview context and a deliverable target at <span className="mono">product/research/depot-vs-codespaces.md</span>.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section className="entry" id="act-2">
+      <div className="entry-rune" title="Font and Wireframe Wolves">ᛞ</div>
+      <div className="entry-body">
+        <p className="act-label">Act II · Dispatch</p>
+        <h2 className="entry-title">Font and Wireframe Wolves</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">/fire-next-up (multiple invocations)</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p>Pulled the next items from Up Next and dispatched them in rapid succession. <span className="hl">#648</span> (nav font update) sent to Luna for wireframing. <span className="hl">#642</span> (stale theme-variants wireframes) dispatched to Luna as well. Both UX chains — Luna → FiremanDecko → Loki. The queue emptied. Eight wolves now hunting in parallel across Depot sandboxes.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section className="entry" id="act-3">
+      <div className="entry-rune" title="The Auto-Advance Storm">ᛏ</div>
+      <div className="entry-body">
+        <p className="act-label">Act III · Orchestration</p>
+        <h2 className="entry-title">The Auto-Advance Storm</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">/fire-next-up --resume</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p>The <span className="mono">--resume</span> cycle found chains ready to advance. <span className="hl">Merged PR #645</span> (#636 Free Trial page — Loki PASS + CI green). Dispatched <span className="mono">Loki</span> for #647 (Sköll border fix). Dispatched a <span className="hl">Loki bounce-back</span> for #643 (Thrall 5-card limit) where Playwright CI kept failing on <span className="mono">add-card.spec.ts:66</span>. Three actions executed in a single resume cycle — no pause for approval.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section className="entry" id="act-4">
+      <div className="entry-rune" title="The Blinded Oracle">ᚦ</div>
+      <div className="entry-body">
+        <p className="act-label">Act IV · Bug Fix</p>
+        <h2 className="entry-title">The Blinded Oracle</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">i see 5 issues in next up here check it out / jesus, we need to deal with this better</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p>Odin saw five items in Up Next on the GitHub board but <span className="mono">pack-status.mjs --peek</span> returned empty. The hunt began. Four of the five were <span className="hl">PRs auto-added</span> by the GitHub workflow — not issues. The fifth, <span className="hl">#644</span>, was a real issue hidden by <span className="mono">EXCLUDED_LABELS = ["marketing"]</span> on line 20. Two fixes applied: removed the marketing exclusion, and filtered Done items during GraphQL pagination to stop 200+ completed items from bloating every query. HKR'd via PR #653.</p></div>
+          <div className="code-block"><pre><span className="cr">var EXCLUDED_LABELS = ["marketing"];</span>
+<span className="ca">var EXCLUDED_LABELS = [];</span>
+
+<span className="ca">// Filter out Done items during pagination</span>
+<span className="ca">const activeItems = connection.nodes.filter(</span>
+<span className="ca">  (n) => n.fieldValueByName?.name !== "Done"</span>
+<span className="ca">);</span></pre></div>
+          <div className="file-chips">
+            <span className="chip chip-mod">.claude/skills/fire-next-up/scripts/pack-status.mjs</span>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section className="entry" id="act-5">
+      <div className="entry-rune" title="Odin's War Room Filed">ᛟ</div>
+      <div className="entry-body">
+        <p className="act-label">Act V · Product</p>
+        <h2 className="entry-title">Odin's War Room Filed</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">ok we should build a view for me that represents exactly what you see. in fenrir style theme and voice. file an issue</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p>Filed <span className="hl">#654</span> — <em>Pack Status Dashboard: Odin's War Room Console</em>. A Fenrir-themed SPA at <span className="mono">/ledger/pack-status</span> that renders the same data the orchestrator sees. Norse-voiced section headings: "The Wolves Hunt", "The Norns Speak", "Chains Yet Forged", "Scrolls for Odin", "The Howl Commands". Auto-refresh, mobile-friendly, click-to-copy commands. Addendum: locked behind Google Sign-In with admin allow-list in Vercel env vars.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section className="entry" id="act-6">
+      <div className="entry-rune" title="The Second Advance">ᛞ</div>
+      <div className="entry-body">
+        <p className="act-label">Act VI · Orchestration</p>
+        <h2 className="entry-title">The Second Advance</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">/fire-next-up --resume</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p><span className="hl">Merged PR #650</span> (#647 Sköll border — Loki PASS + CI green). Dispatched <span className="mono">Loki</span> for #648 (nav font — FiremanDecko handoff confirmed). #643 bounce-back still failing the same Playwright test. The research for #627 surfaced as complete — PR #651 ready for Odin's review. Presented the findings: stay with Depot, modest cost delta.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section className="entry" id="act-7">
+      <div className="entry-rune" title="The Numbers Lie">ᛇ</div>
+      <div className="entry-body">
+        <p className="act-label">Act VII · Research</p>
+        <h2 className="entry-title">The Numbers Lie</h2>
+
+        <div className="user-msg">
+          <div className="msg-role">
+            <span className="role-badge badge-fireman">Odin</span>
+          </div>
+          <p className="msg-text">20/30 dispatches per week, are you mad we do that many per hour</p>
+        </div>
+        <div className="work-card">
+          <div className="work-body"><p>Odin caught the fatal flaw. FiremanDecko's research assumed 20-30 dispatches/week — <span className="hl">the actual rate is 150-300</span>. Ten dispatches in forty minutes, fifteen per hour. The cost model was off by 5-10x. At corrected volume: Depot ~$435/mo, Codespaces 2-core ~$131/mo, <span className="hl">EC2 spot ~$13/mo</span>. Odin demanded AWS options (EC2, ECS, EKS) be added. Posted corrections on #627 and re-dispatched FiremanDecko to revise with 5-platform comparison and real numbers.</p></div>
+        </div>
+      </div>
+    </section>
+</div>
+
+<footer className="session-footer">
+  <div className="footer-cipher">ᛏ ᛞ ᚦ ᛇ</div>
+  <div className="footer-text">The Pack Runs Lean · Fenrir Ledger Session Chronicle</div>
+  <p className="footer-sub">The wolf remembers everything.</p>
+</footer>
+
+</div>


### PR DESCRIPTION
Adds brandified session chronicle for **lean-wolfhkr1** to the chronicles at `/chronicles/lean-wolfhkr1`.

7 acts covering: 8 agent dispatches, 2 PR merges, pack-status oracle fix, war room console filed, research cost model correction.