### PR TITLE
docs: add development setup guide

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -4,15 +4,17 @@ This directory contains implementation artifacts for the Fenrir Ledger project: 
 
 ---
 
-## Implementation Docs
+## Getting Started
 
-- [README.md](README.md) — This file. Index of all development artifacts.
-- [implementation-plan.md](implementation-plan.md) — Ordered task breakdown for Sprint 1 (scaffold through setup script) and Sprint 2 (Saga Ledger theme, app shell, Easter eggs layer).
-- [qa-handoff.md](qa-handoff.md) — Latest QA handoff: Import Wizard wireframe fixes (PR #136).
+```bash
+bash development/scripts/setup-local.sh
+```
+
+This single command sets up everything: Node deps, environment files, GKE auth, kubectl, and k9s. See the [full setup guide](docs/setup-guide.md) for details, prerequisites, and environment variables.
 
 ## Source Code
 
-- [frontend/](frontend/) — Next.js project root. All `package.json`, `next.config.ts`, `app/`, and `components/` files live here. Vercel is configured with Root Directory set to `development/frontend/`.
+- [frontend/](frontend/) — Next.js project root. All `package.json`, `next.config.ts`, `app/`, and `components/` files live here. Deployed to GKE Autopilot via CI/CD on every push to `main`.
 
 ### Key Source Directories
 
@@ -24,6 +26,12 @@ This directory contains implementation artifacts for the Fenrir Ledger project: 
 | `frontend/src/hooks/` | Custom hooks: useAuth, useEntitlement, useSheetImport, usePickerConfig, useDriveToken |
 | `frontend/src/lib/` | Core libraries: types, storage, card-utils, auth, entitlement, stripe, google, sheets, llm, kv, crypto |
 
+## Docs
+
+- [docs/setup-guide.md](docs/setup-guide.md) — Full setup guide: prerequisites, GKE cluster details, env vars, CI/CD pipeline, project structure.
+- [implementation-plan.md](implementation-plan.md) — Ordered task breakdown for Sprint 1-2.
+
 ## Scripts
 
-- [scripts/setup-local.sh](scripts/setup-local.sh) — Idempotent local dev setup script. Checks Node.js version, runs `npm ci`, copies `.env.example` to `.env.local` if absent, and prints next steps.
+- [scripts/setup-local.sh](scripts/setup-local.sh) — Idempotent local dev setup: Node.js check, `npm ci`, `.env.local`, GKE auth + tools.
+- [../scripts/gke-setup.sh](../scripts/gke-setup.sh) — GKE CLI setup: gcloud, kubectl, gke-gcloud-auth-plugin, k9s, cluster credentials.

--- a/development/docs/setup-guide.md
+++ b/development/docs/setup-guide.md
@@ -1,0 +1,158 @@
+# Fenrir Ledger — Development Setup Guide
+
+Complete setup guide for local development and GKE infrastructure access.
+
+## Prerequisites
+
+| Tool | Version | Install |
+|------|---------|---------|
+| Node.js | >= 18 | [nodejs.org](https://nodejs.org) |
+| npm | (comes with Node) | |
+| gcloud CLI | latest | [cloud.google.com/sdk](https://cloud.google.com/sdk/docs/install) |
+| Docker | latest | [docker.com](https://www.docker.com/products/docker-desktop/) |
+
+The setup script installs the remaining tools automatically (kubectl, gke-gcloud-auth-plugin, k9s).
+
+## Quick Start
+
+```bash
+# Clone and enter the repo
+git clone git@github.com:declanshanaghy/fenrir-ledger.git
+cd fenrir-ledger
+
+# Run the full setup (Node deps + GKE auth + tools)
+bash development/scripts/setup-local.sh
+
+# Start the dev server
+cd development/frontend && npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000).
+
+## What the Setup Script Does
+
+`development/scripts/setup-local.sh` is the single entry point. It runs these steps in order:
+
+1. **Node.js check** — verifies Node >= 18 is installed
+2. **npm dependencies** — runs `npm ci` in `development/frontend/`
+3. **Environment file** — copies `.env.example` to `.env.local` if not present
+4. **GKE setup** — runs `scripts/gke-setup.sh` (see below)
+
+## GKE Setup (Infrastructure Access)
+
+`scripts/gke-setup.sh` configures your local CLI for the GKE Autopilot cluster. It's called automatically by the main setup script but can be re-run independently:
+
+```bash
+bash scripts/gke-setup.sh
+```
+
+This script:
+
+1. Verifies **gcloud CLI** is installed
+2. Installs **kubectl** via gcloud (if missing)
+3. Installs **gke-gcloud-auth-plugin** (if missing)
+4. Installs **k9s** terminal UI via Homebrew (if missing)
+5. Authenticates with Google Cloud (opens browser if needed)
+6. Sets project to `fenrir-ledger-prod`
+7. Fetches GKE cluster credentials for `fenrir-autopilot` in `us-central1`
+8. Verifies cluster connectivity
+
+### GKE Cluster Details
+
+| Property | Value |
+|----------|-------|
+| Project | `fenrir-ledger-prod` |
+| Cluster | `fenrir-autopilot` |
+| Region | `us-central1` |
+| Type | GKE Autopilot (fully managed) |
+| Artifact Registry | `us-central1-docker.pkg.dev/fenrir-ledger-prod/fenrir-images` |
+
+### Useful kubectl Commands
+
+```bash
+# Terminal UI (recommended)
+k9s
+
+# App pods
+kubectl get pods -n fenrir-app
+
+# Services and external IPs
+kubectl get svc -n fenrir-app
+
+# Ingress (external hostname/IP)
+kubectl get ingress -n fenrir-app
+
+# App logs
+kubectl logs -n fenrir-app -l app.kubernetes.io/name=fenrir-app
+
+# Agent sandbox jobs
+kubectl get jobs -n fenrir-agents
+kubectl logs job/<job-name> -n fenrir-agents --follow
+```
+
+## Environment Variables
+
+Copy the example file and fill in values:
+
+```bash
+cp development/frontend/.env.example development/frontend/.env.local
+```
+
+Required variables for local development:
+
+| Variable | Purpose |
+|----------|---------|
+| `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | Google OAuth client ID |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
+| `GOOGLE_PICKER_API_KEY` | Google Picker API key |
+| `FENRIR_ANTHROPIC_API_KEY` | Anthropic API key for LLM extraction |
+| `ENTITLEMENT_ENCRYPTION_KEY` | AES-256 key for entitlement tokens |
+| `STRIPE_SECRET_KEY` | Stripe secret key |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key |
+| `STRIPE_WEBHOOK_SECRET` | Stripe webhook signing secret |
+| `STRIPE_PRICE_ID` | Stripe price ID for Karl tier |
+| `KV_REST_API_URL` | KV store REST API URL |
+| `KV_REST_API_TOKEN` | KV store REST API token |
+
+## Dev Server with Stripe
+
+For Stripe webhook testing, use the services script:
+
+```bash
+bash .claude/scripts/services.sh start    # Starts dev server + Stripe CLI
+bash .claude/scripts/services.sh stop     # Stops everything
+bash .claude/scripts/services.sh status   # Check status
+bash .claude/scripts/services.sh logs     # Tail frontend logs
+```
+
+## CI/CD Pipeline
+
+Every push to `main` triggers the unified deploy pipeline (`.github/workflows/deploy.yml`):
+
+1. **Terraform** — ensures GKE infrastructure is up to date
+2. **Build & Push** — Docker build, push to Artifact Registry
+3. **Deploy** — rolling update to GKE Autopilot (zero-downtime)
+4. **Health Check** — verifies `/api/health` via Ingress IP
+
+## Project Structure
+
+```
+fenrir-ledger/
+  development/
+    frontend/           # Next.js app (src/, public/, package.json)
+    scripts/            # setup-local.sh
+    docs/               # This guide and other dev docs
+  infrastructure/
+    main.tf             # Terraform provider + GCP APIs
+    gke.tf              # GKE Autopilot cluster
+    iam.tf              # Workload Identity + IAM
+    variables.tf        # Terraform variables
+    k8s/app/            # K8s manifests (deployment, service, ingress)
+    k8s/agents/         # Agent sandbox job template + dispatch script
+  scripts/
+    gke-setup.sh        # GKE CLI setup (kubectl, k9s, auth)
+  quality/
+    scripts/            # verify.sh, test runners
+    test-suites/        # Playwright E2E tests
+  .github/workflows/    # CI/CD pipelines
+```


### PR DESCRIPTION
## Summary
- Adds `development/docs/setup-guide.md` — full setup instructions, GKE details, env vars, CI/CD, project structure
- Updates `development/README.md` with Getting Started section, removes stale Vercel references

## Test plan
- [ ] Links in README resolve correctly
- [ ] Setup guide content is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)