### PR TITLE
fix: use region not zone for GKE Autopilot

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,8 @@
 #   GCP_PROJECT_ID              — Google Cloud project ID
 #   GCP_SA_KEY                  — Base64-encoded service account JSON key
 #   GCP_REGION                  — GCP region (e.g. us-central1)
-#   GCP_ZONE                    — GCP zone (e.g. us-central1-a)
+#   GCP_ZONE                    — GCP zone (e.g. us-central1-a, used by Terraform)
+#   GCP_REGION                  — GCP region (e.g. us-central1, used by GKE)
 #   GKE_CLUSTER_NAME            — GKE cluster name (e.g. fenrir-autopilot)
 #   GOOGLE_CLIENT_SECRET        — OAuth client secret
 #   NEXT_PUBLIC_GOOGLE_CLIENT_ID — OAuth client ID
@@ -191,7 +192,7 @@ jobs:
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GCP_ZONE }}
+          location: ${{ secrets.GCP_REGION }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Ensure namespaces and service accounts exist
@@ -289,7 +290,7 @@ jobs:
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GCP_ZONE }}
+          location: ${{ secrets.GCP_REGION }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Health check via Ingress

--- a/infrastructure/gke.tf
+++ b/infrastructure/gke.tf
@@ -10,7 +10,7 @@ resource "google_container_cluster" "autopilot" {
 
   name     = var.cluster_name
   project  = var.project_id
-  location = var.zone # Zonal = free cluster management fee ($74.40/mo credit)
+  location = var.region # Autopilot clusters are always regional
 
   # Enable Autopilot mode
   enable_autopilot = true

--- a/scripts/gke-setup.sh
+++ b/scripts/gke-setup.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 
 PROJECT_ID="fenrir-ledger-prod"
 CLUSTER_NAME="fenrir-autopilot"
-ZONE="us-central1-a"
 REGION="us-central1"
 
 info()  { echo "✓ $*"; }
@@ -70,7 +69,7 @@ info "Project set to: ${PROJECT_ID}"
 echo ""
 echo "Fetching GKE cluster credentials..."
 gcloud container clusters get-credentials "$CLUSTER_NAME" \
-  --zone "$ZONE" \
+  --region "$REGION" \
   --project "$PROJECT_ID"
 info "kubectl context configured for: ${CLUSTER_NAME}"
 


### PR DESCRIPTION
## Summary
- GKE Autopilot clusters are always regional — fix all references from zone to region
- `scripts/gke-setup.sh`: use `--region` instead of `--zone`
- `deploy.yml`: use `GCP_REGION` secret for get-gke-credentials location
- `infrastructure/gke.tf`: use `var.region` instead of `var.zone`
- Set `GCP_REGION=us-central1` GitHub secret

## Test plan
- [ ] `bash scripts/gke-setup.sh` connects to cluster
- [ ] Deploy pipeline get-gke-credentials step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)