### PR TITLE
feat: pre-bake Playwright deps into agent sandbox image

### DIFF
--- a/.claude/scripts/sandbox-setup.sh
+++ b/.claude/scripts/sandbox-setup.sh
@@ -73,8 +73,13 @@ if [ ! -e "$REPO_ROOT/quality/node_modules" ]; then
 fi
 
 # 6. Install Playwright browsers + system deps (Chromium only for speed)
-npx playwright install --with-deps chromium 2>/dev/null || npx playwright install chromium
-echo "[ok] Playwright chromium installed"
+#    Skip if already pre-baked in Docker image (saves ~60s)
+if npx playwright install --dry-run chromium 2>/dev/null | grep -q "already installed"; then
+  echo "[ok] Playwright chromium already installed (pre-baked)"
+else
+  npx playwright install --with-deps chromium 2>/dev/null || npx playwright install chromium
+  echo "[ok] Playwright chromium installed"
+fi
 
 # 7. Verify critical versions
 NEXT_VER=$(npx next --version 2>/dev/null || echo "unknown")

--- a/.github/workflows/build-agent-sandbox.yml
+++ b/.github/workflows/build-agent-sandbox.yml
@@ -2,7 +2,8 @@
 # Docker Build & Push — Agent Sandbox Image
 #
 # Builds the agent sandbox container and pushes to Google Artifact Registry.
-# Triggers on changes to agent infrastructure files or manual dispatch.
+# Triggers on changes to agent infrastructure files, package-lock changes
+# (which affect pre-baked Playwright version), or manual dispatch.
 #
 # Required GitHub Secrets:
 #   GCP_PROJECT_ID   — Google Cloud project ID
@@ -12,12 +13,17 @@
 
 name: Build Agent Sandbox Image
 
+concurrency:
+  group: build-agent-sandbox
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]
     paths:
       - "infrastructure/k8s/agents/Dockerfile"
       - "infrastructure/k8s/agents/entrypoint.sh"
+      - "development/frontend/package-lock.json"
   workflow_dispatch:
     inputs:
       image_tag:
@@ -40,24 +46,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push agent sandbox image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./infrastructure/k8s/agents/Dockerfile

--- a/infrastructure/k8s/agents/Dockerfile
+++ b/infrastructure/k8s/agents/Dockerfile
@@ -2,8 +2,8 @@
 # Agent Sandbox Container — Fenrir Ledger
 #
 # Ephemeral container for running Claude Code agent tasks on GKE Autopilot.
-# Pre-bakes Node.js, Claude CLI, GitHub CLI, and system dependencies
-# to minimize cold-start time for agent Jobs.
+# Pre-bakes Node.js, Claude CLI, GitHub CLI, Playwright browsers + system
+# deps, and a warm npm cache to minimize cold-start time for agent Jobs.
 #
 # Build:
 #   docker build -t us-central1-docker.pkg.dev/fenrir-ledger-prod/fenrir-images/agent-sandbox:latest \
@@ -21,16 +21,42 @@ LABEL description="Fenrir Ledger agent sandbox for Claude Code tasks"
 # Avoid interactive prompts during package install
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install system dependencies required by agents
+# --------------------------------------------------------------------------
+# 1. System dependencies — git, curl, jq, plus Playwright's system libs
+# --------------------------------------------------------------------------
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     curl \
     ca-certificates \
     jq \
     openssh-client \
+    # Playwright Chromium system dependencies (avoids slow `--with-deps` at runtime)
+    libnss3 \
+    libnspr4 \
+    libatk1.0-0 \
+    libatk-bridge2.0-0 \
+    libcups2 \
+    libdrm2 \
+    libdbus-1-3 \
+    libxkbcommon0 \
+    libatspi2.0-0 \
+    libxcomposite1 \
+    libxdamage1 \
+    libxfixes3 \
+    libxrandr2 \
+    libgbm1 \
+    libpango-1.0-0 \
+    libcairo2 \
+    libasound2 \
+    libwayland-client0 \
+    fonts-liberation \
+    fonts-noto-color-emoji \
+    xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-# Install GitHub CLI
+# --------------------------------------------------------------------------
+# 2. GitHub CLI
+# --------------------------------------------------------------------------
 RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
       -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
@@ -39,17 +65,33 @@ RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Claude Code CLI globally
+# --------------------------------------------------------------------------
+# 3. Claude Code CLI (global)
+# --------------------------------------------------------------------------
 RUN npm install -g @anthropic-ai/claude-code@latest
 
-# Create workspace directory (matches Depot convention)
+# --------------------------------------------------------------------------
+# 4. Pre-install Playwright Chromium browser binary
+#    Version is pinned to whatever @playwright/test ships with.
+#    sandbox-setup.sh skips this step when browsers are already present.
+# --------------------------------------------------------------------------
+COPY development/frontend/package.json development/frontend/package-lock.json /tmp/frontend/
+RUN cd /tmp/frontend \
+    && npm ci --prefer-offline 2>/dev/null || npm ci \
+    && npx playwright install chromium \
+    && rm -rf /tmp/frontend
+
+# --------------------------------------------------------------------------
+# 5. Workspace + git config
+# --------------------------------------------------------------------------
 WORKDIR /workspace
 
-# Pre-configure git for agent commits
 RUN git config --global init.defaultBranch main \
     && git config --global advice.detachedHead false
 
-# Agent entrypoint script — clones repo, runs sandbox setup, executes task
+# --------------------------------------------------------------------------
+# 6. Entrypoint — clones repo, runs sandbox setup, executes task
+# --------------------------------------------------------------------------
 COPY infrastructure/k8s/agents/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 


### PR DESCRIPTION
## Summary
- Pre-bake Playwright Chromium browser + system libs into the agent sandbox Docker image (~60-90s saved per session)
- Move `docker-build-agents.yml` from `infrastructure/k8s/agents/` to `.github/workflows/` where GitHub Actions can find it
- Bump action versions to avoid Node.js 20 deprecation warnings
- Add `package-lock.json` as a trigger path (Playwright version changes need image rebuild)
- Update `sandbox-setup.sh` to skip Playwright install when browsers are already present

## Test plan
- [ ] Build image locally and verify Chromium is pre-installed
- [ ] Trigger workflow_dispatch to build and push image to Artifact Registry
- [ ] Dispatch a GKE agent job and verify it starts without `ErrImagePull`

🤖 Generated with [Claude Code](https://claude.com/claude-code)