### PR TITLE
fix: add www variant to OAuth redirect_uri allowlist

### DIFF
--- a/development/frontend/src/app/api/auth/token/route.ts
+++ b/development/frontend/src/app/api/auth/token/route.ts
@@ -37,6 +37,10 @@ import { log } from "@/lib/logger";
 const ALLOWED_ORIGINS = new Set([
   "http://localhost:9653",
   ...(process.env.APP_BASE_URL ? [process.env.APP_BASE_URL] : []),
+  // Support www variant — redirect_uri origin must match
+  ...(process.env.APP_BASE_URL?.includes("://") && !process.env.APP_BASE_URL.includes("://www.")
+    ? [`${process.env.APP_BASE_URL.replace("://", "://www.")}`]
+    : []),
 ]);
 
 /** Google token endpoint. */


### PR DESCRIPTION
## Summary
Our own `/api/auth/token` route was rejecting `https://www.fenrirledger.com` because `ALLOWED_ORIGINS` only had `APP_BASE_URL` (`https://fenrirledger.com` — no www). Auto-derives the www variant.

Fixes #876

## Root cause
```
ALLOWED_ORIGINS = {localhost:9653, https://fenrirledger.com}
Request:  redirect_uri=https://www.fenrirledger.com/ledger/auth/callback
Result:   400 "redirect_uri origin is not whitelisted"
```
Google config was fine — it was our own validation blocking it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)