### PR TITLE
fix: add missing uptime_check_host TF var to deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -101,6 +101,7 @@ jobs:
           TF_VAR_region: ${{ secrets.GCP_REGION }}
           TF_VAR_zone: ${{ secrets.GCP_ZONE }}
           TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
+          TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
 
       - name: Terraform Apply
         run: terraform apply -input=false -auto-approve tfplan


### PR DESCRIPTION
## Summary
- Adds `TF_VAR_uptime_check_host` to deploy workflow Terraform Plan step
- Secret `TF_VAR_UPTIME_CHECK_HOST` already set (fenrirledger.com)
- Fixes deploy failure: `No value for required variable "uptime_check_host"`

## Test plan
- [x] Secret set in GitHub
- [x] Deploy workflow will pass the var on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)