### PR TITLE
Issue #945 - feat: deploy monitor service to GKE

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,11 @@
 #   UMAMI_OAUTH2_PROXY_COOKIE_SECRET — 32-byte cookie secret for Umami oauth2-proxy sidecar
 #                                       Generate: openssl rand -hex 16  (32 hex chars = 32 bytes)
 #                                       MUST be exactly 16, 24, or 32 bytes — see oauth2-proxy docs
+#   MONITOR_OAUTH2_PROXY_COOKIE_SECRET — 32-byte cookie secret for Odin's Throne oauth2-proxy sidecar
+#                                        Generate: openssl rand -hex 16  (32 hex chars = 32 bytes)
+#                                        MUST be exactly 16, 24, or 32 bytes — see oauth2-proxy docs
+#   ODINS_THRONE_CLIENT_ID            — Google OAuth client ID for Odin's Throne
+#   ODINS_THRONE_CLIENT_SECRET        — Google OAuth client secret for Odin's Throne
 # --------------------------------------------------------------------------
 
 name: Deploy to GKE
@@ -604,6 +609,19 @@ jobs:
       - name: Ensure fenrir-monitor namespace
         run: |
           kubectl create namespace fenrir-monitor --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Create/update Odin's Throne oauth2-proxy secrets
+        # oauth2-proxy requires OAUTH2_PROXY_COOKIE_SECRET to be exactly 16, 24, or 32 bytes.
+        # Created imperatively (NOT via Helm template) to prevent placeholder values from
+        # values.yaml overwriting real credentials on every helm upgrade.
+        run: |
+          kubectl create secret generic odin-throne-oauth2-proxy-secrets \
+            --namespace=fenrir-monitor \
+            --from-literal=GOOGLE_CLIENT_ID="${{ secrets.ODINS_THRONE_CLIENT_ID }}" \
+            --from-literal=GOOGLE_CLIENT_SECRET="${{ secrets.ODINS_THRONE_CLIENT_SECRET }}" \
+            --from-literal=OAUTH2_PROXY_COOKIE_SECRET="${{ secrets.MONITOR_OAUTH2_PROXY_COOKIE_SECRET }}" \
+            --from-literal=emails.txt="declanshanaghy@gmail.com" \
+            --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Set up Helm
         uses: azure/setup-helm@v4

--- a/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
@@ -23,6 +23,15 @@ spec:
         {{- include "odin-throne.labels" (dict "component" "monitor-ui") | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 15
+      {{- if .Values.oauth2Proxy.enabled }}
+      volumes:
+        - name: oauth2-proxy-emails
+          secret:
+            secretName: odin-throne-oauth2-proxy-secrets
+            items:
+              - key: emails.txt
+                path: emails.txt
+      {{- end }}
       containers:
         - name: odin-throne-ui
           image: "{{ .Values.ui.image.repository }}:{{ .Values.ui.image.tag }}"
@@ -49,3 +58,62 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 3
             failureThreshold: 3
+        {{- if .Values.oauth2Proxy.enabled }}
+        - name: oauth2-proxy
+          image: "{{ .Values.oauth2Proxy.image.repository }}:{{ .Values.oauth2Proxy.image.tag }}"
+          imagePullPolicy: {{ .Values.oauth2Proxy.image.pullPolicy }}
+          args:
+            - --provider=google
+            - --client-id=$(GOOGLE_CLIENT_ID)
+            - --client-secret=$(GOOGLE_CLIENT_SECRET)
+            - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
+            - --email-domain=*
+            - --authenticated-emails-file=/etc/oauth2-proxy/emails.txt
+            - --upstream=http://localhost:80
+            - --http-address=0.0.0.0:{{ .Values.oauth2Proxy.port }}
+            - --redirect-url={{ .Values.oauth2Proxy.redirectUrl }}
+            - --cookie-secure=true
+            - --cookie-samesite=lax
+          ports:
+            - name: oauth2-proxy
+              containerPort: {{ .Values.oauth2Proxy.port }}
+              protocol: TCP
+          env:
+            - name: GOOGLE_CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: odin-throne-oauth2-proxy-secrets
+                  key: GOOGLE_CLIENT_ID
+            - name: GOOGLE_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: odin-throne-oauth2-proxy-secrets
+                  key: GOOGLE_CLIENT_SECRET
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: odin-throne-oauth2-proxy-secrets
+                  key: OAUTH2_PROXY_COOKIE_SECRET
+          volumeMounts:
+            - name: oauth2-proxy-emails
+              mountPath: /etc/oauth2-proxy
+              readOnly: true
+          resources:
+            {{- toYaml .Values.oauth2Proxy.resources | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.oauth2Proxy.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.oauth2Proxy.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+        {{- end }}

--- a/infrastructure/helm/odin-throne/templates/service-ui.yaml
+++ b/infrastructure/helm/odin-throne/templates/service-ui.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Values.namespace }}
   labels:
     {{- include "odin-throne.labels" (dict "component" "monitor-ui") | nindent 4 }}
+  annotations:
+    cloud.google.com/backend-config: '{"default":"odin-throne-ui-backend-config"}'
+    cloud.google.com/neg: '{"ingress":true}'
 spec:
   type: ClusterIP
   selector:
@@ -12,5 +15,9 @@ spec:
   ports:
     - name: http
       port: 80
+      {{- if .Values.oauth2Proxy.enabled }}
+      targetPort: oauth2-proxy
+      {{- else }}
       targetPort: http
+      {{- end }}
       protocol: TCP

--- a/infrastructure/helm/odin-throne/values-prod.yaml
+++ b/infrastructure/helm/odin-throne/values-prod.yaml
@@ -30,5 +30,9 @@ ingress:
   hosts:
     - monitor.fenrirledger.com
 
+oauth2Proxy:
+  enabled: true
+  redirectUrl: "https://monitor.fenrirledger.com/oauth2/callback"
+
 rbac:
   enabled: true

--- a/infrastructure/helm/odin-throne/values.yaml
+++ b/infrastructure/helm/odin-throne/values.yaml
@@ -138,6 +138,28 @@ rbac:
   enabled: true
   agentsNamespace: fenrir-agents
 
+# -- oauth2-proxy Sidecar (in UI pod) -------------------------------------
+# Fronts the nginx UI container. Credentials created imperatively by CI.
+oauth2Proxy:
+  enabled: true
+  image:
+    repository: quay.io/oauth2-proxy/oauth2-proxy
+    tag: v7.6.0
+    pullPolicy: IfNotPresent
+  port: 4180
+  redirectUrl: "https://monitor.fenrirledger.com/oauth2/callback"
+  resources:
+    requests:
+      cpu: "50m"
+      memory: "64Mi"
+      ephemeral-storage: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "128Mi"
+      ephemeral-storage: "128Mi"
+  # oauth2-proxy secrets are created imperatively by the deploy-odin-throne CI step.
+  # They are NOT rendered from values.yaml. See secrets.yaml template for details.
+
 # -- Secrets ---------------------------------------------------------------
 secrets:
   enabled: false


### PR DESCRIPTION
## Summary
- Add oauth2-proxy sidecar to Odin's Throne UI deployment (`deployment-ui.yaml`) — same pattern as Umami analytics, protecting `monitor.fenrirledger.com` with Google OAuth from day one
- Add `cloud.google.com/backend-config` and `neg` annotations to `service-ui.yaml` so GKE Ingress BackendConfig health checks route to oauth2-proxy's `/ping` endpoint (port 4180)
- Add `oauth2Proxy` values section to `values.yaml` and `values-prod.yaml`
- Add imperative `kubectl create secret` step for `odin-throne-oauth2-proxy-secrets` in `deploy-odin-throne` CI job (uses `ODINS_THRONE_CLIENT_ID`, `ODINS_THRONE_CLIENT_SECRET`, `MONITOR_OAUTH2_PROXY_COOKIE_SECRET` GitHub secrets)
- Document new required GitHub secrets in workflow header

The chart scaffold, DNS record (`monitor.fenrirledger.com`), static IP (`monitor-ip`), build jobs, and deploy job were already in place — this PR completes the oauth2-proxy protection layer.

Closes #945

## Test plan
- [ ] Verify `helm template ./infrastructure/helm/odin-throne -f values-prod.yaml` renders without errors
- [ ] Verify `odin-throne-ui` Service targets port `oauth2-proxy` (4180) when oauth2Proxy is enabled
- [ ] Verify `odin-throne-oauth2-proxy-secrets` is created by the deploy job before Helm runs
- [ ] Deploy to GKE and confirm `https://monitor.fenrirledger.com/` redirects to Google OAuth
- [ ] Confirm `/ping` health check passes from GKE BackendConfig

## QA Verdict: PASS

**Reviewed by Loki (QA) — 2026-03-15**

### New Tests: 0 (infrastructure-only change)

This PR touches exclusively infrastructure files — no testable application code changed:

| File | Type |
|------|------|
| `.github/workflows/deploy.yml` | CI/CD deploy workflow (YAML) |
| `infrastructure/helm/odin-throne/templates/deployment-ui.yaml` | Helm template |
| `infrastructure/helm/odin-throne/templates/service-ui.yaml` | Helm template |
| `infrastructure/helm/odin-throne/values-prod.yaml` | Helm values |
| `infrastructure/helm/odin-throne/values.yaml` | Helm values |

Per QA rules: Helm charts, deploy workflows, and YAML config files are explicitly outside the automated test boundary. Infrastructure-only changes are verified by build + tsc only.

### Verification Results

- **Vitest:** 59 test files, 771 tests — all passing (no regressions)
- **tsc:** PASS — zero TypeScript errors
- **Working tree:** Clean, branch up to date with `origin/main`
- **quality/reports/:** Clean (no stale report files)

### Issues Found

None.

### Tests Passed (Existing Suite)

- All 771 existing unit and integration tests pass without modification
- No regressions introduced by this infrastructure-only change

Generated with [Claude Code](https://claude.com/claude-code)