### PR TITLE
fix: remove 'I Am No Ordinary Ledger' from free-trial page

### DIFF
--- a/development/frontend/src/__tests__/marketing/free-trial-page.test.tsx
+++ b/development/frontend/src/__tests__/marketing/free-trial-page.test.tsx
@@ -139,10 +139,10 @@ describe("FreeTrialContent — Feature Showcase", () => {
     expect(heading.tagName.toLowerCase()).toBe("h2");
   });
 
-  it("renders exactly 7 feature cards", () => {
+  it("renders exactly 6 feature cards", () => {
     const featureList = screen.getByLabelText("Trial features");
     const items = within(featureList).getAllByRole("listitem");
-    expect(items).toHaveLength(7);
+    expect(items).toHaveLength(6);
   });
 
   it("all feature card titles start with 'I' (wolf-voice)", () => {
@@ -152,7 +152,6 @@ describe("FreeTrialContent — Feature Showcase", () => {
       "I Guard the Whole Pack",
       "I Devour Your Spreadsheets",
       "I Remember the Fallen",
-      "I Am No Ordinary Ledger",
       "I Follow You Everywhere",
     ];
     for (const title of expectedTitles) {
@@ -162,7 +161,7 @@ describe("FreeTrialContent — Feature Showcase", () => {
 
   it("each feature card has a 'Yours Free' tag", () => {
     const tags = screen.getAllByText("Yours Free");
-    expect(tags).toHaveLength(7);
+    expect(tags).toHaveLength(6);
   });
 });
 

--- a/development/frontend/src/app/(marketing)/free-trial/FreeTrialContent.tsx
+++ b/development/frontend/src/app/(marketing)/free-trial/FreeTrialContent.tsx
@@ -71,16 +71,9 @@ const TRIAL_FEATURES: TrialFeature[] = [
     desc: "Closed cards pass into Valhalla \u2014 my hall of the honored dead. What you earned, what you paid, how long each chain held. Nothing is forgotten.",
   },
   {
-    id: "norse-ui",
-    rune: "\u16DF",
-    ordinal: "Feature 06",
-    title: "I Am No Ordinary Ledger",
-    desc: "Dark war room. Elder Futhark runes. Hidden fragments for the bold. Other trackers are spreadsheets. I am something that bites back.",
-  },
-  {
     id: "mobile-dashboard",
     rune: "\u16A2",
-    ordinal: "Feature 07",
+    ordinal: "Feature 06",
     title: "I Follow You Everywhere",
     desc: "Full power on a phone screen. At the airport, at checkout, on the couch. I ride in your pocket. The hunt never pauses.",
   },
@@ -259,7 +252,7 @@ function FeatureShowcase() {
             What I Bring to the Hunt
           </h2>
           <p className="font-body text-base italic text-muted-foreground max-w-[480px] mx-auto leading-[1.65]">
-            Seven weapons. All sharpened. All yours the moment I wake.
+            Six weapons. All sharpened. All yours the moment I wake.
           </p>
         </div>
 

--- a/development/frontend/src/app/(marketing)/free-trial/page.tsx
+++ b/development/frontend/src/app/(marketing)/free-trial/page.tsx
@@ -6,7 +6,7 @@
  *
  * Sections:
  *   1. Hero — "I Hunt For 30 Days. Free."
- *   2. Feature Showcase — 7 compact cards in 3-col grid
+ *   2. Feature Showcase — 6 compact cards in 3-col grid
  *   3. Timeline — 3-step 30-day journey (Day 1 / Day 15 / Day 30)
  *   4. After Trial — Thrall vs Karl tier comparison
  *   5. Final CTA — "Unleash Me"

--- a/quality/test-suites/free-trial.spec.ts
+++ b/quality/test-suites/free-trial.spec.ts
@@ -45,22 +45,22 @@ test("hero contains 'No credit card. No chains.' trust line", async ({
   expect(text).toContain("No chains");
 });
 
-test("feature showcase displays exactly 7 cards with 'Yours Free' tags", async ({
+test("feature showcase displays exactly 6 cards with 'Yours Free' tags", async ({
   page,
 }) => {
   await page.goto("/free-trial", { waitUntil: "networkidle" });
   const featureList = page.locator('[aria-label="Trial features"]');
   const items = page.locator('[aria-label="Trial features"] li');
   const count = await items.count();
-  expect(count).toBe(7);
+  expect(count).toBe(6);
 
   // Verify "Yours Free" tags
   const tags = page.locator('text="Yours Free"');
   const tagCount = await tags.count();
-  expect(tagCount).toBe(7);
+  expect(tagCount).toBe(6);
 });
 
-test("all 7 feature card titles start with 'I' (wolf-voice)", async ({
+test("all 6 feature card titles start with 'I' (wolf-voice)", async ({
   page,
 }) => {
   await page.goto("/free-trial", { waitUntil: "networkidle" });
@@ -70,7 +70,6 @@ test("all 7 feature card titles start with 'I' (wolf-voice)", async ({
     "I Guard the Whole Pack",
     "I Devour Your Spreadsheets",
     "I Remember the Fallen",
-    "I Am No Ordinary Ledger",
     "I Follow You Everywhere",
   ];
 


### PR DESCRIPTION
PR for issue: #672

Removes the 'I Am No Ordinary Ledger' section from the /free-trial marketing page.

**Changes:**
- `free-trial/page.tsx` — updated comment (7 → 6 feature cards)
- `free-trial/FreeTrialContent.tsx` — removed `norse-ui` feature entry, updated ordinal for remaining Feature 06, changed "Seven weapons" → "Six weapons"
- `free-trial-page.test.tsx` — updated Vitest expectations (7 → 6 cards, removed title)
- `free-trial.spec.ts` — updated Playwright expectations (7 → 6 cards, removed title)

**Verification:**
- Visit /free-trial and confirm section is gone
- Confirm page layout flows correctly
- tsc PASS, build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)