### PR TITLE
feat: agent-logs right-column tmux stacking

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -25,7 +25,7 @@ Composes a prompt from templates and spawns the agent via GKE Autopilot K8s Jobs
 ```
 Call 1: Read <agent>.md           (skip if already in context)
 Call 2: bash dispatch-job.sh ... && node pack-status.mjs --move N in-progress
-Call 3: tmux split-window -h "node agent-logs.mjs <SESSION_ID> --tools"
+Call 3: node agent-logs.mjs <SESSION_ID> --tools --spawn-pane
 ```
 
 If issue data + agent template are already in context, that's **2 tool calls** (spawn + board move, then log tail).
@@ -236,13 +236,22 @@ node "<repo-root>/.claude/skills/fire-next-up/scripts/pack-status.mjs" --move <N
 After a successful GKE dispatch, open a tmux pane streaming the parsed agent logs.
 The pod may take 30-60s to schedule — `agent-logs.mjs` polls automatically.
 
+**Layout rule:** Agent logs always stack in the **right column** of the tmux window.
+The orchestrator stays in the left pane. `agent-logs.mjs` sets pane titles (`agent-logs-<N>`)
+and detects existing log panes to stack into.
+
+**Single dispatch:**
 ```bash
-tmux split-window -h "node \"<repo-root>/infrastructure/k8s/agents/agent-logs.mjs\" \"<SESSION_ID>\" --tools"
+node "<repo-root>/infrastructure/k8s/agents/agent-logs.mjs" "<SESSION_ID>" --tools --spawn-pane
 ```
 
-For parallel dispatches (`--parallel`), use `--all --tmux` to split all active jobs:
+The `--spawn-pane` flag tells agent-logs.mjs to spawn itself into a tmux pane using
+the right-column stacking logic (detect existing log column, stack vertically if found,
+or create new right column at 40% width if not). This replaces manual `tmux split-window`.
+
+**Parallel dispatches (`--parallel`):**
 ```bash
-tmux split-window -h "node \"<repo-root>/infrastructure/k8s/agents/agent-logs.mjs\" --all --tmux --tools"
+node "<repo-root>/infrastructure/k8s/agents/agent-logs.mjs" --all --tmux --tools
 ```
 
 This runs in a separate tmux pane — it does NOT block the orchestrator.

--- a/infrastructure/k8s/agents/agent-logs.mjs
+++ b/infrastructure/k8s/agents/agent-logs.mjs
@@ -121,6 +121,7 @@ const opts = {
   tools: false,
   thinking: false,
   tmux: false,
+  spawnPane: false,
   all: false,
   targets: [],
   issueNum: null,
@@ -133,6 +134,7 @@ for (let i = 0; i < args.length; i++) {
     case "--thinking":   opts.thinking = true; break;
     case "--no-follow":  opts.follow = false; break;
     case "--tmux":       opts.tmux = true; break;
+    case "--spawn-pane": opts.spawnPane = true; break;
     case "--all":        opts.all = true; break;
     case "--namespace":  opts.namespace = args[++i]; break;
     case "--issue":      opts.issueNum = args[++i]; break;
@@ -201,6 +203,86 @@ if (!opts.targets.length) {
   process.exit(1);
 }
 
+// -- spawn-pane mode: re-exec self in a tmux pane --------------------------
+if (opts.spawnPane && opts.targets.length > 0) {
+  const scriptPath = import.meta.filename;
+  const extraFlags = [
+    opts.tools && "--tools",
+    opts.thinking && "--thinking",
+    opts.raw && "--raw",
+    !opts.follow && "--no-follow",
+    `--namespace`, opts.namespace,
+  ].filter(Boolean).join(" ");
+  const target = opts.targets[0];
+  const cmd = `node "${scriptPath}" "${target}" ${extraFlags}`;
+
+  // Detect existing log column and stack, or create new right column
+  const existing = (() => {
+    try {
+      const panes = execSync(
+        `tmux list-panes -F '#{pane_id} #{pane_title} #{pane_left}'`,
+        { encoding: "utf8" }
+      ).trim().split("\n");
+      let best = null;
+      for (const line of panes) {
+        const parts = line.split(" ");
+        const [id, title, left] = [parts[0], parts[1], parts[2]];
+        if (title && title.startsWith("agent-logs")) {
+          if (!best || Number(left) > Number(best.left)) {
+            best = { id, left };
+          }
+        }
+      }
+      return best?.id || null;
+    } catch { return null; }
+  })();
+
+  if (existing) {
+    execSync(`tmux split-window -v -t '${existing}' -l 30% '${cmd}'`);
+  } else {
+    execSync(`tmux split-window -h -l 40% '${cmd}'`);
+  }
+  process.exit(0);
+}
+
+// -- tmux layout helpers -----------------------------------------------------
+// Layout: left pane = orchestrator, right column = stacked agent logs.
+// Uses a named "agent-logs" pane title to detect existing log column.
+
+function findLogColumn() {
+  // Look for any pane with title containing "agent-logs"
+  try {
+    const panes = execSync(
+      `tmux list-panes -F '#{pane_id} #{pane_title} #{pane_left}'`,
+      { encoding: "utf8" }
+    ).trim().split("\n");
+    // Find rightmost pane that's an agent-log pane
+    let best = null;
+    for (const line of panes) {
+      const [id, title, left] = line.split(" ");
+      if (title && title.startsWith("agent-logs")) {
+        if (!best || Number(left) > Number(best.left)) {
+          best = { id, left };
+        }
+      }
+    }
+    return best?.id || null;
+  } catch {
+    return null;
+  }
+}
+
+function spawnLogPane(cmd) {
+  const existing = findLogColumn();
+  if (existing) {
+    // Stack vertically in the existing log column
+    execSync(`tmux split-window -v -t '${existing}' -l 30% '${cmd}'`);
+  } else {
+    // Create new right column (40% width)
+    execSync(`tmux split-window -h -l 40% '${cmd}'`);
+  }
+}
+
 // -- tmux split mode ---------------------------------------------------------
 if (opts.tmux && opts.targets.length > 1) {
   const scriptPath = import.meta.filename;
@@ -215,11 +297,7 @@ if (opts.tmux && opts.targets.length > 1) {
   for (let i = 1; i < opts.targets.length; i++) {
     const job = resolveJobName(opts.targets[i]);
     const cmd = `node "${scriptPath}" "${job}" ${extraFlags}`;
-    if (i === 1) {
-      execSync(`tmux split-window -h '${cmd}'`);
-    } else {
-      execSync(`tmux split-window -v -t "{right}" '${cmd}'`);
-    }
+    spawnLogPane(cmd);
   }
   // First target runs in this process
   opts.targets = [opts.targets[0]];
@@ -580,6 +658,9 @@ function streamLogs(jobName) {
 
 async function streamJob(jobName) {
   const { issue, step, agent } = parseSessionId(jobName);
+
+  // Set tmux pane title for layout detection
+  try { execSync(`tmux select-pane -T 'agent-logs-${issue}'`, { stdio: "ignore" }); } catch {}
 
   // Header — adapts to terminal width
   const title = `#${issue} ${agent} (step ${step})`;


### PR DESCRIPTION
## Summary
- `--spawn-pane` flag spawns agent-logs into a tmux pane with smart stacking
- Detects existing log column via pane titles, stacks vertically if found
- First dispatch creates 40% right column, subsequent stack within it
- Dispatch skill updated to use `--spawn-pane` instead of raw `tmux split-window`

## Test plan
- [x] First --spawn-pane creates right column
- [x] Second --spawn-pane stacks vertically in existing column
- [x] Orchestrator pane stays on left undisturbed

🤖 Generated with [Claude Code](https://claude.com/claude-code)