### PR TITLE
chore: add GKE setup script, deprecate Depot

### DIFF
--- a/.claude/scripts/depot-setup.sh
+++ b/.claude/scripts/depot-setup.sh
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+# DEPRECATED — Depot is being replaced by GKE Autopilot K8s Jobs.
+# Use scripts/gke-setup.sh instead.
+# This script remains for backward compatibility during migration.
+#
 # depot-setup.sh — One-time Depot remote builder setup for Fenrir Ledger
 #
 # This script configures the Depot CLI for remote agent sandboxes.
@@ -14,6 +18,9 @@
 #
 # Ref: ADR-007 (architecture/adrs/ADR-007-remote-builder-platforms.md)
 #      GitHub Issue #192
+
+echo "⚠  DEPRECATED: Depot is being replaced by GKE Autopilot. Use 'bash scripts/gke-setup.sh' instead."
+echo ""
 
 set -euo pipefail
 

--- a/development/scripts/setup-local.sh
+++ b/development/scripts/setup-local.sh
@@ -93,6 +93,21 @@ else
   info "Created .env.local from .env.example ✓"
 fi
 
+# ── GKE setup (required) ────────────────────────────────────────────────────
+header "GKE / kubectl setup..."
+
+GKE_SETUP="${REPO_ROOT}/scripts/gke-setup.sh"
+if [ ! -f "${GKE_SETUP}" ]; then
+  error "scripts/gke-setup.sh not found. Repo may be incomplete."
+fi
+
+if ! command -v gcloud &>/dev/null; then
+  error "gcloud CLI is required. Install: https://cloud.google.com/sdk/docs/install"
+fi
+
+bash "${GKE_SETUP}"
+info "GKE setup complete ✓"
+
 # ── Done ──────────────────────────────────────────────────────────────────────
 header "Setup complete!"
 echo ""
@@ -100,4 +115,7 @@ echo -e "  ${GREEN}To start the development server:${RESET}"
 echo -e "  ${BOLD}cd development/frontend && npm run dev${RESET}"
 echo ""
 echo -e "  Then open: ${BOLD}http://localhost:3000${RESET}"
+echo ""
+echo -e "  ${GREEN}Other setup scripts:${RESET}"
+echo -e "  ${BOLD}bash scripts/gke-setup.sh${RESET}  — Reconfigure kubectl for GKE"
 echo ""

--- a/scripts/gke-setup.sh
+++ b/scripts/gke-setup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# gke-setup.sh — Configure local CLI for Fenrir Ledger GKE Autopilot
+#
+# Installs missing tools, authenticates, and configures kubectl context.
+# Safe to re-run (idempotent).
+#
+# Usage: bash .claude/scripts/gke-setup.sh
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+PROJECT_ID="fenrir-ledger-prod"
+CLUSTER_NAME="fenrir-autopilot"
+ZONE="us-central1-a"
+REGION="us-central1"
+
+info()  { echo "✓ $*"; }
+warn()  { echo "⚠ $*"; }
+fail()  { echo "✗ $*" >&2; exit 1; }
+
+# --------------------------------------------------------------------------
+# 1. Check prerequisites
+# --------------------------------------------------------------------------
+echo "=== Fenrir Ledger GKE Setup ==="
+echo ""
+
+# gcloud
+if ! command -v gcloud &>/dev/null; then
+  fail "gcloud CLI not found. Install: https://cloud.google.com/sdk/docs/install"
+fi
+info "gcloud $(gcloud version --format='value(version)' 2>/dev/null || gcloud --version | head -1 | awk '{print $4}')"
+
+# kubectl
+if ! command -v kubectl &>/dev/null; then
+  echo "Installing kubectl via gcloud..."
+  gcloud components install kubectl --quiet
+fi
+info "kubectl found at $(which kubectl)"
+
+# gke-gcloud-auth-plugin (required for GKE auth)
+if ! command -v gke-gcloud-auth-plugin &>/dev/null; then
+  echo "Installing gke-gcloud-auth-plugin..."
+  gcloud components install gke-gcloud-auth-plugin --quiet
+fi
+info "gke-gcloud-auth-plugin installed"
+
+# --------------------------------------------------------------------------
+# 2. Authenticate (if needed)
+# --------------------------------------------------------------------------
+echo ""
+ACTIVE_ACCOUNT=$(gcloud auth list --filter="status=ACTIVE" --format="value(account)" 2>/dev/null || true)
+
+if [ -z "$ACTIVE_ACCOUNT" ]; then
+  echo "No active gcloud account. Launching browser login..."
+  gcloud auth login --update-adc
+  ACTIVE_ACCOUNT=$(gcloud auth list --filter="status=ACTIVE" --format="value(account)")
+fi
+info "Authenticated as: ${ACTIVE_ACCOUNT}"
+
+# --------------------------------------------------------------------------
+# 3. Set project
+# --------------------------------------------------------------------------
+echo ""
+gcloud config set project "$PROJECT_ID" --quiet
+info "Project set to: ${PROJECT_ID}"
+
+# --------------------------------------------------------------------------
+# 4. Get GKE credentials (configures kubectl context)
+# --------------------------------------------------------------------------
+echo ""
+echo "Fetching GKE cluster credentials..."
+gcloud container clusters get-credentials "$CLUSTER_NAME" \
+  --zone "$ZONE" \
+  --project "$PROJECT_ID"
+info "kubectl context configured for: ${CLUSTER_NAME}"
+
+# --------------------------------------------------------------------------
+# 5. Verify
+# --------------------------------------------------------------------------
+echo ""
+echo "=== Verification ==="
+
+CONTEXT=$(kubectl config current-context 2>/dev/null || true)
+info "Current context: ${CONTEXT}"
+
+echo ""
+echo "Cluster info:"
+kubectl cluster-info 2>/dev/null | head -2 || warn "Could not reach cluster (may still be provisioning)"
+
+echo ""
+echo "Nodes:"
+kubectl get nodes 2>/dev/null || warn "Could not list nodes (Autopilot scales on demand)"
+
+echo ""
+echo "Namespaces:"
+kubectl get namespaces 2>/dev/null || warn "Could not list namespaces"
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "Useful commands:"
+echo "  kubectl get pods -n fenrir-app          # App pods"
+echo "  kubectl get svc -n fenrir-app           # Services"
+echo "  kubectl get ingress -n fenrir-app       # Ingress + external IP"
+echo "  kubectl logs -n fenrir-app -l app.kubernetes.io/name=fenrir-app  # App logs"


### PR DESCRIPTION
## Summary
- Adds `scripts/gke-setup.sh` — installs gke-gcloud-auth-plugin, authenticates, configures kubectl
- Makes GKE setup required in `development/scripts/setup-local.sh` (gcloud is now mandatory)
- Marks `.claude/scripts/depot-setup.sh` as deprecated with warning banner

## Test plan
- [ ] `bash scripts/gke-setup.sh` configures kubectl context
- [ ] `bash development/scripts/setup-local.sh` runs GKE setup as required step
- [ ] `bash .claude/scripts/depot-setup.sh` shows deprecation warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)