### PR TITLE
fix: reduce agent job TTL to 5 minutes

### DIFF
--- a/infrastructure/k8s/agents/job-template.yaml
+++ b/infrastructure/k8s/agents/job-template.yaml
@@ -26,8 +26,9 @@ metadata:
     app.kubernetes.io/component: agent-sandbox
     fenrir.dev/session-id: "{{SESSION_ID}}"
 spec:
-  # Auto-delete completed/failed Jobs after 1 hour
-  ttlSecondsAfterFinished: 3600
+  # Auto-delete completed/failed Jobs after 5 minutes
+  # Logs persist in Cloud Logging — no need to keep Jobs around
+  ttlSecondsAfterFinished: 300
 
   # Max runtime: 60 minutes — prevents runaway agents
   activeDeadlineSeconds: 3600


### PR DESCRIPTION
## Summary
- Reduce `ttlSecondsAfterFinished` from 3600 (1hr) to 300 (5min)
- Logs persist in Cloud Logging, no need for stale Jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)