### PR TITLE
fix: block Umami analytics in Playwright E2E tests

### DIFF
--- a/quality/test-suites/auth-returnto/auth-returnto.spec.ts
+++ b/quality/test-suites/auth-returnto/auth-returnto.spec.ts
@@ -23,7 +23,7 @@
  *   - Unit tests in src/__tests__/auth/ (PKCE generation, validation)
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import { clearAllStorage } from "../helpers/test-fixtures";
 
 // ─── Shared setup ─────────────────────────────────────────────────────────────

--- a/quality/test-suites/auth/auth-callback.spec.ts
+++ b/quality/test-suites/auth/auth-callback.spec.ts
@@ -31,7 +31,7 @@
  *   4. Verify anonymous cards are merged (if any existed pre-login)
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import { clearAllStorage } from "../helpers/test-fixtures";
 
 // ─── Shared setup ─────────────────────────────────────────────────────────────

--- a/quality/test-suites/auth/sign-in.spec.ts
+++ b/quality/test-suites/auth/sign-in.spec.ts
@@ -9,7 +9,7 @@
  * Data isolation: clearAllStorage() before each test.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import { clearAllStorage } from "../helpers/test-fixtures";
 
 test.beforeEach(async ({ page }) => {

--- a/quality/test-suites/card-lifecycle/add-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/add-card.spec.ts
@@ -9,7 +9,7 @@
  * Data isolation: clearAllStorage() before each test.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import {
   seedHousehold,
   clearAllStorage,

--- a/quality/test-suites/card-lifecycle/close-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/close-card.spec.ts
@@ -8,7 +8,7 @@
  * Data isolation: clearAllStorage() before each test.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import {
   makeCard,
   seedCards,

--- a/quality/test-suites/card-lifecycle/delete-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/delete-card.spec.ts
@@ -8,7 +8,7 @@
  * Data isolation: clearAllStorage() before each test.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import {
   makeCard,
   seedCards,

--- a/quality/test-suites/card-lifecycle/edit-card.spec.ts
+++ b/quality/test-suites/card-lifecycle/edit-card.spec.ts
@@ -8,7 +8,7 @@
  * Data isolation: clearAllStorage() before each test.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import {
   makeCard,
   seedCards,

--- a/quality/test-suites/card-lifecycle/wizard-save.spec.ts
+++ b/quality/test-suites/card-lifecycle/wizard-save.spec.ts
@@ -8,7 +8,7 @@
  * Data isolation: clearAllStorage() before each test.
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect } from "../helpers/analytics-block";
 import {
   seedHousehold,
   clearAllStorage,

--- a/quality/test-suites/helpers/analytics-block.ts
+++ b/quality/test-suites/helpers/analytics-block.ts
@@ -1,0 +1,17 @@
+import { test as base } from "@playwright/test";
+
+/**
+ * Extended Playwright test fixture that blocks Umami analytics requests.
+ * Import { test, expect } from this module instead of "@playwright/test"
+ * to prevent E2E runs from polluting production analytics data.
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.route("**/analytics.fenrirledger.com/**", (route) =>
+      route.abort(),
+    );
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";


### PR DESCRIPTION
## Summary

- Adds `analytics-block.ts` shared fixture that aborts requests to `analytics.fenrirledger.com` via `page.route()`
- Updates all 8 spec files to import `test`/`expect` from the fixture instead of `@playwright/test`
- Prevents CI E2E runs from polluting production Umami analytics data (was generating 57 fake pageviews per run)

## Test plan

- [ ] Playwright tests still pass with the new import
- [ ] No new Umami sessions appear during test runs against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)