### PR TITLE
fix: /agent-logs --all spawns non-blocking panes

### DIFF
--- a/.claude/commands/agent-logs.md
+++ b/.claude/commands/agent-logs.md
@@ -7,7 +7,7 @@ Stream agent execution logs from GKE Autopilot K8s Jobs.
 The argument `$ARGUMENTS` can be:
 - An issue number (e.g. `714`) — finds the latest job for that issue
 - A session ID (e.g. `issue-714-step1-firemandecko-3a19c027`) — direct lookup
-- `--all` — all active agent jobs
+- `--all` or `all` — all active agent jobs
 
 ## Instructions
 
@@ -15,24 +15,36 @@ The argument `$ARGUMENTS` can be:
    - Strip `#` prefix if present
    - If it looks like a session ID (`issue-N-stepS-agent-uuid`), use directly
    - If it's a number, resolve to the latest job via `--issue`
-   - If `--all`, pass through
+   - If `--all` or `all`, use the --all flow below
 
-2. Run `agent-logs.mjs` with `--spawn-pane` to open in a tmux right-column pane:
+2. **For a single target** — spawn one pane:
 
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel)
 node "$REPO_ROOT/infrastructure/k8s/agents/agent-logs.mjs" <target> --tools --spawn-pane
 ```
 
-For `--all`:
+3. **For `--all`** — get all active jobs and spawn a pane for EACH one using `--spawn-pane`:
+
 ```bash
-node "$REPO_ROOT/infrastructure/k8s/agents/agent-logs.mjs" --all --tmux --tools
+REPO_ROOT=$(git rev-parse --show-toplevel)
+kubectl get jobs -n fenrir-agents \
+  -o jsonpath='{range .items[?(@.status.active)]}{.metadata.name}{"\n"}{end}' | \
+while read job; do
+  [ -z "$job" ] && continue
+  sid="${job#agent-}"
+  node "$REPO_ROOT/infrastructure/k8s/agents/agent-logs.mjs" "$sid" --tools --spawn-pane
+done
 ```
 
-3. Report back:
+**IMPORTANT:** Do NOT use `--all --tmux` — that blocks the current process. Always loop
+with `--spawn-pane` so each agent gets its own non-blocking tmux pane.
+
+4. Report back:
 ```
-Streaming <target> in tmux pane
+Streaming N active agents in tmux panes
 ```
+Or if no active agents: "No active agent jobs found."
 
 ## Additional flags (pass through from $ARGUMENTS)
 


### PR DESCRIPTION
## Summary
- `/agent-logs --all` now loops active jobs with `--spawn-pane` each
- No longer blocks the orchestrator process
- Documented the pattern so future invocations don't regress

🤖 Generated with [Claude Code](https://claude.com/claude-code)