### PR TITLE
fix: backport Umami infra to Terraform + align Helm ingress pattern

### DIFF
--- a/infrastructure/dns.tf
+++ b/infrastructure/dns.tf
@@ -20,6 +20,18 @@ resource "google_compute_global_address" "app_ip" {
   depends_on = [google_project_service.apis]
 }
 
+import {
+  to = google_compute_global_address.umami_ip
+  id = "projects/fenrir-ledger-prod/global/addresses/umami-ip"
+}
+
+resource "google_compute_global_address" "umami_ip" {
+  name    = "umami-ip"
+  project = var.project_id
+
+  depends_on = [google_project_service.apis]
+}
+
 # --------------------------------------------------------------------------
 # Cloud DNS Managed Zone
 # --------------------------------------------------------------------------
@@ -66,5 +78,5 @@ resource "google_dns_record_set" "analytics" {
   type         = "A"
   ttl          = 300
 
-  rrdatas = [google_compute_global_address.app_ip.address]
+  rrdatas = [google_compute_global_address.umami_ip.address]
 }

--- a/infrastructure/helm/umami/templates/ingress.yaml
+++ b/infrastructure/helm/umami/templates/ingress.yaml
@@ -7,11 +7,11 @@ metadata:
   labels:
     {{- include "umami.labels" . | nindent 4 }}
   annotations:
-    {{- toYaml .Values.ingress.annotations | nindent 4 }}
+    kubernetes.io/ingress.class: {{ .Values.ingress.className | default "gce" | quote }}
+    {{- range $key, $value := .Values.ingress.annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
-  {{- if .Values.ingress.className }}
-  ingressClassName: {{ .Values.ingress.className }}
-  {{- end }}
   rules:
     {{- range .Values.ingress.hosts }}
     - host: {{ . }}

--- a/infrastructure/helm/umami/values-prod.yaml
+++ b/infrastructure/helm/umami/values-prod.yaml
@@ -75,7 +75,7 @@ postgresql:
 # -- Ingress Production Config -----------------------------------------
 ingress:
   enabled: true
-  className: ""  # Empty = default GCE controller on Autopilot (ingressClassName: gce is NOT recognized)
+  className: "gce"  # Used as annotation kubernetes.io/ingress.class (not spec.ingressClassName)
   hosts:
     - analytics.fenrirledger.com
   annotations:

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -53,6 +53,11 @@ output "static_ip" {
   value       = google_compute_global_address.app_ip.address
 }
 
+output "umami_ip" {
+  description = "Reserved global static IP for Umami analytics Ingress"
+  value       = google_compute_global_address.umami_ip.address
+}
+
 output "dns_nameservers" {
   description = "Google Cloud DNS nameservers — set these as custom nameservers at your registrar"
   value       = google_dns_managed_zone.app.name_servers


### PR DESCRIPTION
## Summary
- **Terraform:** Add `umami-ip` static IP resource (with import block), fix `analytics.fenrirledger.com` DNS to point to it
- **Helm:** Align Umami ingress to use annotation `kubernetes.io/ingress.class` (matches working fenrir-app pattern on Autopilot)
- Closes #845

## What was breaking
Every deploy, Terraform reset `analytics.fenrirledger.com` → `107.178.250.240` (app IP). Should be `34.13.119.189` (umami IP).

## Test plan
- [x] Terraform: `umami_ip` resource with import block for existing IP
- [x] DNS: analytics record references `umami_ip.address`
- [x] Helm: ingress uses annotation pattern matching fenrir-app

🤖 Generated with [Claude Code](https://claude.com/claude-code)