### PR TITLE
fix: agent sandbox .dockerignore for image build

### DIFF
--- a/infrastructure/k8s/agents/Dockerfile.dockerignore
+++ b/infrastructure/k8s/agents/Dockerfile.dockerignore
@@ -1,0 +1,36 @@
+# --------------------------------------------------------------------------
+# Docker ignore — Agent Sandbox Image
+# Minimal exclusions — agent image needs infrastructure/ and .claude/ files
+# --------------------------------------------------------------------------
+
+# Git
+.git
+.gitignore
+
+# Node
+**/node_modules
+**/.next
+**/out
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+
+# Environment files
+**/.env
+**/.env.local
+**/.env.production
+**/.env.*.local
+
+# Test artifacts
+**/playwright-report
+**/test-results
+**/coverage
+
+# Terraform state (but keep .tf files for context)
+**/*.tfstate*
+
+# Large directories not needed in agent image
+sessions/


### PR DESCRIPTION
## Summary
- Root `.dockerignore` excludes `infrastructure/` and `.claude/` — needed by agent sandbox Dockerfile
- Add `infrastructure/k8s/agents/Dockerfile.dockerignore` (BuildKit per-Dockerfile convention)
- Fixes `ErrImagePull` blocking all GKE agent dispatches

## Test plan
- [ ] Trigger `Build Agent Sandbox Image` workflow and verify it passes
- [ ] Dispatch a GKE agent job and verify pod starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)