### PR TITLE
fix: resolve Terraform Autopilot errors

### DIFF
--- a/infrastructure/gke.tf
+++ b/infrastructure/gke.tf
@@ -64,7 +64,6 @@ resource "google_container_cluster" "autopilot" {
       "POD",
       "DEPLOYMENT",
       "STATEFUL_SET",
-      "DAEMON_SET",
       "HPA",
     ]
 

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -17,10 +17,13 @@ resource "google_service_account" "app_workload" {
 }
 
 # Allow the K8s service account to impersonate the GCP service account
+# Depends on cluster because the Workload Identity pool doesn't exist until the cluster is created
 resource "google_service_account_iam_member" "app_workload_identity" {
   service_account_id = google_service_account.app_workload.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[fenrir-app/fenrir-app-sa]"
+
+  depends_on = [google_container_cluster.autopilot]
 }
 
 # App pods can read from Cloud Storage (for assets, config, etc.)
@@ -59,6 +62,8 @@ resource "google_service_account_iam_member" "agents_workload_identity" {
   service_account_id = google_service_account.agents_workload.name
   role               = "roles/iam.workloadIdentityUser"
   member             = "serviceAccount:${var.project_id}.svc.id.goog[fenrir-agents/fenrir-agents-sa]"
+
+  depends_on = [google_container_cluster.autopilot]
 }
 
 # Agent pods can read/write Cloud Storage (for sandbox artifacts)
@@ -96,6 +101,7 @@ resource "google_project_iam_member" "deploy_gke_admin" {
 # --------------------------------------------------------------------------
 
 resource "google_billing_budget" "monthly_budget" {
+  count    = var.billing_account_id != "" ? 1 : 0
   provider = google-beta
 
   billing_account = var.billing_account_id

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -57,9 +57,9 @@ variable "deploy_service_account" {
 }
 
 variable "billing_account_id" {
-  description = "GCP billing account ID (format: XXXXXX-XXXXXX-XXXXXX)"
+  description = "GCP billing account ID (format: XXXXXX-XXXXXX-XXXXXX). If empty, billing budget is skipped."
   type        = string
-  # No default — must be provided at apply time
+  default     = ""
 }
 
 variable "cost_alert_amount" {


### PR DESCRIPTION
Fixes 3 Terraform apply errors from the deploy pipeline:

1. **DAEMON_SET** removed from monitoring — not supported in Autopilot
2. **Workload Identity** bindings now `depends_on` the cluster — identity pool requires the cluster to exist first
3. **Billing budget** now optional — skips if `billing_account_id` is empty