### PR TITLE
fix(monitor-ui): JetBrains Mono in agent message bubbles

### DIFF
--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -874,7 +874,7 @@ body {
   text-transform: uppercase;
 }
 .agent-bubble-text {
-  font-family: 'Source Serif 4', 'Georgia', serif;
+  font-family: 'JetBrains Mono', monospace;
   color: var(--text-saga);
   font-size: 0.75rem; line-height: 1.6;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- Switch `.agent-bubble-text` font from `Source Serif 4` to `JetBrains Mono` for fixed-width Norse terminal aesthetic
- Headers (agent name + title) remain in Cinzel

Closes #1078

## Test plan
- [ ] Verify agent message text renders in JetBrains Mono on monitor.fenrirledger.com
- [ ] Confirm header text (agent name/title) still uses Cinzel

🤖 Generated with [Claude Code](https://claude.com/claude-code)