### PR TITLE
fix: add www domain to Terraform SSL cert

### DIFF
--- a/infrastructure/gke.tf
+++ b/infrastructure/gke.tf
@@ -105,6 +105,6 @@ resource "google_compute_managed_ssl_certificate" "app_cert" {
   name     = "fenrir-app-cert"
 
   managed {
-    domains = [var.domain]
+    domains = [var.domain, "www.${var.domain}"]
   }
 }


### PR DESCRIPTION
## Summary
- Terraform `google_compute_managed_ssl_certificate` only had `fenrirledger.com`
- Added `www.fenrirledger.com` to match K8s ManagedCertificate and ingress

## Test plan
- [ ] `terraform plan` shows cert update with both domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)