### PR TITLE
fix: add namespace/SA setup to deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -194,6 +194,15 @@ jobs:
           location: ${{ secrets.GCP_ZONE }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
+      - name: Ensure namespaces and service accounts exist
+        run: |
+          kubectl create namespace fenrir-app --dry-run=client -o yaml | kubectl apply -f -
+          kubectl create serviceaccount fenrir-app-sa \
+            --namespace=fenrir-app --dry-run=client -o yaml | kubectl apply -f -
+          kubectl annotate serviceaccount fenrir-app-sa \
+            --namespace=fenrir-app --overwrite \
+            iam.gke.io/gcp-service-account=fenrir-app-workload@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+
       - name: Create/update K8s secrets
         run: |
           kubectl create secret generic fenrir-app-secrets \

--- a/infrastructure/k8s/app/ingress.yaml
+++ b/infrastructure/k8s/app/ingress.yaml
@@ -22,8 +22,8 @@ metadata:
     kubernetes.io/ingress.class: "gce"
     # Reference the Google-managed SSL cert created by Terraform
     networking.gke.io/managed-certificates: "fenrir-app-cert"
-    # Redirect HTTP to HTTPS
-    kubernetes.io/ingress.allow-http: "false"
+    # Allow HTTP until DNS/SSL is configured (health checks need it)
+    kubernetes.io/ingress.allow-http: "true"
     # Backend health check configuration
     cloud.google.com/backend-config: '{"default":"fenrir-app-backend-config"}'
 spec:


### PR DESCRIPTION
## Summary
- Adds idempotent namespace + service account creation before K8s secrets/manifests apply
- Annotates service account for Workload Identity binding
- Enables HTTP on ingress for health checks (no DNS/SSL yet)

Fixes deploy job failure: namespace `fenrir-app` didn't exist on fresh cluster.

## Test plan
- [ ] Deploy pipeline creates namespace and SA successfully
- [ ] K8s secrets apply without error
- [ ] Manifests apply and pods start
- [ ] Health check passes via Ingress IP

🤖 Generated with [Claude Code](https://claude.com/claude-code)