### PR TITLE
fix: add missing claude-oauth-token to agent secrets template

### DIFF
--- a/infrastructure/k8s/agents/README.md
+++ b/infrastructure/k8s/agents/README.md
@@ -22,6 +22,7 @@ dispatch skill → dispatch-job.sh → kubectl apply → GKE Autopilot Job
 | `job-template.yaml` | K8s Job spec template with placeholders |
 | `secrets-template.yaml` | K8s Secret template (DO NOT commit real values) |
 | `dispatch-job.sh` | Script to generate and apply Job manifests |
+| `agent-logs.mjs` | Stream + parse agent JSONL logs (saves to `tmp/agent-logs/`) |
 
 ## Setup
 
@@ -41,8 +42,12 @@ docker push us-central1-docker.pkg.dev/fenrir-ledger-prod/fenrir-images/agent-sa
 kubectl create secret generic agent-secrets \
   --namespace fenrir-agents \
   --from-literal=anthropic-api-key="<your-anthropic-key>" \
-  --from-literal=gh-token="<your-github-token>"
+  --from-literal=gh-token="<fine-grained-pat>" \
+  --from-literal=claude-oauth-token="<claude-code-oauth-token>"
 ```
+
+**Note:** `gh-token` must be a **fine-grained PAT** (not classic) scoped to this repo with
+Contents, Pull requests, Issues, Workflows, and Metadata permissions.
 
 ### 3. Dispatch an agent
 
@@ -67,13 +72,19 @@ bash infrastructure/k8s/agents/dispatch-job.sh \
 
 ```bash
 # List running agent jobs
-kubectl get jobs -n fenrir-agents
+just agent-jobs
 
-# Follow agent logs
-kubectl logs job/<job-name> -n fenrir-agents --follow
+# Stream parsed agent logs (with pod startup polling)
+just agent-log-issue 744
 
-# Check pod status
-kubectl get pods -n fenrir-agents
+# Stream all active agents in tmux panes
+just agent-log-all
+
+# Dump finished session logs
+just agent-log-dump <session-id>
+
+# Generate HTML report from saved logs
+/brandify-agent <session-id>
 ```
 
 Cloud Logging also captures all agent output automatically via GKE's workload logging.

--- a/infrastructure/k8s/agents/secrets-template.yaml
+++ b/infrastructure/k8s/agents/secrets-template.yaml
@@ -4,14 +4,20 @@
 # K8s Secret for agent sandbox environment variables.
 # DO NOT commit with real values — this is a template only.
 #
-# Create the actual secret:
+# Create the actual secret (all 3 keys required):
 #   kubectl create secret generic agent-secrets \
 #     --namespace fenrir-agents \
 #     --from-literal=anthropic-api-key="<YOUR_KEY>" \
-#     --from-literal=gh-token="<YOUR_TOKEN>"
+#     --from-literal=gh-token="<FINE_GRAINED_PAT>" \
+#     --from-literal=claude-oauth-token="<CLAUDE_CODE_OAUTH_TOKEN>"
 #
 # Or apply this template after filling in base64-encoded values:
 #   echo -n "your-key" | base64
+#
+# Notes:
+#   - gh-token MUST be a fine-grained PAT (not classic) with:
+#     Contents, Pull requests, Issues, Workflows, Metadata permissions
+#   - claude-oauth-token is the Claude Code CLI subscription token
 # --------------------------------------------------------------------------
 
 apiVersion: v1
@@ -24,8 +30,9 @@ metadata:
     app.kubernetes.io/component: agent-sandbox
 type: Opaque
 data:
-  # Base64-encoded values — replace with actual encoded secrets
   # echo -n "<your-anthropic-key>" | base64
   anthropic-api-key: "REPLACE_WITH_BASE64_ENCODED_KEY"
-  # echo -n "<your-github-token>" | base64
+  # echo -n "<fine-grained-pat>" | base64
   gh-token: "REPLACE_WITH_BASE64_ENCODED_TOKEN"
+  # echo -n "<claude-code-oauth-token>" | base64
+  claude-oauth-token: "REPLACE_WITH_BASE64_ENCODED_TOKEN"


### PR DESCRIPTION
## Summary
- Added `claude-oauth-token` to `secrets-template.yaml` — was missing, caused `CreateContainerConfigError`
- Updated secret creation docs to require fine-grained PAT (not classic)
- Updated README with `agent-logs.mjs` file reference and `just` recipe commands

## Test plan
- [x] Verified secret with all 3 keys resolves the container config error
- [x] Agent pod starts successfully after secret fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)