### PR TITLE
fix: add --verbose for stream-json agent output

### DIFF
--- a/infrastructure/k8s/agents/entrypoint.sh
+++ b/infrastructure/k8s/agents/entrypoint.sh
@@ -145,6 +145,7 @@ CLAUDE_ARGS=(
   "--model" "${AGENT_MODEL}"
   "--print"
   "--output-format" "stream-json"
+  "--verbose"
   "-p" "${DECODED_PROMPT}"
 )
 


### PR DESCRIPTION
## Summary
- `--output-format stream-json` requires `--verbose` flag with `--print`
- Fixes agent startup error: `Error: When using --print, --output-format=stream-json requires --verbose`

🤖 Generated with [Claude Code](https://claude.com/claude-code)