### PR TITLE
fix: add googleusercontent.com to SSRF redirect whitelist

### DIFF
--- a/development/frontend/src/lib/sheets/url-validation.ts
+++ b/development/frontend/src/lib/sheets/url-validation.ts
@@ -32,6 +32,8 @@ export function isValidRedirectTarget(urlString: string, context: string = "redi
     const allowedDomains = [
       "docs.google.com",
       "sheets.google.com",
+      // Google's export CDN — Sheets CSV export redirects here
+      "googleusercontent.com",
       // Google's various redirects and services
       "ssl.gstatic.com",
       "accounts.google.com",


### PR DESCRIPTION
## Summary
Google Sheets CSV export redirects to `doc-*.sheets.googleusercontent.com` which was missing from the SSRF prevention whitelist. All URL imports were failing with `FETCH_ERROR: Invalid redirect target`.

Added `googleusercontent.com` to the allowed domains list.

## Test plan
- [ ] Import a Google Sheet via URL — should succeed (was returning 500)
- [ ] Import via Google Picker — should still work
- [ ] CSV upload — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)