### PR TITLE
fix: restore GCP_REGION for GKE credentials in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -200,7 +200,7 @@ jobs:
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GCP_ZONE }}
+          location: ${{ secrets.GCP_REGION }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Ensure namespaces and service accounts exist
@@ -344,7 +344,7 @@ jobs:
         uses: google-github-actions/get-gke-credentials@v3
         with:
           cluster_name: ${{ secrets.GKE_CLUSTER_NAME }}
-          location: ${{ secrets.GCP_ZONE }}
+          location: ${{ secrets.GCP_REGION }}
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
       - name: Health check via Ingress


### PR DESCRIPTION
## Summary
PR #840 changed `get-gke-credentials` location from `GCP_REGION` to `GCP_ZONE`. GKE Autopilot is regional — needs `GCP_REGION`. This broke all deploys.

## Test plan
- [x] Reverted both occurrences (deploy + health-check jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)