### PR TITLE
fix: isolate stripe listen secret from .env.local

### DIFF
--- a/.claude/scripts/services.sh
+++ b/.claude/scripts/services.sh
@@ -34,7 +34,7 @@ STRIPE_LOG="${LOG_DIR}/stripe-listen.log"
 PORT_FILE="${FRONTEND_DIR}/.port"
 STRIPE_PID_FILE="${FRONTEND_DIR}/.stripe-listen.pid"
 ENV_FILE="${FRONTEND_DIR}/.env.local"
-WEBHOOK_BACKUP="${FRONTEND_DIR}/.env.local.stripe-backup"
+STRIPE_OVERRIDE="${FRONTEND_DIR}/.env.stripe-listen"
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -140,19 +140,18 @@ do_start() {
     exit 1
   fi
 
-  # -- 2. Inject ephemeral secret into .env.local --
-  grep "^STRIPE_WEBHOOK_SECRET=" "$ENV_FILE" > "$WEBHOOK_BACKUP" 2>/dev/null || true
-  if grep -q "^STRIPE_WEBHOOK_SECRET=" "$ENV_FILE"; then
-    sed -i '' "s|^STRIPE_WEBHOOK_SECRET=.*|STRIPE_WEBHOOK_SECRET=\"${local_secret}\"|" "$ENV_FILE"
-  else
-    echo "STRIPE_WEBHOOK_SECRET=\"${local_secret}\"" >> "$ENV_FILE"
-  fi
-  echo "Stripe listen: running (webhook secret injected)"
+  # -- 2. Write ephemeral secret to separate override file (NEVER touch .env.local) --
+  echo "STRIPE_WEBHOOK_SECRET=\"${local_secret}\"" > "$STRIPE_OVERRIDE"
+  echo "Stripe listen: running (webhook secret in .env.stripe-listen)"
 
-  # -- 3. Start vercel dev --
+  # -- 3. Start vercel dev (with stripe override if present) --
   echo "Starting frontend (vercel dev) on port ${PORT}..."
   > "$FRONTEND_LOG"
-  nohup bash -c "cd '$REPO_ROOT' && npx vercel dev --listen $PORT" >> "$FRONTEND_LOG" 2>&1 &
+  STRIPE_ENV=""
+  if [[ -f "$STRIPE_OVERRIDE" ]]; then
+    STRIPE_ENV="export $(grep -v '^#' "$STRIPE_OVERRIDE" | xargs) &&"
+  fi
+  nohup bash -c "${STRIPE_ENV} cd '$REPO_ROOT' && npx vercel dev --listen $PORT" >> "$FRONTEND_LOG" 2>&1 &
 
   if [[ "$PORT" == "0" ]]; then
     ACTUAL=$(wait_for_port)
@@ -189,15 +188,7 @@ do_stop() {
     echo "Stripe listen: stopped"
   fi
 
-  # Restore original webhook secret
-  if [[ -f "$WEBHOOK_BACKUP" ]]; then
-    original=$(cat "$WEBHOOK_BACKUP")
-    if [[ -n "$original" ]] && [[ -f "$ENV_FILE" ]]; then
-      sed -i '' "s|^STRIPE_WEBHOOK_SECRET=.*|${original}|" "$ENV_FILE"
-      echo "Stripe listen: webhook secret restored"
-    fi
-    rm -f "$WEBHOOK_BACKUP"
-  fi
+  rm -f "$STRIPE_OVERRIDE"
 
   # Stop frontend
   if p=$(frontend_pid); then

--- a/.claude/skills/dev-server/scripts/stripe.sh
+++ b/.claude/skills/dev-server/scripts/stripe.sh
@@ -10,7 +10,7 @@ mkdir -p "$LOG_DIR"
 LOG="${LOG_DIR}/stripe-listen.log"
 PID_FILE="${FRONTEND_DIR}/.stripe-listen.pid"
 ENV_FILE="${FRONTEND_DIR}/.env.local"
-WEBHOOK_BACKUP="${FRONTEND_DIR}/.env.local.stripe-backup"
+STRIPE_OVERRIDE="${FRONTEND_DIR}/.env.stripe-listen"
 
 pid() {
   if [[ -f "$PID_FILE" ]]; then
@@ -55,13 +55,9 @@ case "${1:-status}" in
       sleep 1
     done
     if [[ -n "$local_secret" ]]; then
-      grep "^STRIPE_WEBHOOK_SECRET=" "$ENV_FILE" > "$WEBHOOK_BACKUP" 2>/dev/null || true
-      if grep -q "^STRIPE_WEBHOOK_SECRET=" "$ENV_FILE"; then
-        sed -i '' "s|^STRIPE_WEBHOOK_SECRET=.*|STRIPE_WEBHOOK_SECRET=\"${local_secret}\"|" "$ENV_FILE"
-      else
-        echo "STRIPE_WEBHOOK_SECRET=\"${local_secret}\"" >> "$ENV_FILE"
-      fi
-      echo "stripe: running (webhook secret injected)"
+      # Write to separate override file — NEVER touch .env.local
+      echo "STRIPE_WEBHOOK_SECRET=\"${local_secret}\"" > "$STRIPE_OVERRIDE"
+      echo "stripe: running (webhook secret in .env.stripe-listen)"
     else
       echo "stripe: WARNING — could not detect webhook secret after 15s"
     fi
@@ -70,15 +66,8 @@ case "${1:-status}" in
     if p=$(pid); then
       kill "$p" 2>/dev/null
       rm -f "$PID_FILE"
-      # Restore original webhook secret
-      if [[ -f "$WEBHOOK_BACKUP" ]]; then
-        original=$(cat "$WEBHOOK_BACKUP")
-        if [[ -n "$original" ]] && [[ -f "$ENV_FILE" ]]; then
-          sed -i '' "s|^STRIPE_WEBHOOK_SECRET=.*|${original}|" "$ENV_FILE"
-        fi
-        rm -f "$WEBHOOK_BACKUP"
-      fi
-      echo "stripe: stopped (webhook secret restored)"
+      rm -f "$STRIPE_OVERRIDE"
+      echo "stripe: stopped"
     else
       echo "stripe: not running"
     fi

--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -378,6 +378,18 @@ const mode = args[0] || "audit";
 const envVars = parseKeyValueFile(ENV_FILE);
 const secretsVars = parseKeyValueFile(SECRETS_FILE);
 
+// Guard: refuse to sync STRIPE_WEBHOOK_SECRET if stripe listen override is active
+const STRIPE_OVERRIDE = join(REPO_ROOT, "development", "frontend", ".env.stripe-listen");
+if (existsSync(STRIPE_OVERRIDE) && (mode === "--sync" || mode === "--fix-all" || mode === "--push")) {
+  const pushingStripe = mode === "--push" && args[1] === "STRIPE_WEBHOOK_SECRET";
+  if (mode !== "--push" || pushingStripe) {
+    console.error(`${C.red}BLOCKED:${C.r} ${STRIPE_OVERRIDE} exists — stripe listen is active (or was not stopped cleanly).`);
+    console.error(`The STRIPE_WEBHOOK_SECRET in .env.local may be overridden by an ephemeral CLI value.`);
+    console.error(`Run: ${C.bold}rm ${STRIPE_OVERRIDE}${C.r} (or stop stripe via services.sh stop) then retry.`);
+    process.exit(1);
+  }
+}
+
 if (!existsSync(ENV_FILE) && !existsSync(SECRETS_FILE)) {
   console.error(`${C.red}Missing both ${ENV_FILE} and ${SECRETS_FILE}${C.r}`);
   process.exit(1);


### PR DESCRIPTION
## Summary
- `stripe.sh` and `services.sh` now write ephemeral webhook secret to `.env.stripe-listen` instead of overwriting `.env.local`
- `sync-secrets.mjs` refuses to sync if `.env.stripe-listen` exists (stripe listen active or not stopped cleanly)
- Prevents the contamination pipeline that caused production Stripe webhook signature failures twice

## Test plan
- [ ] Run `services.sh start` — verify `.env.stripe-listen` created, `.env.local` untouched
- [ ] Run `services.sh stop` — verify `.env.stripe-listen` deleted
- [ ] Run `sync-secrets.mjs --push STRIPE_WEBHOOK_SECRET` while `.env.stripe-listen` exists — should be blocked
- [ ] Run `sync-secrets.mjs --verify` — should work (read-only, no guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)