### PR TITLE
Issue #974 - fix: Norse error tablet for TTL-expired sessions

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -18,6 +18,8 @@ export function App() {
     setActiveSessionId,
     clearEntries,
     handleMessage: handleLogMessage,
+    isTtlExpired,
+    streamError,
   } = useLogStream();
 
   const prevSessionRef = useRef<string | null>(null);
@@ -64,12 +66,16 @@ export function App() {
     [send, setActiveSessionId, clearEntries]
   );
 
-  // Re-subscribe only on actual reconnect (wsState transitions to "open")
+  // Re-subscribe only on actual reconnect (wsState transitions to "open").
+  // Skip re-subscribe if the session ended with a TTL-expired error — the pod
+  // is gone and retrying would just loop the same error again.
+  const isTtlExpiredRef = useRef(isTtlExpired);
+  isTtlExpiredRef.current = isTtlExpired;
   const prevWsState = useRef(wsState);
   useEffect(() => {
     const wasDisconnected = prevWsState.current !== "open";
     prevWsState.current = wsState;
-    if (wsState === "open" && wasDisconnected && activeSessionId) {
+    if (wsState === "open" && wasDisconnected && activeSessionId && !isTtlExpiredRef.current) {
       send({ type: "subscribe", sessionId: activeSessionId });
     }
   }, [wsState, activeSessionId, send]);
@@ -92,6 +98,8 @@ export function App() {
             activeJob={activeJob}
             wsState={wsState}
             isFixture={isFixture}
+            isTtlExpired={isTtlExpired}
+            streamError={streamError}
             onSetSpeed={(speed) => {
               if (activeSessionId) {
                 send({ type: "set-speed", sessionId: activeSessionId, speed });

--- a/development/monitor-ui/src/__tests__/norse-error-tablet.test.tsx
+++ b/development/monitor-ui/src/__tests__/norse-error-tablet.test.tsx
@@ -1,0 +1,289 @@
+/**
+ * Vitest tests for issue #974 — Norse error tablet and TTL-expired loop prevention.
+ *
+ * AC tested:
+ * - NorseErrorTablet renders with role="alert" and correct aria-label
+ * - Session ID is displayed in the tablet
+ * - Heading uses Cinzel Decorative styling class
+ * - Error message is displayed verbatim
+ * - Rune decorations are present
+ * - useLogStream correctly sets isTtlExpired when stream-error + stream-end received
+ * - useLogStream.isTtlExpired is false for non-TTL errors
+ * - useLogStream.clearEntries resets isTtlExpired
+ * - LogViewer renders NorseErrorTablet (not log-terminal) when isTtlExpired=true
+ */
+
+import { describe, it, expect, afterEach } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { NorseErrorTablet } from "../components/NorseErrorTablet";
+import { LogViewer } from "../components/LogViewer";
+import { useLogStream, TTL_ERROR_PATTERN } from "../hooks/useLogStream";
+import type { DisplayJob } from "../lib/types";
+
+afterEach(cleanup);
+
+// ── Test fixtures ─────────────────────────────────────────────────────────────
+
+const TTL_MESSAGE =
+  "Logs unavailable — the pod for session issue-974-step1-test has been cleaned up (job TTL expired).";
+
+const NON_TTL_MESSAGE =
+  "Access denied to pod logs for session issue-974-step1-test. Contact your cluster administrator.";
+
+const MOCK_JOB: DisplayJob = {
+  sessionId: "issue-974-step1-test",
+  name: "agent-issue-974-step1-test",
+  issue: "974",
+  step: "1",
+  agentKey: "fireman",
+  agentName: "FiremanDecko",
+  status: "failed",
+  startTime: null,
+  completionTime: null,
+};
+
+// ── NorseErrorTablet rendering ────────────────────────────────────────────────
+
+describe("NorseErrorTablet — rendering (issue #974)", () => {
+  it("renders with role=alert", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    const tablet = container.querySelector("[role='alert']");
+    expect(tablet).not.toBeNull();
+  });
+
+  it("has aria-label indicating TTL expired", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    const tablet = container.querySelector("[role='alert']");
+    expect(tablet?.getAttribute("aria-label")).toMatch(/TTL expired|session error/i);
+  });
+
+  it("displays the session ID", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    expect(container.textContent).toContain("issue-974-step1-test");
+  });
+
+  it("displays the error message", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    expect(container.textContent).toContain("cleaned up");
+    expect(container.textContent).toContain("TTL expired");
+  });
+
+  it("renders the Cinzel Decorative heading element", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    const heading = container.querySelector(".net-heading");
+    expect(heading).not.toBeNull();
+    expect(heading?.tagName).toBe("H1");
+  });
+
+  it("renders Elder Futhark rune decorations", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    // Should contain at least one rune character from the Elder Futhark
+    expect(container.textContent).toMatch(/[ᚠᚢᚦᚨᚱᚲᚷᚹᚺᚾᛁᛃᛇᛈᛉᛊᛏᛒᛖᛗᛚᛜᛞᛟ]/);
+  });
+
+  it("uses .norse-error-tablet root class", () => {
+    const { container } = render(
+      <NorseErrorTablet sessionId="issue-974-step1-test" message={TTL_MESSAGE} />
+    );
+    expect(container.querySelector(".norse-error-tablet")).not.toBeNull();
+  });
+});
+
+// ── useLogStream — TTL tracking ───────────────────────────────────────────────
+
+describe("useLogStream — isTtlExpired state (issue #974)", () => {
+  it("isTtlExpired is false by default", () => {
+    const { result } = renderHook(() => useLogStream());
+    expect(result.current.isTtlExpired).toBe(false);
+  });
+
+  it("isTtlExpired is false after stream-error alone (no stream-end yet)", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        message: TTL_MESSAGE,
+      });
+    });
+    expect(result.current.isTtlExpired).toBe(false);
+  });
+
+  it("isTtlExpired becomes true after stream-error then stream-end with TTL message", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        message: TTL_MESSAGE,
+      });
+      result.current.handleMessage({
+        type: "stream-end",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        reason: "failed",
+      });
+    });
+    expect(result.current.isTtlExpired).toBe(true);
+  });
+
+  it("isTtlExpired is false when error is not TTL-related", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        message: NON_TTL_MESSAGE,
+      });
+      result.current.handleMessage({
+        type: "stream-end",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        reason: "failed",
+      });
+    });
+    expect(result.current.isTtlExpired).toBe(false);
+  });
+
+  it("clearEntries resets isTtlExpired to false", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        message: TTL_MESSAGE,
+      });
+      result.current.handleMessage({
+        type: "stream-end",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        reason: "failed",
+      });
+    });
+    expect(result.current.isTtlExpired).toBe(true);
+
+    act(() => {
+      result.current.clearEntries();
+    });
+    expect(result.current.isTtlExpired).toBe(false);
+  });
+
+  it("streamError is set after receiving stream-error message", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-error",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        message: TTL_MESSAGE,
+      });
+    });
+    expect(result.current.streamError).toBe(TTL_MESSAGE);
+  });
+
+  it("streamEnded is set after receiving stream-end message", () => {
+    const { result } = renderHook(() => useLogStream());
+    act(() => {
+      result.current.handleMessage({
+        type: "stream-end",
+        ts: Date.now(),
+        sessionId: "issue-974-step1-test",
+        reason: "completed",
+      });
+    });
+    expect(result.current.streamEnded).toBe(true);
+  });
+});
+
+// ── TTL_ERROR_PATTERN ─────────────────────────────────────────────────────────
+
+describe("TTL_ERROR_PATTERN", () => {
+  it("matches TTL-expired messages", () => {
+    expect(TTL_ERROR_PATTERN.test(TTL_MESSAGE)).toBe(true);
+  });
+
+  it("matches pod-not-found alternative message", () => {
+    const altMsg =
+      "Pod for session issue-974-step1-loki has been cleaned up (job TTL expired). Logs are no longer available from the cluster.";
+    expect(TTL_ERROR_PATTERN.test(altMsg)).toBe(true);
+  });
+
+  it("does not match non-TTL error messages", () => {
+    expect(TTL_ERROR_PATTERN.test(NON_TTL_MESSAGE)).toBe(false);
+  });
+});
+
+// ── LogViewer — Norse tablet vs log terminal ──────────────────────────────────
+
+describe("LogViewer — renders NorseErrorTablet when isTtlExpired (issue #974)", () => {
+  it("renders NorseErrorTablet (not log-terminal) when isTtlExpired=true", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        isTtlExpired={true}
+        streamError={TTL_MESSAGE}
+      />
+    );
+    expect(container.querySelector(".norse-error-tablet")).not.toBeNull();
+    expect(container.querySelector(".log-terminal")).toBeNull();
+  });
+
+  it("renders log-terminal (not NorseErrorTablet) when isTtlExpired=false", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        isTtlExpired={false}
+        streamError={null}
+      />
+    );
+    expect(container.querySelector(".log-terminal")).not.toBeNull();
+    expect(container.querySelector(".norse-error-tablet")).toBeNull();
+  });
+
+  it("NorseErrorTablet has role=alert within LogViewer", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        isTtlExpired={true}
+        streamError={TTL_MESSAGE}
+      />
+    );
+    expect(container.querySelector("[role='alert']")).not.toBeNull();
+  });
+
+  it("NorseErrorTablet displays the session ID within LogViewer", () => {
+    const { container } = render(
+      <LogViewer
+        entries={[]}
+        activeJob={MOCK_JOB}
+        wsState="open"
+        isTtlExpired={true}
+        streamError={TTL_MESSAGE}
+      />
+    );
+    expect(container.textContent).toContain("issue-974-step1-test");
+  });
+});

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -4,6 +4,7 @@ import type { LogEntry } from "../hooks/useLogStream";
 import type { DisplayJob } from "../lib/types";
 import { StatusBadge } from "./StatusBadge";
 import { ToolBlock } from "./ToolBlock";
+import { NorseErrorTablet } from "./NorseErrorTablet";
 import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_ICONS, STATUS_LABELS } from "../lib/constants";
 
 interface Props {
@@ -11,10 +12,12 @@ interface Props {
   activeJob: DisplayJob | null;
   wsState: "connecting" | "open" | "closed" | "error";
   isFixture?: boolean;
+  isTtlExpired?: boolean;
+  streamError?: string | null;
   onSetSpeed?: (speed: number) => void;
 }
 
-export function LogViewer({ entries, activeJob, wsState, isFixture, onSetSpeed }: Props) {
+export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, streamError, onSetSpeed }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [fixtureSpeed, setFixtureSpeed] = useState(1);
   const [fixturePaused, setFixturePaused] = useState(false);
@@ -69,6 +72,32 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, onSetSpeed }
           <div className="empty-title">All Nine Worlds await</div>
           <div className="empty-sub">Select an agent session to stream its logs</div>
         </div>
+      </main>
+    );
+  }
+
+  // TTL-expired sessions get the full-pane Norse error tablet instead of the log terminal
+  if (isTtlExpired && streamError) {
+    return (
+      <main className="content" aria-label="Log viewer">
+        <div className="content-header" aria-label="Active session">
+          <span className="session-title">
+            {activeJob.agentName} &mdash; #{activeJob.issue} Step {activeJob.step} (
+            {activeJob.sessionId})
+          </span>
+          <span className="header-badges">
+            <span
+              className="job-status-badge"
+              style={{ color: STATUS_COLORS[activeJob.status] }}
+              title={`Job status: ${activeJob.status}`}
+              aria-label={`Job status: ${STATUS_LABELS[activeJob.status]}`}
+            >
+              {STATUS_ICONS[activeJob.status]} {STATUS_LABELS[activeJob.status]}
+            </span>
+            <StatusBadge state={wsState} />
+          </span>
+        </div>
+        <NorseErrorTablet sessionId={activeJob.sessionId} message={streamError} />
       </main>
     );
   }

--- a/development/monitor-ui/src/components/NorseErrorTablet.tsx
+++ b/development/monitor-ui/src/components/NorseErrorTablet.tsx
@@ -1,0 +1,58 @@
+/**
+ * NorseErrorTablet — full-pane error display for TTL-expired sessions.
+ *
+ * Shown when a pod's TTL has expired and logs are no longer available.
+ * Styled as an ancient stone tablet: Elder Futhark rune decorations,
+ * Cinzel Decorative headings, void-black bg, gold accents.
+ */
+
+// Elder Futhark rows used as decorative borders
+const RUNE_ROW_TOP = "ᚠ ᚢ ᚦ ᚨ ᚱ ᚲ ᚷ ᚹ ᚺ ᚾ ᛁ ᛃ ᛇ ᛈ ᛉ ᛊ ᛏ ᛒ ᛖ ᛗ ᛚ ᛜ ᛞ ᛟ";
+const RUNE_ROW_BTM = "ᛟ ᛞ ᛜ ᛚ ᛗ ᛖ ᛒ ᛏ ᛊ ᛉ ᛈ ᛇ ᛃ ᛁ ᚾ ᚺ ᚹ ᚷ ᚲ ᚱ ᚨ ᚦ ᚢ ᚠ";
+const RUNE_GLYPH = "ᚦ"; // Thurisaz — warning / thorn
+
+interface Props {
+  sessionId: string;
+  message: string;
+}
+
+export function NorseErrorTablet({ sessionId, message }: Props) {
+  return (
+    <div
+      className="norse-error-tablet"
+      role="alert"
+      aria-label="Session error: pod TTL expired"
+      aria-live="assertive"
+    >
+      <div className="net-rune-border" aria-hidden="true">
+        {RUNE_ROW_TOP}
+      </div>
+
+      <div className="net-glyph" aria-hidden="true">
+        {RUNE_GLYPH}
+      </div>
+
+      <h1 className="net-heading">The Eternal Halls Are Sealed</h1>
+      <p className="net-subheading">This vessel has departed Yggdrasil</p>
+
+      <div className="net-divider" aria-hidden="true">
+        ᚠ ᚢ ᚦ ᛟ ᛞ ᛜ ᛚ ᛟ ᚦ ᚢ ᚠ
+      </div>
+
+      <p className="net-body">{message}</p>
+
+      <div className="net-session" aria-label={`Session ID: ${sessionId}`}>
+        <span className="net-session-label">Session</span>
+        <span className="net-session-value">{sessionId}</span>
+      </div>
+
+      <div className="net-seal" aria-hidden="true">
+        ᚠᚢᚦ &mdash; So it is written, so shall it remain &mdash; ᚦᚢᚠ
+      </div>
+
+      <div className="net-rune-border" aria-hidden="true">
+        {RUNE_ROW_BTM}
+      </div>
+    </div>
+  );
+}

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -69,9 +69,14 @@ function parseEntrypointLine(line: string): LogEntry {
   return { id: nextId(), type: "raw", text: line };
 }
 
+/** TTL / pod-not-found patterns emitted by friendlyK8sError */
+export const TTL_ERROR_PATTERN = /TTL expired|cleaned up/i;
+
 export function useLogStream() {
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
+  const [streamError, setStreamError] = useState<string | null>(null);
+  const [streamEnded, setStreamEnded] = useState(false);
   const taskPromptBuffer = useRef<string[]>([]);
   const inTaskPrompt = useRef(false);
 
@@ -80,6 +85,8 @@ export function useLogStream() {
     entryCounter = 0;
     taskPromptBuffer.current = [];
     inTaskPrompt.current = false;
+    setStreamError(null);
+    setStreamEnded(false);
   }, []);
 
   const handleMessage = useCallback((msg: ServerMessage) => {
@@ -131,11 +138,13 @@ export function useLogStream() {
       }
       processEvent(ev);
     } else if (msg.type === "stream-error") {
+      setStreamError(msg.message);
       setEntries((prev) => [
         ...prev,
         { id: nextId(), type: "error", message: msg.message },
       ]);
     } else if (msg.type === "stream-end") {
+      setStreamEnded(true);
       setEntries((prev) => {
         // Mark any open batch as complete before adding stream-end
         const updated = prev.map((e) =>
@@ -336,11 +345,16 @@ export function useLogStream() {
     ]);
   }, []);
 
+  const isTtlExpired = streamEnded && streamError !== null && TTL_ERROR_PATTERN.test(streamError);
+
   return {
     entries,
     activeSessionId,
     setActiveSessionId,
     clearEntries,
     handleMessage,
+    streamError,
+    streamEnded,
+    isTtlExpired,
   };
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -687,3 +687,111 @@ body {
   .content { height: 60vh; }
   html, body { overflow: auto; }
 }
+
+/* ── Norse Error Tablet ────────────────────────────────────────────────────── */
+/* Full-pane display for TTL-expired sessions. Ancient stone tablet aesthetic. */
+
+.norse-error-tablet {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 3rem 2rem;
+  background: #07070d;
+  gap: 1.25rem;
+  overflow-y: auto;
+  text-align: center;
+  animation: fadeSlideIn 0.4s ease;
+}
+
+.net-rune-border {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  color: #c9920a;
+  letter-spacing: 0.3em;
+  opacity: 0.5;
+  user-select: none;
+  word-break: break-all;
+  max-width: 480px;
+}
+
+.net-glyph {
+  font-size: 4rem;
+  color: #c9920a;
+  line-height: 1;
+  text-shadow: 0 0 24px rgba(201, 146, 10, 0.6), 0 0 8px rgba(201, 146, 10, 0.3);
+  user-select: none;
+}
+
+.net-heading {
+  font-family: 'Cinzel Decorative', 'Cinzel', serif;
+  font-size: 1.4rem;
+  font-weight: 700;
+  color: #c9920a;
+  letter-spacing: 0.08em;
+  text-shadow: 0 0 16px rgba(201, 146, 10, 0.4);
+  max-width: 520px;
+}
+
+.net-subheading {
+  font-family: 'Cinzel', serif;
+  font-size: 0.9rem;
+  font-weight: 400;
+  color: #a0a0b0;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.net-divider {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #c9920a;
+  letter-spacing: 0.5em;
+  opacity: 0.4;
+  user-select: none;
+}
+
+.net-body {
+  font-family: 'Source Serif 4', serif;
+  font-size: 0.95rem;
+  color: #f5f5f5;
+  line-height: 1.7;
+  max-width: 480px;
+  border: 1px solid rgba(201, 146, 10, 0.25);
+  padding: 1.25rem 1.5rem;
+  border-radius: 4px;
+  background: rgba(201, 146, 10, 0.04);
+}
+
+.net-session {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.net-session-label {
+  font-family: 'Cinzel', serif;
+  font-size: 0.65rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: #606070;
+}
+
+.net-session-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.8rem;
+  color: #a0a0b0;
+  letter-spacing: 0.05em;
+}
+
+.net-seal {
+  font-family: 'Cinzel', serif;
+  font-size: 0.7rem;
+  color: #c9920a;
+  letter-spacing: 0.15em;
+  opacity: 0.6;
+  margin-top: 0.5rem;
+}

--- a/development/monitor/src/__tests__/ttl-error-stream-end.test.ts
+++ b/development/monitor/src/__tests__/ttl-error-stream-end.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Vitest tests for issue #974 — TTL-expired error sends stream-end to halt the loop.
+ *
+ * AC tested:
+ * - When streamPodLogs error callback fires, server sends stream-error THEN stream-end
+ * - Client receives both messages in order (error before end)
+ * - After stream-end, no further messages are sent for the session
+ * - A second subscribe attempt during the same connection is blocked (subscription guard)
+ * - Pod-not-found path (findPodForSession returns null) sends stream-error + stream-end
+ */
+
+import { createServer } from "node:http";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { WebSocket } from "ws";
+
+// ── Captured mocks ────────────────────────────────────────────────────────────
+
+const capture = vi.hoisted(() => ({
+  streamErrorCb: null as ((err: Error) => void) | null,
+  streamDoneCb: null as (() => void) | null,
+  findPodResult: null as string | null,
+}));
+
+vi.mock("../k8s.js", () => ({
+  listAgentJobs: vi.fn().mockResolvedValue([]),
+  watchAgentJobs: vi.fn(),
+  mapAgentJobToJob: vi.fn(),
+  findPodForSession: vi.fn(async () => capture.findPodResult),
+  streamPodLogs: vi.fn(
+    (
+      _pod: unknown,
+      _ns: unknown,
+      _onLine: unknown,
+      onDone: () => void,
+      onError: (err: Error) => void
+    ) => {
+      capture.streamDoneCb = onDone;
+      capture.streamErrorCb = onError;
+      return Promise.resolve(() => { /* cancel */ });
+    }
+  ),
+}));
+
+import { attachWebSocketServer } from "../ws.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function connectAndCollect(port: number) {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}/ws`);
+  const queue: string[] = [];
+  const waiters: Array<(s: string) => void> = [];
+
+  ws.on("message", (data) => {
+    const s = String(data);
+    const waiter = waiters.shift();
+    if (waiter) waiter(s);
+    else queue.push(s);
+  });
+
+  const nextMsg = (ms = 4000) =>
+    new Promise<string>((resolve, reject) => {
+      const msg = queue.shift();
+      if (msg) { resolve(msg); return; }
+      const t = setTimeout(() => {
+        const idx = waiters.indexOf(resolve);
+        if (idx !== -1) waiters.splice(idx, 1);
+        reject(new Error(`WS msg timeout after ${ms}ms`));
+      }, ms);
+      waiters.push((s) => { clearTimeout(t); resolve(s); });
+    });
+
+  const open = new Promise<void>((resolve, reject) => {
+    ws.once("open", () => resolve());
+    ws.once("error", reject);
+  });
+
+  return { ws, nextMsg, open };
+}
+
+function waitForType<T extends { type: string }>(
+  nextMsg: () => Promise<string>,
+  type: string,
+  maxMessages = 10
+): Promise<T> {
+  const tryNext = async (remaining: number): Promise<T> => {
+    if (remaining === 0) throw new Error(`Did not find type="${type}" in ${maxMessages} messages`);
+    const raw = await nextMsg();
+    const parsed = JSON.parse(raw) as T;
+    if (parsed.type === type) return parsed;
+    return tryNext(remaining - 1);
+  };
+  return tryNext(maxMessages);
+}
+
+// ── Suite ─────────────────────────────────────────────────────────────────────
+
+describe("WebSocket server — TTL error loop prevention (issue #974)", () => {
+  let httpServer: ReturnType<typeof createServer>;
+  let port: number;
+
+  beforeEach(async () => {
+    capture.streamErrorCb = null;
+    capture.streamDoneCb = null;
+    capture.findPodResult = "pod-issue-974-step1"; // pod exists by default
+    httpServer = createServer();
+    attachWebSocketServer(httpServer as Parameters<typeof attachWebSocketServer>[0]);
+    await new Promise<void>((resolve) => {
+      httpServer.listen(0, "127.0.0.1", () => resolve());
+    });
+    port = (httpServer.address() as { port: number }).port;
+  }, 15_000);
+
+  afterEach(async () => {
+    httpServer.closeAllConnections?.();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  }, 15_000);
+
+  // ── AC: stream-error followed immediately by stream-end ───────────────────
+
+  it("sends stream-error then stream-end when streamPodLogs fires error callback", async () => {
+    const { ws, nextMsg, open } = connectAndCollect(port);
+    await open;
+    await waitForType(nextMsg, "jobs-snapshot");
+
+    ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step1-loki" }));
+
+    // Wait for streamPodLogs mock to register its callbacks
+    await new Promise<void>((resolve) => {
+      const poll = setInterval(() => {
+        if (capture.streamErrorCb) { clearInterval(poll); resolve(); }
+      }, 10);
+    });
+
+    // Trigger a 404-style error from streamPodLogs
+    const httpError = Object.assign(new Error("HTTP status code 404 Not Found"), {});
+    capture.streamErrorCb!(httpError);
+
+    try {
+      const errMsg = await waitForType<{ type: string; sessionId: string; message: string }>(
+        nextMsg, "stream-error"
+      );
+      expect(errMsg.type).toBe("stream-error");
+      expect(errMsg.sessionId).toBe("issue-974-step1-loki");
+      expect(errMsg.message).toMatch(/cleaned up|TTL expired/i);
+
+      const endMsg = await waitForType<{ type: string; sessionId: string; reason: string }>(
+        nextMsg, "stream-end"
+      );
+      expect(endMsg.type).toBe("stream-end");
+      expect(endMsg.sessionId).toBe("issue-974-step1-loki");
+      expect(endMsg.reason).toBe("failed");
+    } finally {
+      ws.close();
+    }
+  });
+
+  // ── AC: stream-error message carries friendly text, not raw HTTP ──────────
+
+  it("stream-error message is human-readable (no raw HTTP artefacts)", async () => {
+    const { ws, nextMsg, open } = connectAndCollect(port);
+    await open;
+    await waitForType(nextMsg, "jobs-snapshot");
+
+    ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step2-loki" }));
+
+    await new Promise<void>((resolve) => {
+      const poll = setInterval(() => {
+        if (capture.streamErrorCb) { clearInterval(poll); resolve(); }
+      }, 10);
+    });
+
+    capture.streamErrorCb!(new Error("HTTP status code 404 Body: undefined Content-Type: application/json"));
+
+    try {
+      const errMsg = await waitForType<{ type: string; message: string }>(nextMsg, "stream-error");
+      expect(errMsg.message).not.toMatch(/HTTP status code/i);
+      expect(errMsg.message).not.toMatch(/Body: undefined/i);
+      expect(errMsg.message).not.toMatch(/Content-Type/i);
+    } finally {
+      ws.close();
+    }
+  });
+
+  // ── AC: pod-not-found path sends stream-error + stream-end ────────────────
+
+  it("sends stream-error + stream-end when findPodForSession returns null", async () => {
+    capture.findPodResult = null; // simulate pod not found
+    const { ws, nextMsg, open } = connectAndCollect(port);
+    await open;
+    await waitForType(nextMsg, "jobs-snapshot");
+
+    ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step3-loki" }));
+
+    try {
+      const errMsg = await waitForType<{ type: string; sessionId: string; message: string }>(
+        nextMsg, "stream-error"
+      );
+      expect(errMsg.type).toBe("stream-error");
+      expect(errMsg.sessionId).toBe("issue-974-step3-loki");
+      expect(errMsg.message).toMatch(/cleaned up|TTL expired/i);
+
+      const endMsg = await waitForType<{ type: string; sessionId: string }>(
+        nextMsg, "stream-end"
+      );
+      expect(endMsg.type).toBe("stream-end");
+      expect(endMsg.sessionId).toBe("issue-974-step3-loki");
+    } finally {
+      ws.close();
+    }
+  });
+
+  // ── AC: second subscribe for same session is blocked during connection ─────
+
+  it("blocks a duplicate subscribe for the same session during the same connection", async () => {
+    const { ws, nextMsg, open } = connectAndCollect(port);
+    await open;
+    await waitForType(nextMsg, "jobs-snapshot");
+
+    // First subscribe
+    ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step4-loki" }));
+
+    await new Promise<void>((resolve) => {
+      const poll = setInterval(() => {
+        if (capture.streamErrorCb) { clearInterval(poll); resolve(); }
+      }, 10);
+    });
+
+    capture.streamErrorCb!(new Error("HTTP status code 404"));
+    await waitForType(nextMsg, "stream-error");
+    await waitForType(nextMsg, "stream-end");
+
+    // Reset captured callbacks to detect if a new stream is started
+    capture.streamErrorCb = null;
+    capture.streamDoneCb = null;
+
+    // Second subscribe for the same session — should be a no-op
+    ws.send(JSON.stringify({ type: "subscribe", sessionId: "issue-974-step4-loki" }));
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 200));
+
+    // Callbacks should NOT have been populated again (subscription guard prevented it)
+    expect(capture.streamErrorCb).toBeNull();
+    expect(capture.streamDoneCb).toBeNull();
+
+    ws.close();
+  });
+});

--- a/development/monitor/src/ws.ts
+++ b/development/monitor/src/ws.ts
@@ -296,12 +296,10 @@ async function startLogStream(
         });
       },
       (err) => {
-        send(ws, {
-          type: "stream-error",
-          ts: Date.now(),
-          sessionId,
-          message: friendlyK8sError(err.message, sessionId),
-        });
+        const friendly = friendlyK8sError(err.message, sessionId);
+        send(ws, { type: "stream-error", ts: Date.now(), sessionId, message: friendly });
+        // Always send stream-end so the client unsubscribes and stops retrying
+        send(ws, { type: "stream-end", ts: Date.now(), sessionId, reason: "failed" });
       },
       { follow: !isCompleted }
     );


### PR DESCRIPTION
## Summary

Fixes #974

- **Backend (`ws.ts`)**: Send `stream-end` (reason: `"failed"`) immediately after `stream-error` in the `streamPodLogs` error callback. This closes the stream from the server's side and prevents the retry loop — the subscription guard (`subscriptions.has(sessionId)`) then blocks any repeat subscribe during the same connection.
- **Frontend (`useLogStream`)**: Track `streamError` and `streamEnded` state; expose `isTtlExpired` (true when a TTL/pod-not-found error is followed by stream-end).
- **Frontend (`NorseErrorTablet`)**: Full-pane stone tablet component — Elder Futhark rune borders, Cinzel Decorative heading, Thurisaz warning glyph, void-black bg (`#07070d`), gold accent (`#c9920a`), session ID displayed.
- **Frontend (`LogViewer`)**: When `isTtlExpired=true`, render `<NorseErrorTablet>` instead of the log terminal. Other sessions in the sidebar remain unaffected.
- **Frontend (`App`)**: Skip re-subscribe for TTL-expired sessions on WS reconnect, preventing the loop from restarting after a reconnection.

## Files changed

- `development/monitor/src/ws.ts` — backend error callback fix
- `development/monitor-ui/src/hooks/useLogStream.ts` — TTL error tracking
- `development/monitor-ui/src/components/NorseErrorTablet.tsx` — new component
- `development/monitor-ui/src/components/LogViewer.tsx` — tablet rendering
- `development/monitor-ui/src/App.tsx` — reconnect guard
- `development/monitor-ui/src/styles/index.css` — Norse tablet styles
- `development/monitor/src/__tests__/ttl-error-stream-end.test.ts` — backend tests
- `development/monitor-ui/src/__tests__/norse-error-tablet.test.tsx` — frontend tests

## Test plan

- [ ] TTL-expired session shows Norse tablet exactly once — no loop
- [ ] `stream-error` always followed by `stream-end` (reason: `failed`) in backend tests
- [ ] `isTtlExpired` becomes `true` after stream-error + stream-end with TTL message
- [ ] `isTtlExpired` remains `false` for non-TTL errors (e.g. 403 access denied)
- [ ] `clearEntries()` resets `isTtlExpired` when switching sessions
- [ ] Norse tablet renders `role=alert`, session ID, Futhark runes, Cinzel heading
- [ ] LogViewer shows tablet (no `.log-terminal`) when `isTtlExpired=true`
- [ ] Other sidebar sessions remain clickable and functional
- [ ] WS reconnect does **not** re-subscribe TTL-expired sessions
- [ ] tsc: PASS, build: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)