### PR TITLE
fix: add umami-ip to Terraform, fix analytics DNS record

### DIFF
--- a/infrastructure/dns.tf
+++ b/infrastructure/dns.tf
@@ -20,6 +20,18 @@ resource "google_compute_global_address" "app_ip" {
   depends_on = [google_project_service.apis]
 }
 
+import {
+  to = google_compute_global_address.umami_ip
+  id = "projects/fenrir-ledger-prod/global/addresses/umami-ip"
+}
+
+resource "google_compute_global_address" "umami_ip" {
+  name    = "umami-ip"
+  project = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
 # --------------------------------------------------------------------------
 # Cloud DNS Managed Zone
 # --------------------------------------------------------------------------
@@ -66,5 +78,5 @@ resource "google_dns_record_set" "analytics" {
   type         = "A"
   ttl          = 300
 
-  rrdatas = [google_compute_global_address.app_ip.address]
+  rrdatas = [google_compute_global_address.umami_ip.address]
 }

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -53,6 +53,11 @@ output "static_ip" {
   value       = google_compute_global_address.app_ip.address
 }
 
+output "umami_ip" {
+  description = "Reserved global static IP for Umami analytics Ingress"
+  value       = google_compute_global_address.umami_ip.address
+}
+
 output "dns_nameservers" {
   description = "Google Cloud DNS nameservers — set these as custom nameservers at your registrar"
   value       = google_dns_managed_zone.app.name_servers


### PR DESCRIPTION
## Summary
- Added `google_compute_global_address.umami_ip` with import block for existing resource
- Fixed `analytics.fenrirledger.com` DNS to point to `umami_ip` instead of `app_ip`
- Added `umami_ip` output
- Closes #845

## What was happening
Every deploy workflow run, Terraform reset `analytics.fenrirledger.com` back to `107.178.250.240` (app IP), breaking Umami access at `34.13.119.189`.

## Test plan
- [x] Import block handles existing `umami-ip` resource
- [x] Analytics DNS record references `umami_ip.address`

🤖 Generated with [Claude Code](https://claude.com/claude-code)