### PR TITLE
Issue #937 - fix: use correct OAuth client for Umami

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -536,8 +536,8 @@ jobs:
         run: |
           kubectl create secret generic umami-oauth2-proxy-secrets \
             --namespace=fenrir-analytics \
-            --from-literal=GOOGLE_CLIENT_ID="${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}" \
-            --from-literal=GOOGLE_CLIENT_SECRET="${{ secrets.GOOGLE_CLIENT_SECRET }}" \
+            --from-literal=GOOGLE_CLIENT_ID="${{ secrets.ODINS_THRONE_CLIENT_ID }}" \
+            --from-literal=GOOGLE_CLIENT_SECRET="${{ secrets.ODINS_THRONE_CLIENT_SECRET }}" \
             --from-literal=OAUTH2_PROXY_COOKIE_SECRET="${{ secrets.UMAMI_OAUTH2_PROXY_COOKIE_SECRET }}" \
             --from-literal=emails.txt="declanshanaghy@gmail.com" \
             --dry-run=client -o yaml | kubectl apply -f -


### PR DESCRIPTION
Fixes #937

Umami's oauth2-proxy needs the Odin's Throne OAuth client, not the main app client. Switches GitHub secrets references from `NEXT_PUBLIC_GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` to `ODINS_THRONE_CLIENT_ID`/`ODINS_THRONE_CLIENT_SECRET`.

Cluster already hotfixed.