### PR TITLE
fix: agent entrypoint git auth for GKE containers

### DIFF
--- a/infrastructure/k8s/agents/entrypoint.sh
+++ b/infrastructure/k8s/agents/entrypoint.sh
@@ -35,9 +35,10 @@ if [ -z "${GH_TOKEN:-}" ]; then
   exit 1
 fi
 
-# Configure gh CLI auth
-echo "${GH_TOKEN}" | gh auth login --with-token
-gh auth setup-git
+# Configure git to use GH_TOKEN for HTTPS auth
+# gh CLI automatically uses GH_TOKEN env var — no login needed.
+# For git clone/push, configure credential helper to use the token directly.
+git config --global credential.helper '!f() { echo "username=x-access-token"; echo "password=${GH_TOKEN}"; }; f'
 echo "[ok] git credentials configured"
 
 # Git identity for commits


### PR DESCRIPTION
## Summary
- `gh auth setup-git` fails when `GH_TOKEN` is an env var (no stored cred to wire)
- Replace with `git config --global credential.helper` that passes the token directly
- Fixes agent pods crashing immediately on startup (exit code 1)

## Test plan
- [ ] Re-dispatch a GKE agent job and verify it clones the repo successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)