### PR TITLE
feat: split Justfile into mod hierarchy + add trial REPL

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,17 +1,20 @@
 # Fenrir Ledger — Project Commands
 # Run `just --list` to see all available recipes.
+# Run `just --list <module>` to see recipes in a submodule (e.g., `just --list frontend`).
 
 set dotenv-load := false
 set shell := ["bash", "-euo", "pipefail", "-c"]
 
 repo_root := justfile_directory()
-frontend   := repo_root / "development" / "frontend"
-monitor    := repo_root / "development" / "monitor"
-scripts    := repo_root / "scripts"
-quality    := repo_root / "quality" / "scripts"
-k8s_agents := repo_root / "infrastructure" / "k8s" / "agents"
-services   := repo_root / ".claude" / "scripts" / "services.sh"
-pack       := repo_root / ".claude" / "skills" / "fire-next-up" / "scripts" / "pack-status.mjs"
+services  := repo_root / ".claude" / "scripts" / "services.sh"
+scripts   := repo_root / "scripts"
+pack      := repo_root / ".claude" / "skills" / "fire-next-up" / "scripts" / "pack-status.mjs"
+
+# ── Submodules ─────────────────────────────────────────────────────────────
+
+mod frontend 'development/frontend'
+mod quality 'quality'
+mod infra 'infrastructure'
 
 # ── Dev Environment ─────────────────────────────────────────────────────────
 
@@ -23,7 +26,7 @@ dev:
 dev-monitor:
     #!/usr/bin/env bash
     set -uo pipefail
-    cd "{{monitor}}"
+    cd "{{repo_root}}/development/monitor"
     if [ -f .secrets ]; then
       set -a
       # shellcheck source=/dev/null
@@ -35,7 +38,7 @@ dev-monitor:
       echo "[dev-monitor]          Create it with: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, SESSION_SECRET, ALLOWED_EMAIL"
       echo "[dev-monitor]          OAuth redirect URI must be: http://localhost:3001/auth/callback"
     fi
-    ctx=$(kubectl config current-context 2>/dev/null || echo "NOT CONFIGURED — run: just gke-setup")
+    ctx=$(kubectl config current-context 2>/dev/null || echo "NOT CONFIGURED — run: just infra gke-setup")
     echo "[dev-monitor] kubectl context: ${ctx}"
     echo "[dev-monitor] Starting Odin's Throne → http://localhost:3001"
     exec npm run dev
@@ -64,133 +67,6 @@ stripe-logs:
 setup:
     bash "{{repo_root}}/development/scripts/setup-local.sh"
 
-# ── Build & Verify ──────────────────────────────────────────────────────────
-
-# Run TypeScript type checking
-tsc:
-    bash "{{quality}}/verify.sh" --step tsc
-
-# Run Next.js production build
-build:
-    bash "{{quality}}/verify.sh" --step build
-
-# Run tsc + build
-check: tsc build
-
-# Run unit tests (Vitest)
-test-unit:
-    bash "{{quality}}/verify.sh" --step unit
-
-# Run E2E tests (Playwright)
-test-e2e:
-    bash "{{quality}}/verify.sh" --step e2e
-
-# Run a specific Playwright test suite by slug
-test-suite slug:
-    bash "{{quality}}/verify.sh" --step test -x "{{slug}}"
-
-# Run full verification (tsc + build + all tests)
-verify:
-    bash "{{quality}}/verify.sh"
-
-# Run full verification, stop on first failure
-verify-fast:
-    bash "{{quality}}/verify.sh" --fail-fast
-
-# ── Code Coverage ───────────────────────────────────────────────────────────
-
-# Generate unit test coverage (Vitest only)
-coverage-unit:
-    node "{{quality}}/coverage.mjs" --unit-only
-
-# Generate E2E coverage (Playwright only)
-coverage-e2e:
-    node "{{quality}}/coverage.mjs" --e2e-only
-
-# Generate combined coverage (Vitest + Playwright)
-coverage:
-    node "{{quality}}/coverage.mjs"
-
-# Merge existing coverage reports into combined
-coverage-combine:
-    node "{{quality}}/coverage-combine.mjs"
-
-# Generate coverage index page
-coverage-index:
-    node "{{quality}}/coverage-index.mjs"
-
-# ── QA ──────────────────────────────────────────────────────────────────────
-
-# Run Loki's test bloat critique
-qa-critique:
-    bash "{{quality}}/loki-critique.sh"
-
-# Dry-run test bloat critique (stdout only)
-qa-critique-dry:
-    bash "{{quality}}/loki-critique.sh" --dry-run
-
-# Show route coverage table per test suite
-qa-routes:
-    bash "{{quality}}/loki-critique.sh" --pattern-check
-
-# ── GKE / Kubernetes ────────────────────────────────────────────────────────
-
-# Show full GKE cluster + app status
-gke-status:
-    bash "{{scripts}}/gke-status.sh"
-
-# Configure local kubectl for GKE Autopilot (one-time)
-gke-setup:
-    bash "{{scripts}}/gke-setup.sh"
-
-# Bootstrap IAM roles for deploy service account
-gke-bootstrap-iam project_id="fenrir-ledger-prod":
-    bash "{{scripts}}/bootstrap-iam.sh" "{{project_id}}"
-
-# Launch Agent Monitor web UI (auto-starts kubectl proxy)
-agent-monitor:
-    node "{{repo_root}}/development/agent-monitor/serve.mjs"
-
-# List agent jobs in GKE
-agent-jobs:
-    kubectl get jobs -n fenrir-agents --sort-by=.metadata.creationTimestamp \
-      -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].type,CREATED:.metadata.creationTimestamp'
-
-# List active (running) agent jobs
-agent-jobs-active:
-    kubectl get jobs -n fenrir-agents \
-      -o jsonpath='{range .items[?(@.status.active)]}{.metadata.name}{"\n"}{end}'
-
-# ── Agent Logs ──────────────────────────────────────────────────────────────
-
-# Stream parsed logs for an agent by session ID
-agent-log session_id:
-    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}"
-
-# Stream parsed logs for the latest agent job on an issue
-agent-log-issue issue:
-    node "{{k8s_agents}}/agent-logs.mjs" --issue "{{issue}}"
-
-# Stream logs with tool calls visible
-agent-log-verbose session_id:
-    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --tools
-
-# Stream logs with tool calls + thinking
-agent-log-debug session_id:
-    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --tools --thinking
-
-# Dump finished agent logs (no follow)
-agent-log-dump session_id:
-    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --no-follow --tools
-
-# Stream all active agent logs in tmux panes
-agent-log-all:
-    node "{{k8s_agents}}/agent-logs.mjs" --all --tmux
-
-# Show raw JSONL for an agent session
-agent-log-raw session_id:
-    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --raw
-
 # ── Pack Status (Project Board) ─────────────────────────────────────────────
 
 # Show full pack status dashboard
@@ -213,12 +89,6 @@ pack-resume issue:
 pack-move issue status:
     node "{{pack}}" --move "{{issue}}" "{{status}}"
 
-# ── Agent Reports ──────────────────────────────────────────────────────────
-
-# List saved agent log files
-agent-logs-list:
-    @ls -lht "{{repo_root}}/tmp/agent-logs/"*.log 2>/dev/null || echo "No agent logs in tmp/agent-logs/"
-
 # ── Secrets ─────────────────────────────────────────────────────────────────
 
 # Audit all secrets (GitHub, K8s, .env.local)
@@ -235,14 +105,10 @@ secrets-fix-quotes:
 
 # ── Utilities ───────────────────────────────────────────────────────────────
 
-# Generate a 256-bit encryption key
-gen-key:
-    bash "{{quality}}/generate-encryption-key.sh"
-
 # Install Fenrir terminal skin (iTerm2/Ghostty/WezTerm)
 terminal-install:
     bash "{{repo_root}}/terminal/install.sh"
 
-# Clean build artifacts and coverage reports
+# Clean all build artifacts and coverage reports
 clean:
-    rm -rf "{{frontend}}/.next" "{{frontend}}/out" quality/reports/
+    rm -rf "{{repo_root}}/development/frontend/.next" "{{repo_root}}/development/frontend/out" quality/reports/

--- a/development/frontend/Justfile
+++ b/development/frontend/Justfile
@@ -1,0 +1,57 @@
+# Frontend — Build, Test, and Trial Management
+# Invoked via: just frontend <recipe>
+
+set dotenv-load := false
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+this_dir   := source_directory()
+repo_root  := this_dir / "../.."
+quality    := repo_root / "quality" / "scripts"
+frontend   := this_dir
+
+# ── Build & Verify ──────────────────────────────────────────────────────────
+
+# Run TypeScript type checking
+tsc:
+    bash "{{quality}}/verify.sh" --step tsc
+
+# Run Next.js production build
+build:
+    bash "{{quality}}/verify.sh" --step build
+
+# Run tsc + build
+check: tsc build
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+# Run unit tests (Vitest)
+test-unit:
+    bash "{{quality}}/verify.sh" --step unit
+
+# Run E2E tests (Playwright)
+test-e2e:
+    bash "{{quality}}/verify.sh" --step e2e
+
+# Run a specific Playwright test suite by slug
+test-suite slug:
+    bash "{{quality}}/verify.sh" --step test -x "{{slug}}"
+
+# Run full verification (tsc + build + all tests)
+verify:
+    bash "{{quality}}/verify.sh"
+
+# Run full verification, stop on first failure
+verify-fast:
+    bash "{{quality}}/verify.sh" --fail-fast
+
+# ── Trial / Subscription ───────────────────────────────────────────────────
+
+# Interactive REPL for managing trial state in Redis (auto port-forwards if needed)
+adjust-trial *args:
+    node "{{frontend}}/scripts/trial-adjust.mjs" {{args}}
+
+# ── Utilities ───────────────────────────────────────────────────────────────
+
+# Clean build artifacts
+clean:
+    rm -rf "{{frontend}}/.next" "{{frontend}}/out"

--- a/development/frontend/scripts/trial-adjust.mjs
+++ b/development/frontend/scripts/trial-adjust.mjs
@@ -1,0 +1,588 @@
+#!/usr/bin/env node
+/**
+ * trial-adjust.mjs — Interactive REPL for managing trial state in Redis.
+ *
+ * Usage:
+ *   just frontend adjust-trial                        # from repo root (recommended)
+ *   node development/frontend/scripts/trial-adjust.mjs  # direct invocation
+ *
+ * For production: kubectl port-forward svc/redis 6379:6379 -n fenrir-app
+ *
+ * Trial identity:
+ *   - Trial key in Redis: trial:{fingerprint}
+ *   - Fingerprint = SHA-256(navigator.userAgent + deviceId)
+ *   - deviceId is stored in browser localStorage under "fenrir:device-id"
+ *   - To find yours: browser DevTools console → localStorage.getItem('fenrir:device-id')
+ *   - Or just use "list" in this REPL to see all trials and pick by number
+ */
+
+import { createRequire } from "node:module";
+const require = createRequire(import.meta.url);
+const Redis = require("ioredis").default;
+import { createInterface } from "node:readline";
+import { parseArgs } from "node:util";
+import { execSync, spawn } from "node:child_process";
+import { createConnection } from "node:net";
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const TRIAL_DURATION_DAYS = 30;
+const TRIAL_TTL_SECONDS = 60 * 24 * 60 * 60;
+const STATUS_EMOJI = { active: "\u001b[32m●\u001b[0m", expired: "\u001b[31m●\u001b[0m", converted: "\u001b[33m★\u001b[0m", none: "\u001b[90m○\u001b[0m" };
+const BOLD = "\u001b[1m";
+const DIM = "\u001b[2m";
+const RESET = "\u001b[0m";
+const GOLD = "\u001b[33m";
+const GREEN = "\u001b[32m";
+const RED = "\u001b[31m";
+const CYAN = "\u001b[36m";
+
+// ── Args ─────────────────────────────────────────────────────────────────────
+
+const { values } = parseArgs({
+  options: {
+    "redis-url": { type: "string" },
+    help:        { type: "boolean", short: "h", default: false },
+  },
+  strict: true,
+});
+
+if (values.help) {
+  console.log(`
+${BOLD}trial-adjust.mjs${RESET} — Interactive REPL for managing trial state in Redis.
+
+${BOLD}Usage:${RESET}
+  just frontend adjust-trial                          # from repo root (recommended)
+  just frontend adjust-trial --redis-url <url>        # custom Redis URL
+
+${BOLD}How to identify yourself:${RESET}
+  Trial keys in Redis use a browser fingerprint: SHA-256(userAgent + deviceId).
+  Your deviceId is in browser localStorage under "fenrir:device-id".
+
+  Easiest method: run "list" in the REPL — it shows all trials with numbered
+  shortcuts. Then "use 1" to select yours.
+
+${BOLD}For production Redis:${RESET}
+  kubectl port-forward svc/redis 6379:6379 -n fenrir-app
+`);
+  process.exit(0);
+}
+
+// ── Port-forward management ──────────────────────────────────────────────────
+
+const PF_NAMESPACE = "fenrir-app";
+const PF_SERVICE = "svc/redis";
+const PF_LOCAL_PORT = 6379;
+const PF_REMOTE_PORT = 6379;
+
+let portForwardProc = null; // track child process so we can kill on exit
+
+/** Check if localhost:6379 is accepting connections. */
+function isPortOpen(port, host = "127.0.0.1", timeoutMs = 1000) {
+  return new Promise((resolve) => {
+    const sock = createConnection({ port, host, timeout: timeoutMs });
+    sock.once("connect", () => { sock.destroy(); resolve(true); });
+    sock.once("error", () => { sock.destroy(); resolve(false); });
+    sock.once("timeout", () => { sock.destroy(); resolve(false); });
+  });
+}
+
+/** Check if kubectl is available and cluster is reachable. */
+function hasKubectl() {
+  try {
+    execSync("kubectl cluster-info --request-timeout=3s", { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Start kubectl port-forward in the background. Returns when the port is ready. */
+async function startPortForward() {
+  console.log(`${DIM}Starting kubectl port-forward ${PF_SERVICE} ${PF_LOCAL_PORT}:${PF_REMOTE_PORT} -n ${PF_NAMESPACE}...${RESET}`);
+
+  portForwardProc = spawn(
+    "kubectl",
+    ["port-forward", PF_SERVICE, `${PF_LOCAL_PORT}:${PF_REMOTE_PORT}`, "-n", PF_NAMESPACE],
+    { stdio: ["ignore", "pipe", "pipe"], detached: false }
+  );
+
+  // Log stderr for debugging but don't spam
+  let stderrBuf = "";
+  portForwardProc.stderr.on("data", (chunk) => { stderrBuf += chunk.toString(); });
+  portForwardProc.on("exit", (code) => {
+    if (code && code !== 0) {
+      console.error(`${RED}Port-forward exited with code ${code}${RESET}`);
+      if (stderrBuf.trim()) console.error(`${DIM}${stderrBuf.trim()}${RESET}`);
+    }
+    portForwardProc = null;
+  });
+
+  // Wait up to 10s for the port to open
+  for (let i = 0; i < 20; i++) {
+    await new Promise((r) => setTimeout(r, 500));
+    if (await isPortOpen(PF_LOCAL_PORT)) {
+      console.log(`${GREEN}Port-forward established${RESET} ${DIM}(localhost:${PF_LOCAL_PORT} → ${PF_SERVICE})${RESET}`);
+      return true;
+    }
+  }
+
+  console.error(`${RED}Port-forward timed out after 10s${RESET}`);
+  portForwardProc?.kill();
+  portForwardProc = null;
+  return false;
+}
+
+/** Clean up port-forward on exit. */
+function cleanupPortForward() {
+  if (portForwardProc) {
+    portForwardProc.kill();
+    portForwardProc = null;
+  }
+}
+process.on("exit", cleanupPortForward);
+process.on("SIGINT", () => { cleanupPortForward(); process.exit(0); });
+process.on("SIGTERM", () => { cleanupPortForward(); process.exit(0); });
+
+// ── Redis connection ─────────────────────────────────────────────────────────
+
+const redisUrl = values["redis-url"] || process.env.REDIS_URL || "redis://localhost:6379";
+const isLocalhost = /localhost|127\.0\.0\.1/.test(redisUrl);
+
+// If targeting localhost and port isn't open, auto-setup port-forward
+if (isLocalhost && !(await isPortOpen(PF_LOCAL_PORT))) {
+  console.log(`${DIM}Redis not reachable on localhost:${PF_LOCAL_PORT}${RESET}`);
+
+  if (!hasKubectl()) {
+    console.error(`${RED}kubectl not available or cluster unreachable.${RESET}`);
+    console.error(`${DIM}Either start Redis locally or configure kubectl for GKE.${RESET}`);
+    process.exit(1);
+  }
+
+  const ok = await startPortForward();
+  if (!ok) {
+    console.error(`${RED}Could not establish port-forward. Check your GKE access.${RESET}`);
+    process.exit(1);
+  }
+}
+
+const redis = new Redis(redisUrl, { lazyConnect: true, maxRetriesPerRequest: 1 });
+
+try {
+  await redis.connect();
+} catch {
+  console.error(`${RED}Failed to connect to Redis at ${redisUrl}${RESET}`);
+  process.exit(1);
+}
+
+console.log(`${GREEN}Connected to Redis${RESET} ${DIM}(${redisUrl})${RESET}`);
+
+// ── State ────────────────────────────────────────────────────────────────────
+
+let selectedFp = null;       // currently selected fingerprint
+let trialIndex = [];         // cached list from last "list" command: [fingerprint, ...]
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function computeStatus(trial) {
+  if (!trial) return { remainingDays: 0, status: "none" };
+  if (trial.convertedDate) return { remainingDays: 0, status: "converted", convertedDate: trial.convertedDate };
+  const elapsed = Math.floor((Date.now() - new Date(trial.startDate).getTime()) / 86400000);
+  const remaining = Math.max(0, TRIAL_DURATION_DAYS - elapsed);
+  return { remainingDays: remaining, status: remaining <= 0 ? "expired" : "active" };
+}
+
+function shortFp(fp) {
+  return `${fp.slice(0, 12)}...${fp.slice(-8)}`;
+}
+
+function printTrial(trial, fp, ttl) {
+  const s = computeStatus(trial);
+  const emoji = STATUS_EMOJI[s.status];
+  console.log();
+  console.log(`  ${BOLD}Fingerprint:${RESET}  ${shortFp(fp)}  ${DIM}(full: ${fp})${RESET}`);
+  console.log(`  ${BOLD}Status:${RESET}       ${emoji} ${s.status}`);
+  console.log(`  ${BOLD}Start date:${RESET}   ${trial.startDate}`);
+  console.log(`  ${BOLD}Elapsed:${RESET}      ${TRIAL_DURATION_DAYS - s.remainingDays} days`);
+  console.log(`  ${BOLD}Remaining:${RESET}    ${s.remainingDays} days`);
+  if (trial.convertedDate) {
+    console.log(`  ${BOLD}Converted:${RESET}    ${trial.convertedDate}`);
+  }
+  if (ttl !== undefined) {
+    console.log(`  ${BOLD}Redis TTL:${RESET}    ${ttl}s (${Math.round(ttl / 86400)}d)`);
+  }
+  console.log();
+}
+
+async function getTrial(fp) {
+  const raw = await redis.get(`trial:${fp}`);
+  return raw ? JSON.parse(raw) : null;
+}
+
+async function setTrial(fp, trial) {
+  await redis.set(`trial:${fp}`, JSON.stringify(trial), "EX", TRIAL_TTL_SECONDS);
+}
+
+function requireSelected() {
+  if (!selectedFp) {
+    console.log(`${RED}No trial selected.${RESET} Use ${CYAN}list${RESET} then ${CYAN}use <N>${RESET} to select one.`);
+    return false;
+  }
+  return true;
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+
+const commands = {
+  async list() {
+    const keys = await redis.keys("trial:*");
+    if (keys.length === 0) {
+      console.log("\n  No trial keys found in Redis.\n");
+      return;
+    }
+    keys.sort();
+    trialIndex = keys.map((k) => k.replace("trial:", ""));
+
+    console.log(`\n  ${BOLD}#   Fingerprint              Status     Remaining   Started${RESET}`);
+    console.log(`  ${DIM}${"─".repeat(70)}${RESET}`);
+    for (let i = 0; i < keys.length; i++) {
+      const fp = trialIndex[i];
+      const raw = await redis.get(keys[i]);
+      if (!raw) continue;
+      const trial = JSON.parse(raw);
+      const s = computeStatus(trial);
+      const emoji = STATUS_EMOJI[s.status];
+      const selected = fp === selectedFp ? `${GOLD}→${RESET}` : " ";
+      const started = new Date(trial.startDate).toLocaleDateString();
+      console.log(`  ${selected}${String(i + 1).padStart(2)}  ${shortFp(fp)}  ${emoji} ${s.status.padEnd(10)} ${String(s.remainingDays).padStart(2)}d left     ${started}`);
+    }
+    console.log(`\n  ${DIM}Use "use <N>" to select a trial${RESET}\n`);
+  },
+
+  async use(args) {
+    const n = parseInt(args[0], 10);
+    if (isNaN(n) || n < 1 || n > trialIndex.length) {
+      // Check if it's a raw fingerprint
+      if (args[0] && /^[0-9a-f]{64}$/i.test(args[0])) {
+        selectedFp = args[0].toLowerCase();
+        const trial = await getTrial(selectedFp);
+        if (!trial) {
+          console.log(`${RED}No trial found for that fingerprint.${RESET}`);
+          selectedFp = null;
+          return;
+        }
+        const ttl = await redis.ttl(`trial:${selectedFp}`);
+        console.log(`${GREEN}Selected:${RESET}`);
+        printTrial(trial, selectedFp, ttl);
+        return;
+      }
+      console.log(`${RED}Invalid selection.${RESET} Run ${CYAN}list${RESET} first, then ${CYAN}use <N>${RESET} or ${CYAN}use <fingerprint>${RESET}.`);
+      return;
+    }
+    selectedFp = trialIndex[n - 1];
+    const trial = await getTrial(selectedFp);
+    if (!trial) {
+      console.log(`${RED}Trial no longer exists.${RESET} Run ${CYAN}list${RESET} to refresh.`);
+      selectedFp = null;
+      return;
+    }
+    const ttl = await redis.ttl(`trial:${selectedFp}`);
+    console.log(`${GREEN}Selected:${RESET}`);
+    printTrial(trial, selectedFp, ttl);
+  },
+
+  async status() {
+    if (!requireSelected()) return;
+    const trial = await getTrial(selectedFp);
+    if (!trial) {
+      console.log(`${RED}Trial no longer exists.${RESET}`);
+      selectedFp = null;
+      return;
+    }
+    const ttl = await redis.ttl(`trial:${selectedFp}`);
+    printTrial(trial, selectedFp, ttl);
+  },
+
+  async shift(args) {
+    if (!requireSelected()) return;
+    const days = parseInt(args[0], 10);
+    if (isNaN(days)) {
+      console.log(`${RED}Usage: shift <days>${RESET}  (e.g., shift -25 for 5 days remaining)`);
+      return;
+    }
+    const trial = await getTrial(selectedFp);
+    if (!trial) {
+      console.log(`${RED}Trial no longer exists.${RESET} Use ${CYAN}reset${RESET} to create one.`);
+      return;
+    }
+    const oldDate = trial.startDate;
+    const newDate = new Date(new Date(oldDate).getTime() + days * 86400000);
+    const updated = { ...trial, startDate: newDate.toISOString() };
+    await setTrial(selectedFp, updated);
+    const s = computeStatus(updated);
+    console.log(`\n  ${BOLD}Shifted ${days > 0 ? "+" : ""}${days} days${RESET}`);
+    console.log(`  Old: ${oldDate}`);
+    console.log(`  New: ${updated.startDate}`);
+    console.log(`  ${STATUS_EMOJI[s.status]} ${s.status} — ${s.remainingDays}d remaining\n`);
+  },
+
+  async set(args) {
+    if (!requireSelected()) return;
+    const remaining = parseInt(args[0], 10);
+    if (isNaN(remaining) || remaining < 0) {
+      console.log(`${RED}Usage: set <remaining-days>${RESET}  (e.g., set 5 for 5 days left, set 0 for expired)`);
+      return;
+    }
+    const trial = await getTrial(selectedFp);
+    const daysAgo = TRIAL_DURATION_DAYS - remaining;
+    const newStart = new Date(Date.now() - daysAgo * 86400000).toISOString();
+    const updated = { ...(trial || {}), startDate: newStart };
+    delete updated.convertedDate; // un-convert if setting days
+    await setTrial(selectedFp, updated);
+    const s = computeStatus(updated);
+    console.log(`\n  ${BOLD}Set to ${remaining} days remaining${RESET}`);
+    console.log(`  Start date: ${newStart}`);
+    console.log(`  ${STATUS_EMOJI[s.status]} ${s.status} — ${s.remainingDays}d remaining\n`);
+  },
+
+  async reset() {
+    if (!requireSelected()) return;
+    const updated = { startDate: new Date().toISOString() };
+    await setTrial(selectedFp, updated);
+    console.log(`\n  ${GREEN}Trial reset to today${RESET}`);
+    console.log(`  Start date: ${updated.startDate}`);
+    console.log(`  ${STATUS_EMOJI.active} active — ${TRIAL_DURATION_DAYS}d remaining\n`);
+  },
+
+  async expire() {
+    if (!requireSelected()) return;
+    const trial = await getTrial(selectedFp);
+    const expired = new Date(Date.now() - 31 * 86400000).toISOString();
+    const updated = { ...(trial || {}), startDate: expired };
+    delete updated.convertedDate;
+    await setTrial(selectedFp, updated);
+    console.log(`\n  ${RED}Trial expired${RESET}`);
+    console.log(`  Start date: ${expired} (31 days ago)`);
+    console.log(`  ${STATUS_EMOJI.expired} expired — 0d remaining\n`);
+  },
+
+  async convert() {
+    if (!requireSelected()) return;
+    const trial = await getTrial(selectedFp);
+    if (!trial) {
+      console.log(`${RED}No trial exists.${RESET} Use ${CYAN}reset${RESET} to create one first.`);
+      return;
+    }
+    const updated = { ...trial, convertedDate: new Date().toISOString() };
+    await setTrial(selectedFp, updated);
+    console.log(`\n  ${GOLD}Trial marked as converted${RESET}`);
+    console.log(`  Converted at: ${updated.convertedDate}\n`);
+  },
+
+  async unconvert() {
+    if (!requireSelected()) return;
+    const trial = await getTrial(selectedFp);
+    if (!trial) {
+      console.log(`${RED}No trial exists.${RESET}`);
+      return;
+    }
+    if (!trial.convertedDate) {
+      console.log(`  Trial is not converted — nothing to do.`);
+      return;
+    }
+    const updated = { ...trial };
+    delete updated.convertedDate;
+    await setTrial(selectedFp, updated);
+    const s = computeStatus(updated);
+    console.log(`\n  ${GREEN}Conversion removed${RESET}`);
+    console.log(`  ${STATUS_EMOJI[s.status]} ${s.status} — ${s.remainingDays}d remaining\n`);
+  },
+
+  async delete_trial() {
+    if (!requireSelected()) return;
+    await redis.del(`trial:${selectedFp}`);
+    console.log(`\n  ${RED}Trial deleted${RESET} for ${shortFp(selectedFp)}`);
+    console.log(`  ${DIM}User will get a fresh trial on next sign-up.${RESET}\n`);
+    selectedFp = null;
+  },
+
+  async create(args) {
+    const fp = args[0];
+    if (!fp || !/^[0-9a-f]{64}$/i.test(fp)) {
+      console.log(`${RED}Usage: create <64-char-hex-fingerprint>${RESET}`);
+      console.log(`${DIM}Get your fingerprint from browser DevTools — see "identity" command.${RESET}`);
+      return;
+    }
+    const existing = await getTrial(fp);
+    if (existing) {
+      console.log(`${RED}Trial already exists for that fingerprint.${RESET} Use ${CYAN}use${RESET} to select it.`);
+      return;
+    }
+    const trial = { startDate: new Date().toISOString() };
+    await setTrial(fp, trial);
+    selectedFp = fp;
+    console.log(`\n  ${GREEN}Trial created${RESET}`);
+    printTrial(trial, fp);
+  },
+
+  async keys() {
+    const allKeys = await redis.keys("*");
+    const grouped = {};
+    for (const k of allKeys.sort()) {
+      const prefix = k.split(":")[0];
+      grouped[prefix] = (grouped[prefix] || 0) + 1;
+    }
+    console.log(`\n  ${BOLD}All Redis keys by prefix:${RESET}`);
+    console.log(`  ${DIM}${"─".repeat(40)}${RESET}`);
+    for (const [prefix, count] of Object.entries(grouped).sort()) {
+      console.log(`  ${prefix.padEnd(25)} ${count}`);
+    }
+    console.log(`\n  ${DIM}Total: ${allKeys.length} keys${RESET}\n`);
+  },
+
+  async entitlements() {
+    const keys = await redis.keys("entitlement:*");
+    if (keys.length === 0) {
+      console.log("\n  No entitlement keys found.\n");
+      return;
+    }
+    console.log(`\n  ${BOLD}Entitlements (${keys.length}):${RESET}`);
+    console.log(`  ${DIM}${"─".repeat(60)}${RESET}`);
+    for (const key of keys.sort()) {
+      const raw = await redis.get(key);
+      if (!raw) continue;
+      const ent = JSON.parse(raw);
+      const sub = key.replace("entitlement:", "");
+      const emoji = ent.active ? `${GREEN}●${RESET}` : `${RED}●${RESET}`;
+      console.log(`  ${emoji} ${shortFp(sub)}  tier=${ent.tier}  active=${ent.active}`);
+    }
+    console.log();
+  },
+
+  identity() {
+    console.log(`
+  ${BOLD}How to find your trial fingerprint:${RESET}
+
+  1. Open ${CYAN}fenrirledger.com${RESET} in your browser
+  2. Open DevTools (F12) → Console
+  3. Run:
+
+     ${GOLD}localStorage.getItem('fenrir:device-id')${RESET}
+
+     This gives your deviceId (a UUID).
+
+  4. The fingerprint is SHA-256(navigator.userAgent + deviceId).
+     To compute it in the console:
+
+     ${GOLD}async function fp() {
+       const did = localStorage.getItem('fenrir:device-id');
+       const data = new TextEncoder().encode(navigator.userAgent + did);
+       const hash = await crypto.subtle.digest('SHA-256', data);
+       return [...new Uint8Array(hash)].map(b => b.toString(16).padStart(2,'0')).join('');
+     }
+     fp().then(console.log)${RESET}
+
+  5. Or just use ${CYAN}list${RESET} here — if you only have one trial, that's you.
+`);
+  },
+
+  help() {
+    console.log(`
+  ${BOLD}Trial REPL Commands${RESET}
+  ${DIM}${"─".repeat(55)}${RESET}
+
+  ${BOLD}Discovery${RESET}
+    ${CYAN}list${RESET}                   List all trials with numbered shortcuts
+    ${CYAN}identity${RESET}               How to find your fingerprint
+    ${CYAN}keys${RESET}                   Show all Redis key prefixes
+    ${CYAN}entitlements${RESET}            Show all Stripe entitlements
+
+  ${BOLD}Selection${RESET}
+    ${CYAN}use <N>${RESET}                Select trial by number from list
+    ${CYAN}use <fingerprint>${RESET}       Select trial by full 64-char fingerprint
+    ${CYAN}status${RESET}                 Show selected trial details
+
+  ${BOLD}Time Travel${RESET}
+    ${CYAN}set <days>${RESET}             Set remaining days (e.g., "set 5" = 5 days left)
+    ${CYAN}shift <days>${RESET}           Shift start date by N days (e.g., "shift -25")
+    ${CYAN}reset${RESET}                  Reset to fresh 30-day trial (today)
+    ${CYAN}expire${RESET}                 Instantly expire the trial
+
+  ${BOLD}Conversion${RESET}
+    ${CYAN}convert${RESET}                Mark trial as converted (paid)
+    ${CYAN}unconvert${RESET}              Remove conversion, restore trial status
+
+  ${BOLD}Lifecycle${RESET}
+    ${CYAN}create <fingerprint>${RESET}    Create a new trial for a fingerprint
+    ${CYAN}delete${RESET}                 Delete the selected trial entirely
+
+  ${BOLD}Other${RESET}
+    ${CYAN}help${RESET}                   This help
+    ${CYAN}quit${RESET} / ${CYAN}exit${RESET} / ${CYAN}Ctrl+C${RESET}    Exit
+`);
+  },
+};
+
+// ── REPL ─────────────────────────────────────────────────────────────────────
+
+function prompt() {
+  const sel = selectedFp ? ` ${GOLD}${shortFp(selectedFp)}${RESET}` : "";
+  return `${BOLD}trial${RESET}${sel}${BOLD}>${RESET} `;
+}
+
+const rl = createInterface({
+  input: process.stdin,
+  output: process.stdout,
+  prompt: prompt(),
+  terminal: true,
+});
+
+console.log(`\n  ${BOLD}${GOLD}Fenrir Ledger — Trial Manager${RESET}`);
+console.log(`  ${DIM}Type "help" for commands, "list" to see all trials${RESET}\n`);
+rl.prompt();
+
+rl.on("line", async (line) => {
+  const parts = line.trim().split(/\s+/);
+  const cmd = parts[0]?.toLowerCase();
+  const args = parts.slice(1);
+
+  if (!cmd) {
+    rl.setPrompt(prompt());
+    rl.prompt();
+    return;
+  }
+
+  if (cmd === "quit" || cmd === "exit" || cmd === "q") {
+    console.log(`${DIM}Disconnecting...${RESET}`);
+    await redis.quit();
+    cleanupPortForward();
+    process.exit(0);
+  }
+
+  // Alias "delete" → "delete_trial" to avoid reserved word
+  const cmdKey = cmd === "delete" ? "delete_trial" : cmd;
+  const handler = commands[cmdKey];
+
+  if (!handler) {
+    console.log(`${RED}Unknown command: ${cmd}${RESET}. Type ${CYAN}help${RESET} for available commands.`);
+    rl.setPrompt(prompt());
+    rl.prompt();
+    return;
+  }
+
+  try {
+    await handler(args);
+  } catch (err) {
+    console.error(`${RED}Error: ${err.message}${RESET}`);
+  }
+
+  rl.setPrompt(prompt());
+  rl.prompt();
+});
+
+rl.on("close", async () => {
+  console.log(`\n${DIM}Disconnecting...${RESET}`);
+  await redis.quit();
+  cleanupPortForward();
+  process.exit(0);
+});

--- a/infrastructure/Justfile
+++ b/infrastructure/Justfile
@@ -1,0 +1,74 @@
+# Infrastructure — GKE, Agents, and K8s Management
+# Invoked via: just infra <recipe>
+
+set dotenv-load := false
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+this_dir   := source_directory()
+repo_root  := this_dir / ".."
+scripts    := repo_root / "scripts"
+k8s_agents := this_dir / "k8s" / "agents"
+
+# ── GKE / Kubernetes ────────────────────────────────────────────────────────
+
+# Show full GKE cluster + app status
+gke-status:
+    bash "{{scripts}}/gke-status.sh"
+
+# Configure local kubectl for GKE Autopilot (one-time)
+gke-setup:
+    bash "{{scripts}}/gke-setup.sh"
+
+# Bootstrap IAM roles for deploy service account
+gke-bootstrap-iam project_id="fenrir-ledger-prod":
+    bash "{{scripts}}/bootstrap-iam.sh" "{{project_id}}"
+
+# ── Agent Jobs ──────────────────────────────────────────────────────────────
+
+# Launch Agent Monitor web UI (auto-starts kubectl proxy)
+agent-monitor:
+    node "{{repo_root}}/development/agent-monitor/serve.mjs"
+
+# List agent jobs in GKE
+agent-jobs:
+    kubectl get jobs -n fenrir-agents --sort-by=.metadata.creationTimestamp \
+      -o custom-columns='NAME:.metadata.name,STATUS:.status.conditions[0].type,CREATED:.metadata.creationTimestamp'
+
+# List active (running) agent jobs
+agent-jobs-active:
+    kubectl get jobs -n fenrir-agents \
+      -o jsonpath='{range .items[?(@.status.active)]}{.metadata.name}{"\n"}{end}'
+
+# ── Agent Logs ──────────────────────────────────────────────────────────────
+
+# Stream parsed logs for an agent by session ID
+agent-log session_id:
+    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}"
+
+# Stream parsed logs for the latest agent job on an issue
+agent-log-issue issue:
+    node "{{k8s_agents}}/agent-logs.mjs" --issue "{{issue}}"
+
+# Stream logs with tool calls visible
+agent-log-verbose session_id:
+    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --tools
+
+# Stream logs with tool calls + thinking
+agent-log-debug session_id:
+    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --tools --thinking
+
+# Dump finished agent logs (no follow)
+agent-log-dump session_id:
+    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --no-follow --tools
+
+# Stream all active agent logs in tmux panes
+agent-log-all:
+    node "{{k8s_agents}}/agent-logs.mjs" --all --tmux
+
+# Show raw JSONL for an agent session
+agent-log-raw session_id:
+    node "{{k8s_agents}}/agent-logs.mjs" "{{session_id}}" --raw
+
+# List saved agent log files
+agent-logs-list:
+    @ls -lht "{{repo_root}}/tmp/agent-logs/"*.log 2>/dev/null || echo "No agent logs in tmp/agent-logs/"

--- a/quality/Justfile
+++ b/quality/Justfile
@@ -1,0 +1,49 @@
+# Quality — Coverage and QA Critique
+# Invoked via: just quality <recipe>
+
+set dotenv-load := false
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+scripts := source_directory() / "scripts"
+
+# ── Code Coverage ───────────────────────────────────────────────────────────
+
+# Generate unit test coverage (Vitest only)
+coverage-unit:
+    node "{{scripts}}/coverage.mjs" --unit-only
+
+# Generate E2E coverage (Playwright only)
+coverage-e2e:
+    node "{{scripts}}/coverage.mjs" --e2e-only
+
+# Generate combined coverage (Vitest + Playwright)
+coverage:
+    node "{{scripts}}/coverage.mjs"
+
+# Merge existing coverage reports into combined
+coverage-combine:
+    node "{{scripts}}/coverage-combine.mjs"
+
+# Generate coverage index page
+coverage-index:
+    node "{{scripts}}/coverage-index.mjs"
+
+# ── QA ──────────────────────────────────────────────────────────────────────
+
+# Run Loki's test bloat critique
+critique:
+    bash "{{scripts}}/loki-critique.sh"
+
+# Dry-run test bloat critique (stdout only)
+critique-dry:
+    bash "{{scripts}}/loki-critique.sh" --dry-run
+
+# Show route coverage table per test suite
+routes:
+    bash "{{scripts}}/loki-critique.sh" --pattern-check
+
+# ── Utilities ───────────────────────────────────────────────────────────────
+
+# Generate a 256-bit encryption key
+gen-key:
+    bash "{{scripts}}/generate-encryption-key.sh"


### PR DESCRIPTION
## Summary
- Split monolithic root Justfile into `mod` submodules: `just frontend`, `just quality`, `just infra`
- Add interactive trial-adjust REPL (`just frontend adjust-trial`) for testing trial lifetime — auto port-forwards Redis
- Uses `source_directory()` in sub-Justfiles for correct path resolution through `mod`

## Test plan
- [ ] `just --list` shows root recipes + 3 submodules
- [ ] `just frontend adjust-trial --help` prints usage
- [ ] `just frontend tsc` runs TypeScript checking
- [ ] `just quality coverage` runs coverage
- [ ] `just infra gke-status` shows cluster status
- [ ] Trial REPL auto-starts port-forward when Redis not reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)