### PR TITLE
fix: strip monitoring components to Autopilot-compatible values

### DIFF
--- a/infrastructure/gke.tf
+++ b/infrastructure/gke.tf
@@ -60,11 +60,6 @@ resource "google_container_cluster" "autopilot" {
   monitoring_config {
     enable_components = [
       "SYSTEM_COMPONENTS",
-      "STORAGE",
-      "POD",
-      "DEPLOYMENT",
-      "STATEFUL_SET",
-      "HPA",
     ]
 
     managed_prometheus {


### PR DESCRIPTION
Autopilot only supports SYSTEM_COMPONENTS. Removes invalid components.