### PR TITLE
Issue #974 - fix: TTL-expired error loop + Norse error tablet

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -18,7 +18,11 @@ export function App() {
     setActiveSessionId,
     clearEntries,
     handleMessage: handleLogMessage,
+    terminalError,
   } = useLogStream();
+
+  // Sessions that received a terminal error — never re-subscribe on reconnect
+  const terminalSessionsRef = useRef<Set<string>>(new Set());
 
   const prevSessionRef = useRef<string | null>(null);
 
@@ -64,13 +68,23 @@ export function App() {
     [send, setActiveSessionId, clearEntries]
   );
 
+  // Track sessions with terminal errors — they must not be re-subscribed
+  useEffect(() => {
+    if (terminalError && activeSessionId) {
+      terminalSessionsRef.current.add(activeSessionId);
+    }
+  }, [terminalError, activeSessionId]);
+
   // Re-subscribe only on actual reconnect (wsState transitions to "open")
+  // Skip sessions that ended with a terminal error (pod-not-found / TTL expired)
   const prevWsState = useRef(wsState);
   useEffect(() => {
     const wasDisconnected = prevWsState.current !== "open";
     prevWsState.current = wsState;
     if (wsState === "open" && wasDisconnected && activeSessionId) {
-      send({ type: "subscribe", sessionId: activeSessionId });
+      if (!terminalSessionsRef.current.has(activeSessionId)) {
+        send({ type: "subscribe", sessionId: activeSessionId });
+      }
     }
   }, [wsState, activeSessionId, send]);
 
@@ -92,6 +106,7 @@ export function App() {
             activeJob={activeJob}
             wsState={wsState}
             isFixture={isFixture}
+            terminalError={terminalError}
             onSetSpeed={(speed) => {
               if (activeSessionId) {
                 send({ type: "set-speed", sessionId: activeSessionId, speed });

--- a/development/monitor-ui/src/__tests__/norse-error-tablet.test.tsx
+++ b/development/monitor-ui/src/__tests__/norse-error-tablet.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * Vitest tests for issue #974 — Norse error tablet (TTL expired / pod-not-found)
+ *
+ * AC tested:
+ * - terminalError state is set in useLogStream when stream-error arrives
+ * - terminalError is cleared in clearEntries (session switch)
+ * - LogViewer renders Norse error tablet (full-pane) when terminalError is set
+ * - Norse tablet shows session ID
+ * - Norse tablet has role="alert" for accessibility
+ * - Norse tablet replaces log terminal (log entries are not shown)
+ * - Normal log entries render when terminalError is null
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { LogViewer } from "../components/LogViewer";
+import { useLogStream } from "../hooks/useLogStream";
+import type { LogEntry } from "../hooks/useLogStream";
+import type { DisplayJob } from "../lib/types";
+
+afterEach(cleanup);
+
+// Minimal DisplayJob
+const MOCK_JOB: DisplayJob = {
+  sessionId: "issue-974-step1-fireman",
+  name: "agent-issue-974-step1-fireman",
+  issue: "974",
+  step: "1",
+  agentKey: "fireman",
+  agentName: "FiremanDecko",
+  status: "failed",
+  startTime: Date.now(),
+  completionTime: null,
+};
+
+const TTL_ERROR_MSG =
+  "Logs unavailable — the pod for session issue-974-step1-fireman has been cleaned up (job TTL expired).";
+
+// ── useLogStream — terminalError state ───────────────────────────────────────
+
+describe("useLogStream — terminalError state (issue #974)", () => {
+  it("starts with terminalError null", () => {
+    const { result } = renderHook(() => useLogStream());
+    expect(result.current.terminalError).toBeNull();
+  });
+
+  it("sets terminalError when stream-error is received", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-fireman",
+        message: TTL_ERROR_MSG,
+      });
+    });
+    expect(result.current.terminalError).toBe(TTL_ERROR_MSG);
+  });
+
+  it("clears terminalError on clearEntries (session switch)", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-fireman",
+        message: TTL_ERROR_MSG,
+      });
+    });
+    expect(result.current.terminalError).toBe(TTL_ERROR_MSG);
+    act(() => {
+      result.current.clearEntries();
+    });
+    expect(result.current.terminalError).toBeNull();
+  });
+
+  it("also adds an error entry to entries on stream-error", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-fireman",
+        message: TTL_ERROR_MSG,
+      });
+    });
+    const errorEntry = result.current.entries.find((e) => e.type === "error");
+    expect(errorEntry).toBeDefined();
+    expect(errorEntry?.message).toBe(TTL_ERROR_MSG);
+  });
+});
+
+// ── LogViewer — Norse error tablet rendering ─────────────────────────────────
+
+describe("LogViewer — Norse error tablet (issue #974)", () => {
+  it("renders Norse error tablet when terminalError is set", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={TTL_ERROR_MSG}
+      />
+    );
+    const tablet = container.querySelector(".norse-error-stone");
+    expect(tablet).not.toBeNull();
+  });
+
+  it("Norse error pane has role=alert", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={TTL_ERROR_MSG}
+      />
+    );
+    const alert = container.querySelector("[role='alert']");
+    expect(alert).not.toBeNull();
+  });
+
+  it("Norse error tablet shows the session ID", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={TTL_ERROR_MSG}
+      />
+    );
+    expect(container.textContent).toContain(MOCK_JOB.sessionId);
+  });
+
+  it("Norse error tablet shows the error message", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={TTL_ERROR_MSG}
+      />
+    );
+    expect(container.textContent).toContain("cleaned up");
+    expect(container.textContent).toContain("TTL expired");
+  });
+
+  it("Norse error tablet replaces log-terminal (no .log-terminal when terminalError is set)", () => {
+    const entries: LogEntry[] = [
+      { id: "l1", type: "raw", text: "some log line" },
+    ];
+    const { container } = render(
+      <LogViewer
+        entries={entries}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={TTL_ERROR_MSG}
+      />
+    );
+    expect(container.querySelector(".log-terminal")).toBeNull();
+    expect(container.querySelector(".norse-error-stone")).not.toBeNull();
+  });
+
+  it("renders log-terminal normally when terminalError is null", () => {
+    const entries: LogEntry[] = [
+      { id: "l1", type: "raw", text: "some log line" },
+    ];
+    const { container } = render(
+      <LogViewer
+        entries={entries}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={null}
+      />
+    );
+    expect(container.querySelector(".log-terminal")).not.toBeNull();
+    expect(container.querySelector(".norse-error-stone")).toBeNull();
+  });
+
+  it("Norse error pane has aria-label for accessibility", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        terminalError={TTL_ERROR_MSG}
+      />
+    );
+    const pane = container.querySelector(".norse-error-pane");
+    expect(pane?.getAttribute("aria-label")).toBeTruthy();
+  });
+});

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -12,9 +12,10 @@ interface Props {
   wsState: "connecting" | "open" | "closed" | "error";
   isFixture?: boolean;
   onSetSpeed?: (speed: number) => void;
+  terminalError?: string | null;
 }
 
-export function LogViewer({ entries, activeJob, wsState, isFixture, onSetSpeed }: Props) {
+export function LogViewer({ entries, activeJob, wsState, isFixture, onSetSpeed, terminalError }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [fixtureSpeed, setFixtureSpeed] = useState(1);
   const [fixturePaused, setFixturePaused] = useState(false);
@@ -92,18 +93,25 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, onSetSpeed }
           <StatusBadge state={wsState} />
         </span>
       </div>
-      <div
-        className="log-terminal"
-        ref={termRef}
-        role="log"
-        aria-live="polite"
-        aria-label="Session logs"
-        onScroll={handleScroll}
-      >
-        {entries.map((entry) => (
-          <LogLine key={entry.id} entry={entry} {...(activeJob?.agentKey ? { agentKey: activeJob.agentKey } : {})} {...(activeJob?.agentName ? { agentName: activeJob.agentName } : {})} />
-        ))}
-      </div>
+      {terminalError ? (
+        <NorseErrorTablet
+          message={terminalError}
+          sessionId={activeJob.sessionId}
+        />
+      ) : (
+        <div
+          className="log-terminal"
+          ref={termRef}
+          role="log"
+          aria-live="polite"
+          aria-label="Session logs"
+          onScroll={handleScroll}
+        >
+          {entries.map((entry) => (
+            <LogLine key={entry.id} entry={entry} {...(activeJob?.agentKey ? { agentKey: activeJob.agentKey } : {})} {...(activeJob?.agentName ? { agentName: activeJob.agentName } : {})} />
+          ))}
+        </div>
+      )}
       <div className="log-controls">
         {isFixture && (
           <div className="speed-controls">
@@ -288,6 +296,42 @@ function NorseTablet({ text }: { text: string }) {
           <div className="norse-tablet-seal">
             {"\u16B1\u16A0\u16C7\u16BE\u16A0\u16B1"} &mdash; So it is written, so it shall be done &mdash; {"\u16B1\u16A0\u16C7\u16BE\u16A0\u16B1"}
           </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Elder Futhark runes for decorative rows
+const RUNE_ROW = "\u16A0 \u16A2 \u16A6 \u16A8 \u16B1 \u16B2 \u16B7 \u16B9 \u16BA \u16BE \u16C1 \u16C3 \u16C7 \u16C8 \u16C9 \u16CA \u16CF \u16D2 \u16D6 \u16D7 \u16DA \u16DC \u16DE \u16DF";
+
+function NorseErrorTablet({
+  message,
+  sessionId,
+}: {
+  message: string;
+  sessionId: string;
+}) {
+  return (
+    <div className="norse-error-pane" role="alert" aria-label="Session logs unavailable">
+      <div className="norse-error-stone" aria-label="Norse error tablet">
+        <div className="norse-error-rune-row" aria-hidden="true">
+          {RUNE_ROW}
+        </div>
+        <div className="norse-error-body">
+          <div className="norse-error-sigil" aria-hidden="true">{"\u16B1"}</div>
+          <div className="norse-error-heading">The Saga Is Silent</div>
+          <div className="norse-error-divider" aria-hidden="true" />
+          <p className="norse-error-message">{message}</p>
+          <div className="norse-error-session" aria-label={`Session ID: ${sessionId}`}>
+            Session: {sessionId}
+          </div>
+          <p className="norse-error-sub">
+            The cluster has reclaimed these logs &mdash; this session&apos;s runes are lost to the void.
+          </p>
+        </div>
+        <div className="norse-error-rune-row-bottom" aria-hidden="true">
+          {RUNE_ROW}
         </div>
       </div>
     </div>

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -72,11 +72,13 @@ function parseEntrypointLine(line: string): LogEntry {
 export function useLogStream() {
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [terminalError, setTerminalError] = useState<string | null>(null);
   const taskPromptBuffer = useRef<string[]>([]);
   const inTaskPrompt = useRef(false);
 
   const clearEntries = useCallback(() => {
     setEntries([]);
+    setTerminalError(null);
     entryCounter = 0;
     taskPromptBuffer.current = [];
     inTaskPrompt.current = false;
@@ -131,6 +133,7 @@ export function useLogStream() {
       }
       processEvent(ev);
     } else if (msg.type === "stream-error") {
+      setTerminalError(msg.message);
       setEntries((prev) => [
         ...prev,
         { id: nextId(), type: "error", message: msg.message },
@@ -342,5 +345,6 @@ export function useLogStream() {
     setActiveSessionId,
     clearEntries,
     handleMessage,
+    terminalError,
   };
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -406,6 +406,108 @@ body {
   opacity: 0.7;
 }
 
+/* ── Norse Error Tablet (full-pane TTL/pod-not-found state) ─────────────── */
+.norse-error-pane {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  height: 100%;
+  padding: 2rem;
+  background: var(--void);
+}
+.norse-error-stone {
+  width: 100%;
+  max-width: 560px;
+  border: 2px solid var(--gold);
+  border-radius: 8px;
+  background: linear-gradient(160deg, #08080f 0%, #0e0e1a 45%, #08080f 100%);
+  box-shadow:
+    0 0 32px rgba(201, 146, 10, 0.18),
+    0 0 8px rgba(201, 146, 10, 0.08),
+    inset 0 1px 0 rgba(201, 146, 10, 0.12),
+    inset 0 -1px 0 rgba(201, 146, 10, 0.06);
+  overflow: hidden;
+}
+.norse-error-rune-row {
+  display: flex;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.65rem 1rem 0.5rem;
+  background: linear-gradient(90deg, transparent, rgba(201,146,10,0.07) 50%, transparent);
+  border-bottom: 1px solid rgba(201, 146, 10, 0.3);
+  font-size: 0.9rem;
+  color: var(--gold);
+  letter-spacing: 0.05em;
+  opacity: 0.75;
+}
+.norse-error-body {
+  padding: 1.6rem 1.8rem 1.4rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+}
+.norse-error-sigil {
+  font-size: 2rem;
+  color: var(--gold-bright);
+  text-shadow: 0 0 16px rgba(240, 180, 41, 0.5);
+  line-height: 1;
+}
+.norse-error-heading {
+  font-family: 'Cinzel Decorative', serif;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--gold-bright);
+  letter-spacing: 0.08em;
+  text-align: center;
+  text-shadow: 0 0 24px rgba(240, 180, 41, 0.3);
+}
+.norse-error-divider {
+  width: 60%;
+  height: 1px;
+  background: linear-gradient(90deg, transparent, rgba(201,146,10,0.5), transparent);
+}
+.norse-error-message {
+  font-family: 'Cinzel', serif;
+  font-size: 0.78rem;
+  color: var(--text-rune);
+  text-align: center;
+  line-height: 1.6;
+  letter-spacing: 0.02em;
+}
+.norse-error-session {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  color: var(--gold);
+  background: rgba(201, 146, 10, 0.08);
+  border: 1px solid rgba(201, 146, 10, 0.25);
+  border-radius: 4px;
+  padding: 0.35rem 0.75rem;
+  letter-spacing: 0.04em;
+}
+.norse-error-sub {
+  font-family: 'Cinzel', serif;
+  font-size: 0.65rem;
+  color: var(--text-void);
+  text-align: center;
+  letter-spacing: 0.04em;
+  font-style: italic;
+}
+.norse-error-rune-row-bottom {
+  display: flex;
+  justify-content: center;
+  gap: 0.55rem;
+  padding: 0.5rem 1rem 0.65rem;
+  background: linear-gradient(90deg, transparent, rgba(201,146,10,0.07) 50%, transparent);
+  border-top: 1px solid rgba(201, 146, 10, 0.3);
+  font-size: 0.9rem;
+  color: var(--gold);
+  letter-spacing: 0.05em;
+  opacity: 0.75;
+}
+
 /* ── Entrypoint group (collapsible) ─────────────── */
 .ep-group {
   border: 1px solid var(--rune-border);

--- a/development/monitor/src/__tests__/ws.test.ts
+++ b/development/monitor/src/__tests__/ws.test.ts
@@ -25,6 +25,8 @@ import { WebSocket } from "ws";
 
 const capture = vi.hoisted(() => ({
   watchCb: null as ((...a: unknown[]) => void) | null,
+  streamPodLogsErrorCb: null as ((err: Error) => void) | null,
+  streamPodLogsCancelFn: vi.fn() as ReturnType<typeof vi.fn>,
 }));
 
 vi.mock("../k8s.js", () => ({
@@ -35,7 +37,18 @@ vi.mock("../k8s.js", () => ({
     }
   ),
   mapAgentJobToJob: vi.fn(),
-  streamPodLogs: vi.fn(),
+  streamPodLogs: vi.fn().mockImplementation(
+    async (
+      _pod: unknown,
+      _ns: unknown,
+      _onLine: unknown,
+      _onDone: unknown,
+      onError: (err: Error) => void
+    ) => {
+      capture.streamPodLogsErrorCb = onError;
+      return capture.streamPodLogsCancelFn;
+    }
+  ),
   findPodForSession: vi.fn().mockResolvedValue(null),
 }));
 
@@ -287,6 +300,102 @@ describe("WebSocket server — job status broadcasts (issue #963)", () => {
     } finally {
       c1.ws.close();
       c2.ws.close();
+    }
+  });
+});
+
+// ── Terminal error handling (issue #974) ───────────────────────────────────────
+
+describe("WebSocket server — terminal error handling (issue #974)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let port: number;
+
+  beforeEach(async () => {
+    capture.watchCb = null;
+    capture.streamPodLogsErrorCb = null;
+    capture.streamPodLogsCancelFn = vi.fn();
+    httpServer = createServer();
+    attachWebSocketServer(httpServer as Parameters<typeof attachWebSocketServer>[0]);
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    port = (httpServer.address() as { port: number }).port;
+  }, 15_000);
+
+  afterEach(async () => {
+    httpServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  }, 15_000);
+
+  it("sends stream-error followed by stream-end(failed) when pod is not found", async () => {
+    // findPodForSession returns null → pod-not-found path (no fixture)
+    const { ws, nextMsg, open } = connectAndCollect(port);
+    await open;
+    await waitForType(nextMsg, "jobs-snapshot");
+    try {
+      ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step1-test" }));
+      const errMsg = await waitForType<{ type: string; sessionId: string; message: string }>(
+        nextMsg, "stream-error"
+      );
+      expect(errMsg.sessionId).toBe("issue-974-step1-test");
+      expect(errMsg.message).toContain("cleaned up");
+      const endMsg = await waitForType<{ type: string; sessionId: string; reason: string }>(
+        nextMsg, "stream-end"
+      );
+      expect(endMsg.sessionId).toBe("issue-974-step1-test");
+    } finally {
+      ws.close();
+    }
+  });
+
+  it("sends stream-end only once even if error fires multiple times (terminated guard)", async () => {
+    // Mock findPodForSession to return a pod so we hit streamPodLogs
+    const { findPodForSession } = await import("../k8s.js");
+    vi.mocked(findPodForSession).mockResolvedValueOnce("pod-issue-974");
+
+    const { ws, nextMsg, open } = connectAndCollect(port);
+    await open;
+    await waitForType(nextMsg, "jobs-snapshot");
+    try {
+      ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step1-dupe" }));
+
+      // Wait for the subscribe to be processed and streamPodLogs to be called
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+
+      // Fire the error callback twice to simulate K8s client retrying
+      const errCb = capture.streamPodLogsErrorCb!;
+      expect(errCb).not.toBeNull();
+      errCb(new Error("HTTP status code 404 — pod not found"));
+      errCb(new Error("HTTP status code 404 — pod not found"));
+
+      const errMsg = await waitForType<{ type: string; message: string }>(nextMsg, "stream-error");
+      expect(errMsg.message).toContain("cleaned up");
+
+      const endMsg = await waitForType<{ type: string; reason: string }>(nextMsg, "stream-end");
+      expect(endMsg.reason).toBe("failed");
+
+      // Verify no second stream-error arrives
+      let secondError: string | null = null;
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(() => resolve(), 200);
+        const check = async () => {
+          try {
+            const m = JSON.parse(await Promise.race([
+              nextMsg(200),
+              new Promise<never>((_, r) => setTimeout(() => r(new Error("timeout")), 200)),
+            ])) as { type: string };
+            if (m.type === "stream-error") secondError = m.type;
+          } catch { /* timeout = no message = correct */ }
+          clearTimeout(t);
+          resolve();
+        };
+        void check();
+      });
+      expect(secondError).toBeNull();
+    } finally {
+      // Restore mock to default
+      vi.mocked(findPodForSession).mockResolvedValue(null);
+      ws.close();
     }
   });
 });

--- a/development/monitor/src/ws.ts
+++ b/development/monitor/src/ws.ts
@@ -270,6 +270,9 @@ async function startLogStream(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const events: any[] = [];
 
+    // Guard against multiple error callbacks (e.g. K8s client retrying after 404)
+    let terminated = false;
+
     const cancel = await streamPodLogs(
       podName,
       namespace,
@@ -296,11 +299,20 @@ async function startLogStream(
         });
       },
       (err) => {
+        if (terminated) return;
+        terminated = true;
         send(ws, {
           type: "stream-error",
           ts: Date.now(),
           sessionId,
           message: friendlyK8sError(err.message, sessionId),
+        });
+        // Always follow with stream-end so the client knows the stream is done
+        send(ws, {
+          type: "stream-end",
+          ts: Date.now(),
+          sessionId,
+          reason: "failed",
         });
       },
       { follow: !isCompleted }


### PR DESCRIPTION
## Summary

- **Backend (`ws.ts`)**: Add `terminated` guard in the `streamPodLogs` error callback — the stream-error fires exactly once and is always followed by `stream-end(failed)`, stopping K8s client retries from looping.
- **Frontend (`useLogStream`)**: Expose `terminalError` state; set on `stream-error`, cleared on session switch (`clearEntries`).
- **Frontend (`App.tsx`)**: Track terminal-error sessions in a ref; skip re-subscription on WebSocket reconnect for those sessions.
- **Frontend (`LogViewer`)**: When `terminalError` is set, replace the log-terminal pane with a full-pane **Norse error tablet** — Elder Futhark rune rows, Cinzel Decorative heading "The Saga Is Silent", void-black background, gold accent, session ID, contextual message.

## Test plan

- [ ] `bash quality/scripts/verify.sh --step tsc` passes
- [ ] `bash quality/scripts/verify.sh --step build` passes (37 routes)
- [ ] New `norse-error-tablet.test.tsx`: useLogStream terminalError state, LogViewer Norse tablet rendering (7 tests)
- [ ] Extended `ws.test.ts`: stream-error+stream-end sent once on pod-not-found; `terminated` guard prevents duplicate messages (2 new tests)
- [ ] Select a session with TTL-expired logs → Norse tablet appears once, no loop
- [ ] Switch to a different session → works normally
- [ ] WebSocket reconnect with terminal-error session active → no re-subscription

Fixes #974

🤖 Generated with [Claude Code](https://claude.com/claude-code)