### PR TITLE
fix: exempt /api/health from HTTPS redirect

### DIFF
--- a/development/frontend/src/middleware.ts
+++ b/development/frontend/src/middleware.ts
@@ -31,9 +31,9 @@ export function middleware(request: NextRequest) {
 
   // -----------------------------------------------------------------------
   // Canonical domain redirect: www → apex, HTTP → HTTPS
-  // Skip in development (localhost)
+  // Skip in development (localhost) and health check endpoint (GCP probes use HTTP)
   // -----------------------------------------------------------------------
-  if (hostname !== "localhost" && hostname !== "127.0.0.1") {
+  if (hostname !== "localhost" && hostname !== "127.0.0.1" && pathname !== "/api/health") {
     const isWww = hostname.startsWith("www.");
     const isHttp = protocol === "http:" || request.headers.get("x-forwarded-proto") === "http";
 


### PR DESCRIPTION
## Summary
- GCP health check probes use plain HTTP on port 3000
- Middleware was redirecting HTTP→HTTPS, causing health checks to fail (301)
- All backends marked UNHEALTHY → 502 Bad Gateway on fenrirledger.com
- Fix: skip the canonical redirect for `/api/health`

## Test plan
- [ ] Health check returns 200 on HTTP after deploy
- [ ] Backends go HEALTHY in GCP load balancer
- [ ] fenrirledger.com resolves properly