### PR TITLE
feat: Norse-themed brandify-agent reports + chronicles planning

### DIFF
--- a/development/monitor-ui/src/__tests__/loki-1036-session-transitions.test.tsx
+++ b/development/monitor-ui/src/__tests__/loki-1036-session-transitions.test.tsx
@@ -54,17 +54,7 @@ const SECOND_JOB: DisplayJob = {
   agentName: "Freya",
 };
 
-const TTL_JOB: DisplayJob = {
-  ...ACTIVE_JOB,
-  status: "failed",
-  sessionId: "issue-1036-loki-ttl",
-};
 
-const NODE_JOB: DisplayJob = {
-  ...ACTIVE_JOB,
-  status: "failed",
-  sessionId: "issue-1036-loki-node",
-};
 
 function text(t: string): LogEntry {
   return { id: `e-${Math.random()}`, type: "assistant-text", text: t };
@@ -184,12 +174,12 @@ describe("Round-trip session transitions — hooks stability (issue #1036)", () 
 
 describe("Various log entry types render without crash (issue #1036)", () => {
   const ENTRIES: LogEntry[] = [
-    { id: "e-sys", type: "system", detail: "System initialized", text: undefined },
+    { id: "e-sys", type: "system", detail: "System initialized" },
     { id: "e-tool", type: "tool-use", text: "Read file", toolName: "Read", toolInput: '{"path":"/foo"}' },
-    { id: "e-warn", type: "warning", message: "Low disk space", text: undefined },
-    { id: "e-err", type: "error", message: "Connection refused", text: undefined },
+    { id: "e-warn", type: "warning", message: "Low disk space" },
+    { id: "e-err", type: "error", message: "Connection refused" },
     { id: "e-raw", type: "raw", text: "raw log output" },
-    { id: "e-end", type: "stream-end", reason: "completed", text: undefined },
+    { id: "e-end", type: "stream-end", reason: "completed" },
     { id: "e-txt", type: "assistant-text", text: "Some agent response" },
     { id: "e-think", type: "assistant-text", detail: "thinking", text: "thinking..." },
   ];
@@ -202,7 +192,7 @@ describe("Various log entry types render without crash (issue #1036)", () => {
 
   it("renders system entry without crash", () => {
     const entries: LogEntry[] = [
-      { id: "e1", type: "system", detail: "init", text: undefined },
+      { id: "e1", type: "system", detail: "init" },
     ];
     expect(() =>
       render(<LogViewer entries={entries} activeJob={ACTIVE_JOB} wsState="open" />)
@@ -211,7 +201,7 @@ describe("Various log entry types render without crash (issue #1036)", () => {
 
   it("renders warning entry without crash", () => {
     const entries: LogEntry[] = [
-      { id: "e1", type: "warning", message: "Something went wrong", text: undefined },
+      { id: "e1", type: "warning", message: "Something went wrong" },
     ];
     expect(() =>
       render(<LogViewer entries={entries} activeJob={ACTIVE_JOB} wsState="open" />)
@@ -220,7 +210,7 @@ describe("Various log entry types render without crash (issue #1036)", () => {
 
   it("renders error entry without crash", () => {
     const entries: LogEntry[] = [
-      { id: "e1", type: "error", message: "Fatal error", text: undefined },
+      { id: "e1", type: "error", message: "Fatal error" },
     ];
     expect(() =>
       render(<LogViewer entries={entries} activeJob={ACTIVE_JOB} wsState="open" />)
@@ -229,7 +219,7 @@ describe("Various log entry types render without crash (issue #1036)", () => {
 
   it("renders stream-end entry without crash", () => {
     const entries: LogEntry[] = [
-      { id: "e1", type: "stream-end", reason: "done", text: undefined },
+      { id: "e1", type: "stream-end", reason: "done" },
     ];
     expect(() =>
       render(<LogViewer entries={entries} activeJob={ACTIVE_JOB} wsState="open" />)
@@ -238,7 +228,7 @@ describe("Various log entry types render without crash (issue #1036)", () => {
 
   it("renders verdict entry without crash", () => {
     const entries: LogEntry[] = [
-      { id: "e1", type: "verdict", verdictResult: "PASS", text: undefined },
+      { id: "e1", type: "verdict", verdictResult: "PASS" },
     ];
     expect(() =>
       render(<LogViewer entries={entries} activeJob={ACTIVE_JOB} wsState="open" />)

--- a/development/monitor-ui/src/__tests__/loki-error-boundary.test.tsx
+++ b/development/monitor-ui/src/__tests__/loki-error-boundary.test.tsx
@@ -167,7 +167,7 @@ describe("ErrorBoundary — Loki tablet (issue #1037)", () => {
       </ErrorBoundary>
     );
     const runeBorders = container.querySelectorAll(".loki-eb-rune-border");
-    runeBorders.forEach((el) => {
+    runeBorders.forEach((el: any) => {
       expect(el.getAttribute("aria-hidden")).toBe("true");
     });
   });


### PR DESCRIPTION
## Summary
- Full Norse styling for brandify-agent HTML reports (decree, callback, explosions, toolbox, avatars)
- Agent-logs clobber protection fix for running vs finished jobs
- Heckler avatars moved to permanent repo location
- Product design brief for Agent Chronicles MDX parity (issues #1047-#1051)

## Test plan
- [ ] `/brandify-agent <session-id>` generates styled HTML with correct agent avatar
- [ ] All-Father's Decree renders with rune sections
- [ ] Agent callback footer shows agent-specific quote
- [ ] Explosions have Norse tremble animation
- [ ] Consecutive tool-only turns merge into one toolbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)