### PR TITLE
fix: grant dns.admin role to deploy SA

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -96,6 +96,12 @@ resource "google_project_iam_member" "deploy_gke_admin" {
   member  = "serviceAccount:${var.deploy_service_account}"
 }
 
+resource "google_project_iam_member" "deploy_dns_admin" {
+  project = var.project_id
+  role    = "roles/dns.admin"
+  member  = "serviceAccount:${var.deploy_service_account}"
+}
+
 # --------------------------------------------------------------------------
 # Cost Alerts — Budget notification
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Deploy SA needs `roles/dns.admin` to create Cloud DNS zones (added in #684)
- Terraform apply failed with 403 Forbidden on `google_dns_managed_zone`
- Role also granted via `gcloud` for immediate effect

## Test plan
- [ ] Re-run deploy pipeline — Terraform should create DNS zone successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)