### PR TITLE
fix: remove ingressClassName from Umami — GCE controller requires empty default

### DIFF
--- a/infrastructure/helm/umami/templates/ingress.yaml
+++ b/infrastructure/helm/umami/templates/ingress.yaml
@@ -9,7 +9,9 @@ metadata:
   annotations:
     {{- toYaml .Values.ingress.annotations | nindent 4 }}
 spec:
+  {{- if .Values.ingress.className }}
   ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ . }}

--- a/infrastructure/helm/umami/values-prod.yaml
+++ b/infrastructure/helm/umami/values-prod.yaml
@@ -75,7 +75,7 @@ postgresql:
 # -- Ingress Production Config -----------------------------------------
 ingress:
   enabled: true
-  className: "gce"
+  className: ""  # Empty = default GCE controller on Autopilot (ingressClassName: gce is NOT recognized)
   hosts:
     - analytics.fenrirledger.com
   annotations:


### PR DESCRIPTION
## Summary
- GKE Autopilot's GCE LB controller ignores `ingressClassName: gce` — only processes empty default
- Umami Ingress had no LB address for 40+ minutes because of this
- Also fixed analytics DNS (was overwritten to fenrir-app IP by Terraform)

## Test plan
- [x] Removed ingressClassName → GCE controller immediately started syncing
- [x] DNS updated: analytics.fenrirledger.com → 34.13.119.189 (umami-ip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)