### PR TITLE
fix: bump docker actions for Node.js 24 compat

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -137,11 +137,11 @@ jobs:
         run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push app image
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile


### PR DESCRIPTION
## Summary
- `docker/setup-buildx-action` v3 → v4
- `docker/build-push-action` v6 → v7
- Fixes Node.js 20 deprecation warnings (mandatory Node.js 24 after June 2026)

🤖 Generated with [Claude Code](https://claude.com/claude-code)