### PR TITLE
fix: downgrade all dispatch agents to Haiku

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -51,9 +51,9 @@ If issue data + agent template are already in context, that's **2 tool calls** (
 
 | Agent | Remote (GKE) | Local (`--local`) |
 |-------|--------------|-------------------|
-| Luna | `claude-sonnet-4-6` | `sonnet` |
-| FiremanDecko | `claude-opus-4-6` | `opus` |
-| Freya | `claude-sonnet-4-6` | `sonnet` |
+| Luna | `claude-haiku-4-5-20251001` | `haiku` |
+| FiremanDecko | `claude-haiku-4-5-20251001` | `haiku` |
+| Freya | `claude-haiku-4-5-20251001` | `haiku` |
 | Loki | `claude-haiku-4-5-20251001` | `haiku` |
 | Heimdall | `claude-haiku-4-5-20251001` | `haiku` |
 


### PR DESCRIPTION
## Summary
All 5 agent roles now dispatch with claude-haiku-4-5-20251001 instead of opus/sonnet.
Prompts are detailed enough that Haiku handles them fine at a fraction of the cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)