### PR TITLE
fix: guard MarketingNavbar against null pathname

### DIFF
--- a/development/frontend/src/components/marketing/MarketingNavbar.tsx
+++ b/development/frontend/src/components/marketing/MarketingNavbar.tsx
@@ -34,7 +34,8 @@ const NAV_LINKS = [
 // ── MarketingNavbar ────────────────────────────────────────────────────────────
 
 /** Check whether a nav link matches the current pathname. */
-export function isNavLinkActive(pathname: string, href: string): boolean {
+export function isNavLinkActive(pathname: string | null, href: string): boolean {
+  if (!pathname) return false;
   return pathname === href || pathname.startsWith(href + "/");
 }
 


### PR DESCRIPTION
## Summary
- `usePathname()` returns null in test environments
- `isNavLinkActive` called `.startsWith()` on null → TypeError
- Added null guard — return false when pathname is null
- Unblocks PRs #832 and #833 which both fail on this

## Test plan
- [x] Fix is trivially correct (null guard)
- [ ] CI should pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)