### PR TITLE
feat: stream-json output for agent verbose logging

### DIFF
--- a/infrastructure/k8s/agents/entrypoint.sh
+++ b/infrastructure/k8s/agents/entrypoint.sh
@@ -144,6 +144,7 @@ AGENT_MODEL="${AGENT_MODEL:-claude-sonnet-4-6}"
 CLAUDE_ARGS=(
   "--model" "${AGENT_MODEL}"
   "--print"
+  "--output-format" "stream-json"
   "-p" "${DECODED_PROMPT}"
 )
 


### PR DESCRIPTION
## Summary
- Add `--output-format stream-json` to Claude Code CLI args
- Every tool call, response chunk, and result streams in real time
- Makes `kubectl logs --follow` actually useful for monitoring agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)