### PR TITLE
fix: dispatch-job.sh multiline prompt handling via base64

### DIFF
--- a/architecture/system-design.md
+++ b/architecture/system-design.md
@@ -177,13 +177,13 @@ graph TD
     classDef background fill:#2C2C2C,stroke:#444,color:#FFF
 
     %% Entry points
-    browser([User Browser]) -->|HTTP GET /| dashpage[Dashboard Page - /app/page.tsx]
-    browser -->|HTTP GET /cards/new| newpage[Add Card Page -/app/cards/new/page.tsx]
-    browser -->|HTTP GET /cards/id/edit| editpage[Edit Card Page -/app/cards/id/edit/page.tsx]
-    browser -->|HTTP GET /valhalla| valpage[Valhalla Page -/app/valhalla/page.tsx]
-    browser -->|HTTP GET /sign-in| signinpage[Sign-In Page -/app/sign-in/page.tsx]
-    browser -->|HTTP GET /auth/callback| callbackpage[Auth Callback -/app/auth/callback/page.tsx]
-    browser -->|HTTP GET /settings| settingspage[Settings Page -/app/settings/page.tsx]
+    browser([User Browser]) -->|GET /ledger| dashpage[Dashboard Page - /ledger]
+    browser -->|GET /ledger/cards/new| newpage[Add Card Page - /ledger/cards/new]
+    browser -->|GET /ledger/cards/id/edit| editpage[Edit Card Page - /ledger/cards/id/edit]
+    browser -->|GET /ledger/valhalla| valpage[Valhalla Page - /ledger/valhalla]
+    browser -->|GET /ledger/sign-in| signinpage[Sign-In Page - /ledger/sign-in]
+    browser -->|GET /ledger/auth/callback| callbackpage[Auth Callback - /ledger/auth/callback]
+    browser -->|GET /ledger/settings| settingspage[Settings Page - /ledger/settings]
 
     %% Auth + entitlement contexts
     authctx[AuthContext -anonymous or authenticated] --> dashpage

--- a/infrastructure/k8s/agents/dispatch-job.sh
+++ b/infrastructure/k8s/agents/dispatch-job.sh
@@ -78,24 +78,30 @@ fi
 # --------------------------------------------------------------------------
 # Substitute placeholders
 # --------------------------------------------------------------------------
-# The task prompt needs to be properly escaped for YAML embedding.
-# We use a simple approach: the prompt is passed as-is in the env var.
-# For multiline prompts, the entrypoint reads TASK_PROMPT from env.
+# Simple placeholders are substituted via sed.
+# TASK_PROMPT is base64-encoded to avoid YAML/shell escaping issues.
+# The container entrypoint must decode TASK_PROMPT before use.
 
-MANIFEST=$(cat "$TEMPLATE" \
-  | sed "s|{{JOB_NAME}}|${JOB_NAME}|g" \
-  | sed "s|{{SESSION_ID}}|${SESSION_ID}|g" \
-  | sed "s|{{BRANCH}}|${BRANCH}|g" \
-  | sed "s|{{AGENT_MODEL}}|${MODEL}|g" \
-  | sed "s|{{IMAGE_TAG}}|${IMAGE_TAG}|g"
-)
+PROMPT_B64=$(printf '%s' "$PROMPT" | base64 | tr -d '\n')
 
-# Handle TASK_PROMPT separately — it can contain special chars.
-# We base64-encode it and the entrypoint will decode it.
-# Actually, the prompt goes directly as env var value in the Job spec.
-# For safety, we write a temporary file with the full manifest.
 TMPFILE=$(mktemp /tmp/agent-job-XXXXXX.yaml)
-echo "$MANIFEST" | sed "s|{{TASK_PROMPT}}|${PROMPT}|g" > "$TMPFILE"
+
+awk \
+  -v job_name="$JOB_NAME" \
+  -v session_id="$SESSION_ID" \
+  -v branch="$BRANCH" \
+  -v model="$MODEL" \
+  -v image_tag="$IMAGE_TAG" \
+  -v prompt_b64="$PROMPT_B64" \
+  '{
+    gsub(/\{\{JOB_NAME\}\}/, job_name)
+    gsub(/\{\{SESSION_ID\}\}/, session_id)
+    gsub(/\{\{BRANCH\}\}/, branch)
+    gsub(/\{\{AGENT_MODEL\}\}/, model)
+    gsub(/\{\{IMAGE_TAG\}\}/, image_tag)
+    gsub(/\{\{TASK_PROMPT\}\}/, prompt_b64)
+    print
+  }' "$TEMPLATE" > "$TMPFILE"
 
 # --------------------------------------------------------------------------
 # Apply or dry-run

--- a/infrastructure/k8s/agents/entrypoint.sh
+++ b/infrastructure/k8s/agents/entrypoint.sh
@@ -112,6 +112,13 @@ if [ -z "${TASK_PROMPT:-}" ]; then
   exit 1
 fi
 
+# Decode base64-encoded prompt (dispatch-job.sh encodes to avoid YAML issues)
+DECODED_PROMPT=$(echo "${TASK_PROMPT}" | base64 -d 2>/dev/null) || {
+  # If decode fails, assume prompt is plaintext (backward compat)
+  DECODED_PROMPT="${TASK_PROMPT}"
+  echo "[WARN] TASK_PROMPT is not base64-encoded — using as plaintext"
+}
+
 # --------------------------------------------------------------------------
 # 7. Run Claude Code CLI
 # --------------------------------------------------------------------------
@@ -119,7 +126,7 @@ AGENT_MODEL="${AGENT_MODEL:-claude-sonnet-4-6}"
 CLAUDE_ARGS=(
   "--model" "${AGENT_MODEL}"
   "--print"
-  "-p" "${TASK_PROMPT}"
+  "-p" "${DECODED_PROMPT}"
 )
 
 if [ "${SKIP_PERMISSIONS:-false}" = "true" ]; then


### PR DESCRIPTION
## Summary
- Fixes the multiline prompt bug in `dispatch-job.sh` that broke GKE agent dispatch
- Prompts are now base64-encoded before YAML embedding, decoded by `entrypoint.sh`
- Uses `awk` instead of `sed` for all placeholder substitution
- Backward compatible: entrypoint falls back to plaintext if base64 decode fails
- Also fixes stale routes in system-design.md (`/` → `/ledger/`)

## Test plan
- [x] Dry-run with multiline prompt containing pipes, quotes, braces, `$HOME`, newlines
- [x] Verified base64 round-trip preserves all content exactly
- [ ] Live GKE dispatch test after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)