### PR TITLE
fix: www→apex and HTTP→HTTPS redirects

### DIFF
--- a/development/frontend/src/middleware.ts
+++ b/development/frontend/src/middleware.ts
@@ -22,11 +22,28 @@
  * See ADR-005 for the auth architecture. See ADR-008 for API route auth.
  */
 
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { generateNonce } from "@/lib/csp-nonce";
 import { buildSecurityHeaders } from "@/lib/csp-headers";
 
-export function middleware() {
+export function middleware(request: NextRequest) {
+  const { hostname, protocol, pathname, search } = request.nextUrl;
+
+  // -----------------------------------------------------------------------
+  // Canonical domain redirect: www → apex, HTTP → HTTPS
+  // Skip in development (localhost)
+  // -----------------------------------------------------------------------
+  if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+    const isWww = hostname.startsWith("www.");
+    const isHttp = protocol === "http:" || request.headers.get("x-forwarded-proto") === "http";
+
+    if (isWww || isHttp) {
+      const canonicalHost = hostname.replace(/^www\./, "");
+      const url = `https://${canonicalHost}${pathname}${search}`;
+      return NextResponse.redirect(url, 301);
+    }
+  }
+
   const nonce = generateNonce();
 
   // Clone response and inject nonce into headers for layout/scripts to read

--- a/infrastructure/k8s/app/ingress.yaml
+++ b/infrastructure/k8s/app/ingress.yaml
@@ -45,6 +45,16 @@ spec:
                 name: fenrir-app
                 port:
                   number: 80
+    - host: www.fenrirledger.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fenrir-app
+                port:
+                  number: 80
 
 ---
 # --------------------------------------------------------------------------
@@ -61,6 +71,7 @@ metadata:
 spec:
   domains:
     - fenrirledger.com
+    - www.fenrirledger.com
 
 ---
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Middleware redirects `www.fenrirledger.com` → `fenrirledger.com` (301)
- Middleware redirects HTTP → HTTPS (301, via x-forwarded-proto check)
- Ingress accepts `www.fenrirledger.com` traffic
- ManagedCertificate covers both `fenrirledger.com` and `www.fenrirledger.com`
- Skipped in dev (localhost/127.0.0.1)

## Test plan
- [ ] `curl -I http://www.fenrirledger.com` → 301 to `https://fenrirledger.com`
- [ ] `curl -I http://fenrirledger.com` → 301 to `https://fenrirledger.com`
- [ ] `curl -I https://www.fenrirledger.com` → 301 to `https://fenrirledger.com`
- [ ] `https://fenrirledger.com` serves the app
- [ ] localhost dev still works without redirects

🤖 Generated with [Claude Code](https://claude.com/claude-code)