### PR TITLE
chore: add fixture-log skill and workflow docs

### DIFF
--- a/.claude/skills/fixture-log/SKILL.md
+++ b/.claude/skills/fixture-log/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: fixture-log
+description: Retrieves agent log files from GKE and saves them as fixtures for the monitor UI. Use when the user says "save fixture", "fixture-log", "download agent log", "save agent log to fixtures", or "grab the logs".
+allowed-tools: Bash
+argument-hint: <session-id | #issue-number> [--all]
+---
+
+# fixture-log
+
+## Purpose
+
+You retrieve agent log files from GKE jobs in the `fenrir-agents` namespace and save them as JSONL fixtures for the monitor UI development environment.
+
+## Arguments
+
+You will receive one of the following via `$ARGUMENTS`:
+
+| Arg | Description |
+|-----|-------------|
+| `<session-id>` | Full session ID, e.g. `issue-783-step1-firemandecko-4d31c13c` |
+| `#N` | Issue number -- looks up the latest job(s) for that issue |
+| `--all` | Save logs for ALL running/completed agent jobs |
+
+## Workflow
+
+When invoked, follow these steps exactly:
+
+### 1. Determine the repo root
+
+```bash
+REPO_ROOT=$(git -C /Users/declanshanaghy/src/github.com/declanshanaghy/fenrir-ledger rev-parse --show-toplevel)
+```
+
+Ensure the fixtures directory exists:
+
+```bash
+mkdir -p "$REPO_ROOT/development/monitor/fixtures"
+```
+
+### 2. Resolve session IDs
+
+**If given a direct session ID** (e.g. `issue-783-step1-firemandecko-4d31c13c`):
+- Use it directly. The k8s job name is `agent-<SESSION_ID>`.
+
+**If given `#N`** (issue number):
+- Find matching jobs by label first:
+  ```bash
+  kubectl get jobs -n fenrir-agents -l fenrir.dev/issue=N -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+  ```
+- If that returns nothing, fall back to name matching:
+  ```bash
+  kubectl get jobs -n fenrir-agents -o name | grep "issue-N-"
+  ```
+- Process ALL matching jobs (there may be multiple steps for one issue).
+
+**If given `--all`**:
+- List all agent jobs:
+  ```bash
+  kubectl get jobs -n fenrir-agents -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}'
+  ```
+- Process each one using the download flow below.
+
+### 3. Download each job's logs (temp-then-verify-then-copy)
+
+For each job name (e.g. `agent-issue-783-step1-firemandecko-4d31c13c`):
+
+Extract the session ID by stripping the `agent-` prefix from the job name.
+
+```bash
+SESSION_ID="<extracted-session-id>"
+JOB_NAME="agent-${SESSION_ID}"
+TEMP_FILE="/tmp/agent-${SESSION_ID}.jsonl"
+DEST_FILE="$REPO_ROOT/development/monitor/fixtures/agent-${SESSION_ID}.jsonl"
+
+# Step A: Download to temp
+kubectl logs "job/${JOB_NAME}" -n fenrir-agents > "$TEMP_FILE" 2>&1
+
+# Step B: Check for server errors in the output
+if grep -q "Error from server" "$TEMP_FILE"; then
+  echo "FAIL: ${JOB_NAME} -- kubectl returned a server error"
+  cat "$TEMP_FILE"
+  rm -f "$TEMP_FILE"
+  # Continue to next job if processing multiple, otherwise stop
+  continue 2>/dev/null || exit 1
+fi
+
+# Step C: Verify content exists (at least 1 line of real content)
+LINES=$(wc -l < "$TEMP_FILE" | tr -d ' ')
+if [ "$LINES" -lt 1 ]; then
+  echo "FAIL: ${JOB_NAME} -- downloaded log is empty (pod may have been cleaned up)"
+  rm -f "$TEMP_FILE"
+  continue 2>/dev/null || exit 1
+fi
+
+# Step D: Copy to fixtures (overwrites existing -- fresher logs are always better)
+cp "$TEMP_FILE" "$DEST_FILE"
+SIZE=$(wc -c < "$DEST_FILE" | tr -d ' ')
+
+echo "OK: ${LINES} lines, ${SIZE} bytes -> development/monitor/fixtures/agent-${SESSION_ID}.jsonl"
+```
+
+### 4. Clean up temp files
+
+Remove any temp files that were successfully copied:
+
+```bash
+rm -f /tmp/agent-*.jsonl
+```
+
+## Error Handling Rules
+
+Follow these rules strictly:
+
+1. **NEVER write an empty or error file to fixtures.** Always download to `/tmp` first and verify.
+2. If `kubectl logs` fails (pod not found, logs evicted), report the error clearly and skip that job.
+3. If the temp file is empty (0 lines), delete it and report failure.
+4. If the temp file contains "Error from server", treat it as failure -- do NOT copy to fixtures.
+5. If processing multiple jobs (`#N` or `--all`), continue to the next job on failure rather than stopping entirely.
+6. Always report the final tally: how many succeeded, how many failed.
+
+## Report
+
+After processing all jobs, report a summary:
+
+```
+=== fixture-log results ===
+Saved:  N fixture(s)
+Failed: M job(s)
+
+Fixtures written:
+  - development/monitor/fixtures/agent-<id1>.jsonl (123 lines, 45.2 KB)
+  - development/monitor/fixtures/agent-<id2>.jsonl (456 lines, 128.7 KB)
+
+Failures:
+  - agent-<id3>: pod not found (logs evicted)
+```
+
+If all jobs succeeded, omit the Failures section. If all failed, omit the Fixtures section.

--- a/development/docs/github-workflows.md
+++ b/development/docs/github-workflows.md
@@ -1,0 +1,220 @@
+# GitHub Actions Workflows
+
+## Deploy Pipeline (`deploy.yml`)
+
+Runs on every push to `main` and `workflow_dispatch`. Builds, tests, and deploys services to GKE Autopilot.
+
+### Pipeline Overview
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '18px'}}}%%
+graph LR
+    classDef primary fill:#03A9F4,stroke:#0288D1,color:#FFF
+    classDef healthy fill:#4CAF50,stroke:#388E3C,color:#FFF
+    classDef warning fill:#FF9800,stroke:#F57C00,color:#FFF
+    classDef background fill:#2C2C2C,stroke:#444,color:#FFF
+
+    detect([Detect Changes]) ==> build-app[Build App Image]
+    detect ==> build-monitor[Build Monitor Image]
+    detect ==> build-monitor-ui[Build Monitor UI Image]
+    detect ==> terraform[Terraform]
+    detect ==> deploy-redis[Deploy Redis]
+    detect ==> deploy-umami[Deploy Umami]
+
+    build-app ==> test-app[Test App]
+    test-app ==> deploy-app[Deploy App]
+
+    build-monitor ==> deploy-odin[Deploy Odin's Throne]
+    build-monitor-ui ==> deploy-odin
+
+    class detect background
+    class build-app,build-monitor,build-monitor-ui primary
+    class test-app warning
+    class deploy-app,deploy-odin,deploy-redis,deploy-umami,terraform healthy
+```
+
+### Change Detection
+
+The `detect-changes` job inspects `git diff HEAD~1 HEAD` and produces boolean outputs that gate all downstream jobs. On `workflow_dispatch`, all outputs are forced `true`.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '18px'}}}%%
+graph TD
+    classDef primary fill:#03A9F4,stroke:#0288D1,color:#FFF
+    classDef healthy fill:#4CAF50,stroke:#388E3C,color:#FFF
+    classDef background fill:#2C2C2C,stroke:#444,color:#FFF
+
+    diff([git diff HEAD~1 HEAD]) --> app{app?}
+    diff --> k8sapp{k8s-app?}
+    diff --> monitor{monitor?}
+    diff --> monui{monitor-ui?}
+    diff --> helmodin{helm-odin?}
+    diff --> infra{infra?}
+    diff --> redis{redis?}
+    diff --> umami{umami?}
+
+    app -->|"development/frontend/ - Dockerfile - package*.json"| build-app[build-app]
+    k8sapp -->|"infrastructure/k8s/app/"| build-app
+    monitor -->|"development/monitor/"| build-monitor[build-monitor]
+    monui -->|"development/monitor-ui/"| build-monitor-ui[build-monitor-ui]
+    helmodin -->|"infrastructure/helm/odin-throne/"| deploy-odin[deploy-odin-throne]
+    infra -->|"infrastructure/terraform/ - infrastructure/monitoring/"| terraform[terraform]
+    redis -->|"infrastructure/k8s/app/redis-statefulset.yaml"| deploy-redis[deploy-redis]
+    umami -->|"infrastructure/helm/umami/"| deploy-umami[deploy-umami]
+
+    class diff background
+    class app,k8sapp,monitor,monui,helmodin,infra,redis,umami primary
+    class build-app,build-monitor,build-monitor-ui,deploy-odin,terraform,deploy-redis,deploy-umami healthy
+```
+
+| Output | Paths | Consumer |
+|--------|-------|----------|
+| `app` | `development/frontend/`, `Dockerfile`, `package*.json` | build-app |
+| `k8s-app` | `infrastructure/k8s/app/` | build-app, deploy-app |
+| `monitor` | `development/monitor/` | build-monitor |
+| `monitor-ui` | `development/monitor-ui/` | build-monitor-ui |
+| `helm-odin` | `infrastructure/helm/odin-throne/` | deploy-odin-throne |
+| `infra` | `infrastructure/terraform/`, `infrastructure/monitoring/` | terraform |
+| `redis` | `infrastructure/k8s/app/redis-statefulset.yaml` | deploy-redis |
+| `umami` | `infrastructure/helm/umami/` | deploy-umami |
+
+### App Pipeline — Build, Test, Deploy
+
+The main application follows a strict build-test-deploy chain. No deployment without passing tests.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '18px'}}}%%
+graph LR
+    classDef primary fill:#03A9F4,stroke:#0288D1,color:#FFF
+    classDef healthy fill:#4CAF50,stroke:#388E3C,color:#FFF
+    classDef warning fill:#FF9800,stroke:#F57C00,color:#FFF
+    classDef critical fill:#F44336,stroke:#D32F2F,color:#FFF
+    classDef background fill:#2C2C2C,stroke:#444,color:#FFF
+
+    build[Build Docker Image] -->|"push to Artifact Registry"| test[Test - tsc + Vitest]
+    test -->|"all green"| resolve[Resolve Image Tag]
+    resolve -->|"new build: SHA tag"| deploy[Helm Deploy to GKE]
+    resolve -->|"k8s-only: current cluster tag"| deploy
+
+    test -->|"failure"| stop([Pipeline Stops])
+
+    class build primary
+    class test warning
+    class deploy healthy
+    class stop critical
+    class resolve background
+```
+
+**Image tag resolution:** When a new image was built, the deploy uses `$IMAGE_TAG` (commit SHA). When only K8s manifests or Helm values changed (no new build), the deploy queries the cluster for the currently running image tag.
+
+```bash
+# Resolve tag from cluster when no new image was built
+kubectl get deployment fenrir-app -n fenrir-app \
+  -o jsonpath='{.spec.template.spec.containers[?(@.name=="fenrir-app")].image}' \
+  | rev | cut -d: -f1 | rev
+```
+
+### Monitor Pipeline — Odin's Throne
+
+Two images (API + UI) with independent builds but a single combined deploy.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '18px'}}}%%
+graph TD
+    classDef primary fill:#03A9F4,stroke:#0288D1,color:#FFF
+    classDef healthy fill:#4CAF50,stroke:#388E3C,color:#FFF
+    classDef background fill:#2C2C2C,stroke:#444,color:#FFF
+
+    detect([Detect Changes]) --> build-api[Build Monitor API]
+    detect --> build-ui[Build Monitor UI]
+    detect -->|"helm-odin changed"| resolve
+
+    build-api --> resolve[Resolve Image Tags]
+    build-ui --> resolve
+    resolve --> deploy[Helm Deploy Odin's Throne]
+
+    class detect background
+    class build-api,build-ui primary
+    class resolve background
+    class deploy healthy
+```
+
+**Deploy triggers when:**
+- Either monitor image was built successfully, OR
+- Only Helm chart files changed (no build needed — resolve tags from cluster)
+
+**Deploy blocks when:**
+- Either build job failed (not skipped — failed)
+
+### Infrastructure Jobs
+
+Terraform, Redis, and Umami run independently — no cross-dependencies with app or monitor pipelines.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '18px'}}}%%
+graph LR
+    classDef healthy fill:#4CAF50,stroke:#388E3C,color:#FFF
+    classDef background fill:#2C2C2C,stroke:#444,color:#FFF
+
+    detect([Detect Changes]) -->|"infra changed"| terraform[Terraform Plan + Apply]
+    detect -->|"redis manifest changed"| redis[Deploy Redis StatefulSet]
+    detect -->|"umami chart changed"| umami[Deploy Umami - Helm]
+
+    class detect background
+    class terraform,redis,umami healthy
+```
+
+### Job Dependency Summary
+
+| Job | Depends On | Runs When |
+|-----|-----------|-----------|
+| `detect-changes` | -- | Always |
+| `terraform` | detect-changes | `infra == true` |
+| `build-app` | detect-changes | `app == true` OR `k8s-app == true` |
+| `test-app` | build-app | build-app succeeded |
+| `deploy-app` | test-app, build-app, detect-changes | test-app succeeded |
+| `build-monitor` | detect-changes | `monitor == true` |
+| `build-monitor-ui` | detect-changes | `monitor-ui == true` |
+| `deploy-odin-throne` | build-monitor, build-monitor-ui, detect-changes | Any build succeeded OR `helm-odin == true` (no failures) |
+| `deploy-redis` | detect-changes | `redis == true` |
+| `deploy-umami` | detect-changes | `umami == true` |
+
+### Concurrency
+
+```yaml
+concurrency:
+  group: deploy-main
+  cancel-in-progress: false
+```
+
+Deploy runs are serialized — queued, never cancelled. This prevents mid-deploy interruptions.
+
+---
+
+## CI Tests Pipeline (`ci-tests.yml`)
+
+Runs on every push to non-main branches when frontend or test files change.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'fontSize': '18px'}}}%%
+graph LR
+    classDef primary fill:#03A9F4,stroke:#0288D1,color:#FFF
+    classDef warning fill:#FF9800,stroke:#F57C00,color:#FFF
+    classDef healthy fill:#4CAF50,stroke:#388E3C,color:#FFF
+
+    push([Push to PR branch]) --> tsc[TypeScript Check]
+    tsc --> unit[Vitest Unit Tests]
+    unit --> e2e[Playwright E2E - vs prod]
+    e2e --> report[Upload Report + PR Comment]
+
+    class push primary
+    class tsc,unit warning
+    class e2e warning
+    class report healthy
+```
+
+**Path filters:** Only triggers on changes to `development/frontend/**`, `quality/test-suites/**`, or `.github/workflows/ci-tests.yml`.
+
+**Target:** Tests run against live production (`https://fenrirledger.com`), not a staging environment.
+
+**PR comment:** Upserts a single results table per PR (updates on each push, doesn't spam).


### PR DESCRIPTION
## Summary
- Add fixture-log skill definition (`.claude/skills/fixture-log/SKILL.md`)
- Add GitHub Actions workflows documentation (`development/docs/github-workflows.md`)

## Test plan
- [x] No code changes, docs/config only

🤖 Generated with [Claude Code](https://claude.com/claude-code)