### PR TITLE
fix: auto-collapse tool groups in log viewer when auto-scrolling (#1017)

### DIFF
--- a/development/monitor-ui/src/__tests__/tool-group-auto-collapse.test.tsx
+++ b/development/monitor-ui/src/__tests__/tool-group-auto-collapse.test.tsx
@@ -1,0 +1,276 @@
+/**
+ * Vitest tests for issue #1017 — Tool groups in log viewer auto-collapse
+ * when auto-scrolling is enabled.
+ *
+ * AC tested:
+ * - The latest tool-batch group starts expanded
+ * - Previous tool-batch groups collapse when a newer one arrives (auto-scroll on)
+ * - Manual toggle works: user can re-open a collapsed group
+ * - Completion of a batch triggers auto-collapse (existing behaviour, preserved)
+ * - When auto-scroll is re-enabled, non-latest batches collapse
+ */
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { render, cleanup, act } from "@testing-library/react";
+import { useState } from "react";
+import { LogViewer } from "../components/LogViewer";
+import type { LogEntry } from "../hooks/useLogStream";
+import type { DisplayJob } from "../lib/types";
+
+vi.mock("../lib/localStorageLogs", () => ({
+  downloadLog: vi.fn(),
+  appendLogLine: vi.fn(),
+  getLog: vi.fn().mockReturnValue(""),
+}));
+
+afterEach(cleanup);
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MOCK_JOB: DisplayJob = {
+  sessionId: "issue-1017-step1-test",
+  name: "agent-issue-1017-step1-test",
+  issue: "1017",
+  step: "1",
+  agentKey: "firemandecko",
+  agentName: "FiremanDecko",
+  status: "running",
+  startTime: Date.now(),
+  completionTime: null,
+  issueTitle: "Tool groups auto-collapse during auto-scroll",
+  branchName: "fix/issue-1017-tool-group-collapse",
+};
+
+function makeBatch(id: string, label: string, complete = false): LogEntry {
+  return {
+    id,
+    type: "tool-batch",
+    text: label,
+    complete,
+    children: [
+      {
+        id: `${id}-child`,
+        type: "tool-use",
+        toolName: "Read",
+        toolBadge: "📖",
+        toolPreview: "reading file",
+        toolId: `tool-${id}`,
+      },
+    ],
+  };
+}
+
+function allBatchDivs(container: HTMLElement): NodeListOf<Element> {
+  return container.querySelectorAll(".ev-tool-batch");
+}
+
+function isOpen(el: Element): boolean {
+  return el.classList.contains("open");
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("ToolBatchGroup auto-collapse — issue #1017", () => {
+  it("single batch starts expanded (it is the latest)", () => {
+    const entries: LogEntry[] = [makeBatch("b1", "1 reading")];
+    const { container } = render(
+      <LogViewer entries={entries} activeJob={MOCK_JOB} wsState="open" />
+    );
+    const batches = allBatchDivs(container);
+    expect(batches.length).toBe(1);
+    expect(isOpen(batches[0]!)).toBe(true);
+  });
+
+  it("previous batch collapses when a new batch appears (auto-scroll on by default)", () => {
+    // Start with one batch (it is latest → open).
+    function Wrapper() {
+      const [entries, setEntries] = useState<LogEntry[]>([
+        makeBatch("b1", "1 reading"),
+      ]);
+      return (
+        <>
+          <button
+            data-testid="add"
+            onClick={() =>
+              setEntries((prev) => [...prev, makeBatch("b2", "1 editing")])
+            }
+          >
+            add
+          </button>
+          <LogViewer entries={entries} activeJob={MOCK_JOB} wsState="open" />
+        </>
+      );
+    }
+
+    const { container } = render(<Wrapper />);
+
+    // Before: one batch, open
+    expect(allBatchDivs(container).length).toBe(1);
+    expect(isOpen(allBatchDivs(container)[0]!)).toBe(true);
+
+    // Add second batch
+    act(() => {
+      (container.querySelector("[data-testid=add]") as HTMLButtonElement).click();
+    });
+
+    const batches = allBatchDivs(container);
+    expect(batches.length).toBe(2);
+    // First batch (b1) should now be collapsed
+    expect(isOpen(batches[0]!)).toBe(false);
+    // Second batch (b2) — the new latest — should remain open
+    expect(isOpen(batches[1]!)).toBe(true);
+  });
+
+  it("completed batch auto-collapses (existing behaviour preserved)", () => {
+    function Wrapper() {
+      const [entries, setEntries] = useState<LogEntry[]>([
+        makeBatch("b1", "1 reading", false),
+      ]);
+      return (
+        <>
+          <button
+            data-testid="complete"
+            onClick={() =>
+              setEntries([makeBatch("b1", "1 reading", true)])
+            }
+          >
+            complete
+          </button>
+          <LogViewer entries={entries} activeJob={MOCK_JOB} wsState="open" />
+        </>
+      );
+    }
+
+    const { container } = render(<Wrapper />);
+    expect(isOpen(allBatchDivs(container)[0]!)).toBe(true);
+
+    act(() => {
+      (
+        container.querySelector("[data-testid=complete]") as HTMLButtonElement
+      ).click();
+    });
+
+    expect(isOpen(allBatchDivs(container)[0]!)).toBe(false);
+  });
+
+  it("user can manually re-open a collapsed previous batch", () => {
+    function Wrapper() {
+      const [entries, setEntries] = useState<LogEntry[]>([
+        makeBatch("b1", "1 reading"),
+      ]);
+      return (
+        <>
+          <button
+            data-testid="add"
+            onClick={() =>
+              setEntries((prev) => [...prev, makeBatch("b2", "1 editing")])
+            }
+          >
+            add
+          </button>
+          <LogViewer entries={entries} activeJob={MOCK_JOB} wsState="open" />
+        </>
+      );
+    }
+
+    const { container } = render(<Wrapper />);
+
+    // Add second batch — first should collapse
+    act(() => {
+      (container.querySelector("[data-testid=add]") as HTMLButtonElement).click();
+    });
+
+    const batches = allBatchDivs(container);
+    expect(isOpen(batches[0]!)).toBe(false);
+
+    // Click header of first batch to re-open it
+    act(() => {
+      (batches[0]!.querySelector(".ev-tool-batch-header") as HTMLElement).click();
+    });
+
+    expect(isOpen(allBatchDivs(container)[0]!)).toBe(true);
+  });
+
+  it("multiple previous batches all collapse when new batch arrives", () => {
+    function Wrapper() {
+      const [entries, setEntries] = useState<LogEntry[]>([
+        makeBatch("b1", "1 reading"),
+        makeBatch("b2", "1 editing"),
+      ]);
+      return (
+        <>
+          <button
+            data-testid="add"
+            onClick={() =>
+              setEntries((prev) => [...prev, makeBatch("b3", "1 committing")])
+            }
+          >
+            add
+          </button>
+          <LogViewer entries={entries} activeJob={MOCK_JOB} wsState="open" />
+        </>
+      );
+    }
+
+    const { container } = render(<Wrapper />);
+
+    // Initially: b1 closed (not latest), b2 open (latest)
+    let batches = allBatchDivs(container);
+    expect(batches.length).toBe(2);
+    expect(isOpen(batches[0]!)).toBe(false);
+    expect(isOpen(batches[1]!)).toBe(true);
+
+    act(() => {
+      (container.querySelector("[data-testid=add]") as HTMLButtonElement).click();
+    });
+
+    batches = allBatchDivs(container);
+    expect(batches.length).toBe(3);
+    expect(isOpen(batches[0]!)).toBe(false);
+    expect(isOpen(batches[1]!)).toBe(false);
+    expect(isOpen(batches[2]!)).toBe(true);
+  });
+
+  it("non-latest batches collapse when auto-scroll is re-enabled", () => {
+    // LogViewer auto-scroll starts ON. To test re-enable we:
+    // 1. Add two batches (second is latest, first collapses)
+    // 2. Re-open the first batch manually (simulating user expanding while scrolled up)
+    // 3. Click the autoscroll-fab to toggle off then back on
+    // 4. Verify the first batch collapses again
+
+    const initialEntries: LogEntry[] = [
+      makeBatch("b1", "1 reading"),
+      makeBatch("b2", "1 editing"),
+    ];
+    function Wrapper() {
+      return (
+        <LogViewer entries={initialEntries} activeJob={MOCK_JOB} wsState="open" />
+      );
+    }
+
+    const { container } = render(<Wrapper />);
+
+    // b1 starts collapsed (not latest)
+    let batches = allBatchDivs(container);
+    expect(isOpen(batches[0]!)).toBe(false);
+
+    // Manually open b1
+    act(() => {
+      (batches[0]!.querySelector(".ev-tool-batch-header") as HTMLElement).click();
+    });
+    batches = allBatchDivs(container);
+    expect(isOpen(batches[0]!)).toBe(true);
+
+    // Toggle auto-scroll OFF
+    const fab = container.querySelector(".autoscroll-fab") as HTMLButtonElement;
+    act(() => { fab.click(); });
+
+    // Toggle auto-scroll ON again — b1 should collapse (non-latest + auto-scroll re-enabled)
+    act(() => { fab.click(); });
+
+    batches = allBatchDivs(container);
+    expect(isOpen(batches[0]!)).toBe(false);
+    // Latest (b2) should still be open
+    expect(isOpen(batches[1]!)).toBe(true);
+  });
+});

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -151,6 +151,14 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
     return null;
   }, [entries]);
 
+  // Track the most recent tool-batch entry so we can keep it expanded during auto-scroll.
+  const lastToolBatchId = useMemo(() => {
+    for (let i = entries.length - 1; i >= 0; i--) {
+      if (entries[i]?.type === "tool-batch") return entries[i]!.id;
+    }
+    return null;
+  }, [entries]);
+
   if (!activeJob) {
     return (
       <main className="content" aria-label="Log viewer">
@@ -212,6 +220,8 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
             {...(activeJob?.agentKey ? { agentKey: activeJob.agentKey } : {})}
             {...(activeJob?.agentName ? { agentName: activeJob.agentName } : {})}
             isLastAssistantText={entry.id === lastAssistantTextId}
+            autoScroll={autoScroll}
+            isLatestBatch={entry.type === "tool-batch" && entry.id === lastToolBatchId}
           />
         ))}
       </div>
@@ -258,7 +268,7 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
   );
 }
 
-function LogLine({ entry, agentKey, agentName, isLastAssistantText }: { entry: LogEntry; agentKey?: string; agentName?: string; isLastAssistantText?: boolean }) {
+function LogLine({ entry, agentKey, agentName, isLastAssistantText, autoScroll, isLatestBatch }: { entry: LogEntry; agentKey?: string; agentName?: string; isLastAssistantText?: boolean; autoScroll?: boolean; isLatestBatch?: boolean }) {
   switch (entry.type) {
     case "system":
       return (
@@ -269,7 +279,7 @@ function LogLine({ entry, agentKey, agentName, isLastAssistantText }: { entry: L
     case "turn-divider":
       return null; // legacy, unused
     case "tool-batch":
-      return <ToolBatchGroup entry={entry} />;
+      return <ToolBatchGroup entry={entry} {...(autoScroll !== undefined ? { autoScroll } : {})} {...(isLatestBatch !== undefined ? { isLatestBatch } : {})} />;
     case "assistant-text":
       if (entry.detail === "thinking") {
         return <div className="ev-thinking">{entry.text}</div>;
@@ -375,10 +385,14 @@ function AgentBubble({
   );
 }
 
-function ToolBatchGroup({ entry }: { entry: LogEntry }) {
-  const [open, setOpen] = useState(true);
+function ToolBatchGroup({ entry, autoScroll, isLatestBatch }: { entry: LogEntry; autoScroll?: boolean; isLatestBatch?: boolean }) {
+  // Start collapsed if auto-scroll is on and this is not the latest batch (handles initial render
+  // with multiple historical batches already in the list).
+  const [open, setOpen] = useState(() => !autoScroll || !!isLatestBatch);
   const hasError = entry.children?.some((c) => c.toolIsError) ?? false;
   const prevCompleteRef = useRef(entry.complete);
+  const prevIsLatestRef = useRef(isLatestBatch);
+  const prevAutoScrollRef = useRef(autoScroll);
 
   // Auto-collapse immediately when batch completes
   useEffect(() => {
@@ -387,6 +401,24 @@ function ToolBatchGroup({ entry }: { entry: LogEntry }) {
       setOpen(false);
     }
   }, [entry.complete]);
+
+  // Auto-collapse when this batch is superseded by a newer one (auto-scroll must be on)
+  useEffect(() => {
+    const wasLatest = prevIsLatestRef.current;
+    prevIsLatestRef.current = isLatestBatch;
+    if (wasLatest && !isLatestBatch && autoScroll) {
+      setOpen(false);
+    }
+  }, [isLatestBatch, autoScroll]);
+
+  // Auto-collapse non-latest batches when auto-scroll is re-enabled
+  useEffect(() => {
+    const wasAutoScroll = prevAutoScrollRef.current;
+    prevAutoScrollRef.current = autoScroll;
+    if (!wasAutoScroll && autoScroll && !isLatestBatch) {
+      setOpen(false);
+    }
+  }, [autoScroll, isLatestBatch]);
 
   return (
     <div className={`ev-tool-batch ${open ? "open" : ""}${hasError ? " batch-error" : ""}${entry.complete ? " complete" : ""}`}>


### PR DESCRIPTION
## Summary

- **`ToolBatchGroup`** now starts collapsed when `autoScroll` is on and it is not the latest batch at mount time — covers historical log loads
- Collapses when a newer batch appears (`isLatestBatch` transitions `true → false` with auto-scroll on)
- Collapses non-latest batches when auto-scroll is re-enabled after the user scrolled up
- Preserves existing `complete → collapse` behaviour
- Manual toggle always works — user can re-open any collapsed group at will

## Changes

- `development/monitor-ui/src/components/LogViewer.tsx`
  - Added `lastToolBatchId` memo in `LogViewer` to identify the latest batch
  - Passed `autoScroll` + `isLatestBatch` through `LogLine` → `ToolBatchGroup`
  - `ToolBatchGroup` initial state derived from `autoScroll && !isLatestBatch`
  - Two new `useEffect`s: collapse on latest-status-lost and on auto-scroll re-enable
- `development/monitor-ui/src/__tests__/tool-group-auto-collapse.test.tsx` — 6 new Vitest tests

## Test plan

- [x] Single batch starts expanded
- [x] Previous batch collapses when new batch arrives (auto-scroll on)
- [x] Completed batch auto-collapses (existing behaviour)
- [x] User can manually re-open a collapsed batch
- [x] Multiple previous batches all collapse when new batch arrives
- [x] Non-latest batches collapse when auto-scroll is re-enabled
- [x] `tsc --noEmit` clean (no new errors)
- [x] `vite build` passes
- [x] 415/415 tests pass

Closes #1017

🤖 Generated with [Claude Code](https://claude.com/claude-code)