### PR TITLE
fix: declare all deploy SA roles in Terraform + bootstrap script

### DIFF
--- a/infrastructure/gke.tf
+++ b/infrastructure/gke.tf
@@ -1,7 +1,7 @@
 # --------------------------------------------------------------------------
 # GKE Autopilot Cluster — Fenrir Ledger
 #
-# Zonal cluster in us-central1-a to qualify for free management fee credit.
+# Regional Autopilot cluster in us-central1.
 # Autopilot mode: Google manages nodes, scaling, security patches.
 # --------------------------------------------------------------------------
 

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -87,18 +87,37 @@ resource "google_project_iam_member" "agents_monitoring" {
 }
 
 # --------------------------------------------------------------------------
-# Deploy service account — GKE access for GitHub Actions
+# Deploy service account — IAM roles for GitHub Actions CI/CD
+#
+# These roles are required for the deploy SA to manage all infrastructure.
+# For a fresh project, run scripts/bootstrap-iam.sh FIRST to grant these
+# roles before the initial terraform apply (chicken-and-egg: Terraform
+# can't grant itself permissions it doesn't yet have).
 # --------------------------------------------------------------------------
 
-resource "google_project_iam_member" "deploy_gke_admin" {
-  project = var.project_id
-  role    = "roles/container.developer"
-  member  = "serviceAccount:${var.deploy_service_account}"
+locals {
+  deploy_roles = [
+    "roles/container.admin",               # GKE cluster management
+    "roles/container.developer",           # K8s resource management
+    "roles/compute.loadBalancerAdmin",     # Ingress / LB management
+    "roles/compute.networkAdmin",          # VPC, subnets, firewall rules
+    "roles/compute.securityAdmin",         # SSL certs, security policies
+    "roles/dns.admin",                     # Cloud DNS zones and records
+    "roles/iam.serviceAccountAdmin",       # Create/manage service accounts
+    "roles/iam.serviceAccountUser",        # Attach SAs to resources
+    "roles/resourcemanager.projectIamAdmin", # Manage IAM bindings
+    "roles/artifactregistry.admin",        # Artifact Registry repos
+    "roles/logging.admin",                 # Cloud Logging config
+    "roles/monitoring.admin",              # Cloud Monitoring config
+    "roles/certificatemanager.editor",     # Managed SSL certs
+  ]
 }
 
-resource "google_project_iam_member" "deploy_dns_admin" {
+resource "google_project_iam_member" "deploy_roles" {
+  for_each = toset(local.deploy_roles)
+
   project = var.project_id
-  role    = "roles/dns.admin"
+  role    = each.value
   member  = "serviceAccount:${var.deploy_service_account}"
 }
 

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -14,7 +14,7 @@ output "cluster_endpoint" {
 }
 
 output "cluster_location" {
-  description = "Location (zone) of the GKE cluster"
+  description = "Location (region) of the GKE cluster"
   value       = google_container_cluster.autopilot.location
 }
 
@@ -35,7 +35,7 @@ output "agents_service_account_email" {
 
 output "kubectl_connect_command" {
   description = "Command to configure kubectl for this cluster"
-  value       = "gcloud container clusters get-credentials ${google_container_cluster.autopilot.name} --zone ${var.zone} --project ${var.project_id}"
+  value       = "gcloud container clusters get-credentials ${google_container_cluster.autopilot.name} --region ${var.region} --project ${var.project_id}"
 }
 
 output "vpc_network" {

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -15,7 +15,7 @@ variable "region" {
 }
 
 variable "zone" {
-  description = "GCP zone for the zonal Autopilot cluster (free tier)"
+  description = "GCP zone (used by Terraform plan env var, not by cluster)"
   type        = string
   default     = "us-central1-a"
 }

--- a/scripts/bootstrap-iam.sh
+++ b/scripts/bootstrap-iam.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# --------------------------------------------------------------------------
+# bootstrap-iam.sh — Grant all required IAM roles before first terraform apply
+#
+# Terraform can't grant itself permissions it doesn't yet have. Run this
+# script once before the initial `terraform apply` on a fresh project to
+# bootstrap the deploy service account with all required roles.
+#
+# Usage:
+#   bash scripts/bootstrap-iam.sh [PROJECT_ID] [SERVICE_ACCOUNT_EMAIL]
+#
+# Defaults:
+#   PROJECT_ID:             fenrir-ledger-prod
+#   SERVICE_ACCOUNT_EMAIL:  fenrir-deploy@fenrir-ledger-prod.iam.gserviceaccount.com
+#
+# Prerequisites:
+#   - gcloud CLI authenticated with Owner or IAM Admin on the project
+#   - The service account must already exist
+# --------------------------------------------------------------------------
+set -euo pipefail
+
+PROJECT_ID="${1:-fenrir-ledger-prod}"
+SA_EMAIL="${2:-fenrir-deploy@${PROJECT_ID}.iam.gserviceaccount.com}"
+
+BOLD='\033[1m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+RESET='\033[0m'
+
+echo -e "${BOLD}Fenrir Ledger — IAM Bootstrap${RESET}"
+echo "  Project: ${PROJECT_ID}"
+echo "  Service Account: ${SA_EMAIL}"
+echo ""
+
+# --------------------------------------------------------------------------
+# Required roles — must match local.deploy_roles in infrastructure/iam.tf
+# --------------------------------------------------------------------------
+ROLES=(
+  "roles/container.admin"
+  "roles/container.developer"
+  "roles/compute.loadBalancerAdmin"
+  "roles/compute.networkAdmin"
+  "roles/compute.securityAdmin"
+  "roles/dns.admin"
+  "roles/iam.serviceAccountAdmin"
+  "roles/iam.serviceAccountUser"
+  "roles/resourcemanager.projectIamAdmin"
+  "roles/artifactregistry.admin"
+  "roles/logging.admin"
+  "roles/monitoring.admin"
+  "roles/certificatemanager.editor"
+)
+
+# --------------------------------------------------------------------------
+# Preflight
+# --------------------------------------------------------------------------
+if ! command -v gcloud &>/dev/null; then
+  echo -e "${RED}Error: gcloud CLI not found.${RESET}" >&2
+  exit 1
+fi
+
+# Verify the SA exists
+if ! gcloud iam service-accounts describe "$SA_EMAIL" --project="$PROJECT_ID" &>/dev/null; then
+  echo -e "${YELLOW}Service account ${SA_EMAIL} does not exist. Creating...${RESET}"
+  gcloud iam service-accounts create "$(echo "$SA_EMAIL" | cut -d@ -f1)" \
+    --project="$PROJECT_ID" \
+    --display-name="Fenrir Deploy (GitHub Actions)" \
+    --description="CI/CD service account for GitHub Actions deployments"
+  echo -e "${GREEN}✓${RESET} Service account created"
+fi
+
+# --------------------------------------------------------------------------
+# Grant roles
+# --------------------------------------------------------------------------
+FAILED=0
+for ROLE in "${ROLES[@]}"; do
+  if gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+    --member="serviceAccount:${SA_EMAIL}" \
+    --role="$ROLE" \
+    --quiet &>/dev/null; then
+    echo -e "  ${GREEN}✓${RESET} ${ROLE}"
+  else
+    echo -e "  ${RED}✗${RESET} ${ROLE} — failed to grant"
+    FAILED=$((FAILED + 1))
+  fi
+done
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo -e "${GREEN}✓${RESET} All ${#ROLES[@]} roles granted successfully."
+  echo ""
+  echo "Next steps:"
+  echo "  1. cd infrastructure"
+  echo "  2. terraform init"
+  echo "  3. terraform plan -var billing_account_id=XXXXXX-XXXXXX-XXXXXX"
+  echo "  4. terraform apply"
+else
+  echo -e "${RED}✗${RESET} ${FAILED} role(s) failed. Check permissions — you need Owner or IAM Admin."
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- All 13 deploy SA roles now declared in `iam.tf` (was only 2)
- New `scripts/bootstrap-iam.sh` — run once before first `terraform apply`
- Fixed stale "zonal" references in comments and outputs (Autopilot is regional)
- `kubectl_connect_command` output uses `--region` not `--zone`

## Test plan
- [ ] `terraform plan` shows no unexpected changes (roles already exist)
- [ ] `bash scripts/bootstrap-iam.sh` works on fresh project
- [ ] Deploy pipeline succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)