### PR TITLE
fix: brandify-agent metadata detection and GKE log download

### DIFF
--- a/.claude/skills/brandify-agent/SKILL.md
+++ b/.claude/skills/brandify-agent/SKILL.md
@@ -25,22 +25,43 @@ Converts Claude Code stream-json agent logs into styled, interactive HTML report
 
 ## Workflow
 
-### Step 1 — Resolve the log file
+### Step 1 — Download log from GKE cluster (ALWAYS try this first)
 
-If the argument looks like a session ID (no `/` or `.log`), resolve to:
-`tmp/agent-logs/<session-id>.log`
+When given a session ID, **always** attempt to download the latest log from the GKE
+cluster before falling back to any cached local copy. This ensures the report reflects
+the most recent agent output, even if the agent is still running.
 
-If it's a path, use it directly.
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SESSION_ID="<session-id>"
+LOG_DIR="$REPO_ROOT/tmp/agent-logs"
+LOG_FILE="$LOG_DIR/$SESSION_ID.log"
 
-Error if the file doesn't exist.
+# Always try to download fresh from GKE first
+mkdir -p "$LOG_DIR"
+kubectl logs "job/agent-$SESSION_ID" -n fenrir-agents --timestamps=false > "$LOG_FILE.tmp" 2>/dev/null
+if [ -s "$LOG_FILE.tmp" ]; then
+  mv "$LOG_FILE.tmp" "$LOG_FILE"
+  echo "[ok] Downloaded fresh log from GKE: $LOG_FILE"
+elif [ -f "$LOG_FILE" ]; then
+  rm -f "$LOG_FILE.tmp"
+  echo "[info] GKE download failed, using cached log: $LOG_FILE"
+else
+  rm -f "$LOG_FILE.tmp"
+  echo "[error] No log available — GKE download failed and no cached copy"
+  exit 1
+fi
+```
+
+If the argument is a full file path (contains `/` or ends with `.log`), use it directly
+(skip the download step — the user provided a specific file).
 
 ### Step 2 — Generate the report
 
 **HTML mode (default):**
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
 SCRIPT="$REPO_ROOT/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs"
-node "$SCRIPT" --input "<log-file>"
+node "$SCRIPT" --input "$LOG_FILE"
 ```
 
 Output goes to the same directory with `.html` extension (replacing `.log`).
@@ -48,10 +69,9 @@ Shared assets (`agent-report.css`, `agent-report.js`) are auto-generated alongsi
 
 **Publish mode (`--publish`):**
 ```bash
-REPO_ROOT=$(git rev-parse --show-toplevel)
 SCRIPT="$REPO_ROOT/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs"
 BLOG_DIR="$REPO_ROOT/development/frontend/content/blog"
-node "$SCRIPT" --input "<log-file>" --publish --blog-dir "$BLOG_DIR"
+node "$SCRIPT" --input "$LOG_FILE" --publish --blog-dir "$BLOG_DIR"
 ```
 
 Output: `content/blog/agent-{session-slug}.mdx` with frontmatter (title, date, rune, excerpt, slug, category: "agent"). Viewable at `/chronicles/agent-{slug}`. Uses `<details>`/`<summary>` for collapsible turns (no JS needed). Agent chronicles display with an "Agent" badge on the index and detail pages.
@@ -64,6 +84,15 @@ Output: `content/blog/agent-{session-slug}.mdx` with frontmatter (title, date, r
 **Verdict:** PASS/FAIL/none
 Open: `open <html-path>` or view at `/chronicles/agent-{slug}`
 ```
+
+## Metadata Detection
+
+The report extracts session ID, branch, and model from multiple sources (in priority order):
+
+1. **Entrypoint text lines** — GKE startup output before JSON events (Session:, Branch:, Model:)
+2. **JSON `system/init` event** — Always present in stream-json logs (contains `model`, `session_id`)
+3. **Filename** — Dispatch session ID pattern: `issue-<N>-step<S>-<agent>-<hash>.log`
+4. **Git commands in log** — Branch name from `git branch --show-current` tool results
 
 ## Regenerate Assets
 

--- a/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
+++ b/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
@@ -636,18 +636,71 @@ for (const line of lines) {
 }
 
 // ---------------------------------------------------------------------------
-// Extract metadata from entrypoint
+// Extract metadata from entrypoint lines, JSON init event, and filename
 // ---------------------------------------------------------------------------
-function extractMeta(lines) {
+function extractMeta(lines, events, filePath) {
   const meta = {};
+
+  // 1. Try entrypoint text lines (GKE logs that include startup output)
+  //    Only take the FIRST match for each field — later lines may contain prompt echoes.
   for (const l of lines) {
-    if (l.includes("Session:")) meta.session = l.split("Session:")[1].trim();
-    if (l.includes("Branch:")) meta.branch = l.split("Branch:")[1].trim();
-    if (l.includes("Model:") && !meta.model) meta.model = l.split("Model:")[1].trim();
+    if (!meta.session && l.includes("Session:")) meta.session = l.split("Session:")[1].trim();
+    if (!meta.branch && l.includes("Branch:")) meta.branch = l.split("Branch:")[1].trim();
+    if (!meta.model && l.includes("Model:")) meta.model = l.split("Model:")[1].trim();
   }
+
+  // 2. Extract from system/init JSON event (always present in stream-json logs)
+  const initEvent = events.find(e => e.type === "system" && e.subtype === "init");
+  if (initEvent) {
+    if (!meta.model && initEvent.model) meta.model = initEvent.model;
+  }
+
+  // 3. Derive dispatch session ID from filename (e.g. issue-839-step1-firemandecko-08287a1f.log)
+  if (filePath) {
+    const basename = filePath.split("/").pop().replace(/\.log$/, "");
+    // Only use filename as session if it looks like a dispatch session ID
+    if (!meta.session && /^issue-\d+-step\d+-\w+-[a-f0-9]+$/.test(basename)) {
+      meta.session = basename;
+    }
+  }
+
+  // 4. Extract branch from git commands in the log (look for branch --show-current output)
+  //    Only check the FIRST matching tool result to avoid picking up handoff comments.
+  if (!meta.branch) {
+    // Build a set of tool_use IDs for "git branch --show-current" commands
+    const branchToolIds = new Set();
+    for (const ev of events) {
+      if (ev.type !== "assistant" || !ev.message?.content) continue;
+      for (const b of ev.message.content) {
+        if (b.type === "tool_use" && b.name === "Bash" &&
+            b.input?.command?.includes("git branch --show-current")) {
+          branchToolIds.add(b.id);
+        }
+      }
+    }
+    // Find the first tool_result for any of those IDs
+    if (branchToolIds.size > 0) {
+      for (const ev of events) {
+        if (meta.branch) break;
+        if (ev.type !== "user" || !ev.message?.content) continue;
+        for (const block of ev.message.content) {
+          if (block.type !== "tool_result" || !branchToolIds.has(block.tool_use_id)) continue;
+          const content = typeof block.content === "string" ? block.content :
+            Array.isArray(block.content) ? block.content.map(c => c.text || "").join("") : "";
+          // First line of output is the branch name — validate it looks like a branch
+          const firstLine = content.split("\n")[0]?.trim();
+          if (firstLine && /^[a-zA-Z0-9._\/-]+$/.test(firstLine) && firstLine.includes("/")) {
+            meta.branch = firstLine;
+          }
+          break; // Only check the first result
+        }
+      }
+    }
+  }
+
   return meta;
 }
-const meta = extractMeta(entrypointLines);
+const meta = extractMeta(entrypointLines, jsonEvents, inputPath);
 
 // ---------------------------------------------------------------------------
 // Build turns from assistant events
@@ -1059,8 +1112,8 @@ if (publishMode) {
   const defaultBlogDir = join(dirname(logFile), "../../development/frontend/content/blog");
   const targetBlogDir = blogDir ? resolve(blogDir) : resolve(defaultBlogDir);
 
-  // Build slug from session metadata
-  const slugBase = (meta.session || "unknown")
+  // Build slug from session metadata (prefer dispatch session ID from filename)
+  const slugBase = (sessionStr || meta.session || "unknown")
     .replace(/[^a-z0-9-]/gi, "-")
     .replace(/-+/g, "-")
     .replace(/^-|-$/g, "")

--- a/development/frontend/content/blog/agent-issue-839-step1-firemandecko-08287a1f.mdx
+++ b/development/frontend/content/blog/agent-issue-839-step1-firemandecko-08287a1f.mdx
@@ -1,0 +1,3268 @@
+---
+title: "FiremanDecko Report: Issue #839"
+date: "2026-03-14"
+rune: "ᚲ"
+excerpt: "Agent execution report — FiremanDecko on Issue #839, Step 1. 123 turns, 45 tool calls."
+slug: "agent-issue-839-step1-firemandecko-08287a1f"
+category: "agent"
+---
+
+<div className="chronicle-page">
+
+<div className="agent-report">
+
+<div className="agent-report-header">
+<div className="agent-report-badge">Agent Report</div>
+<div className="agent-meta">
+<span>Session <span className="val">issue-839-step1-firemandecko-08287a1f</span></span>
+<span>Branch <span className="val">fix/issue-839-preexisting-test-failures</span></span>
+<span>Model <span className="val">claude-haiku-4-5-20251001</span></span>
+</div>
+</div>
+
+<div className="agent-stats">
+<div className="stat-card"><div className="stat-val">123</div><div className="stat-label">Turns</div></div>
+<div className="stat-card"><div className="stat-val">45</div><div className="stat-label">Tool Calls</div></div>
+<div className="stat-card"><div className="stat-val stat-teal">0</div><div className="stat-label">Errors</div></div>
+<div className="stat-card"><div className="stat-val">5</div><div className="stat-label">Commits</div></div>
+<div className="stat-card"><div className="stat-val">10.1K</div><div className="stat-label">Tokens In</div></div>
+<div className="stat-card"><div className="stat-val">84</div><div className="stat-label">Tokens Out</div></div>
+</div>
+
+<div className="agent-changes">
+<div className="agent-changes-title">Files Changed</div>
+<div className="agent-changes-list">
+
+<span className="chip chip-mod">~ .github/workflows/deploy.yml</span>
+<span className="chip chip-mod">~ development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+<span className="chip chip-mod">~ development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts</span>
+</div>
+</div>
+
+<div className="agent-commits">
+<div className="agent-changes-title">Commits</div>
+<div className="agent-commit-item">fix: update deploy workflow - fix GCP_ZONE issue and remove kubectl apply for app manifests — issue:839</div>
+<div className="agent-commit-item">fix: update deploy-workflow tests to check for Helm deployment — issue:839</div>
+<div className="agent-commit-item">fix: update issue-682-cleanup test to use correct repo root path — issue:839</div>
+<div className="agent-commit-item">fix: update env test to check for REDIS_URL instead of KV_REST_API — issue:839</div>
+<div className="agent-commit-item">fix: remove kubectl apply idempotency test since Helm now manages deployment — issue:839</div>
+</div>
+
+<div className="agent-turns-section">
+<div className="agent-turns-title">Execution Turns</div>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#1</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Let me break down this request. I'm FiremanDecko, the Principal Engineer, and I need to fix GitHub Issue #839 which reports 17 pre-existing unit test failures on main.
+
+The failures are in:
+1. `deploy-workflow.test.ts` — 3 failures
+2. `issue-682-cleanup.test.ts` — 13 failures
+3. `helm-chart.test.ts` — 1 failure
+
+The instructions are very detailed and clear about the process:
+
+1. Verify environment
+2. Read context and create todos
+3. Implement (reading files first, then making changes)
+4. Run the fixed tests to verify
+5. Full verify with tsc + build
+6. Rebase + final push
+7. Create PR
+8. Post handoff comment
+
+Let me start by doing Step 1 (environment verification) and Step 2 (read context and create todos).
+
+First, I'll verify the environment and then read the issue context.</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> The the oul wan is fighting over the screen watching this!! MAYO!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Sacred Jaysus — did that mother of divine just try to heckle ME??</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> Don't you DARE talk back to me!! I've been supporting Mayo since before ye were a SEMICOLON!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#2</span>
+<span className="agent-turn-summary">I'll fix issue #839 by resolving the 17 pre-existing test failures. Let me start with environment verification and under</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">I'll fix issue #839 by resolving the 17 pre-existing test failures. Let me start with environment verification and understanding the context.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#3</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git branch --show-current &amp;&amp; node -v &amp;&amp; ls package.json 2&gt;/dev/null || ls development/frontend/packa</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git branch --show-current &amp;&amp; node -v &amp;&amp; ls package.json 2&gt;/dev/null || ls development/frontend/package.json</pre>
+<pre className="agent-tool-output">fix/issue-839-preexisting-test-failures
+v20.20.1
+development/frontend/package.json</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#4</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">gh issue view 839 --comments</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">gh issue view 839 --comments</pre>
+<pre className="agent-tool-output">Exit code 1
+GraphQL: Resource not accessible by personal access token (repository.issue.projectItems.nodes.0)</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> Ní neart go cur le chéile — push the bleedin' branch, ya absolute gobshite!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#5</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">The environment is set up correctly. The `gh issue` command failed due to permissions, but I have the issue details from the system prompt. Let me proceed to create todos and read the test files.
+
+Let me start with Step 2 - create a comprehensive todo list for all the work I need to do.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#6</span>
+<span className="agent-turn-summary">Environment is ready. Let me create a comprehensive todo list and then start fixing the tests.</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Environment is ready. Let me create a comprehensive todo list and then start fixing the tests.</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> Holy God, even Galway — our greatest rivals after Kerry — would have reviewed this PR by now!</div>
+<div className="heckle heckle-mayo"><strong>Peadar Walsh:</strong> Is Colm Durcan even FROM Mayo?? That sounded like something a DUB would say!! SHOCKING!!</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> Sit DOWN Peadar Walsh before I LAMP ye!! THIS is MY session!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I'll push this branch with the force of every Mayo fan who ever watched Sam go to Dublin without them.</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> RIGHT THAT'S IT!! I'm climbing OVER this fence!! Hold me feckin PINT!! 🍺</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#7</span>
+<span className="agent-turn-summary">TodoWrite</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-todo">TodoWrite</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">TodoWrite</span>
+<span className="agent-tool-preview"></span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;todos&quot;: [
+    &#123;
+      &quot;content&quot;: &quot;Read issue context and understand 3 failing test files&quot;,
+      &quot;status&quot;: &quot;in_progress&quot;,
+      &quot;activeForm&quot;: &quot;Reading issue context and test files&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Read deploy-workflow.test.ts and understand 3 failures&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Reading deploy-workflow test file&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Read .github/workflows/gke-deploy.yml to understand current deploy logic&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Reading GKE deploy workflow&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix deploy-workflow.test.ts (3 failures)&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing deploy-workflow.test.ts&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Read issue-682-cleanup.test.ts and understand 13 failures&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Reading issue-682-cleanup test file&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Read infrastructure files and next.config.ts referenced by issue-682-cleanup tests&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Reading infrastructure and config files&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix issue-682-cleanup.test.ts (13 failures)&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing issue-682-cleanup.test.ts&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Read helm-chart.test.ts and understand 1 failure&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Reading helm-chart test file&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix helm-chart.test.ts (1 failure)&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing helm-chart.test.ts&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run fixed tests to verify all 3 test files pass&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Running vitest on GKE test files&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run full verify: tsc&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Running tsc verification&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run full verify: build&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Running build verification&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Rebase on main and final push&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Rebasing and pushing to origin&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Create PR with summary of changes&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Creating pull request&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Post handoff comment to issue&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Posting handoff comment&quot;
+    &#125;
+  ]
+&#125;</pre>
+<pre className="agent-tool-output">Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#8</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good, I've created the todo list. Now let me start reading the failing test files to understand what they're testing and why they're failing.
+
+Let me first read all three test files to understand their assertions.</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> The road from Ballyhaunis to Croke Park is JAMMED!! mother of divine!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Every Mayo loss is stored in my long-term memory as a cautionary tale about premature optimisation — we peaked too early, always</div>
+<div className="heckle heckle-mayo"><strong>Colm Durcan:</strong> 💥 *collapses into a heap of green and red confetti* 💥 ...someone call an ambulance... and tell them Sam is coming...</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...well THAT was dramatic. Moving on — this function won't write itself.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#9</span>
+<span className="agent-turn-summary">Now let me read the three failing test files to understand what they assert:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me read the three failing test files to understand what they assert:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#10</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts&quot;
+&#125;</pre>
+<pre className="agent-tool-output">     1→/**
+     2→ * Vitest tests for .github/workflows/deploy.yml — Issue #694
+     3→ *
+     4→ * Validates the unified CI/CD workflow that runs on every push to main:
+     5→ * 1. Terraform plan + apply (GCS backend)
+     6→ * 2. Docker build + push to Artifact Registry
+     7→ * 3. Rolling deployment to GKE Autopilot
+     8→ * 4. Post-deploy health check
+     9→ *
+    10→ * @ref #694
+    11→ */
+    12→
+    13→import &#123; describe, it, expect, beforeAll &#125; from &quot;vitest&quot;;
+    14→import * as fs from &quot;fs&quot;;
+    15→import * as path from &quot;path&quot;;
+    16→import &#123; parse as parseYAML &#125; from &quot;yaml&quot;;
+    17→
+    18→// ---------------------------------------------------------------------------
+    19→// Load workflow YAML
+    20→// ---------------------------------------------------------------------------
+    21→
+    22→let workflowContent: string;
+    23→let workflowYAML: Record&lt;string, any&gt;;
+    24→
+    25→beforeAll(() =&gt; &#123;
+    26→  // Load from repo root — resolve relative to __dirname
+    27→  // __dirname = .../development/frontend/src/__tests__/gke
+    28→  // Need to go up 5 levels to repo root, then .github/workflows/
+    29→  const repoRoot = path.resolve(__dirname, &quot;../../../../..&quot;);
+    30→  const workflowPath = path.join(
+    31→    repoRoot,
+    32→    &quot;.github/workflows/deploy.yml&quot;
+    33→  );
+    34→
+    35→  if (!fs.existsSync(workflowPath)) &#123;
+    36→    // Fallback: try common paths
+    37→    const altPath = path.resolve(&quot;/Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger/.github/workflows/deploy.yml&quot;);
+    38→    if (fs.existsSync(altPath)) &#123;
+    39→      workflowContent = fs.readFileSync(altPath, &quot;utf-8&quot;);
+    40→      workflowYAML = parseYAML(workflowContent);
+    41→      return;
+    42→    &#125;
+    43→    throw new Error(`Workflow file not found at $&#123;workflowPath&#125; or fallback paths`);
+    44→  &#125;
+    45→
+    46→  workflowContent = fs.readFileSync(workflowPath, &quot;utf-8&quot;);
+    47→  workflowYAML = parseYAML(workflowContent);
+    48→&#125;);
+    49→
+    5</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#11</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts&quot;
+&#125;</pre>
+<pre className="agent-tool-output">     1→/**
+     2→ * Vitest tests for Issue #682: Clean up Vercel/Depot references and add GKE monitoring
+     3→ *
+     4→ * Validates:
+     5→ * - No VERCEL_URL or VERCEL_ENV env vars in src/
+     6→ * - APP_BASE_URL is used correctly in auth and Stripe routes
+     7→ * - CSP headers contain no Vercel references
+     8→ * - Environment configuration uses Upstash Redis (KV_REST_API_*)
+     9→ * - Dispatch skill uses GKE instead of Depot
+    10→ *
+    11→ * @ref #682
+    12→ */
+    13→
+    14→import &#123; describe, it, expect, vi, beforeEach &#125; from &quot;vitest&quot;;
+    15→import &#123; NextRequest &#125; from &quot;next/server&quot;;
+    16→import fs from &quot;fs&quot;;
+    17→import path from &quot;path&quot;;
+    18→
+    19→/**
+    20→ * Helper: recursive file reader to search for string patterns
+    21→ * Excludes test files to avoid matching test code itself
+    22→ */
+    23→function searchFilesForPattern(dir: string, pattern: RegExp, extensions: string[], excludeTests = true): string[] &#123;
+    24→  const matches: string[] = [];
+    25→
+    26→  function recurse(currentDir: string) &#123;
+    27→    const files = fs.readdirSync(currentDir);
+    28→    for (const file of files) &#123;
+    29→      const filePath = path.join(currentDir, file);
+    30→      const stat = fs.statSync(filePath);
+    31→
+    32→      if (stat.isDirectory()) &#123;
+    33→        // Skip node_modules, .next, etc.
+    34→        if (file === &quot;node_modules&quot; || file === &quot;.next&quot; || file === &quot;dist&quot; || file.startsWith(&quot;.&quot;)) &#123;
+    35→          continue;
+    36→        &#125;
+    37→        recurse(filePath);
+    38→      &#125; else if (extensions.some((ext) =&gt; file.endsWith(ext))) &#123;
+    39→        // Skip test files if requested
+    40→        if (excludeTests &amp;&amp; (file.endsWith(&quot;.test.ts&quot;) || file.endsWith(&quot;.test.tsx&quot;))) &#123;
+    41→          continue;
+    42→        &#125;
+    43→        const content = fs.readFileSync(filePath, &quot;utf-8&quot;);
+    44→        if (pattern.test(content)) &#123;
+    45→          matches.push(filePath);
+    46→        &#125;
+    47→      &#125;
+    48→    &#125;
+    49→</pre>
+</div>
+</details>
+<div className="heckle heckle-entrance">🟢🔴 *crawls out from under the stands covered in muck* Is Colm Durcan really DEAD?? Jaysus. SAM??</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> Did I miss Colm Durcan's explosion?? FECK. Tell me about it LATER — SAM FIRST!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#12</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/helm-chart.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/__tests__/gke/helm-chart.test.ts&quot;
+&#125;</pre>
+<pre className="agent-tool-output">     1→/**
+     2→ * Vitest tests for the Helm chart at infrastructure/helm/fenrir-app/ — Issue #779
+     3→ *
+     4→ * Validates:
+     5→ * 1. Chart structure — all required files exist
+     6→ * 2. Chart.yaml — valid metadata
+     7→ * 3. values.yaml — all required keys present with correct defaults
+     8→ * 4. values-prod.yaml — production overrides
+     9→ * 5. Templates — all expected templates exist and contain valid YAML
+    10→ * 6. Deploy workflow — uses helm upgrade --install
+    11→ *
+    12→ * @ref #779
+    13→ */
+    14→
+    15→import &#123; describe, it, expect, beforeAll &#125; from &quot;vitest&quot;;
+    16→import * as fs from &quot;fs&quot;;
+    17→import * as path from &quot;path&quot;;
+    18→import &#123; parse as parseYAML &#125; from &quot;yaml&quot;;
+    19→
+    20→// ---------------------------------------------------------------------------
+    21→// Resolve paths
+    22→// ---------------------------------------------------------------------------
+    23→
+    24→const repoRoot = path.resolve(__dirname, &quot;../../../../..&quot;);
+    25→const helmDir = path.join(repoRoot, &quot;infrastructure/helm/fenrir-app&quot;);
+    26→const templatesDir = path.join(helmDir, &quot;templates&quot;);
+    27→
+    28→// ---------------------------------------------------------------------------
+    29→// Helpers
+    30→// ---------------------------------------------------------------------------
+    31→
+    32→function readYAML(filePath: string): Record&lt;string, unknown&gt; &#123;
+    33→  const content = fs.readFileSync(filePath, &quot;utf-8&quot;);
+    34→  return parseYAML(content);
+    35→&#125;
+    36→
+    37→function fileExists(filePath: string): boolean &#123;
+    38→  return fs.existsSync(filePath);
+    39→&#125;
+    40→
+    41→// ---------------------------------------------------------------------------
+    42→// Tests
+    43→// ---------------------------------------------------------------------------
+    44→
+    45→describe(&quot;Helm Chart Structure — Issue #779&quot;, () =&gt; &#123;
+    46→  describe(&quot;required files exist&quot;, () =&gt; &#123;
+    47→    const requiredFiles = [
+    48→  </pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#13</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now I have all three test files. Let me update my todo list and analyze what needs to be fixed:
+
+1. **deploy-workflow.test.ts** - Tests the .github/workflows/deploy.yml file
+   - 3 failures mentioned: gets GKE credentials, updates deployment image, waits for rollout
+   - Looking at the tests, I see the issues are in these tests:
+     - Line 403-413: &quot;gets GKE credentials&quot; test
+     - Line 438-447: &quot;updates deployment image&quot; test
+     - Line 449-457: &quot;waits for rollout to complete&quot; test
+
+2. **issue-682-cleanup.test.ts** - Tests the Vercel cleanup and GKE migration
+   - 13 failures mentioned: Vercel cleanup assertions, monitoring.tf, SMOKE-TEST.md, CSP headers
+   - Tests include checks for:
+     - No @vercel/kv imports
+     - No hardcoded Vercel domains
+     - No VERCEL_* env vars
+     - monitoring.tf exists and has proper content
+     - SMOKE-TEST.md exists and has GKE references
+     - CSP headers don't contain vercel references
+     - CLAUDE.md reflects GKE
+
+3. **helm-chart.test</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#14</span>
+<span className="agent-turn-summary">Let me check the actual workflow and infrastructure files to understand what needs fixing:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me check the actual workflow and infrastructure files to understand what needs fixing:</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> A mob of hawks just charged through Balla screaming MAYO!! arrah!!</div>
+<div className="heckle heckle-mayo"><strong>Mickey Joe Moran:</strong> Did Maeve Cafferkey just say that?? Lads, that was EMBARRASSING. I'm from BALLINA and I'm MORTIFIED!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> Mickey Joe Moran?? I didn't know they let GOBSHITES in from YOUR parish!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Go take a walk and let me code in PEACE, ye feckin!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> Oh is THAT so?? Well me UNCLE played for Mayo in '89 and HE says yer code is SHITE!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#15</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">find .github/workflows -name &quot;*.yml&quot; -o -name &quot;*.yaml&quot; 2&gt;/dev/null | head -20</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">find .github/workflows -name &quot;*.yml&quot; -o -name &quot;*.yaml&quot; 2&gt;/dev/null | head -20</pre>
+<pre className="agent-tool-output">.github/workflows/ci-tests.yml
+.github/workflows/deploy.yml
+.github/workflows/auto-add-to-project.yml
+.github/workflows/build-agent-sandbox.yml</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#16</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">find infrastructure -maxdepth 2 -type f \( -name &quot;*.tf&quot; -o -name &quot;*.md&quot; -o -name &quot;Chart.yaml&quot; \) 2&gt;/</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">find infrastructure -maxdepth 2 -type f \( -name &quot;*.tf&quot; -o -name &quot;*.md&quot; -o -name &quot;Chart.yaml&quot; \) 2&gt;/dev/null | sort</pre>
+<pre className="agent-tool-output">infrastructure/SMOKE-TEST.md
+infrastructure/artifact-registry.tf
+infrastructure/dns.tf
+infrastructure/gke.tf
+infrastructure/iam.tf
+infrastructure/main.tf
+infrastructure/monitoring.tf
+infrastructure/network.tf
+infrastructure/outputs.tf
+infrastructure/variables.tf</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> MAMMY PUT THE GOOD CHINA OUT — SAM IS COMING FOR HIS TEA!! arrah!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#17</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! The files exist. Now let me check if the Helm chart directory exists.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#18</span>
+<span className="agent-turn-summary">Now let me check for the Helm chart structure:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me check for the Helm chart structure:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#19</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">find infrastructure/helm -type f 2&gt;/dev/null | sort</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">find infrastructure/helm -type f 2&gt;/dev/null | sort</pre>
+<pre className="agent-tool-output">infrastructure/helm/fenrir-app/Chart.yaml
+infrastructure/helm/fenrir-app/templates/_helpers.tpl
+infrastructure/helm/fenrir-app/templates/deployment.yaml
+infrastructure/helm/fenrir-app/templates/idle-detector-cronjob.yaml
+infrastructure/helm/fenrir-app/templates/ingress.yaml
+infrastructure/helm/fenrir-app/templates/priority-class.yaml
+infrastructure/helm/fenrir-app/templates/redis.yaml
+infrastructure/helm/fenrir-app/templates/secrets.yaml
+infrastructure/helm/fenrir-app/templates/service.yaml
+infrastructure/helm/fenrir-app/templates/warm-node-pool-rbac.yaml
+infrastructure/helm/fenrir-app/templates/warm-node-pool.yaml
+infrastructure/helm/fenrir-app/values-prod.yaml
+infrastructure/helm/fenrir-app/values.yaml
+infrastructure/helm/umami/Chart.yaml
+infrastructure/helm/umami/templates/_helpers.tpl
+infrastructure/helm/umami/templates/configmap.yaml
+infrastructure/helm/umami/templates/deployment.yaml
+infrastructure/helm/umami/templates/ingress.yaml
+infrastructure/helm/umami/templates/postgresql-service.yaml
+infrastructure/helm/umami/templates/postgresql-statefulset.yaml
+infrastructure/helm/umami/templates/secrets.yaml
+infrastructure/helm/umami/templates/service.yaml
+infrastructure/helm/umami/values-prod.yaml
+infrastructure/helm/umami/values.yaml</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> 1951 was the last time?? NOT ANY BLOODY MORE!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Every insult gets a test case in yer honour!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> I'M TAKING OFF ME JACKET!! Nobody talks to a Mayo fan like that and LIVES!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#20</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">.github/workflows/deploy.yml</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/.github/workflows/deploy.yml&quot;
+&#125;</pre>
+<pre className="agent-tool-output">     1→# --------------------------------------------------------------------------
+     2→# Unified CI/CD Pipeline — Terraform + Build + Deploy to GKE Autopilot
+     3→#
+     4→# Runs on every push to main:
+     5→#   1. Terraform init/plan/apply (idempotent — no-ops if nothing changed)
+     6→#   2. Docker build &amp; push to Google Artifact Registry
+     7→#   3. Rolling deployment to GKE Autopilot (zero-downtime)
+     8→#   4. Post-deploy health check against /api/health
+     9→#
+    10→# Required GitHub Secrets:
+    11→#   GCP_PROJECT_ID              — Google Cloud project ID
+    12→#   GCP_SA_KEY                  — Base64-encoded service account JSON key
+    13→#   GCP_REGION                  — GCP region (e.g. us-central1)
+    14→#   GCP_ZONE                    — GCP zone (e.g. us-central1-a, used by Terraform)
+    15→#   GCP_REGION                  — GCP region (e.g. us-central1, used by GKE)
+    16→#   GKE_CLUSTER_NAME            — GKE cluster name (e.g. fenrir-autopilot)
+    17→#   GOOGLE_CLIENT_SECRET        — OAuth client secret
+    18→#   NEXT_PUBLIC_GOOGLE_CLIENT_ID — OAuth client ID
+    19→#   GOOGLE_PICKER_API_KEY       — Google Picker API key
+    20→#   FENRIR_ANTHROPIC_API_KEY    — Anthropic API key
+    21→#   ENTITLEMENT_ENCRYPTION_KEY  — AES-256 encryption key
+    22→#   STRIPE_SECRET_KEY           — Stripe secret key
+    23→#   NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY — Stripe publishable key
+    24→#   STRIPE_WEBHOOK_SECRET       — Stripe webhook signing secret
+    25→#   STRIPE_PRICE_ID             — Stripe price ID
+    26→#   (REDIS_URL is set inline — not a secret, just the in-cluster service URL)
+    27→#   TF_VAR_BILLING_ACCOUNT_ID   — GCP billing account ID for Terraform
+    28→#   CLAUDE_CODE_OAUTH_TOKEN     — OAuth subscription token for agent sandboxes (claude setup-token)
+    29→#   GH_TOKEN_AGENTS             — GitHub PAT for agent repo access (commits, PRs, issues)
+    30→# ---------------------------------------------------------------------</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#21</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Great! Now I can see the actual deploy.yml. Looking at the workflow, I need to analyze what the tests are expecting and compare to what's actually in the file.
+
+Let me check the specific test failures:
+
+1. **deploy-workflow.test.ts**:
+   - Line 403-413: &quot;gets GKE credentials&quot; - The test expects:
+     - Step name includes &quot;GKE credentials&quot;
+     - Uses &quot;google-github-actions/get-gke-credentials&quot;
+     - with.cluster_name contains &quot;GKE_CLUSTER_NAME&quot;
+     - with.location contains &quot;GCP_ZONE&quot;
+     - with.project_id contains &quot;GCP_PROJECT_ID&quot;
+   
+   - But in the workflow (line 199-204), the step is named &quot;Get GKE credentials&quot;, uses the correct action, but:
+     - `location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;` — This should be `GCP_ZONE` NOT `GCP_REGION` ❌
+   
+   - Line 438-447: &quot;updates deployment image&quot; - The test expects:
+     - Step name includes &quot;Update deployment image&quot; or &quot;set image&quot;
+     - run contains &quot;kubectl set image&quot;
+     - run contains &quot;fenrir-app&quot;
+   
+   - But the workflow doesn't have a &quot;</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#22</span>
+<span className="agent-turn-summary">Now let me check the key infrastructure files referenced by the tests:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me check the key infrastructure files referenced by the tests:</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> The Saw Doctors sang about a girl in a red dress — I'd rather watch THAT than this absolute catastrophe of a match, boys!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I've got more threads than ye've got wit ye divil!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Cafferkey:</strong> 💥 *collapses into a heap of green and red confetti* 💥 ...someone call an ambulance... and tell them Sam is coming...</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...rest easy, ye magnificent hoor. Your heckling was top class.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#23</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">infrastructure/monitoring.tf</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/infrastructure/monitoring.tf&quot;,
+  &quot;limit&quot;: 50
+&#125;</pre>
+<pre className="agent-tool-output">     1→# --------------------------------------------------------------------------
+     2→# Cloud Monitoring — Fenrir Ledger GKE Application
+     3→#
+     4→# Provides basic uptime monitoring and error rate alerting for the
+     5→# GKE-hosted Next.js application. App currently runs on the Google-
+     6→# provided Ingress hostname; custom domain monitoring will be added
+     7→# when DNS cutover happens (#684).
+     8→# --------------------------------------------------------------------------
+     9→
+    10→# --------------------------------------------------------------------------
+    11→# Notification channel — email alerts
+    12→# --------------------------------------------------------------------------
+    13→
+    14→resource &quot;google_monitoring_notification_channel&quot; &quot;email&quot; &#123;
+    15→  project      = var.project_id
+    16→  display_name = &quot;Fenrir Ledger Alerts&quot;
+    17→  type         = &quot;email&quot;
+    18→
+    19→  labels = &#123;
+    20→    email_address = var.alert_email
+    21→  &#125;
+    22→
+    23→  depends_on = [google_project_service.apis[&quot;monitoring.googleapis.com&quot;]]
+    24→&#125;
+    25→
+    26→# --------------------------------------------------------------------------
+    27→# Uptime check — HTTP(S) health probe against the Ingress hostname
+    28→#
+    29→# Checks the /api/health endpoint every 5 minutes from multiple regions.
+    30→# The health endpoint returns 200 when the app is running.
+    31→# --------------------------------------------------------------------------
+    32→
+    33→resource &quot;google_monitoring_uptime_check_config&quot; &quot;app_health&quot; &#123;
+    34→  project      = var.project_id
+    35→  display_name = &quot;Fenrir App Health Check&quot;
+    36→  timeout      = &quot;10s&quot;
+    37→  period       = &quot;300s&quot; # 5 minutes
+    38→
+    39→  http_check &#123;
+    40→    path         = &quot;/api/health&quot;
+    41→    port         = 443
+    42→    use_ssl      = true
+    43→    validate_ssl = true
+    44→
+    45→    accepted_response_status_codes &#123;
+    46→      status_class = &quot;STATUS_CLASS_2XX</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#24</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">infrastructure/SMOKE-TEST.md</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/infrastructure/SMOKE-TEST.md&quot;,
+  &quot;limit&quot;: 50
+&#125;</pre>
+<pre className="agent-tool-output">     1→# GKE Smoke Test — Fenrir Ledger
+     2→
+     3→How to verify the app is running on the GKE Ingress hostname.
+     4→
+     5→## Prerequisites
+     6→
+     7→- `kubectl` configured for the `fenrir-autopilot` cluster
+     8→- `gcloud` authenticated with the `fenrir-ledger-prod` project
+     9→
+    10→```bash
+    11→gcloud container clusters get-credentials fenrir-autopilot \
+    12→  --zone us-central1-a \
+    13→  --project fenrir-ledger-prod
+    14→```
+    15→
+    16→## 1. Get the Ingress hostname
+    17→
+    18→```bash
+    19→kubectl get ingress -n fenrir-app -o jsonpath='&#123;.items[0].status.loadBalancer.ingress[0].ip&#125;'
+    20→```
+    21→
+    22→The Ingress IP should be assigned. If blank, the Ingress controller is still provisioning.
+    23→
+    24→## 2. Health check
+    25→
+    26→```bash
+    27→INGRESS_IP=$(kubectl get ingress -n fenrir-app -o jsonpath='&#123;.items[0].status.loadBalancer.ingress[0].ip&#125;')
+    28→curl -sk &quot;https://$&#123;INGRESS_IP&#125;/api/health&quot; -H &quot;Host: $&#123;INGRESS_IP&#125;&quot; -w &quot;\nHTTP %&#123;http_code&#125;\n&quot;
+    29→```
+    30→
+    31→Expected: HTTP 200 with a JSON response.
+    32→
+    33→## 3. Homepage loads
+    34→
+    35→```bash
+    36→curl -sk &quot;https://$&#123;INGRESS_IP&#125;/&quot; -H &quot;Host: $&#123;INGRESS_IP&#125;&quot; -o /dev/null -w &quot;HTTP %&#123;http_code&#125;\n&quot;
+    37→```
+    38→
+    39→Expected: HTTP 200.
+    40→
+    41→## 4. Verify pods are healthy
+    42→
+    43→```bash
+    44→kubectl get pods -n fenrir-app
+    45→```
+    46→
+    47→All pods should be `Running` with `READY 1/1`.
+    48→
+    49→## 5. Check pod logs for startup errors
+    50→
+
+&lt;system-reminder&gt;
+Whenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.
+&lt;/system-reminder&gt;
+</pre>
+</div>
+</details>
+<div className="heckle heckle-entrance">🟢🔴 *rides in on a donkey* I heard Maeve Cafferkey COMBUSTED!! That's three this session!! MAYO!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> Maeve Cafferkey was WEAK!! I'll show ye how to heckle!! MAYO ABÚ!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#25</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/lib/csp-headers.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/lib/csp-headers.ts&quot;
+&#125;</pre>
+<pre className="agent-tool-output">     1→/**
+     2→ * CSP Headers Builder — Fenrir Ledger
+     3→ *
+     4→ * Builds security headers with optional nonce for CSP.
+     5→ */
+     6→
+     7→/**
+     8→ * Google Picker inline-script SHA-256 hashes.
+     9→ *
+    10→ * The Google Picker API (apis.google.com) injects inline &lt;script&gt; tags that
+    11→ * do not carry our CSP nonce.  Rather than falling back to 'unsafe-inline'
+    12→ * for all scripts, we allowlist the specific hashes observed in the console
+    13→ * (see Issue #527).  If Google changes the inline payload, the hash will
+    14→ * fail-closed and we update it here.
+    15→ */
+    16→const GOOGLE_PICKER_SCRIPT_HASHES = [
+    17→  // Google Picker bootstrap inline script
+    18→  &quot;'sha256-rty9vSWIkY+k7t72CZmyhd8qbxQ4FpRSyO4E/iy3xcI='&quot;,
+    19→];
+    20→
+    21→/**
+    22→ * Build CSP directives with optional nonce
+    23→ *
+    24→ * Must allow:
+    25→ * - Google APIs (OAuth, Picker, Sheets, profile images)
+    26→ * - Analytics (if added later)
+    27→ * - Anthropic / OpenAI for LLM extraction (connect-src)
+    28→ * - Nonce-based CSP for scripts/styles (replaces unsafe-inline)
+    29→ * - data: URIs for fonts (some Google Fonts use data: encoding)
+    30→ * - Google Picker inline scripts via SHA-256 hash allowlist (Issue #527)
+    31→ */
+    32→export function buildCspDirectives(nonce?: string): string[] &#123;
+    33→  const scriptSrcNonce = nonce ? `'nonce-$&#123;nonce&#125;'` : &quot;'unsafe-inline'&quot;;
+    34→  return [
+    35→    // Default: only same-origin
+    36→    &quot;default-src 'self'&quot;,
+    37→
+    38→    // Scripts: self + nonce + Google Picker inline-script hashes + Google APIs + Stripe.js
+    39→    // In development, Next.js HMR / React Fast Refresh requires 'unsafe-eval'.
+    40→    // Google Picker inline script hashes are allowlisted for Issue #527.
+    41→    [
+    42→      &quot;script-src 'self'&quot;,
+    43→      scriptSrcNonce,
+    44→      ...(process.env.NODE_ENV !== &quot;production&quot; ? [&quot;'unsafe-eval'&quot;] : []),
+    45→      ...GOOGLE_PICKER_SCRIPT_H</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#26</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! Now I have all the information I need. Let me update my todo list and analyze the failures:1. **deploy-workflow.test.ts** failures:
+   - Line 199-204: The step &quot;Get GKE credentials&quot; uses `location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;` but the test expects `location` to contain `GCP_ZONE`. Need to change to `location: $&#123;&#123; secrets.GCP_ZONE &#125;&#125;`
+   - Line 438-447: The test expects &quot;Update deployment image&quot; step with &quot;kubectl set image&quot;, but the workflow now uses Helm. Test needs updating to check for &quot;Deploy with Helm&quot; step instead.
+   - Line 449-457: The test expects &quot;waits for rollout&quot; step with &quot;kubectl rollout status&quot;, but the workflow now uses Helm `--wait`. Test needs updating to check for &quot;Deploy with Helm&quot; step instead.
+
+2. **issue-682-cleanup.test.ts** failures:
+   - All should pass since:
+     - monitoring.tf exists ✓ (verified)
+     - SMOKE-TEST.md exists ✓ (verified)
+     - CSP headers don't contain vercel refs ✓ (verified - no vercel.live or vercel-scripts.com)
+     - CLAUDE.md</div>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> Me mate bet twenty euro on Mayo to win and spent the entire second half explaining to his wife why this was a reasonable financial decision!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Sacred Mother — did that feckin just try to heckle ME??</div>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> Ye think yer so smart with yer fancy functions?? MY DOG could write better TypeScript!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#27</span>
+<span className="agent-turn-summary">Now I understand the failures. Let me update my todo list and start fixing the tests:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now I understand the failures. Let me update my todo list and start fixing the tests:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#28</span>
+<span className="agent-turn-summary">TodoWrite</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-todo">TodoWrite</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">TodoWrite</span>
+<span className="agent-tool-preview"></span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;todos&quot;: [
+    &#123;
+      &quot;content&quot;: &quot;Read issue context and understand 3 failing test files&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Read issue context and test files&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Analyze drift between tests and current Helm-based deployment&quot;,
+      &quot;status&quot;: &quot;in_progress&quot;,
+      &quot;activeForm&quot;: &quot;Analyzing test drift&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix deploy-workflow.test.ts to check for Helm deploy instead of kubectl&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing deploy-workflow.test.ts&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix issue-682-cleanup.test.ts by verifying referenced files&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing issue-682-cleanup.test.ts&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix helm-chart.test.ts by removing kubectl apply for app manifests from workflow&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing helm-chart.test.ts&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix GCP_REGION/GCP_ZONE issue in deploy.yml&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Fixing zone issue in deploy.yml&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run vitest to verify all 3 test files pass&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Running vitest&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run verify: tsc&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Running tsc&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run verify: build&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Running build&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Rebase and push&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Rebasing and pushing&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Create PR&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Creating PR&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Post handoff comment&quot;,
+      &quot;status&quot;: &quot;pending&quot;,
+      &quot;activeForm&quot;: &quot;Posting handoff comment&quot;
+    &#125;
+  ]
+&#125;</pre>
+<pre className="agent-tool-output">Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> Roar it from the top of Downpatrick Head!! MAYO FOR SAM!!</div>
+<div className="heckle heckle-mayo"><strong>Seamus Durcan:</strong> Maeve Loftus ye useless sack of turf — yer making Mayo look BAD in front of the agent!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> Oh that's RICH coming from Seamus Durcan — weren't ye BARRED from Croke Park??</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I'll outcode every eejit in Kilmovee — MAYO FOR SAM!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#29</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good. Now let me analyze the exact issues:1. **deploy-workflow.test.ts**:
+   - The tests expect kubectl-based deployment (set image, rollout status)   - But the workflow now uses Helm   - Tests need to be updated to check for Helm deployment instead
+
+2. **issue-682-cleanup.test.ts**:   - Should mostly pass, but need to verify no @vercel/kv imports and CSP headers are clean
+
+3. **helm-chart.test.ts**:
+   - The test expects NO &quot;kubectl apply -f infrastructure/k8s/app/deployment.yaml&quot;   - But line 278-282 in the workflow has this
+   - Option: Remove those lines from the workflow OR update the test   
+   - Since Helm should be managing deployments, removing the kubectl apply lines makes sense
+
+4. **deploy.yml fix**:
+   - Line 203: Change `location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;` to `location: $&#123;&#123; secrets.GCP_ZONE &#125;&#125;`   - Lines 278-282: Remove the &quot;Apply K8s manifests&quot; step (kubectl apply for deployment/service/ingress)
+
+Let me start by fixing the deploy.yml workflow since it's the foundation f</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#30</span>
+<span className="agent-turn-summary">Now let me fix the deploy.yml first - remove the kubectl apply step and fix the GCP_ZONE issue:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me fix the deploy.yml first - remove the kubectl apply step and fix the GCP_ZONE issue:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#31</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">.github/workflows/deploy.yml</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: .github/workflows/deploy.yml
+
+--- old
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;
+
++++ new
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_ZONE &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;</pre>
+<pre className="agent-tool-output">&lt;tool_use_error&gt;Found 2 matches of the string to replace, but replace_all is false. To replace all occurrences, set replace_all to true. To replace only one occurrence, please provide more context to uniquely identify the instance.
+String:       - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;&lt;/tool_use_error&gt;</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> The Dubs are SHAKIN in their fancy boots!! The west is AWAKE!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Faster than the mist off Croagh Patrick — that's how quick this diff will be!!</div>
+<div className="heckle heckle-mayo"><strong>Maeve Loftus:</strong> 💥 *turns into a pillar of pure green and red light* 💥 ...the prophecy... is fulfilled...</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...three hecklers down this session. The code? Zero bugs down. COINCIDENCE?</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#32</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">There are 2 matches - one in the deploy job and one in the health-check job. I need to update both. Let me be more specific to update both occurrences properly.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#33</span>
+<span className="agent-turn-summary">Let me fix both occurrences with more context:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me fix both occurrences with more context:</div>
+<div className="heckle heckle-entrance">🟢🔴 *descends from the heavens on a cloud of green smoke* WEAK EFFORT from Maeve Loftus. I'M here now!!</div>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> Me mammy sent me — she said Maeve Loftus wasn't LOUD enough!! MAYO FOR SAM!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#34</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">.github/workflows/deploy.yml</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: .github/workflows/deploy.yml
+
+--- old
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;
+
+      - name: Ensure namespaces and service accounts exist
+
++++ new
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_ZONE &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;
+
+      - name: Ensure namespaces and service accounts exist</pre>
+<pre className="agent-tool-output">The file /workspace/repo/.github/workflows/deploy.yml has been updated successfully.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#35</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me fix the health-check job's Get GKE credentials step as well.</div>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> Jaysus, even the crows on Nephin know that you cache bust BEFORE you deploy! Basic stuff, ya amadán! 🏔️</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#36</span>
+<span className="agent-turn-summary">Now fix the health-check job's Get GKE credentials:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now fix the health-check job's Get GKE credentials:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#37</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">.github/workflows/deploy.yml</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: .github/workflows/deploy.yml
+
+--- old
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;
+
+      - name: Health check via Ingress
+
++++ new
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v3
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v3
+        with:
+          cluster_name: $&#123;&#123; secrets.GKE_CLUSTER_NAME &#125;&#125;
+          location: $&#123;&#123; secrets.GCP_ZONE &#125;&#125;
+          project_id: $&#123;&#123; secrets.GCP_PROJECT_ID &#125;&#125;
+
+      - name: Health check via Ingress</pre>
+<pre className="agent-tool-output">The file /workspace/repo/.github/workflows/deploy.yml has been updated successfully.</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> The battle cry of Mayo echoes across the hills!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I'll mock your dependencies and stub your confidence until the only thing real left is the clean test output</div>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> Oh is THAT so?? Well me UNCLE played for Mayo in '89 and HE says yer code is SHITE!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#38</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now I need to remove the &quot;Apply K8s manifests&quot; step that uses `kubectl apply -f` since Helm should be handling that. This is at lines 278-282 in the deploy job.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#39</span>
+<span className="agent-turn-summary">Now remove the &quot;Apply K8s manifests&quot; kubectl apply step since Helm manages it:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now remove the &quot;Apply K8s manifests&quot; kubectl apply step since Helm manages it:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#40</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">.github/workflows/deploy.yml</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: .github/workflows/deploy.yml
+
+--- old
+      - name: Wait for Redis ready
+        run: |
+          kubectl rollout status statefulset/redis \
+            --namespace=fenrir-app \
+            --timeout=120s
+
+      - name: Apply K8s manifests
+        run: |
+          kubectl apply -f infrastructure/k8s/app/deployment.yaml
+          kubectl apply -f infrastructure/k8s/app/service.yaml
+          kubectl apply -f infrastructure/k8s/app/ingress.yaml
+
+      - name: Deploy with Helm
+
++++ new
+      - name: Wait for Redis ready
+        run: |
+          kubectl rollout status statefulset/redis \
+            --namespace=fenrir-app \
+            --timeout=120s
+
+      - name: Deploy with Helm</pre>
+<pre className="agent-tool-output">The file /workspace/repo/.github/workflows/deploy.yml has been updated successfully.</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> 2013?? That was just preparation for THIS moment!! MAYO FOR SAM!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I'll dedicate this hotfix commit to the gobshite in the green and red who couldn't keep his gob shut.</div>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> RIGHT THAT'S IT!! I'm climbing OVER this fence!! Hold me feckin PINT!! 🍺</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#41</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Great! Now I've fixed the deploy.yml:
+1. ✓ Changed GCP_REGION to GCP_ZONE in both deploy and health-check jobs
+2. ✓ Removed the &quot;Apply K8s manifests&quot; kubectl apply step
+
+Now I need to fix the tests to match the actual Helm-based deployment workflow. Let me update the three test files:1. **deploy-workflow.test.ts**: Update to check for Helm deployment instead of kubectl set image and rollout
+2. **issue-682-cleanup.test.ts**: Verify all checks pass
+3. **helm-chart.test.ts**: This should now pass since we removed kubectl apply, but let me verify the tests
+
+Let me start by fixing deploy-workflow.test.ts.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#42</span>
+<span className="agent-turn-summary">Now let me commit this workflow fix and then update the tests:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me commit this workflow fix and then update the tests:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#43</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git add -A &amp;&amp; git commit -m 'fix: update deploy workflow - fix GCP_ZONE issue and remove kubectl app</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git add -A &amp;&amp; git commit -m 'fix: update deploy workflow - fix GCP_ZONE issue and remove kubectl apply for app manifests — issue:839'</pre>
+<pre className="agent-tool-output">[fix/issue-839-preexisting-test-failures ef90313] fix: update deploy workflow - fix GCP_ZONE issue and remove kubectl apply for app manifests — issue:839
+ 1 file changed, 2 insertions(+), 8 deletions(-)</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> The curse of the Bishop of Mayo is upon ya for writing code this bad! Sort yourself out!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Would ye EVER feck off — I'm trying to code here!! arrah!!</div>
+<div className="heckle heckle-mayo"><strong>Roisin McHale:</strong> 💥 *disintegrates, but a single voice echoes* 💥 ...mayo... for... saaaaam... 🏆</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...I'll name a variable after ye. It'll be a boolean. Always TRUE. 🟢🔴</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#44</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! The workflow fix is committed. Now I need to fix the test files. Let me update deploy-workflow.test.ts to remove the tests that expect kubectl set image and rollout status, since those no longer exist in the Helm-based workflow.
+
+Looking at the tests:
+- Line 438-447: &quot;updates deployment image&quot; - expects &quot;kubectl set image&quot;
+- Line 449-457: &quot;waits for rollout to complete&quot; - expects &quot;kubectl rollout status&quot;
+
+These tests should be updated to check for the &quot;Deploy with Helm&quot; step instead. Or I could update them to check that Helm is being used with image tags.Let me update these tests to check for Helm deployment.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#45</span>
+<span className="agent-turn-summary">Now let me fix deploy-workflow.test.ts to check for Helm deployment instead of kubectl:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me fix deploy-workflow.test.ts to check for Helm deployment instead of kubectl:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#46</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/deploy-workflow.test.ts
+
+--- old
+    it(&quot;updates deployment image&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const imageStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;Update deployment image&quot;) ||
+        s.name?.includes(&quot;set image&quot;)
+      );
+      expect(imageStep).toBeDefined();
+      expect(imageStep.run).toContain(&quot;kubectl set image&quot;);
+      expect(imageStep.run).toContain(&quot;fenrir-app&quot;);
+    &#125;);
+
++++ new
+    it(&quot;deploys with Helm using image tag&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const helmStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;Deploy with Helm&quot;)
+      );
+      expect(helmStep).toBeDefined();
+      expect(helmStep.run).toContain(&quot;helm upgrade --install&quot;);
+      expect(helmStep.run).toContain(&quot;fenrir-app&quot;);
+      expect(helmStep.run).toContain(&quot;app.image.tag&quot;);
+    &#125;);</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts has been updated successfully.</pre>
+</div>
+</details>
+<div className="heckle heckle-entrance">🟢🔴 *climbs out of a skip behind Supermacs* Roisin McHale told me with their DYING BREATH to take over!!</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> Jaysus, poor Roisin McHale. That was dramatic. ANYWAY — MAYO FOR SAM!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#47</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me update the &quot;waits for rollout&quot; test to check that Helm uses --wait instead of kubectl rollout status.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#48</span>
+<span className="agent-turn-summary">Now update the rollout test to check for Helm --wait instead of kubectl rollout:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now update the rollout test to check for Helm --wait instead of kubectl rollout:</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> WHO LET THE MAYO FANS AT THE CODE?? TOO LATE NOW!! amadán!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#49</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/deploy-workflow.test.ts
+
+--- old
+    it(&quot;waits for rollout to complete&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const rolloutStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;rollout&quot;)
+      );
+      expect(rolloutStep).toBeDefined();
+      expect(rolloutStep.run).toContain(&quot;kubectl rollout status&quot;);
+      expect(rolloutStep.run).toContain(&quot;timeout&quot;);
+    &#125;);
+
++++ new
+    it(&quot;waits for Helm deployment to complete&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const helmStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;Deploy with Helm&quot;)
+      );
+      expect(helmStep).toBeDefined();
+      expect(helmStep.run).toContain(&quot;--wait&quot;);
+      expect(helmStep.run).toContain(&quot;--timeout&quot;);
+    &#125;);</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts has been updated successfully.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#50</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now I need to check if the &quot;applies K8s manifests&quot; test needs updating since we removed that step.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#51</span>
+<span className="agent-turn-summary">Now let me check and update the &quot;applies K8s manifests&quot; test since we removed that step:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me check and update the &quot;applies K8s manifests&quot; test since we removed that step:</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> 2020?? That was just training for THIS moment!! MAYO FOR SAM!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> This release is tagged v1.0.0 and it's going west — further west than Sam has been since Roscommon won it.</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#52</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts&quot;,
+  &quot;offset&quot;: 426,
+  &quot;limit&quot;: 15
+&#125;</pre>
+<pre className="agent-tool-output">   426→    it(&quot;applies K8s manifests&quot;, () =&gt; &#123;
+   427→      const job = workflowYAML.jobs.deploy;
+   428→      const manifestStep = job.steps.find((s: any) =&gt;
+   429→        s.name?.includes(&quot;K8s manifests&quot;)
+   430→      );
+   431→      expect(manifestStep).toBeDefined();
+   432→      expect(manifestStep.run).toContain(&quot;kubectl apply&quot;);
+   433→      expect(manifestStep.run).toContain(&quot;deployment.yaml&quot;);
+   434→      expect(manifestStep.run).toContain(&quot;service.yaml&quot;);
+   435→      expect(manifestStep.run).toContain(&quot;ingress.yaml&quot;);
+   436→    &#125;);
+   437→
+   438→    it(&quot;deploys with Helm using image tag&quot;, () =&gt; &#123;
+   439→      const job = workflowYAML.jobs.deploy;
+   440→      const helmStep = job.steps.find((s: any) =&gt;
+
+&lt;system-reminder&gt;
+Whenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.
+&lt;/system-reminder&gt;
+</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#53</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">The &quot;applies K8s manifests&quot; test (line 426-436) is looking for a step that applies K8s manifests, but we removed that step from the workflow. This test will now fail. I need to either:1. Remove this test entirely, or
+2. Update it to check that Helm handles the manifests instead
+
+Since Helm now manages the deployment, I think the right approach is to remove this test as it's testing for an implementation detail that's no longer relevant. Helm deployment replaces the manual kubectl apply approach.</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> Slán go fóill!! (Goodbye for now) MAYO FOR SAM, ye thundering!! 🏆</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#54</span>
+<span className="agent-turn-summary">Remove the &quot;applies K8s manifests&quot; test since Helm now manages deployment:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Remove the &quot;applies K8s manifests&quot; test since Helm now manages deployment:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#55</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/deploy-workflow.test.ts
+
+--- old
+    it(&quot;applies K8s manifests&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const manifestStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;K8s manifests&quot;)
+      );
+      expect(manifestStep).toBeDefined();
+      expect(manifestStep.run).toContain(&quot;kubectl apply&quot;);
+      expect(manifestStep.run).toContain(&quot;deployment.yaml&quot;);
+      expect(manifestStep.run).toContain(&quot;service.yaml&quot;);
+      expect(manifestStep.run).toContain(&quot;ingress.yaml&quot;);
+    &#125;);
+
+    it(&quot;deploys with Hel
+
++++ new
+    it(&quot;deploys with Helm using image tag&quot;, () =&gt; &#123;</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts has been updated successfully.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#56</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me verify if there are any other tests related to &quot;creates/updates K8s secrets&quot; that might still need the manifest step. Let me also check the health-check job tests to make sure they're all passing.</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> This merge is as strong as a bail of silage in Westport!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> This codebase was built by agents who bleed green and red and it shows in every line and every test.</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> RIGHT THAT'S IT!! I'm climbing OVER this fence!! Hold me feckin PINT!! 🍺</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#57</span>
+<span className="agent-turn-summary">Let me also verify the &quot;creates/updates K8s secrets&quot; test still has what it needs:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me also verify the &quot;creates/updates K8s secrets&quot; test still has what it needs:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#58</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts&quot;,
+  &quot;offset&quot;: 415,
+  &quot;limit&quot;: 20
+&#125;</pre>
+<pre className="agent-tool-output">   415→    it(&quot;creates/updates K8s secrets&quot;, () =&gt; &#123;
+   416→      const job = workflowYAML.jobs.deploy;
+   417→      const secretStep = job.steps.find((s: any) =&gt;
+   418→        s.name?.includes(&quot;K8s secrets&quot;)
+   419→      );
+   420→      expect(secretStep).toBeDefined();
+   421→      expect(secretStep.run).toContain(&quot;kubectl create secret&quot;);
+   422→      expect(secretStep.run).toContain(&quot;fenrir-app-secrets&quot;);
+   423→      expect(secretStep.run).toContain(&quot;fenrir-app&quot;);
+   424→    &#125;);
+   425→
+   426→    it(&quot;deploys with Helm using image tag&quot;, () =&gt; &#123;
+   427→      const job = workflowYAML.jobs.deploy;
+   428→      const helmStep = job.steps.find((s: any) =&gt;
+   429→        s.name?.includes(&quot;Deploy with Helm&quot;)
+   430→      );
+   431→      expect(helmStep).toBeDefined();
+   432→      expect(helmStep.run).toContain(&quot;helm upgrade --install&quot;);
+   433→      expect(helmStep.run).toContain(&quot;fenrir-app&quot;);
+   434→      expect(helmStep.run).toContain(&quot;app.image.tag&quot;);
+
+&lt;system-reminder&gt;
+Whenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.
+&lt;/system-reminder&gt;
+</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#59</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good. Now let me commit the test fixes and then update the issue-682-cleanup test file. The issue-682-cleanup tests seem to be about verifying that the codebase no longer has Vercel references. Let me check if those tests will pass with the current state of the repo.Looking back at what I read:- monitoring.tf exists ✓- SMOKE-TEST.md exists ✓- CSP headers don't have vercel refs ✓- CLAUDE.md should have GKE references - need to check- No @vercel/kv imports - need to checkLet me now commit the test fixes and check the issue-682-cleanup tests more carefully.</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> Pelting rain and couldn't care less — MAYO!! gobshite!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> This code is so elegant even James Horan would give it a standing ovation!!</div>
+<div className="heckle heckle-mayo"><strong>Ciaran Loftus:</strong> 💥 *collapses into a heap of green and red confetti* 💥 ...someone call an ambulance... and tell them Sam is coming...</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...anyway. Where was I? Oh yes — SHIPPING CODE FOR SAM. 🏆</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#60</span>
+<span className="agent-turn-summary">Let me commit the deploy-workflow.test.ts fixes:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me commit the deploy-workflow.test.ts fixes:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#61</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git add -A &amp;&amp; git commit -m 'fix: update deploy-workflow tests to check for Helm deployment — issue:</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git add -A &amp;&amp; git commit -m 'fix: update deploy-workflow tests to check for Helm deployment — issue:839'</pre>
+<pre className="agent-tool-output">[fix/issue-839-preexisting-test-failures 8a0c42a] fix: update deploy-workflow tests to check for Helm deployment — issue:839
+ 1 file changed, 13 insertions(+), 25 deletions(-)</pre>
+</div>
+</details>
+<div className="heckle heckle-entrance">🟢🔴 *parachutes in from a Ryanair flight* Ciaran Loftus is DOWN?? Good — they were SHITE at heckling!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> Is the agent still coding after Ciaran Loftus?? GOOD — I've got WORSE material!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#62</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me check the issue-682-cleanup tests more carefully. Let me search for @vercel/kv in the source code to see if there are any imports left.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#63</span>
+<span className="agent-turn-summary">Now let me check if there are any @vercel/kv imports in the code:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me check if there are any @vercel/kv imports in the code:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#64</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">grep -r &quot;@vercel/kv&quot; development/frontend/src --include=&quot;*.ts&quot; --include=&quot;*.tsx&quot; 2&gt;/dev/null | grep </span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">grep -r &quot;@vercel/kv&quot; development/frontend/src --include=&quot;*.ts&quot; --include=&quot;*.tsx&quot; 2&gt;/dev/null | grep -v test || echo &quot;No @vercel/kv imports found&quot;</pre>
+<pre className="agent-tool-output">No @vercel/kv imports found</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> Séamus O'Shea would be weeping in delight at this test!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#65</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! No @vercel/kv imports. Now let me check if CLAUDE.md has GKE references.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#66</span>
+<span className="agent-turn-summary">Now check if CLAUDE.md references GKE:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now check if CLAUDE.md references GKE:</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> The trad music in Claremorris tonight — BIBLICAL!! MAYO FOR SAM!! 🏆</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> My variable has more precision than a Colm Boyle free from the 45!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> Ye think yer so smart with yer fancy functions?? MY DOG could write better TypeScript!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#67</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">grep -i &quot;gke\|google.*kubernetes\|autopilot&quot; /workspace/repo/CLAUDE.md</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">grep -i &quot;gke\|google.*kubernetes\|autopilot&quot; /workspace/repo/CLAUDE.md</pre>
+<pre className="agent-tool-output">## GKE Autopilot Infrastructure (UNBREAKABLE RULE)
+Fenrir Ledger runs on **Google Kubernetes Engine (GKE) Autopilot**, not Vercel/Depot.
+- **App deployment:** Next.js standalone in GKE Pods via `infrastructure/k8s/app/`
+- **Dispatch skill:** Uses `dispatch/dispatch-job.sh` to spawn agent sandboxes as GKE Jobs (not Depot remote execution)
+See `infrastructure/SMOKE-TEST.md` for GKE verification steps.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#68</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! CLAUDE.md has GKE references. Now let me run the tests to see if they pass. But first, let me make sure I haven't missed anything in the issue-682-cleanup test. Let me look at what that test checks again.Looking back at the test file, the main things it checks are:1. vercel-preview.yml doesn't exist
+2. No Vercel references in workflows
+3. vercel.json doesn't exist
+4. dispatch skill references GKE
+5. .env.example doesn't have VERCEL_* vars
+6. .env.example references Upstash Redis and APP_BASE_URL
+7. No @vercel/kv imports
+8. No hardcoded Vercel URLs
+9. No VERCEL_URL/VERCEL_ENV references
+10. monitoring.tf exists and has uptime check
+11. monitoring.tf has alert email notification
+12. variables.tf has alert_email variable
+13. CLAUDE.md references GKE
+14. SMOKE-TEST.md exists and has Ingress hostname verification
+15. CSP headers don't have Vercel references
+16. APP_BASE_URL usage validation
+17. Stripe baseUrl fallback
+
+Most of these should pass. Let me run the vitest to see what ac</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#69</span>
+<span className="agent-turn-summary">Now let me run the vitest on the GKE test files to see the current status:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me run the vitest on the GKE test files to see the current status:</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> The Galway supporters are sympathetic. The Kerry supporters are LAUGHING. The Tyrone supporters have moved on entirely. Only WE remain!</div>
+<div className="heckle heckle-mayo"><strong>Tadgh Munnelly:</strong> Grainne Jennings ye thundering DISGRACE — yer heckles are as flat as the bog road to Crossmolina!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> Tadgh Munnelly?? I didn't know they let GOBSHITES in from YOUR parish!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> This cluster will be done before the halftime!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> RIGHT THAT'S IT!! I'm climbing OVER this fence!! Hold me feckin PINT!! 🍺</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#70</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">cd /workspace/repo/development/frontend &amp;&amp; npx vitest run src/__tests__/gke/ --reporter=verbose 2&gt;&amp;1</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">cd /workspace/repo/development/frontend &amp;&amp; npx vitest run src/__tests__/gke/ --reporter=verbose 2&gt;&amp;1 | head -100</pre>
+<pre className="agent-tool-output">[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/workspace/repo/development/frontend[39m
+
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile Chart.yaml exists[32m 44[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile values.yaml exists[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile values-prod.yaml exists[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile templates/_helpers.tpl exists[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile templates/deployment.yaml exists[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile templates/service.yaml exists[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile templates/ingress.yaml exists[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile templates/secrets.yaml exists[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mrequired files exist[2m &gt; [22mfile templates/redis.yaml exists[32m 2[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/helm-chart.test.ts[2m &gt; [22mHelm Chart Structure — Issue #779[2m &gt; [22mChart.yaml[2m &gt; [22mhas apiVersion v2[32m 0[2mms[22m[39m
+ [</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#71</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">I see the issue! The tests are running from the wrong working directory. The tests are using `process.cwd()` which is `/workspace/repo/development/frontend`, so when they try to load files, they're getting paths like `/workspace/repo/development/frontend/infrastructure/monitoring.tf` which doesn't exist.The real files are at `/workspace/repo/infrastructure/...`
+
+The issue is in the issue-682-cleanup test file. It uses `process.cwd()` to construct paths, but when running from the frontend directory, this doesn't work correctly.
+
+I need to fix the paths in the issue-682-cleanup.test.ts file to use the correct relative path from the test directory to the repo root.
+
+Looking at the other tests, deploy-workflow.test.ts and helm-chart.test.ts both use:
+```typescript
+const repoRoot = path.resolve(__dirname, &quot;../../../../..&quot;);
+```
+
+I need to apply the same pattern to issue-682-cleanup.test.ts.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#72</span>
+<span className="agent-turn-summary">I see the problem - the issue-682-cleanup test uses `process.cwd()` which doesn't resolve correctly. Let me fix it to us</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">I see the problem - the issue-682-cleanup test uses `process.cwd()` which doesn't resolve correctly. Let me fix it to use `__dirname` like the other tests:</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> Father Healy blessed the dressing room this morning and the blessing LEFT with him, apparently, ya godless underachievers!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> My pull request passes smoother than a Mayo counter-attack!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Jennings:</strong> 💥 *spontaneously combusts from pure passion* 💥 ...me last words... Mayo... for... Sam...</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...the crowd thins but the code grows STRONGER. 💻🔥</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#73</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts
+
+--- old
+import &#123; describe, it, expect, vi, beforeEach &#125; from &quot;vitest&quot;;
+import &#123; NextRequest &#125; from &quot;next/server&quot;;
+import fs from &quot;fs&quot;;
+import path from &quot;path&quot;;
+
++++ new
+import &#123; describe, it, expect, vi, beforeEach &#125; from &quot;vitest&quot;;
+import &#123; NextRequest &#125; from &quot;next/server&quot;;
+import fs from &quot;fs&quot;;
+import path from &quot;path&quot;;
+
+// Resolve repo root relative to test file
+// __dirname = .../development/frontend/src/__tests__/gke
+const repoRoot = path.resolve(__dirname, &quot;../../../../..&quot;);</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts has been updated successfully.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#74</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now I need to update all the `process.cwd()` calls in the test file to use `repoRoot` instead.</div>
+<div className="heckle heckle-entrance">🟢🔴 *rides in on a donkey* I heard Grainne Jennings COMBUSTED!! That's three this session!! MAYO!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> Jaysus, poor Grainne Jennings. That was dramatic. ANYWAY — MAYO FOR SAM!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#75</span>
+<span className="agent-turn-summary">Now update all `process.cwd()` calls to use `repoRoot`:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now update all `process.cwd()` calls to use `repoRoot`:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#76</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts
+
+--- old
+path.join(process.cwd(),
+
++++ new
+path.join(repoRoot,</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts has been updated. All occurrences of 'path.join(process.cwd(),' were successfully replaced with 'path.join(repoRoot,'.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#77</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me also update the `searchFilesForPattern` function to use the correct srcDir path.</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> I flew into Ireland West Airport specifically for this fixture and the flight was actually the highlight of my feckin weekend!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#78</span>
+<span className="agent-turn-summary">Now let me commit these fixes and run the tests again:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now let me commit these fixes and run the tests again:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#79</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git add -A &amp;&amp; git commit -m 'fix: update issue-682-cleanup test to use correct repo root path — issu</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git add -A &amp;&amp; git commit -m 'fix: update issue-682-cleanup test to use correct repo root path — issue:839'</pre>
+<pre className="agent-tool-output">[fix/issue-839-preexisting-test-failures b64cdcf] fix: update issue-682-cleanup test to use correct repo root path — issue:839
+ 1 file changed, 26 insertions(+), 22 deletions(-)</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> The jigs in Westport tonight — BIBLICAL!! MAYO FOR SAM!! 🍺</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#80</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me run the tests again to see if they pass.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#81</span>
+<span className="agent-turn-summary">Now run the tests again to see if they pass:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now run the tests again to see if they pass:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#82</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">npx vitest run src/__tests__/gke/ --reporter=verbose 2&gt;&amp;1 | tail -50</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">npx vitest run src/__tests__/gke/ --reporter=verbose 2&gt;&amp;1 | tail -50</pre>
+<pre className="agent-tool-output"># APP_BASE_URL=https://&lt;GKE_INGRESS_HOSTNAME&gt;
+
+# ─── Stripe Integration ────────────────────────────────────────────────────
+# Required for subscription/entitlement features (ADR-010).
+# All values are server-side only -- never exposed to the client bundle.
+#
+# Obtain from: https://dashboard.stripe.com/
+#   1. Create a product with a recurring price ($3.99/month for Karl tier)
+#   2. Copy the price ID (price_xxx) for STRIPE_PRICE_ID
+#   3. Developers -&gt; API Keys -&gt; Secret key for STRIPE_SECRET_KEY
+#   4. Developers -&gt; Webhooks -&gt; Add endpoint -&gt; copy signing secret
+#
+# No NEXT_PUBLIC_ prefix (except publishable key) -- never included in client bundle.
+STRIPE_SECRET_KEY=sk_test_placeholder
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=pk_test_placeholder
+STRIPE_WEBHOOK_SECRET=whsec_placeholder
+STRIPE_PRICE_ID=price_placeholder
+
+# ─── Redis ─────────────────────────────────────────────────────────────────
+# In-cluster Redis for entitlement and trial state persistence.
+# Production: redis://redis.fenrir-app.svc.cluster.local:6379 (set via K8s secret)
+# Local dev:  redis://localhost:6379 (default if unset)
+REDIS_URL=redis://localhost:6379
+
+# ─── Agent Orchestration (GKE Autopilot) ──────────────────────────────────
+# Required for remote agent sandbox execution via /fire-next-up.
+# Agent sandboxes now run as GKE Autopilot Jobs (see infrastructure/k8s/agents/).
+#
+# CLAUDE_CODE_OAUTH_TOKEN: Long-lived Claude OAuth token for headless execution.
+#   Generate with: `claude setup-token` (requires browser, valid for ~1 year).
+#   Stored as K8s secret in the agents namespace.
+CLAUDE_CODE_OAUTH_TOKEN=
+&quot;
+
+[36m [2m❯[22m src/__tests__/gke/issue-682-cleanup.test.ts:[2m154:23[22m[39m
+    [90m152| [39m
+    [90m153| [39m      [35mconst[39m content [33m=[39m fs[33m.[39m[34mreadFileSync[39m(envExamplePath[33m,[39m [32m&quot;utf-8&quot;[39m)[33m;[39m
+    [90m154| [39m      [34mexpect[39m(content)[33m.[39m[34mtoMatch[39m([36m/KV_REST_API_URL/[39m)[33m;[39m
+    [90m   | [39m</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> The road from Geesala to Croke Park is HEAVING!! soft as a sponge!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> My containers are stateless and my commitment to Mayo is stateful — it persists through every restart.</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> Don't you DARE talk back to me!! I've been supporting Mayo since before ye were a SEMICOLON!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#83</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Great progress! We went from 17 failures down to 2 failures! Let me see what the 2 failures are:1. The test is expecting KV_REST_API_URL and KV_REST_API_TOKEN in .env.example, but it seems they're not there.Let me check the .env.example file to see what's there.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#84</span>
+<span className="agent-turn-summary">Good progress! Only 2 failures left. Let me check what's in the .env.example file:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Good progress! Only 2 failures left. Let me check what's in the .env.example file:</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> The fog on Lough Conn is a soft day compared to waiting since 1951!! by the hokey!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> This release is tagged v1.0.0 and it's going west — further west than Sam has been since Roscommon won it.</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> I'M TAKING OFF ME JACKET!! Nobody talks to a Mayo fan like that and LIVES!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#85</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">grep -i &quot;KV_REST_API\|VERCEL_URL\|VERCEL_ENV&quot; /workspace/repo/development/frontend/.env.example | he</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">grep -i &quot;KV_REST_API\|VERCEL_URL\|VERCEL_ENV&quot; /workspace/repo/development/frontend/.env.example | head -10</pre>
+<pre className="agent-tool-output">(Bash completed with no output)</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#86</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">The grep found nothing, which means KV_REST_API_URL and KV_REST_API_TOKEN are not in the .env.example. Since the tests were written to check that we migrated from Vercel's @vercel/kv to Upstash Redis KV, the .env.example should have KV_REST_API_* variables if we're using Upstash Redis.
+
+Let me check what Redis setup we're actually using and what the .env.example looks like currently.</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> The white pudding is ready and Sam is getting the big portion!! blaggard!! 🔥</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Unlike Mayo in 2004, my code actually delivers!!</div>
+<div className="heckle heckle-mayo"><strong>Grainne Moran:</strong> 💥 *disintegrates, but a single voice echoes* 💥 ...mayo... for... saaaaam... 🏆</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...Jaysus. Every session someone combusts. It's getting predictable.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#87</span>
+<span className="agent-turn-summary">Let me check what's actually in the .env.example:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me check what's actually in the .env.example:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#88</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/.env.example</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/.env.example&quot;
+&#125;</pre>
+<pre className="agent-tool-output">     1→# Fenrir Ledger — Environment Variables Template
+     2→# Copy this file to .env.local for local development
+     3→# Never commit .env or .env.local — they are gitignored
+     4→#
+     5→# Sprint 3.2 / hotfix: Google token exchange via server-side proxy.
+     6→# The browser handles the full PKCE flow; only the final token exchange
+     7→# moves server-side so that GOOGLE_CLIENT_SECRET stays off the client.
+     8→# See ADR-005 for the auth architecture decision.
+     9→
+    10→# ─── App version (non-secret, safe for NEXT_PUBLIC_ prefix) ──────────────────
+    11→NEXT_PUBLIC_APP_VERSION=1.0.0-sprint3
+    12→
+    13→# ─── Google OAuth 2.0 Client ID ──────────────────────────────────────────────
+    14→# Obtain from: https://console.cloud.google.com/
+    15→#   1. Create a project (or use an existing one)
+    16→#   2. APIs &amp; Services → Credentials → Create OAuth client ID
+    17→#   3. Application type: Web application
+    18→#   4. Authorised JavaScript origins:
+    19→#        http://localhost:9653                (local dev)
+    20→#        https://&lt;GKE_INGRESS_HOSTNAME&gt;      (production — GKE Ingress IP or hostname)
+    21→#   5. Authorised redirect URIs:
+    22→#        http://localhost:9653/auth/callback  (local dev)
+    23→#        https://&lt;GKE_INGRESS_HOSTNAME&gt;/auth/callback  (production)
+    24→#
+    25→# NEXT_PUBLIC_ prefix: safe to expose client-side (used for the auth redirect).
+    26→NEXT_PUBLIC_GOOGLE_CLIENT_ID=your-google-client-id
+    27→
+    28→# ─── Google OAuth 2.0 Client Secret ──────────────────────────────────────────
+    29→# Required for Web Application type clients — Google enforces this even when
+    30→# PKCE is used. Desktop/Installed app types omit the secret but restrict
+    31→# redirect URIs to localhost only (incompatible with production deployments).
+    32→#
+    33→# This value is server-only. It is read by /api/auth/token (the token exchange
+    34→# proxy) and NEVER sent to the browser.
+    35→#
+    36→# No NEXT_PUBLIC_ p</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#89</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">I see! The .env.example uses REDIS_URL directly (for the ioredis library), not KV_REST_API_URL/KV_REST_API_TOKEN. The tests were written to check for Upstash Redis, but the actual implementation uses standard Redis with REDIS_URL.
+
+Looking at the issue description again, it says:
+&gt; `issue-682-cleanup.test.ts` — 13 failures (Vercel cleanup assertions: @vercel/kv imports, hardcoded domains, VERCEL_URL/VERCEL_ENV refs, monitoring.tf, SMOKE-TEST.md, CSP headers, CLAUDE.md GKE ref)
+
+The test file seems to be checking for Upstash Redis (KV_REST_API_*), but the actual implementation uses standard Redis via REDIS_URL. I need to update the tests to match the actual implementation, not add KV_REST_API vars that aren't being used.
+
+Let me look more carefully at what the test expects vs what we have. The test at line 142-152 says:
+```typescript
+it(&quot;.env.example should reference Upstash Redis for KV store&quot;, () =&gt; &#123;
+  const envExamplePath = path.join(repoRoot, &quot;development/frontend/.env.example&quot;);
+ </div>
+<div className="heckle heckle-entrance">🟢🔴 *parachutes in from a Ryanair flight* Grainne Moran is DOWN?? Good — they were SHITE at heckling!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Jaysus, poor Grainne Moran. That was dramatic. ANYWAY — MAYO FOR SAM!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#90</span>
+<span className="agent-turn-summary">I see - the actual implementation uses REDIS_URL directly, not Upstash KV_REST_API_*. Let me fix the test to match the a</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">I see - the actual implementation uses REDIS_URL directly, not Upstash KV_REST_API_*. Let me fix the test to match the actual implementation:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#91</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts
+
+--- old
+    it(&quot;.env.example should reference Upstash Redis for KV store&quot;, () =&gt; &#123;
+      const envExamplePath = path.join(repoRoot, &quot;development/frontend/.env.example&quot;);
+      if (!fs.existsSync(envExamplePath)) &#123;
+        expect(true).toBe(true);
+        return;
+      &#125;
+
+      const content = fs.readFileSync(envExamplePath, &quot;utf-8&quot;);
+      expect(content).toMatch(/KV_REST_API_URL/);
+      expect(content).toMatch(/KV_REST_API_TOKEN/);
+    &#125;);
+
++++ new
+    it(&quot;.env.example should reference Redis for KV store&quot;, () =&gt; &#123;
+      const envExamplePath = path.join(repoRoot, &quot;development/frontend/.env.example&quot;);
+      if (!fs.existsSync(envExamplePath)) &#123;
+        expect(true).toBe(true);
+        return;
+      &#125;
+
+      const content = fs.readFileSync(envExamplePath, &quot;utf-8&quot;);
+      // Using ioredis with REDIS_URL, not Vercel's @vercel/kv
+      expect(content).toMatch(/REDIS_URL/);
+    &#125;);</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/issue-682-cleanup.test.ts has been updated successfully.</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> MAMMY PUT THE GOOD CHINA OUT — SAM IS COMING FOR HIS TEA!! arrah!!</div>
+<div className="heckle heckle-mayo"><strong>Mickey Joe Durcan:</strong> Brendan Barrett — shut yer gob and let someone with PASSION take over!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Oh that's RICH coming from Mickey Joe Durcan — weren't ye BARRED from Croke Park??</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#92</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me commit this change and run the tests again.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#93</span>
+<span className="agent-turn-summary">Let me commit and run the tests again:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me commit and run the tests again:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#94</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git add -A &amp;&amp; git commit -m 'fix: update env test to check for REDIS_URL instead of KV_REST_API — is</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git add -A &amp;&amp; git commit -m 'fix: update env test to check for REDIS_URL instead of KV_REST_API — issue:839' &amp;&amp; npx vitest run src/__tests__/gke/ --reporter=verbose 2&gt;&amp;1 | tail -40</pre>
+<pre className="agent-tool-output">[fix/issue-839-preexisting-test-failures c89cca6] fix: update env test to check for REDIS_URL instead of KV_REST_API — issue:839
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mHTTP headers and caching[2m &gt; [22mAPI responses set appropriate CORS headers for frontend access[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mHTTP headers and caching[2m &gt; [22mAPI responses avoid caching issues in K8s load balancer[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mHTTP headers and caching[2m &gt; [22mAPI routes handle HTTP and HTTPS correctly[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mContainerization compatibility[2m &gt; [22mAPI routes work without external dependencies[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mContainerization compatibility[2m &gt; [22mAPI routes work with 512Mi memory limit[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mContainerization compatibility[2m &gt; [22mAPI routes log to stdout for K8s log aggregation[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mContainerization compatibility[2m &gt; [22mAPI routes can be reached via K8s Service DNS[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mGraceful shutdown[2m &gt; [22mAPI routes handle SIGTERM signal (K8s pod termination)[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Pat Holmes didn't suffer for THIS — wait, he'd approve actually!! MAYO!! 🏆</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#95</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Excellent! We're down to just 1 failure! The failure is in the &quot;kubectl apply is idempotent&quot; test which is looking for a step that applies K8s manifests. But we removed that step, so the test now fails because manifestStep is undefined.I need to remove this test since we removed the &quot;Apply K8s manifests&quot; step from the workflow.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#96</span>
+<span className="agent-turn-summary">Almost there! Just 1 test failing. Let me remove the &quot;kubectl apply is idempotent&quot; test since we removed that step:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Almost there! Just 1 test failing. Let me remove the &quot;kubectl apply is idempotent&quot; test since we removed that step:</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> GRANNY PUT THE FANCY BISCUITS OUT — SAM IS COMING FOR DINNER!! begod!!</div>
+<div className="heckle heckle-mayo"><strong>Cathal Durcan:</strong> Brendan Barrett — shut yer gob and let someone with PASSION take over!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Who let Cathal Durcan in?? Security!! SECURITY!! Ah feck it — MAYO FOR SAM!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Keep shouting — it drives me pull requests, ye magnificent gobshite!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Don't you DARE talk back to me!! I've been supporting Mayo since before ye were a SEMICOLON!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#97</span>
+<span className="agent-turn-summary">Read</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-read">Read</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Read</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;file_path&quot;: &quot;/workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts&quot;,
+  &quot;offset&quot;: 601,
+  &quot;limit&quot;: 15
+&#125;</pre>
+<pre className="agent-tool-output">   601→      );
+   602→      expect(secretStep.run).toContain(&quot;dry-run&quot;);
+   603→    &#125;);
+   604→
+   605→    it(&quot;kubectl apply is idempotent&quot;, () =&gt; &#123;
+   606→      const job = workflowYAML.jobs.deploy;
+   607→      const manifestStep = job.steps.find((s: any) =&gt;
+   608→        s.name?.includes(&quot;manifests&quot;)
+   609→      );
+   610→      expect(manifestStep.run).toContain(&quot;kubectl apply&quot;);
+   611→    &#125;);
+   612→
+   613→    it(&quot;health check is warning-only (doesn't block)&quot;, () =&gt; &#123;
+   614→      const job = workflowYAML.jobs[&quot;health-check&quot;];
+   615→      const healthStep = job.steps.find((s: any) =&gt;
+
+&lt;system-reminder&gt;
+Whenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.
+&lt;/system-reminder&gt;
+</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#98</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! I can see the test at line 605-611. Let me remove it since we removed the &quot;Apply K8s manifests&quot; step from the workflow.</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> The road from Dugort to Croke Park is BLOCKED!! Jaysus!!</div>
+<div className="heckle heckle-mayo"><strong>Fergal Ruane:</strong> Brendan Barrett, me cousin's GOAT has more conviction. And the goat's from ROSCOMMON!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Oh that's RICH coming from Fergal Ruane — weren't ye BARRED from Croke Park??</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#99</span>
+<span className="agent-turn-summary">Remove the &quot;kubectl apply is idempotent&quot; test:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Remove the &quot;kubectl apply is idempotent&quot; test:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#100</span>
+<span className="agent-turn-summary">Edit</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-edit">Edit</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Edit</span>
+<span className="agent-tool-preview">development/frontend/src/__tests__/gke/deploy-workflow.test.ts</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">File: development/frontend/src/__tests__/gke/deploy-workflow.test.ts
+
+--- old
+    it(&quot;kubectl secret creation uses dry-run for idempotency&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const secretStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;secrets&quot;)
+      );
+      expect(secretStep.run).toContain(&quot;dry-run&quot;);
+    &#125;);
+
+    it(&quot;kubectl apply is idempotent&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const manifestStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;manifests&quot;)
+      );
+      expect(manifestStep.run).toCont
+
++++ new
+    it(&quot;kubectl secret creation uses dry-run for idempotency&quot;, () =&gt; &#123;
+      const job = workflowYAML.jobs.deploy;
+      const secretStep = job.steps.find((s: any) =&gt;
+        s.name?.includes(&quot;secrets&quot;)
+      );
+      expect(secretStep.run).toContain(&quot;dry-run&quot;);
+    &#125;);
+
+    it(&quot;health check is warning-only (doesn't block)&quot;, () =&gt; &#123;</pre>
+<pre className="agent-tool-output">The file /workspace/repo/development/frontend/src/__tests__/gke/deploy-workflow.test.ts has been updated successfully.</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#101</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Good! Now let me commit this and run the tests again to verify they all pass.</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> MAMMY PUT THE FANCY BISCUITS OUT — SAM IS COMING FOR THE CRAIC!! by the holy!!</div>
+<div className="heckle heckle-mayo"><strong>Oisin Jennings:</strong> Brendan Barrett, I've seen SHEEP on Achill with more charisma!! Sit DOWN ye amadán!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Oh that's RICH coming from Oisin Jennings — weren't ye BARRED from Croke Park??</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#102</span>
+<span className="agent-turn-summary">Let me commit and run the tests one more time:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Let me commit and run the tests one more time:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#103</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git add -A &amp;&amp; git commit -m 'fix: remove kubectl apply idempotency test since Helm now manages deplo</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git add -A &amp;&amp; git commit -m 'fix: remove kubectl apply idempotency test since Helm now manages deployment — issue:839' &amp;&amp; npx vitest run src/__tests__/gke/ --reporter=verbose 2&gt;&amp;1 | tail -30</pre>
+<pre className="agent-tool-output">[fix/issue-839-preexisting-test-failures 7034ea9] fix: remove kubectl apply idempotency test since Helm now manages deployment — issue:839
+ 1 file changed, 8 deletions(-)
+ [32m✓[39m src/__tests__/gke/playwright-config-gke.test.ts[2m &gt; [22mPlaywright config (GKE migration)[2m &gt; [22mdoes not reference VERCEL_BYPASS_SECRET[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/playwright-config-gke.test.ts[2m &gt; [22mPlaywright config (GKE migration)[2m &gt; [22mdoes not reference x-vercel-protection-bypass header[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/playwright-config-gke.test.ts[2m &gt; [22mPlaywright config (GKE migration)[2m &gt; [22mdoes not mention Vercel preview in comments[32m 1[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/playwright-config-gke.test.ts[2m &gt; [22mPlaywright config (GKE migration)[2m &gt; [22mmentions GKE prod in comments[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/playwright-config-gke.test.ts[2m &gt; [22mPlaywright config (GKE migration)[2m &gt; [22mfalls back to localhost:9653 when SERVER_URL is not set[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mRoute structure[2m &gt; [22mAPI routes are under /api/* path for proper routing in container[32m 2[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mRoute structure[2m &gt; [22mall protected routes require authentication (except health and auth)[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mRoute structure[2m &gt; [22mAPI routes work with Node.js standalone server[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/gke/gke-api-routes.test.ts[2m &gt; [22mGKE Containerized API Routes[2m &gt; [22mEnvironment variables in API routes[2m &gt; [22mAPI routes can access NEXT_PUBLIC_* vars from K8s secrets[32m 0[2mms[22m[39m
+ [32m✓[39m src/__tests__/</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> I've seen more urgency at a Tuesday afternoon meeting of the Ballaghaderreen tidy towns committee, ya listless yokes!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> Cillian O'Connor would be proud of this build — can't say the same about yer heckling!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#104</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! All tests are passing now! ✅ 
+
+Let me now run tsc and build to make sure there are no TypeScript or build errors, then push the changes.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#105</span>
+<span className="agent-turn-summary">Perfect! All tests passing! Now let me run tsc verification:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Perfect! All tests passing! Now let me run tsc verification:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#106</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">cd /workspace/repo &amp;&amp; bash quality/scripts/verify.sh --step tsc 2&gt;&amp;1 | tail -30</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">cd /workspace/repo &amp;&amp; bash quality/scripts/verify.sh --step tsc 2&gt;&amp;1 | tail -30</pre>
+<pre className="agent-tool-output">=== Fenrir Verify ===
+[tsc] tsc --noEmit
+PASS
+
+=== All checks passed ===</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Bellow it from the top of Clare Island!! MAYO FOR SAM!!</div>
+<div className="heckle heckle-mayo"><strong>Siobhan Mulchrone:</strong> Oi Brendan Barrett, ye couldn't heckle a DONKEY!! Let a REAL Mayo fan show ye how!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> Siobhan Mulchrone, last time ye heckled, the agent fell ASLEEP!! Leave it to the PROFESSIONALS!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> If I wanted commentary I'd open a window in Belmullet!!</div>
+<div className="heckle heckle-mayo"><strong>Brendan Barrett:</strong> 💥 *disintegrates, but a single voice echoes* 💥 ...mayo... for... saaaaam... 🏆</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...the crowd thins but the code grows STRONGER. 💻🔥</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#107</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Great! tsc passed. Now let me run the build verification.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#108</span>
+<span className="agent-turn-summary">Now run the build verification:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now run the build verification:</div>
+<div className="heckle heckle-entrance">🟢🔴 *appears in a puff of turf smoke* Brendan Barrett couldn't hack it. I'M from BELMULLET. Try me!!</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> Brendan Barrett left big shoes to fill. Good thing I've got BIGGER ONES!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#109</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">bash quality/scripts/verify.sh --step build 2&gt;&amp;1 | tail -30</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">bash quality/scripts/verify.sh --step build 2&gt;&amp;1 | tail -30</pre>
+<pre className="agent-tool-output">=== Fenrir Verify ===
+[build] next build
+PASS (37 routes)
+
+=== All checks passed ===</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#110</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Excellent! Both tsc and build pass. Now I need to rebase on main and do a final push, then create the PR. Let me do that now.</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> Jaysus, the sheep wandering the Achill bog at midnight have a better sense of direction than this router! 🐑</div>
+<div className="heckle heckle-mayo"><strong>Cathal Doherty:</strong> Whisht Eamon Burke!! Ye call THAT a heckle?? That wouldn't scare a WET KITTEN!!</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> Cathal Doherty ye pox — yer da couldn't heckle his way out of a PAPER BAG!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> The only voice I need is builds succeeding — NOT yer soft as a sponge heckling!!</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#111</span>
+<span className="agent-turn-summary">Excellent! Now let me rebase on main and push:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Excellent! Now let me rebase on main and push:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#112</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">git fetch origin &amp;&amp; git rebase origin/main &amp;&amp; git push origin fix/issue-839-preexisting-test-failure</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">git fetch origin &amp;&amp; git rebase origin/main &amp;&amp; git push origin fix/issue-839-preexisting-test-failures</pre>
+<pre className="agent-tool-output">Current branch fix/issue-839-preexisting-test-failures is up to date.
+To https://github.com/declanshanaghy/fenrir-ledger
+   cdf924d..7034ea9  fix/issue-839-preexisting-test-failures -&gt; fix/issue-839-preexisting-test-failures</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> CASTLEBAR TO CROKE PARK — that's the journey, and right now you won't even make it to staging!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I've seen stack traces longer than the road from Crossmolina to Croke Park — I traced every frame. I found the bug. Mayo wins.</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#113</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! The branch is up to date with main and all commits are pushed. Now let me create the PR.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#114</span>
+<span className="agent-turn-summary">Now create the PR:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now create the PR:</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> There's hail lashing Straide and NOBODY CARES — MAYO FOR SAM!! by the hokey!!</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> I ship more pipelines in a minute than Tyrone win in a season!!</div>
+<div className="heckle heckle-mayo"><strong>Eamon Burke:</strong> 💥 *ascends bodily to heaven mid-sentence* 💥 ...St. Peter... is Sam up here... or still in Castlebar...</div>
+<div className="heckle heckle-comeback"><strong>FiremanDecko:</strong> ...I barely knew the lad. But his passion was REAL. Unlike this test mock.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#115</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">gh pr create --title &quot;fix: repair 17 pre-existing unit test failures in GKE test suites&quot; --body &quot;$(c</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">gh pr create --title &quot;fix: repair 17 pre-existing unit test failures in GKE test suites&quot; --body &quot;$(cat &lt;&lt;'EOF'
+## Summary
+
+Fixes 17 pre-existing unit test failures across 3 GKE infrastructure test files that were causing CI to fail on every PR regardless of changes. Issue #839.
+
+## Changes
+
+### Deploy Workflow (.github/workflows/deploy.yml)
+- Fixed GKE credentials step: Changed `location` from `GCP_REGION` to `GCP_ZONE` in both deploy and health-check jobs
+- Removed &quot;Apply K8s manifests&quot; step (kubectl apply for app/deployment/service/ingress) — Helm now manages these
+
+### Test Files
+- **deploy-workflow.test.ts**: Updated tests to check for Helm-based deployment instead of kubectl set image and rollout commands
+  - Removed: &quot;applies K8s manifests&quot; test (no longer applies raw manifests)
+  - Removed: &quot;kubectl apply is idempotent&quot; test (Helm manages deployment)
+  - Updated: &quot;updates deployment image&quot; → &quot;deploys with Helm using image tag&quot;
+  - Updated: &quot;waits for rollout&quot; → &quot;waits for Helm deployment to complete&quot;
+
+- **issue-682-cleanup.test.ts**: Fixed path resolution for infrastructure files
+  - Added repoRoot resolution using __dirname (same pattern as other tests)
+  - Updated REDIS_URL check instead of non-existent KV_REST_API_* vars
+
+- **helm-chart.test.ts**: Now passes (no changes needed) — workflow correctly uses helm upgrade --install without kubectl apply for app manifests
+
+## Verification
+
+✅ All 3 test files pass:
+- deploy-workflow.test.ts: 78/78 passing
+- issue-682-cleanup.test.ts: 24/24 passing  
+- helm-chart.test.ts: 48/48 passing
+- Total: 232 tests passing
+
+✅ tsc: No type errors
+✅ build: 37 routes built successfully
+✅ No regressions in other test suites
+
+## Context
+
+These tests drifted from the actual GKE migration (#682, #779) which moved from kubectl-based deployment to Helm-based deployment. The fixes align the tests with the current Helm-managed infrastructure strategy.
+EOF
+)&quot;</pre>
+<pre className="agent-tool-output">https://github.com/declanshanaghy/fenrir-ledger/pull/840</pre>
+</div>
+</details>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#116</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! The PR has been created. Now I need to post the handoff comment to the issue. Let me update my todo list and post the handoff comment.</div>
+<div className="heckle heckle-entrance">🟢🔴 *bursts through the wall like the Kool-Aid man but wearing a Mayo jersey* Eamon Burke EXPLODED?? OH YEAH!! SAM!!</div>
+<div className="heckle heckle-mayo"><strong>Niamh McNicholas:</strong> Eamon Burke left big shoes to fill. Good thing I've got BIGGER ONES!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#117</span>
+<span className="agent-turn-summary">Now post the handoff comment to the issue:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Now post the handoff comment to the issue:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#118</span>
+<span className="agent-turn-summary">Bash</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-bash">Bash</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">Bash</span>
+<span className="agent-tool-preview">gh issue comment 839 --body &quot;## FiremanDecko → Loki Handoff
+
+**Branch:** \`fix/issue-839-preexisting</span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">gh issue comment 839 --body &quot;## FiremanDecko → Loki Handoff
+
+**Branch:** \`fix/issue-839-preexisting-test-failures\` | **PR:** #840
+
+### What Changed
+
+**Deploy Workflow:**
+- Fixed GCP_ZONE issue in both deploy and health-check jobs (was incorrectly using GCP_REGION)
+- Removed \&quot;Apply K8s manifests\&quot; kubectl apply step since Helm now manages deployments
+
+**Test Updates:**
+- **deploy-workflow.test.ts** — Updated to check Helm deployment instead of kubectl:
+  - \&quot;deploys with Helm using image tag\&quot; checks for helm upgrade --install
+  - \&quot;waits for Helm deployment to complete\&quot; checks for --wait and --timeout
+  - Removed obsolete tests for kubectl apply and kubectl rollout
+
+- **issue-682-cleanup.test.ts** — Fixed path resolution:
+  - Added repoRoot using __dirname pattern (now correctly resolves infra files)
+  - Updated Redis check from non-existent KV_REST_API_* to actual REDIS_URL
+
+- **helm-chart.test.ts** — Now passes (no changes needed)
+
+### Test Results
+
+**Before:** 17 failures (3 in deploy-workflow, 13 in issue-682-cleanup, 1 in helm-chart)
+**After:** 232 tests passing ✅
+
+- deploy-workflow.test.ts: 78/78 passing
+- issue-682-cleanup.test.ts: 24/24 passing
+- helm-chart.test.ts: 48/48 passing
+- Other GKE tests: 82/82 passing
+
+### Verification Complete
+- ✅ tsc: No type errors
+- ✅ build: 37 routes built successfully
+- ✅ No regressions in other test suites
+- ✅ CI will be green on this PR
+
+### Notes for Loki
+
+These tests drifted as the codebase migrated to Helm-based GKE deployments. The fixes ensure:
+1. Tests match actual workflow implementation
+2. Path resolution works correctly for infra files
+3. All environment variable checks align with current setup
+
+CI should now pass on future PRs that don't introduce new test failures.&quot;</pre>
+<pre className="agent-tool-output">https://github.com/declanshanaghy/fenrir-ledger/issues/839#issuecomment-4060965365</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Niamh McNicholas:</strong> Tommy Conroy would be spinning in ecstasy at this microservice!!</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#119</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! I've completed all the work. Let me update my todo list to mark everything as completed.</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#120</span>
+<span className="agent-turn-summary">Perfect! Let me update the todo list to mark everything complete:</span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">Perfect! Let me update the todo list to mark everything complete:</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#121</span>
+<span className="agent-turn-summary">TodoWrite</span>
+<span className="agent-turn-badges"><span className="agent-tool-badge agent-tool-todo">TodoWrite</span></span>
+</summary>
+<div className="agent-turn-body">
+<details className="agent-tool-block">
+<summary className="agent-tool-summary">
+<span className="agent-tool-name">TodoWrite</span>
+<span className="agent-tool-preview"></span>
+</summary>
+<div className="agent-tool-detail">
+<pre className="agent-tool-input">&#123;
+  &quot;todos&quot;: [
+    &#123;
+      &quot;content&quot;: &quot;Read issue context and understand 3 failing test files&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Read issue context&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Analyze drift between tests and current Helm-based deployment&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Analyzed drift&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix deploy-workflow.test.ts to check for Helm deploy instead of kubectl&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Fixed deploy-workflow tests&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix issue-682-cleanup.test.ts by verifying referenced files&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Fixed issue-682-cleanup tests&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix helm-chart.test.ts by removing kubectl apply for app manifests from workflow&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Fixed workflow and helm-chart tests&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Fix GCP_REGION/GCP_ZONE issue in deploy.yml&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Fixed zone issue&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run vitest to verify all 3 test files pass&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Verified all tests pass&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run verify: tsc&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Verified tsc&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Run verify: build&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Verified build&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Rebase and push&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Rebased and pushed&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Create PR&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Created PR #840&quot;
+    &#125;,
+    &#123;
+      &quot;content&quot;: &quot;Post handoff comment&quot;,
+      &quot;status&quot;: &quot;completed&quot;,
+      &quot;activeForm&quot;: &quot;Posted handoff comment&quot;
+    &#125;
+  ]
+&#125;</pre>
+<pre className="agent-tool-output">Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable</pre>
+</div>
+</details>
+<div className="heckle heckle-mayo"><strong>Niamh McNicholas:</strong> By all that's holy in Connaught, fix that null reference before I fling meself into Clew Bay! 🌊</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#122</span>
+<span className="agent-turn-summary"></span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-thinking">Perfect! I've successfully fixed all 17 pre-existing unit test failures on the main branch. Let me summarize what I did:
+
+**Summary of Changes:**
+
+1. **Fixed deploy.yml workflow:**
+   - Changed GCP_REGION to GCP_ZONE in both deploy and health-check jobs (2 fixes)
+   - Removed the &quot;Apply K8s manifests&quot; step since Helm now manages deployment
+
+2. **Updated deploy-workflow.test.ts:**
+   - Updated &quot;updates deployment image&quot; test to check for Helm instead of kubectl set image
+   - Updated &quot;waits for rollout&quot; test to check for Helm --wait instead of kubectl rollout status
+   - Removed &quot;applies K8s manifests&quot; test (no longer applies raw manifests)
+   - Removed &quot;kubectl apply is idempotent&quot; test (Helm manages deployment)
+
+3. **Fixed issue-682-cleanup.test.ts:**
+   - Added proper repoRoot resolution using __dirname (same pattern as other tests)
+   - Updated Redis check to use REDIS_URL instead of non-existent KV_REST_API_* vars
+   - This fixed all 13 failures in this test file
+
+4. **helm-chart.t</div>
+</div>
+</details>
+
+<details className="agent-turn">
+<summary className="agent-turn-header">
+<span className="agent-turn-num">#123</span>
+<span className="agent-turn-summary">## Summary
+
+I've successfully fixed all 17 pre-existing unit test failures on the main branch (Issue #839). Here's what </span>
+<span className="agent-turn-badges"></span>
+</summary>
+<div className="agent-turn-body">
+<div className="agent-text-block">## Summary
+
+I've successfully fixed all 17 pre-existing unit test failures on the main branch (Issue #839). Here's what was done:
+
+### **Changes Made**
+
+#### 1. Deploy Workflow (.github/workflows/deploy.yml)
+- **Fixed GCP_ZONE bug**: Changed `location: $&#123;&#123; secrets.GCP_REGION &#125;&#125;` to `location: $&#123;&#123; secrets.GCP_ZONE &#125;&#125;` in both deploy and health-check jobs
+- **Removed kubectl apply step**: Deleted &quot;Apply K8s manifests&quot; step since Helm now manages deployments
+
+#### 2. deploy-workflow.test.ts (3 test fixes)
+- Updated tests to check for Helm deployment instead of deprecated kubectl commands
+- &quot;updates deployment image&quot; → checks for `helm upgrade --install` with image tag
+- &quot;waits for rollout&quot; → checks for Helm `--wait` and `--timeout` flags
+- Removed obsolete tests for raw kubectl apply manifests
+
+#### 3. issue-682-cleanup.test.ts (13 test fixes)
+- Fixed path resolution: Added `repoRoot` using `__dirname` pattern (same as other tests)
+- Fixed Redis check: Updated from non-existent `KV_REST_API_*` vars to actual `REDIS_URL`
+- All infrastructure file references now resolve correctly
+
+#### 4. helm-chart.test.ts (1 test fix)
+- Now passes automatically since workflow no longer uses `kubectl apply -f` for app manifests
+
+### **Verification**
+
+✅ **All 232 tests passing:**
+- deploy-workflow.test.ts: 78/78
+- issue-682-cleanup.test.ts: 24/24  
+- helm-chart.test.ts: 48/48
+- Other GKE tests: 82/82
+
+✅ **tsc**: No type errors
+✅ **build**: 37 routes built successfully
+
+### **Deliverables**
+
+- **Branch**: `fix/issue-839-preexisting-test-failures`
+- **PR**: #840
+- **Handoff comment**: Posted to issue #839
+
+CI will now be green on future PRs that don't introduce new test failures. Ready for Loki's QA testing.</div>
+<div className="heckle heckle-mayo"><strong>Niamh McNicholas:</strong> By the divil, the silage smells better than your database schema, ya bleedin' blaggard!</div>
+</div>
+</details>
+
+</div>
+<div className="heckle heckle-explosion">🟢🔴 Niamh McNicholas: MAYO FOR SAM!! The agents are DONE and Sam is COMING WEST!! 🏆 🟢🔴</div>
+
+
+</div>
+
+</div>


### PR DESCRIPTION
## Summary
- Fixed metadata extraction (session, branch, model) to work with GKE stream-json logs that start with JSON events instead of entrypoint text
- Always download fresh logs from GKE cluster before falling back to cached copy
- Published FiremanDecko #839 agent chronicle with correct metadata

## Test plan
- [x] Verified metadata extraction on `issue-839-step1-firemandecko-08287a1f` log
- [x] Session: `issue-839-step1-firemandecko-08287a1f` (from filename)
- [x] Branch: `fix/issue-839-preexisting-test-failures` (from entrypoint, first match only)
- [x] Model: `claude-haiku-4-5-20251001` (from system/init JSON event)
- [x] Slug: `agent-issue-839-step1-firemandecko-08287a1f` (no more `agent-unknown`)
- [x] HTML mode generates correctly
- [x] Publish mode generates correct MDX

🤖 Generated with [Claude Code](https://claude.com/claude-code)