### PR TITLE
fix: prevent monitor log viewer scroll position reset

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -75,13 +75,20 @@ export function App() {
   const isNodeUnreachableRef = useRef(isNodeUnreachable);
   isNodeUnreachableRef.current = isNodeUnreachable;
   const prevWsState = useRef(wsState);
+  const lastSubscribedRef = useRef<string | null>(null);
   useEffect(() => {
     const wasDisconnected = prevWsState.current !== "open";
     prevWsState.current = wsState;
     if (wsState === "open" && wasDisconnected && activeSessionId && !isTtlExpiredRef.current && !isNodeUnreachableRef.current) {
+      // On reconnect to the SAME session, clear entries first to avoid
+      // duplicate log replay stacking on top of existing entries.
+      if (lastSubscribedRef.current === activeSessionId) {
+        clearEntries();
+      }
+      lastSubscribedRef.current = activeSessionId;
       send({ type: "subscribe", sessionId: activeSessionId });
     }
-  }, [wsState, activeSessionId, send]);
+  }, [wsState, activeSessionId, send, clearEntries]);
 
   const activeJob = jobs.find((j) => j.sessionId === activeSessionId) || null;
 

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -98,13 +98,20 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
   const [autoScroll, setAutoScroll] = useState(true);
   const programmaticScrollRef = useRef(false);
 
-  // Auto-scroll when new entries arrive (if enabled)
+  // Auto-scroll when new entries arrive (if enabled).
+  // Depend on entry count + last entry ID, NOT the full array reference.
+  // This prevents scroll resets when the array is reconstructed (e.g. entrypoint grouping).
+  const lastEntryId = entries[entries.length - 1]?.id;
   useEffect(() => {
     if (autoScroll && termRef.current) {
       programmaticScrollRef.current = true;
-      termRef.current.scrollTop = termRef.current.scrollHeight;
+      requestAnimationFrame(() => {
+        if (termRef.current) {
+          termRef.current.scrollTop = termRef.current.scrollHeight;
+        }
+      });
     }
-  }, [entries, autoScroll]);
+  }, [entries.length, lastEntryId, autoScroll]);
 
   // Reset auto-scroll when switching sessions
   useEffect(() => {

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -143,17 +143,26 @@ export function useLogStream() {
             return;
           }
 
-          // Entrypoint section end marker — collapse all prior entries into a group
+          // Entrypoint section end marker — collapse entrypoint entries into a group.
+          // Only moves entrypoint-typed entries into the group's children;
+          // preserves all other entries at the root to avoid a full array rebuild.
           if (/^===\s*Starting Claude Code\s*===/.test(stripped)) {
             inEntrypoint.current = false;
             setEntries((prev) => {
+              const epTypes = new Set(["entrypoint-header", "entrypoint-ok", "entrypoint-info", "entrypoint-fatal"]);
+              const epChildren: LogEntry[] = [];
+              const rest: LogEntry[] = [];
+              for (const e of prev) {
+                if (epTypes.has(e.type)) epChildren.push(e);
+                else rest.push(e);
+              }
               const group: LogEntry = {
                 id: nextId(),
                 type: "entrypoint-group",
                 text: "Agent Sandbox Setup",
-                children: [...prev],
+                children: epChildren,
               };
-              return [group, parseEntrypointLine(stripped)];
+              return [...rest, group, parseEntrypointLine(stripped)];
             });
             return;
           }


### PR DESCRIPTION
## Summary
- Auto-scroll effect depends on `entries.length` + last entry ID, not full array ref
- WebSocket reconnect clears entries before re-subscribing (prevents duplicate replay)
- Entrypoint group only collects entrypoint-typed entries, preserving other root entries

## Test plan
- [x] tsc passes
- [x] Open a live session, scroll up, verify position holds as new entries arrive
- [x] Switch sessions, verify auto-scroll resets to bottom
- [x] WebSocket reconnect doesn't replay from top

🤖 Generated with [Claude Code](https://claude.com/claude-code)