### PR TITLE
fix: correct Odin's Throne job label selector

### DIFF
--- a/infrastructure/helm/odin-throne/values.yaml
+++ b/infrastructure/helm/odin-throne/values.yaml
@@ -24,7 +24,7 @@ app:
     NODE_ENV: "production"
     PORT: "3001"
     K8S_NAMESPACE: "fenrir-agents"
-    JOB_LABEL_SELECTOR: "app=odin-agent"
+    JOB_LABEL_SELECTOR: "app.kubernetes.io/component=agent-sandbox"
 
   # K8s secret containing GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET,
   # ALLOWED_EMAIL, SESSION_SECRET — injected via envFrom.


### PR DESCRIPTION
## Summary
- Fix `JOB_LABEL_SELECTOR` from `app=odin-agent` to `app.kubernetes.io/component=agent-sandbox`
- The monitor was showing zero agents because the K8s query matched nothing

## Test plan
- [ ] Refresh monitor.fenrirledger.com — agents now appear in sidebar
- [ ] /api/jobs returns non-empty list when agents are running

🤖 Generated with [Claude Code](https://claude.com/claude-code)