### PR TITLE
fix: COOP headers for Google Picker OAuth popup (#771)

### DIFF
--- a/development/frontend/src/__tests__/integration/csp-headers.test.ts
+++ b/development/frontend/src/__tests__/integration/csp-headers.test.ts
@@ -174,4 +174,16 @@ describe("Security Headers", () => {
     expect(pp!.value).toContain("camera=()");
     expect(pp!.value).toContain("microphone=()");
   });
+
+  it("includes Cross-Origin-Opener-Policy: same-origin-allow-popups (#771)", () => {
+    const coop = headers.find((h) => h.key === "Cross-Origin-Opener-Policy");
+    expect(coop).toBeDefined();
+    expect(coop!.value).toBe("same-origin-allow-popups");
+  });
+
+  it("includes Cross-Origin-Embedder-Policy: unsafe-none (#771)", () => {
+    const coep = headers.find((h) => h.key === "Cross-Origin-Embedder-Policy");
+    expect(coep).toBeDefined();
+    expect(coep!.value).toBe("unsafe-none");
+  });
 });

--- a/development/frontend/src/lib/csp-headers.ts
+++ b/development/frontend/src/lib/csp-headers.ts
@@ -121,5 +121,19 @@ export function buildSecurityHeaders(nonce?: string): SecurityHeader[] {
       key: "Strict-Transport-Security",
       value: "max-age=63072000; includeSubDomains; preload",
     },
+    // Allow popups (Google OAuth consent, GIS token client) to communicate
+    // back to the opener window. Without this, COOP blocks window.closed
+    // detection and breaks the OAuth popup flow (Issue #771).
+    {
+      key: "Cross-Origin-Opener-Policy",
+      value: "same-origin-allow-popups",
+    },
+    // Required companion to COOP for Google APIs — unsafe-none allows
+    // cross-origin resources (Google Picker iframe, GIS script) to load
+    // without CORP restrictions.
+    {
+      key: "Cross-Origin-Embedder-Policy",
+      value: "unsafe-none",
+    },
   ];
 }


### PR DESCRIPTION
## Summary

- Adds `Cross-Origin-Opener-Policy: same-origin-allow-popups` to security response headers, allowing the Google Identity Services OAuth popup to communicate back to the opener window via `window.closed` detection.
- Adds `Cross-Origin-Embedder-Policy: unsafe-none` to prevent CORP restrictions from blocking Google Picker iframes and GIS scripts.
- Adds Vitest tests for both new headers.

Fixes #771

## What this does NOT fix

The **"API developer key is invalid"** error is a GCP Console configuration issue — the `GOOGLE_PICKER_API_KEY` likely has HTTP referrer restrictions that don't include `fenrirledger.com`. See the comment on #771 for the manual steps Odin needs to take.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run csp-headers.test.ts` — 28/28 pass
- [x] `npx next build` — succeeds
- [ ] Deploy to GKE and verify Google Picker opens without COOP console errors
- [ ] Verify API key works after Odin updates GCP referrer restrictions

🤖 Generated with [Claude Code](https://claude.com/claude-code)