### PR TITLE
fix: add ManagedCertificate template to Umami Helm chart

### DIFF
--- a/infrastructure/helm/umami/templates/managed-certificate.yaml
+++ b/infrastructure/helm/umami/templates/managed-certificate.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: umami-cert
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+spec:
+  domains:
+    {{- range .Values.ingress.hosts }}
+    - {{ . }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary
- Added `managed-certificate.yaml` template to Umami Helm chart
- Ingress annotation referenced `umami-cert` but no template existed to create it
- Also created the cert manually on the cluster to unblock current deploy

## Test plan
- [x] ManagedCertificate created on cluster, status: Provisioning
- [x] Template uses same `ingress.hosts` values as the Ingress

🤖 Generated with [Claude Code](https://claude.com/claude-code)