### PR TITLE
fix: correct Terraform GCS backend bucket name

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -16,11 +16,9 @@ terraform {
     }
   }
 
-  # Remote state in GCS — create the bucket before first apply:
-  #   gsutil mb -l us-central1 gs://fenrir-ledger-tfstate
-  #   gsutil versioning set on gs://fenrir-ledger-tfstate
+  # Remote state in GCS (bucket already exists)
   backend "gcs" {
-    bucket = "fenrir-ledger-tfstate"
+    bucket = "fenrir-ledger-tf-state"
     prefix = "infrastructure"
   }
 }


### PR DESCRIPTION
Fixes the backend bucket reference in `infrastructure/main.tf`.

Config said `fenrir-ledger-tfstate`, actual bucket is `fenrir-ledger-tf-state`.

Refs #694