### PR TITLE
feat: migrate Playwright CI from Vercel preview to GKE prod

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,0 +1,135 @@
+# --------------------------------------------------------------------------
+# CI Tests — TypeScript Check + Unit Tests + Playwright E2E against GKE Prod
+#
+# Runs on every push to PR branches and workflow_dispatch:
+#   1. TypeScript type-checking (tsc --noEmit)
+#   2. Vitest unit tests
+#   3. Playwright E2E tests against https://fenrirledger.com
+#   4. Upload test artifacts + upsert PR comment with results
+#
+# Replaces the former Vercel-deployment-based CI workflow (Issue #734).
+#
+# Required GitHub Secrets:
+#   (none — tests run against the public GKE prod endpoint)
+# --------------------------------------------------------------------------
+
+name: CI Tests
+
+concurrency:
+  group: ci-tests-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches-ignore: [main]
+  workflow_dispatch:
+
+jobs:
+  ci:
+    name: TypeScript + Unit + E2E
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    defaults:
+      run:
+        working-directory: development/frontend
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+          cache-dependency-path: development/frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: TypeScript check
+        id: tsc
+        run: npx tsc --noEmit
+
+      - name: Run unit tests
+        id: unit
+        run: npm run test:unit
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run Playwright E2E tests
+        id: e2e
+        env:
+          SERVER_URL: https://fenrirledger.com
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: development/frontend/playwright-report/
+          retention-days: 14
+
+      - name: Upsert PR comment with CI results
+        if: always() && github.event_name == 'push'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
+            const branch = context.ref.replace('refs/heads/', '');
+
+            // Find open PR for this branch
+            const pulls = await github.rest.pulls.list({
+              owner, repo,
+              head: `${owner}:${branch}`,
+              state: 'open',
+            });
+
+            if (pulls.data.length === 0) return;
+
+            const prNumber = pulls.data[0].number;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const status = '${{ job.status }}' === 'success' ? '✅' : '❌';
+            const marker = '<!-- ci-tests-comment -->';
+
+            const body = [
+              marker,
+              `## ${status} CI Results`,
+              '',
+              `| Check | Status |`,
+              `|-------|--------|`,
+              `| TypeScript | ${'${{ steps.tsc.outcome }}' || '—'} |`,
+              `| Unit Tests | ${'${{ steps.unit.outcome }}' || '—'} |`,
+              `| E2E Tests  | ${'${{ steps.e2e.outcome }}' || '—'} |`,
+              '',
+              `**Commit:** \`${sha.slice(0, 7)}\``,
+              `**Run:** [View details](${runUrl})`,
+              `**Target:** https://fenrirledger.com`,
+            ].join('\n');
+
+            // Upsert: find existing comment or create new
+            const comments = await github.rest.issues.listComments({
+              owner, repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.data.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/development/frontend/playwright.config.ts
+++ b/development/frontend/playwright.config.ts
@@ -14,11 +14,7 @@ export default defineConfig({
   use: {
     baseURL: process.env.SERVER_URL || "http://localhost:9653",
     trace: "off",
-    // Pass Vercel's automation bypass secret as a header so tests can reach
-    // preview deployments that are behind deployment protection.
-    extraHTTPHeaders: process.env.VERCEL_BYPASS_SECRET
-      ? { "x-vercel-protection-bypass": process.env.VERCEL_BYPASS_SECRET }
-      : {},
+    extraHTTPHeaders: {},
   },
   projects: [
     {
@@ -30,7 +26,7 @@ export default defineConfig({
   // Start a production server when no SERVER_URL is provided.
   // Uses `npm start` (serves pre-built .next output) — no on-demand compilation.
   // Reuses an existing server if one is already running.
-  // Skipped entirely when SERVER_URL is set (CI hitting a Vercel preview).
+  // Skipped entirely when SERVER_URL is set (CI hitting GKE prod).
   ...(!process.env.SERVER_URL
     ? {
         webServer: {

--- a/development/frontend/src/__tests__/gke/ci-tests-workflow.test.ts
+++ b/development/frontend/src/__tests__/gke/ci-tests-workflow.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Vitest tests for .github/workflows/ci-tests.yml — Issue #734
+ *
+ * Validates the CI tests workflow that replaces the former Vercel preview-based
+ * CI. Runs tsc, unit tests, and Playwright E2E against GKE prod
+ * (https://fenrirledger.com) on every push to PR branches.
+ *
+ * @ref #734
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { parse as parseYAML } from "yaml";
+
+// ---------------------------------------------------------------------------
+// Load workflow YAML
+// ---------------------------------------------------------------------------
+
+let workflowContent: string;
+let workflowYAML: Record<string, unknown>;
+
+beforeAll(() => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const workflowPath = path.join(repoRoot, ".github/workflows/ci-tests.yml");
+
+  if (!fs.existsSync(workflowPath)) {
+    throw new Error(`Workflow file not found at ${workflowPath}`);
+  }
+
+  workflowContent = fs.readFileSync(workflowPath, "utf-8");
+  workflowYAML = parseYAML(workflowContent) as Record<string, unknown>;
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GitHub Actions Workflow: .github/workflows/ci-tests.yml", () => {
+  describe("Basic structure", () => {
+    it("is valid YAML", () => {
+      expect(workflowYAML).toBeDefined();
+      expect(typeof workflowYAML).toBe("object");
+    });
+
+    it("has the correct name", () => {
+      expect(workflowYAML.name).toBe("CI Tests");
+    });
+
+    it("has on/trigger configuration", () => {
+      expect(workflowYAML.on).toBeDefined();
+    });
+
+    it("has jobs defined", () => {
+      expect(workflowYAML.jobs).toBeDefined();
+      expect(typeof workflowYAML.jobs).toBe("object");
+    });
+  });
+
+  describe("Trigger configuration", () => {
+    it("triggers on push to non-main branches", () => {
+      const on = workflowYAML.on as Record<string, unknown>;
+      const push = on.push as Record<string, unknown>;
+      expect(push).toBeDefined();
+      const branchesIgnore = push["branches-ignore"] as string[];
+      expect(branchesIgnore).toContain("main");
+    });
+
+    it("does NOT trigger on deployment_status (Vercel removed)", () => {
+      const on = workflowYAML.on as Record<string, unknown>;
+      expect(on.deployment_status).toBeUndefined();
+    });
+
+    it("supports workflow_dispatch for manual runs", () => {
+      const on = workflowYAML.on as Record<string, unknown>;
+      expect(on.workflow_dispatch).toBeDefined();
+    });
+  });
+
+  describe("Concurrency", () => {
+    it("uses per-branch concurrency group", () => {
+      const concurrency = workflowYAML.concurrency as Record<string, unknown>;
+      expect(concurrency).toBeDefined();
+      expect(concurrency.group).toContain("github.ref");
+    });
+
+    it("cancels in-progress runs", () => {
+      const concurrency = workflowYAML.concurrency as Record<string, unknown>;
+      expect(concurrency["cancel-in-progress"]).toBe(true);
+    });
+  });
+
+  describe("CI job", () => {
+    const getJob = (): Record<string, unknown> => {
+      const jobs = workflowYAML.jobs as Record<string, Record<string, unknown>>;
+      return jobs.ci;
+    };
+
+    it("exists and is named correctly", () => {
+      const job = getJob();
+      expect(job).toBeDefined();
+      expect(job.name).toContain("TypeScript");
+      expect(job.name).toContain("E2E");
+    });
+
+    it("runs on ubuntu-latest", () => {
+      expect(getJob()["runs-on"]).toBe("ubuntu-latest");
+    });
+
+    it("has pull-requests: write permission for PR comments", () => {
+      const permissions = getJob().permissions as Record<string, string>;
+      expect(permissions["pull-requests"]).toBe("write");
+    });
+
+    it("sets working directory to development/frontend", () => {
+      const defaults = getJob().defaults as Record<string, Record<string, string>>;
+      expect(defaults.run["working-directory"]).toBe("development/frontend");
+    });
+
+    it("checks out code", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const checkoutStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("Checkout")
+      );
+      expect(checkoutStep).toBeDefined();
+      expect(checkoutStep!.uses).toContain("actions/checkout");
+    });
+
+    it("sets up Node.js 20", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const nodeStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("Node")
+      );
+      expect(nodeStep).toBeDefined();
+      expect(nodeStep!.uses).toContain("actions/setup-node");
+      const withBlock = nodeStep!.with as Record<string, unknown>;
+      expect(withBlock["node-version"]).toBe("20");
+    });
+
+    it("installs dependencies with npm ci", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const installStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("Install dependencies")
+      );
+      expect(installStep).toBeDefined();
+      expect(installStep!.run).toBe("npm ci");
+    });
+
+    it("runs TypeScript check with step id", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const tscStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("TypeScript")
+      );
+      expect(tscStep).toBeDefined();
+      expect(tscStep!.id).toBe("tsc");
+      expect(tscStep!.run).toContain("tsc --noEmit");
+    });
+
+    it("runs unit tests with step id", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const unitStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("unit tests")
+      );
+      expect(unitStep).toBeDefined();
+      expect(unitStep!.id).toBe("unit");
+      expect(unitStep!.run).toContain("test:unit");
+    });
+
+    it("installs Playwright browsers (chromium only)", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const installStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("Playwright browsers")
+      );
+      expect(installStep).toBeDefined();
+      expect(installStep!.run).toContain("playwright install");
+      expect(installStep!.run).toContain("chromium");
+    });
+
+    it("runs Playwright E2E with SERVER_URL set to GKE prod", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const e2eStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("Playwright E2E")
+      );
+      expect(e2eStep).toBeDefined();
+      expect(e2eStep!.id).toBe("e2e");
+      const env = e2eStep!.env as Record<string, string>;
+      expect(env.SERVER_URL).toBe("https://fenrirledger.com");
+    });
+
+    it("uploads Playwright report as artifact", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const uploadStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("Upload Playwright")
+      );
+      expect(uploadStep).toBeDefined();
+      expect(uploadStep!.if).toContain("always()");
+      expect(uploadStep!.uses).toContain("actions/upload-artifact");
+    });
+
+    it("upserts PR comment with CI results", () => {
+      const steps = getJob().steps as Array<Record<string, unknown>>;
+      const commentStep = steps.find(
+        (s) => typeof s.name === "string" && s.name.includes("PR comment")
+      );
+      expect(commentStep).toBeDefined();
+      expect(commentStep!.uses).toContain("actions/github-script");
+    });
+  });
+
+  describe("No Vercel references", () => {
+    it("does not reference VERCEL_BYPASS_SECRET", () => {
+      expect(workflowContent).not.toContain("VERCEL_BYPASS_SECRET");
+    });
+
+    it("does not reference VERCEL_AUTOMATION_BYPASS_SECRET", () => {
+      expect(workflowContent).not.toContain("VERCEL_AUTOMATION_BYPASS_SECRET");
+    });
+
+    it("does not reference deployment_status trigger", () => {
+      expect(workflowContent).not.toContain("deployment_status");
+    });
+
+    it("does not reference Vercel preview URL", () => {
+      expect(workflowContent.toLowerCase()).not.toContain("vercel preview");
+    });
+  });
+
+  describe("GKE prod target", () => {
+    it("uses https://fenrirledger.com as SERVER_URL", () => {
+      expect(workflowContent).toContain("https://fenrirledger.com");
+    });
+
+    it("references CI Results in PR comment (not Vercel Preview)", () => {
+      expect(workflowContent).toContain("CI Results");
+    });
+  });
+});

--- a/development/frontend/src/__tests__/gke/playwright-config-gke.test.ts
+++ b/development/frontend/src/__tests__/gke/playwright-config-gke.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Vitest tests for Playwright config — Issue #734
+ *
+ * Validates that the Playwright configuration has been updated to remove
+ * Vercel-specific references (bypass secrets, preview URLs) and correctly
+ * targets GKE prod via SERVER_URL.
+ *
+ * @ref #734
+ */
+
+import { describe, it, expect, beforeAll } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+
+let configContent: string;
+
+beforeAll(() => {
+  const repoRoot = path.resolve(__dirname, "../../../../..");
+  const configPath = path.join(
+    repoRoot,
+    "development/frontend/playwright.config.ts"
+  );
+
+  if (!fs.existsSync(configPath)) {
+    throw new Error(`Playwright config not found at ${configPath}`);
+  }
+
+  configContent = fs.readFileSync(configPath, "utf-8");
+});
+
+describe("Playwright config (GKE migration)", () => {
+  it("reads SERVER_URL for baseURL", () => {
+    expect(configContent).toContain("process.env.SERVER_URL");
+  });
+
+  it("does not reference VERCEL_BYPASS_SECRET", () => {
+    expect(configContent).not.toContain("VERCEL_BYPASS_SECRET");
+  });
+
+  it("does not reference x-vercel-protection-bypass header", () => {
+    expect(configContent).not.toContain("x-vercel-protection-bypass");
+  });
+
+  it("does not mention Vercel preview in comments", () => {
+    expect(configContent.toLowerCase()).not.toContain("vercel preview");
+  });
+
+  it("mentions GKE prod in comments", () => {
+    expect(configContent).toContain("GKE prod");
+  });
+
+  it("falls back to localhost:9653 when SERVER_URL is not set", () => {
+    expect(configContent).toContain("http://localhost:9653");
+  });
+});


### PR DESCRIPTION
## Summary
- Create new `.github/workflows/ci-tests.yml` replacing the former Vercel preview-based CI
- Trigger: push to PR branches + `workflow_dispatch` (no longer `deployment_status`)
- Runs: tsc check, Vitest unit tests, Playwright E2E against `https://fenrirledger.com`
- Remove `VERCEL_BYPASS_SECRET` / `x-vercel-protection-bypass` from Playwright config
- PR comment upsert with CI results table (replaces Vercel Preview comment)
- 34 Vitest tests validating workflow structure and Playwright config changes

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run build` passes
- [x] 34 new Vitest tests pass (ci-tests-workflow + playwright-config-gke)
- [ ] Verify CI workflow runs on this PR push
- [ ] Verify Playwright E2E passes against GKE prod

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)