### PR TITLE
fix: serialize deploy pipeline with concurrency group

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@
 
 name: Deploy to GKE
 
+# Serial deploys — queue runs one after another, never cancel in-flight
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
## Summary
- Adds `concurrency: group: deploy-main` with `cancel-in-progress: false`
- Deploys now queue serially — each run waits for the previous to finish
- No more parallel Terraform applies or overlapping K8s rollouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)