### PR TITLE
Issue #972 - fix: upgrade Node.js 20 → 24 in CI/CD workflows

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
           cache-dependency-path: development/frontend/package-lock.json
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -385,10 +385,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Node 20
+      - name: Set up Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           cache-dependency-path: development/frontend/package-lock.json
 


### PR DESCRIPTION
## Summary

- Upgrades `node-version` from `'20'` to `'24'` in `.github/workflows/deploy.yml` (`test-app` job)
- Upgrades `node-version` from `"20"` to `"24"` in `.github/workflows/ci-tests.yml`
- Eliminates Node.js 20 deprecation warnings in all CI runs

Fixes #972

## Test plan

- [x] `tsc` passes (`bash quality/scripts/verify.sh --step tsc`)
- [x] `build` passes (`bash quality/scripts/verify.sh --step build`) — 37 routes compiled
- [ ] CI run on this PR should show no Node.js 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)