### PR TITLE
feat: Norse restyle — decree grid, agent/tool visual hierarchy

### DIFF
--- a/.claude/skills/dev-server/SKILL.md
+++ b/.claude/skills/dev-server/SKILL.md
@@ -10,24 +10,28 @@ Manages all local development services for Fenrir Ledger.
 ## Usage
 
 ```
-/dev-server                    # Show status of all services
-/dev-server start              # Start all services
-/dev-server stop               # Stop all services
-/dev-server restart             # Restart all services
-/dev-server <service> start    # Start a specific service
-/dev-server <service> stop     # Stop a specific service
-/dev-server <service> logs     # Tail a specific service's logs
+/dev-server                         # Show status of all services
+/dev-server start                   # Start all services
+/dev-server stop                    # Stop all services
+/dev-server restart                 # Restart all services
+/dev-server <service> start         # Start a specific service
+/dev-server <service> stop          # Stop a specific service
+/dev-server <service> logs          # Tail a specific service's logs
+/dev-server odins-throne start      # Start monitor-api + monitor-ui
+/dev-server odins-throne restart    # Restart monitor-api + monitor-ui
 ```
 
 ## Services
 
-| Service | Port | Description |
-|---------|------|-------------|
-| `app` | 9653 (WOLF) | Next.js dev server via `vercel dev` |
-| `stripe` | — | Stripe CLI webhook forwarding to app |
-| `monitor-api` | 3001 | Hono API/WebSocket server (K8s jobs, log streaming) |
-| `monitor-ui` | 3002 | Vite React UI (Odin's Throne — Hlidskjalf) |
-| `proxy` | 8001 | kubectl proxy for GKE cluster access |
+| Service | Alias | Port | Description |
+|---------|-------|------|-------------|
+| `app` | — | 9653 (WOLF) | Next.js dev server via `vercel dev` |
+| `stripe` | — | — | Stripe CLI webhook forwarding to app |
+| `monitor-api` | `odins-throne` | 3001 | Hono API/WebSocket server (K8s jobs, log streaming) |
+| `monitor-ui` | `odins-throne` | 3002 | Vite React UI (Odin's Throne — Hlidskjalf) |
+| `proxy` | — | 8001 | kubectl proxy for GKE cluster access |
+
+**`odins-throne`** is a convenience alias that controls both `monitor-api` and `monitor-ui` together.
 
 ## Scripts
 
@@ -50,6 +54,8 @@ Actions: `start`, `stop`, `status`, `logs`
 | `start` | Run `start` on ALL services |
 | `stop` | Run `stop` on ALL services |
 | `restart` | Run `stop` then `start` on ALL |
+| `odins-throne <action>` | Run `<action>` on `monitor-api` + `monitor-ui` |
+| `monitor <action>` | Same as `odins-throne` |
 | `<service> <action>` | Run `<action>` on that service only |
 | `logs` | Run `logs` on app (default) |
 | `<service> logs` | Tail that service's log |
@@ -63,6 +69,10 @@ SCRIPT_DIR="$REPO_ROOT/.claude/skills/dev-server/scripts"
 # Single service
 bash "$SCRIPT_DIR/<service>.sh" <action>
 
+# odins-throne (both monitor services)
+bash "$SCRIPT_DIR/monitor-api.sh" <action>
+bash "$SCRIPT_DIR/monitor-ui.sh" <action>
+
 # All services (start order)
 for svc in stripe app monitor-api monitor-ui proxy; do
   bash "$SCRIPT_DIR/$svc.sh" <action>
@@ -74,13 +84,13 @@ done
 Show a status table after any action:
 
 ```
-Service       Port   Status
-───────       ────   ──────
-app           9653   running (pid 12345)
-stripe        —      running (pid 12346)
-monitor-api   3001   running (pid 12347)
-monitor-ui    3002   running (pid 12348)
-proxy         8001   not running
+Service         Port   Status
+───────         ────   ──────
+app             9653   running (pid 12345)
+stripe          —      running (pid 12346)
+odins-throne    3001   running (pid 12347)  ← monitor-api
+                3002   running (pid 12348)  ← monitor-ui
+proxy           8001   not running
 ```
 
 ## Notes

--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -48,6 +48,7 @@ export function JobCard({ job, isActive, onClick }: Props) {
         </span>
         <span>Step {job.step}</span>
         <span style={{ color: sColor }}>{sLabel}</span>
+        {job.fixture && <span className="card-fixture-badge" title="Fixture (replayed log)">ᚠ</span>}
       </div>
     </div>
   );

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -316,7 +316,7 @@ function LogLine({ entry, agentKey, agentName, isLastAssistantText, autoScroll, 
         </div>
       );
     case "entrypoint-task":
-      return <NorseTablet text={entry.text ?? ""} />;
+      return <NorseTablet text={entry.text ?? ""} {...(autoScroll !== undefined ? { autoScroll } : {})} />;
     case "warning":
       return <span className="log-warning">{"\u26A0"} {entry.message}</span>;
     case "error":
@@ -379,9 +379,9 @@ function AgentBubble({
   const color = AGENT_COLORS[agentKey ?? ""] ?? "var(--gold)";
 
   return (
-    <div className="agent-bubble">
+    <div className="agent-bubble" style={{ "--agent-accent": color, borderLeftColor: color } as React.CSSProperties}>
       <div className="agent-bubble-header">
-        {avatar && <img className="agent-bubble-avatar" src={avatar} alt={name} />}
+        {avatar && <img className="agent-bubble-avatar" src={avatar} alt={name} style={{ borderColor: color }} />}
         <div className="agent-bubble-identity">
           <span className="agent-bubble-name" style={{ color }}>{name}</span>
           {title && <span className="agent-bubble-title">{title}</span>}
@@ -450,20 +450,20 @@ function ToolBatchGroup({ entry, autoScroll, isLatestBatch }: { entry: LogEntry;
 function parseDecreeSections(text: string): Array<{ glyph: string; title: string; body: string; defaultOpen: boolean }> {
   const SECTION_MAP: Array<{ pattern: RegExp; glyph: string; title: string; defaultOpen?: boolean }> = [
     { pattern: /^You are \w+/m, glyph: "ᛁ", title: "Hear Me, Agent", defaultOpen: true },
-    { pattern: /SANDBOX RULES/m, glyph: "ᚺ", title: "The Sacred Ground", defaultOpen: true },
-    { pattern: /\*\*Step 1/m, glyph: "ᚲ", title: "Consecrate Thy Forge", defaultOpen: true },
-    { pattern: /TODO TRACKING/m, glyph: "ᚾ", title: "The Norns\u2019 Ledger", defaultOpen: true },
-    { pattern: /INCREMENTAL COMMIT/m, glyph: "ᚷ", title: "The Chain of Gleipnir", defaultOpen: true },
-    { pattern: /VERIFY.*tsc.*build/m, glyph: "ᛗ", title: "Trial by Fire", defaultOpen: true },
-    { pattern: /STRICT SCOPE/m, glyph: "ᛏ", title: "The Gjallarhorn Boundary", defaultOpen: true },
-    { pattern: /\*\*Step 2/m, glyph: "ᚱ", title: "Consult the Runes", defaultOpen: true },
-    { pattern: /\*\*Issue details/m, glyph: "ᛃ", title: "The Wound in Yggdrasil", defaultOpen: true },
-    { pattern: /\*\*Step 3[^b]/m, glyph: "ᚠ", title: "Take Up Mj\u00F6lnir", defaultOpen: true },
-    { pattern: /\*\*Step 3b/m, glyph: "ᛊ", title: "Forge the Tests", defaultOpen: true },
-    { pattern: /\*\*Step 4/m, glyph: "ᛒ", title: "Walk the Bifr\u00F6st", defaultOpen: true },
-    { pattern: /\*\*Step 5/m, glyph: "ᛚ", title: "Align with the World Tree", defaultOpen: true },
-    { pattern: /\*\*Step 6/m, glyph: "ᛖ", title: "Present Thy Offering", defaultOpen: true },
-    { pattern: /\*\*Step 7/m, glyph: "ᛞ", title: "Pass the Torch", defaultOpen: true },
+    { pattern: /SANDBOX RULES/m, glyph: "ᚺ", title: "The Sacred Ground" },
+    { pattern: /\*\*Step 1/m, glyph: "ᚲ", title: "Consecrate Thy Forge" },
+    { pattern: /TODO TRACKING/m, glyph: "ᚾ", title: "The Norns\u2019 Ledger" },
+    { pattern: /INCREMENTAL COMMIT/m, glyph: "ᚷ", title: "The Chain of Gleipnir" },
+    { pattern: /VERIFY.*tsc.*build/m, glyph: "ᛗ", title: "Trial by Fire" },
+    { pattern: /STRICT SCOPE/m, glyph: "ᛏ", title: "The Gjallarhorn Boundary" },
+    { pattern: /\*\*Step 2/m, glyph: "ᚱ", title: "Consult the Runes" },
+    { pattern: /\*\*Issue details/m, glyph: "ᛃ", title: "The Wound in Yggdrasil" },
+    { pattern: /\*\*Step 3[^b]/m, glyph: "ᚠ", title: "Take Up Mj\u00F6lnir" },
+    { pattern: /\*\*Step 3b/m, glyph: "ᛊ", title: "Forge the Tests" },
+    { pattern: /\*\*Step 4/m, glyph: "ᛒ", title: "Walk the Bifr\u00F6st" },
+    { pattern: /\*\*Step 5/m, glyph: "ᛚ", title: "Align with the World Tree" },
+    { pattern: /\*\*Step 6/m, glyph: "ᛖ", title: "Present Thy Offering" },
+    { pattern: /\*\*Step 7/m, glyph: "ᛞ", title: "Pass the Torch" },
   ];
 
   // Find section boundaries
@@ -506,13 +506,25 @@ function DecreeSection({ glyph, title, body, defaultOpen, wide }: { glyph: strin
   );
 }
 
-function NorseTablet({ text }: { text: string }) {
+function NorseTablet({ text, autoScroll }: { text: string; autoScroll?: boolean }) {
   const [open, setOpen] = useState(true);
+  const [hasBeenCollapsed, setHasBeenCollapsed] = useState(false);
   const agentMatch = /^You are (\w+)/.exec(text);
   const agent = agentMatch?.[1] ?? "Agent";
   const issueMatch = /#(\d+)/.exec(text);
   const issue = issueMatch?.[1] ?? "";
   const sections = parseDecreeSections(text);
+
+  // Auto-collapse the decree once when auto-scroll is on and the agent starts working
+  // (detected by sections being fully parsed — the decree text doesn't change after initial render)
+  useEffect(() => {
+    if (!autoScroll || hasBeenCollapsed) return;
+    const timer = setTimeout(() => {
+      setOpen(false);
+      setHasBeenCollapsed(true);
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [autoScroll, hasBeenCollapsed]);
 
   return (
     <div className={`norse-tablet ${open ? "open" : ""}`}>
@@ -535,7 +547,7 @@ function NorseTablet({ text }: { text: string }) {
                 title={sec.title}
                 body={sec.body}
                 defaultOpen={sec.defaultOpen}
-                wide={sec.title === "Hear Me, Agent" || sec.title === "The Wound in Yggdrasil"}
+                wide={false}
               />
             ))}
           </div>

--- a/development/monitor-ui/src/hooks/useJobs.ts
+++ b/development/monitor-ui/src/hooks/useJobs.ts
@@ -16,6 +16,7 @@ function parseJob(job: Job): DisplayJob {
     completionTime: job.completedAt ? new Date(job.completedAt).getTime() : null,
     issueTitle: job.issueTitle ?? null,
     branchName: job.branchName ?? null,
+    fixture: job.fixture ?? false,
   };
 }
 

--- a/development/monitor-ui/src/lib/types.ts
+++ b/development/monitor-ui/src/lib/types.ts
@@ -52,6 +52,7 @@ export interface DisplayJob {
   completionTime: number | null;
   issueTitle: string | null;
   branchName: string | null;
+  fixture?: boolean;
 }
 
 // JSONL event types

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -280,6 +280,15 @@ body {
   padding: 1px 5px; border: 1px solid var(--rune-border);
   white-space: nowrap;
 }
+.card-fixture-badge {
+  font-size: 0.55rem;
+  color: var(--gold);
+  border: 1px solid var(--gold-dim-border);
+  border-radius: 2px;
+  padding: 0 3px;
+  opacity: 0.7;
+  margin-left: auto;
+}
 
 /* ── Content area ──────────────────────────────── */
 .content {
@@ -597,9 +606,10 @@ body {
 /* ── Decree tile grid (within NorseTablet) ── */
 .decree-grid {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 0.4rem;
   margin-bottom: 0.5rem;
+  overflow: hidden;
 }
 @media (max-width: 600px) {
   .decree-grid { grid-template-columns: 1fr; }
@@ -610,6 +620,7 @@ body {
   background: rgba(201, 146, 10, 0.03);
   overflow: hidden;
   transition: border-color 0.2s;
+  min-width: 0;
 }
 .decree-section:hover { border-color: var(--gold); }
 .decree-section-header {
@@ -635,19 +646,40 @@ body {
 .decree-section.open .ep-group-chevron { transform: rotate(90deg); }
 .decree-section-body {
   padding: 0.4rem 0.6rem 0.5rem 0.6rem;
-  font-family: 'Source Serif 4', 'Georgia', serif;
-  font-size: 0.65rem; line-height: 1.55;
-  color: var(--text-secondary);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem; line-height: 1.5;
+  color: var(--text-rune);
   white-space: pre-wrap;
-  word-break: break-word;
+  word-break: break-all;
+  overflow-wrap: anywhere;
   border-top: 1px solid var(--gold-dim-border);
-  max-height: 200px;
-  overflow-y: auto;
-  background: linear-gradient(180deg, rgba(7, 7, 13, 0.4) 0%, rgba(7, 7, 13, 0.7) 100%);
+  max-height: 120px;
+  overflow: hidden;
+  position: relative;
+  background: linear-gradient(180deg, rgba(7, 7, 13, 0.4) 0%, rgba(201, 146, 10, 0.02) 100%);
+}
+/* Fade-out at bottom when content is clipped */
+.decree-section-body::after {
+  content: "";
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  height: 2rem;
+  background: linear-gradient(transparent, var(--void));
+  pointer-events: none;
+}
+/* When expanded, remove height limit and fade */
+.decree-section.open .decree-section-body {
+  max-height: none;
+  overflow: visible;
+}
+.decree-section.open .decree-section-body::after {
+  display: none;
 }
 /* Full-width sections (identity + issue details) span the grid */
 .decree-section.decree-wide {
   grid-column: 1 / -1;
+  min-width: 0;
+  max-width: 100%;
 }
 
 /* ── Entrypoint group (collapsible) ─────────────── */
@@ -716,47 +748,50 @@ body {
   animation: fadeSlideIn 0.25s ease;
 }
 /* ── Tool batch (collapsible, auto-collapses) ──── */
+/* ── Tool batch — the thralls that serve ──────── */
 .ev-tool-batch {
-  border: 1px solid var(--kildare-blue);
-  border-right: 3px solid var(--kildare-blue-bright);
-  border-radius: 4px;
-  margin: 0.4rem 0 0.4rem auto;
-  width: 75%;
+  border: 1px solid var(--rune-border);
+  border-right: 2px solid var(--text-void);
+  border-radius: 3px;
+  margin: 0.25rem 0 0.25rem auto;
+  width: 70%;
   overflow: hidden;
   transition: border-color 0.3s, box-shadow 0.3s;
-  animation: fadeSlideIn 0.25s ease;
+  animation: fadeSlideIn 0.2s ease;
+  opacity: 0.85;
 }
-.ev-tool-batch:not(.complete) { box-shadow: 0 0 8px rgba(59, 130, 246, 0.15); }
-.ev-tool-batch.complete { border-color: var(--rune-border); border-right-color: var(--teal-asgard); }
-.ev-tool-batch.batch-error { border-left-color: #ef4444; }
+.ev-tool-batch:not(.complete) { box-shadow: 0 0 4px rgba(96, 96, 112, 0.1); border-right-color: var(--teal-asgard); }
+.ev-tool-batch.complete { border-color: var(--rune-border); border-right-color: var(--text-void); opacity: 0.7; }
+.ev-tool-batch.batch-error { border-left-color: var(--error-strong); opacity: 1; }
 .ev-tool-batch-header {
   display: flex; align-items: center; gap: 0.5rem;
-  padding: 0.35rem 0.6rem;
-  background: var(--tool-batch-header-bg);
+  padding: 0.3rem 0.5rem;
+  background: rgba(42, 42, 62, 0.3);
   cursor: pointer; user-select: none;
   font-family: 'JetBrains Mono', monospace;
-  font-size: 0.7rem;
+  font-size: 0.6rem;
   justify-content: flex-end;
 }
-.ev-tool-batch-header:hover { background: var(--tool-batch-header-hover); }
+.ev-tool-batch-header:hover { background: rgba(42, 42, 62, 0.5); }
 .ev-tool-batch-chevron {
-  color: var(--kildare-blue-bright); font-size: 0.7rem;
+  color: var(--text-void); font-size: 0.6rem;
   transition: transform 0.15s;
 }
 .ev-tool-batch.open .ev-tool-batch-chevron { transform: rotate(90deg); }
 .ev-tool-batch-label {
-  color: var(--kildare-white); font-weight: 600;
+  color: var(--text-rune); font-weight: 500;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: 0.6rem;
 }
 .ev-tool-batch-spinner {
-  width: 10px; height: 10px; border-radius: 50%;
-  border: 2px solid var(--kildare-blue-bright);
+  width: 8px; height: 8px; border-radius: 50%;
+  border: 1.5px solid var(--teal-asgard);
   border-top-color: transparent;
   animation: spin 0.8s linear infinite;
 }
 @keyframes spin { to { transform: rotate(360deg); } }
 .ev-tool-batch-done {
-  color: var(--teal-asgard); font-weight: 700;
+  color: var(--teal-asgard); font-weight: 600; font-size: 0.6rem;
 }
 .ev-tool-batch-body-wrap {
   display: grid;
@@ -798,25 +833,29 @@ body {
 }
 
 /* ── Agent chat bubble ─────────────────────────── */
+/* ── Agent bubble — the ruler's command ────────── */
 .agent-bubble {
   margin: 0.5rem 0;
-  width: 75%;
-  background: var(--forge);
-  border: 1px solid var(--rune-border);
-  border-radius: 8px;
+  width: 80%;
+  background: linear-gradient(135deg, var(--forge) 0%, rgba(201, 146, 10, 0.04) 100%);
+  border: 1px solid var(--gold-dim-border);
+  border-left: 3px solid var(--agent-accent, var(--gold));
+  border-radius: 6px;
   overflow: hidden;
   animation: fadeSlideIn 0.25s ease;
+  box-shadow: 0 2px 8px rgba(201, 146, 10, 0.06);
 }
 .agent-bubble-header {
   display: flex; align-items: center; gap: 0.5rem;
-  padding: 0.4rem 0.6rem;
-  border-bottom: 1px solid var(--rune-border);
-  background: var(--bubble-header-bg);
+  padding: 0.35rem 0.6rem;
+  border-bottom: 1px solid var(--gold-dim-border);
+  background: linear-gradient(90deg, rgba(201, 146, 10, 0.06) 0%, transparent 60%);
 }
 .agent-bubble-avatar {
-  width: 22px; height: 22px; border-radius: 50%;
-  border: 1px solid var(--rune-border);
+  width: 24px; height: 24px; border-radius: 50%;
+  border: 1.5px solid var(--gold-dim-border);
   object-fit: cover; flex-shrink: 0;
+  box-shadow: 0 0 6px rgba(201, 146, 10, 0.2);
 }
 .agent-bubble-identity {
   display: flex; align-items: baseline; gap: 0.4rem;
@@ -824,15 +863,20 @@ body {
 .agent-bubble-name {
   font-family: 'Cinzel', serif;
   font-size: 0.7rem; font-weight: 700;
+  color: var(--gold-bright);
+  letter-spacing: 0.03em;
 }
 .agent-bubble-title {
-  font-family: 'JetBrains Mono', monospace;
-  font-size: 0.55rem;
+  font-family: 'Cinzel', serif;
+  font-size: 0.5rem; font-weight: 400;
   color: var(--text-void);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 .agent-bubble-text {
-  color: var(--mayo-green);
-  font-size: 0.78rem; line-height: 1.6;
+  font-family: 'Source Serif 4', 'Georgia', serif;
+  color: var(--text-saga);
+  font-size: 0.75rem; line-height: 1.6;
   white-space: pre-wrap;
   padding: 0.5rem 0.7rem;
 }


### PR DESCRIPTION
## Summary
- All-Father's Decree parsed into Norse-titled tile grid (3-col, collapsible)
- Agent bubbles: gold commander aesthetic with agent accent colors
- Tool batches: dimmed thrall design, subservient to agents
- Fixture badge on sidebar cards
- Entrypoint grouping fix + Odin seal on decree

## Test plan
- [x] tsc passes
- [x] Decree sections render in 3-col grid with Norse titles
- [x] Agent bubbles show agent-colored borders and gold styling
- [x] Tool batches appear smaller/dimmer than agent messages
- [x] Fixture sessions show ᚠ badge in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)