### PR TITLE
fix: agent job TTL to 30 minutes

### DIFF
--- a/infrastructure/k8s/agents/job-template.yaml
+++ b/infrastructure/k8s/agents/job-template.yaml
@@ -26,9 +26,8 @@ metadata:
     app.kubernetes.io/component: agent-sandbox
     fenrir.dev/session-id: "{{SESSION_ID}}"
 spec:
-  # Auto-delete completed/failed Jobs after 5 minutes
-  # Logs persist in Cloud Logging — no need to keep Jobs around
-  ttlSecondsAfterFinished: 300
+  # Auto-delete completed/failed Jobs after 30 minutes
+  ttlSecondsAfterFinished: 1800
 
   # Max runtime: 60 minutes — prevents runaway agents
   activeDeadlineSeconds: 3600


### PR DESCRIPTION
## Summary
- Set `ttlSecondsAfterFinished: 1800` (30 min) — balanced between fast cleanup and log availability
- Don't rely on Cloud Logging — Cribl integration planned

🤖 Generated with [Claude Code](https://claude.com/claude-code)