### PR TITLE
fix: Agent Monitor timestamp parsing + noise filter

### DIFF
--- a/development/agent-monitor/index.html
+++ b/development/agent-monitor/index.html
@@ -892,25 +892,33 @@
 
     function parseLogLine(line) {
       try {
-        // Log format: timestamp message
-        // Try to parse as JSON if it looks like stream-json format
+        // K8s log format: RFC3339Nano_timestamp<space>message
+        // e.g. "2026-03-14T07:56:05.035178236Z {"type":"assistant",...}"
 
-        // Extract timestamp if present (RFC3339 with space separator)
-        const timestampMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)\s+(.*)$/);
+        // Strip K8s timestamp prefix (RFC3339 with optional nanoseconds)
+        const timestampMatch = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z)\s+(.*)$/);
         const logText = timestampMatch ? timestampMatch[2] : line;
 
-        // Try to parse as JSON (stream-json format)
-        try {
-          const json = JSON.parse(logText);
-          parseStreamJsonEvent(json);
-        } catch {
-          // Not JSON, treat as plain text
-          if (logText.trim()) {
-            addLogEvent({
-              type: 'text',
-              text: logText,
-            });
+        // Try to parse as JSON (Claude Code stream-json format)
+        if (logText.startsWith('{')) {
+          try {
+            const json = JSON.parse(logText);
+            parseStreamJsonEvent(json);
+            return;
+          } catch {
+            // Malformed JSON — fall through to plain text
           }
+        }
+
+        // Non-JSON: entrypoint output, plain text
+        if (logText.trim()) {
+          // Show [ok], ===, Session:, Branch:, Model: lines; skip npm noise
+          if (logText.startsWith('[ok]') || logText.startsWith('[FATAL]') ||
+              logText.startsWith('=== ') || logText.startsWith('Session:') ||
+              logText.startsWith('Branch:') || logText.startsWith('Model:')) {
+            addLogEvent({ type: 'system', text: logText });
+          }
+          // Skip npm install noise, prompt dump, etc.
         }
       } catch (error) {
         console.error('Error parsing log line:', error);


### PR DESCRIPTION
## Summary
- Fixed RFC3339Nano timestamp regex for K8s log API
- Filter entrypoint noise (only show [ok], ===, Session, Branch lines)
- JSON lines now parsed correctly into speech bubbles + hecklers

🤖 Generated with [Claude Code](https://claude.com/claude-code)