### PR TITLE
feat: /dev-server SKILL with sub-service management

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: dev-server
+description: "Start, stop, restart, check status of, or tail logs for the Fenrir Ledger local dev environment."
+---
+
+# Dev Server — Local Development Environment Manager
+
+Manages all local development services for Fenrir Ledger.
+
+## Usage
+
+```
+/dev-server                    # Show status of all services
+/dev-server start              # Start all services
+/dev-server stop               # Stop all services
+/dev-server restart             # Restart all services
+/dev-server <service> start    # Start a specific service
+/dev-server <service> stop     # Stop a specific service
+/dev-server <service> logs     # Tail a specific service's logs
+```
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| `app` | 9653 (WOLF) | Next.js dev server via `vercel dev` |
+| `stripe` | — | Stripe CLI webhook forwarding to app |
+| `odin` | 8316 (Hlidskjalf) | Agent report viewer — serves `tmp/agent-logs/` |
+| `proxy` | 8001 | kubectl proxy for GKE cluster access |
+
+## Scripts
+
+Each service has its own management script in `scripts/`:
+
+```bash
+SCRIPT_DIR="$(git rev-parse --show-toplevel)/.claude/skills/dev-server/scripts"
+bash "$SCRIPT_DIR/<service>.sh" <action>
+```
+
+Actions: `start`, `stop`, `status`, `logs`
+
+## Instructions
+
+### Parse the command
+
+| Input | Action |
+|-------|--------|
+| (no args) or `status` | Run `status` on ALL services |
+| `start` | Run `start` on ALL services |
+| `stop` | Run `stop` on ALL services |
+| `restart` | Run `stop` then `start` on ALL |
+| `<service> <action>` | Run `<action>` on that service only |
+| `logs` | Run `logs` on app (default) |
+| `<service> logs` | Tail that service's log |
+
+### Execute
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+SCRIPT_DIR="$REPO_ROOT/.claude/skills/dev-server/scripts"
+
+# Single service
+bash "$SCRIPT_DIR/<service>.sh" <action>
+
+# All services (start order: stripe → app → odin → proxy)
+for svc in stripe app odin proxy; do
+  bash "$SCRIPT_DIR/$svc.sh" <action>
+done
+```
+
+### Report
+
+Show a status table after any action:
+
+```
+Service    Port   Status
+───────    ────   ──────
+app        9653   running (pid 12345)
+stripe     —      running (pid 12346)
+odin       8316   running (pid 12347)
+proxy      8001   not running
+```
+
+## Notes
+
+- `odin` requires `npx http-server` (installed via npm)
+- `proxy` requires `kubectl` configured for the GKE cluster
+- `stripe` requires Stripe CLI (`brew install stripe/stripe-cli/stripe`)
+- The old `services.sh` script is deprecated — this SKILL replaces it

--- a/.claude/skills/dev-server/scripts/app.sh
+++ b/.claude/skills/dev-server/scripts/app.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# app.sh — manage the Next.js dev server (vercel dev)
+set -euo pipefail
+
+PORT="${FENRIR_FRONTEND_PORT:-9653}"
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+FRONTEND_DIR="${FENRIR_FRONTEND_DIR:-$REPO_ROOT/development/frontend}"
+LOG_DIR="${FRONTEND_DIR}/logs"
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/frontend-server.log"
+PORT_FILE="${FRONTEND_DIR}/.port"
+
+pid() {
+  lsof -ti "TCP:$PORT" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
+case "${1:-status}" in
+  start)
+    if p=$(pid); then
+      echo "app: already running (pid $p) on port $PORT"
+      exit 0
+    fi
+    echo "Starting Next.js dev server on port $PORT..."
+    > "$LOG"
+    nohup bash -c "cd '$REPO_ROOT' && npx vercel dev --listen $PORT" >> "$LOG" 2>&1 &
+    echo "$PORT" > "$PORT_FILE"
+    for _ in $(seq 1 15); do
+      grep -q "Ready" "$LOG" 2>/dev/null && break
+      sleep 1
+    done
+    echo "app: running on port $PORT"
+    ;;
+  stop)
+    if p=$(pid); then
+      kill "$p" 2>/dev/null
+      rm -f "$PORT_FILE"
+      echo "app: stopped"
+    else
+      echo "app: not running"
+    fi
+    ;;
+  status)
+    if p=$(pid); then
+      echo "app: running (pid $p) on port $PORT"
+    else
+      echo "app: not running"
+    fi
+    ;;
+  logs)
+    tail -f "$LOG"
+    ;;
+  *)
+    echo "Usage: app.sh {start|stop|status|logs}"
+    exit 1
+    ;;
+esac

--- a/.claude/skills/dev-server/scripts/odin.sh
+++ b/.claude/skills/dev-server/scripts/odin.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# odin.sh — manage Odin's Agent Monitor (http-server for agent reports)
+# Port 8316 — Hlidskjalf, Odin's high throne from which he sees all nine worlds
+set -euo pipefail
+
+PORT=8316
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+SERVE_DIR="$REPO_ROOT/tmp/agent-logs"
+LOG_DIR="$REPO_ROOT/tmp"
+LOG="${LOG_DIR}/odin-server.log"
+PID_FILE="${LOG_DIR}/.odin-server.pid"
+
+mkdir -p "$SERVE_DIR" "$LOG_DIR"
+
+# Copy Odin assets if missing
+copy_assets() {
+  local profiles="$SERVE_DIR/agents/profiles"
+  mkdir -p "$profiles"
+  [[ ! -f "$SERVE_DIR/favicon.png" ]] && \
+    cp "$REPO_ROOT/.claude/agents/profiles/odin-dark.png" "$SERVE_DIR/favicon.png" 2>/dev/null || true
+  [[ ! -f "$profiles/odin-dark.png" ]] && \
+    cp "$REPO_ROOT/.claude/agents/profiles/odin-dark.png" "$profiles/odin-dark.png" 2>/dev/null || true
+  # Copy all agent profiles
+  for img in "$REPO_ROOT/.claude/agents/profiles/"*-dark.png; do
+    local base; base=$(basename "$img")
+    [[ ! -f "$profiles/$base" ]] && cp "$img" "$profiles/$base" 2>/dev/null || true
+  done
+}
+
+pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    local p; p=$(cat "$PID_FILE")
+    kill -0 "$p" 2>/dev/null && echo "$p" && return 0
+    rm -f "$PID_FILE"
+  fi
+  # Fallback: check by port
+  lsof -ti "TCP:$PORT" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
+case "${1:-status}" in
+  start)
+    if p=$(pid); then
+      echo "odin: already running (pid $p) on port $PORT"
+      echo "  → http://localhost:$PORT/"
+      exit 0
+    fi
+    copy_assets
+    echo "Starting Odin's Agent Monitor on port $PORT..."
+    > "$LOG"
+    nohup npx http-server "$SERVE_DIR" -p "$PORT" -c-1 --cors -s >> "$LOG" 2>&1 &
+    echo $! > "$PID_FILE"
+    sleep 1
+    echo "odin: running on port $PORT"
+    echo "  → http://localhost:$PORT/"
+    ;;
+  stop)
+    if p=$(pid); then
+      kill "$p" 2>/dev/null
+      rm -f "$PID_FILE"
+      echo "odin: stopped"
+    else
+      echo "odin: not running"
+    fi
+    ;;
+  status)
+    if p=$(pid); then
+      echo "odin: running (pid $p) on port $PORT"
+      echo "  → http://localhost:$PORT/"
+    else
+      echo "odin: not running"
+    fi
+    ;;
+  logs)
+    tail -f "$LOG"
+    ;;
+  *)
+    echo "Usage: odin.sh {start|stop|status|logs}"
+    exit 1
+    ;;
+esac

--- a/.claude/skills/dev-server/scripts/proxy.sh
+++ b/.claude/skills/dev-server/scripts/proxy.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# proxy.sh — manage kubectl proxy for GKE cluster access
+set -euo pipefail
+
+PORT=8001
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+LOG_DIR="$REPO_ROOT/tmp"
+LOG="${LOG_DIR}/k8s-proxy.log"
+PID_FILE="${LOG_DIR}/.k8s-proxy.pid"
+
+mkdir -p "$LOG_DIR"
+
+pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    local p; p=$(cat "$PID_FILE")
+    kill -0 "$p" 2>/dev/null && echo "$p" && return 0
+    rm -f "$PID_FILE"
+  fi
+  lsof -ti "TCP:$PORT" -sTCP:LISTEN 2>/dev/null | head -1
+}
+
+case "${1:-status}" in
+  start)
+    if p=$(pid); then
+      echo "proxy: already running (pid $p) on port $PORT"
+      exit 0
+    fi
+    if ! command -v kubectl &>/dev/null; then
+      echo "proxy: ERROR — kubectl not installed"
+      exit 1
+    fi
+    echo "Starting kubectl proxy on port $PORT..."
+    > "$LOG"
+    nohup kubectl proxy --port="$PORT" >> "$LOG" 2>&1 &
+    echo $! > "$PID_FILE"
+    sleep 1
+    echo "proxy: running on port $PORT"
+    echo "  → http://localhost:$PORT/api/v1/namespaces"
+    ;;
+  stop)
+    if p=$(pid); then
+      kill "$p" 2>/dev/null
+      rm -f "$PID_FILE"
+      echo "proxy: stopped"
+    else
+      echo "proxy: not running"
+    fi
+    ;;
+  status)
+    if p=$(pid); then
+      echo "proxy: running (pid $p) on port $PORT"
+    else
+      echo "proxy: not running"
+    fi
+    ;;
+  logs)
+    tail -f "$LOG"
+    ;;
+  *)
+    echo "Usage: proxy.sh {start|stop|status|logs}"
+    exit 1
+    ;;
+esac

--- a/.claude/skills/dev-server/scripts/stripe.sh
+++ b/.claude/skills/dev-server/scripts/stripe.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# stripe.sh — manage Stripe CLI webhook forwarding
+set -euo pipefail
+
+APP_PORT="${FENRIR_FRONTEND_PORT:-9653}"
+REPO_ROOT="$(cd "$(dirname "$0")/../../../.." && pwd)"
+FRONTEND_DIR="${FENRIR_FRONTEND_DIR:-$REPO_ROOT/development/frontend}"
+LOG_DIR="${FRONTEND_DIR}/logs"
+mkdir -p "$LOG_DIR"
+LOG="${LOG_DIR}/stripe-listen.log"
+PID_FILE="${FRONTEND_DIR}/.stripe-listen.pid"
+ENV_FILE="${FRONTEND_DIR}/.env.local"
+WEBHOOK_BACKUP="${FRONTEND_DIR}/.env.local.stripe-backup"
+
+pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    local p; p=$(cat "$PID_FILE")
+    kill -0 "$p" 2>/dev/null && echo "$p" && return 0
+    rm -f "$PID_FILE"
+  fi
+  return 1
+}
+
+get_stripe_key() {
+  [[ -f "$ENV_FILE" ]] && grep "^STRIPE_SECRET_KEY=" "$ENV_FILE" | cut -d= -f2- | tr -d '"'
+}
+
+case "${1:-status}" in
+  start)
+    if p=$(pid); then
+      echo "stripe: already running (pid $p)"
+      exit 0
+    fi
+    if ! command -v stripe &>/dev/null; then
+      echo "stripe: ERROR — Stripe CLI not installed. Run: brew install stripe/stripe-cli/stripe"
+      exit 1
+    fi
+    STRIPE_KEY=$(get_stripe_key)
+    if [[ -z "$STRIPE_KEY" ]]; then
+      echo "stripe: ERROR — STRIPE_SECRET_KEY not found in $ENV_FILE"
+      exit 1
+    fi
+    echo "Starting Stripe webhook forwarding..."
+    > "$LOG"
+    stripe listen \
+      --api-key "$STRIPE_KEY" \
+      --forward-to "http://localhost:${APP_PORT}/api/stripe/webhook" \
+      >> "$LOG" 2>&1 &
+    echo $! > "$PID_FILE"
+    # Wait for ephemeral webhook secret
+    local_secret=""
+    for _ in $(seq 1 15); do
+      local_secret=$(sed -n 's/.*Your webhook signing secret is \(whsec_[a-zA-Z0-9_]*\).*/\1/p' "$LOG" 2>/dev/null | head -1)
+      [[ -n "$local_secret" ]] && break
+      sleep 1
+    done
+    if [[ -n "$local_secret" ]]; then
+      grep "^STRIPE_WEBHOOK_SECRET=" "$ENV_FILE" > "$WEBHOOK_BACKUP" 2>/dev/null || true
+      if grep -q "^STRIPE_WEBHOOK_SECRET=" "$ENV_FILE"; then
+        sed -i '' "s|^STRIPE_WEBHOOK_SECRET=.*|STRIPE_WEBHOOK_SECRET=\"${local_secret}\"|" "$ENV_FILE"
+      else
+        echo "STRIPE_WEBHOOK_SECRET=\"${local_secret}\"" >> "$ENV_FILE"
+      fi
+      echo "stripe: running (webhook secret injected)"
+    else
+      echo "stripe: WARNING — could not detect webhook secret after 15s"
+    fi
+    ;;
+  stop)
+    if p=$(pid); then
+      kill "$p" 2>/dev/null
+      rm -f "$PID_FILE"
+      # Restore original webhook secret
+      if [[ -f "$WEBHOOK_BACKUP" ]]; then
+        original=$(cat "$WEBHOOK_BACKUP")
+        if [[ -n "$original" ]] && [[ -f "$ENV_FILE" ]]; then
+          sed -i '' "s|^STRIPE_WEBHOOK_SECRET=.*|${original}|" "$ENV_FILE"
+        fi
+        rm -f "$WEBHOOK_BACKUP"
+      fi
+      echo "stripe: stopped (webhook secret restored)"
+    else
+      echo "stripe: not running"
+    fi
+    ;;
+  status)
+    if p=$(pid); then
+      echo "stripe: running (pid $p)"
+    else
+      echo "stripe: not running"
+    fi
+    ;;
+  logs)
+    tail -f "$LOG"
+    ;;
+  *)
+    echo "Usage: stripe.sh {start|stop|status|logs}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary
- New `/dev-server` SKILL replacing monolithic `services.sh`
- 4 managed services: app (9653/WOLF), stripe, odin (8316/Hlidskjalf), proxy (8001)
- Each service has its own start/stop/status/logs script
- Odin's Agent Monitor auto-copies profile images on start

## Test plan
- [x] `odin.sh start` — serves agent reports on port 8316
- [x] `odin.sh status` — reports running/not running
- [x] Auto-copies Odin favicon and agent profile images

🤖 Generated with [Claude Code](https://claude.com/claude-code)