### PR TITLE
fix(monitor-ui): remove unused imports breaking CI build

### DIFF
--- a/development/monitor-ui/src/__tests__/loki-1071-pin-to-cache-gaps.test.ts
+++ b/development/monitor-ui/src/__tests__/loki-1071-pin-to-cache-gaps.test.ts
@@ -155,7 +155,6 @@ describe("appendLogLine — cache write only when pinned (edge case)", () => {
 
 describe("pinSession — 20MB total size cap eviction", () => {
   it("evicts oldest cached session when total bytes would exceed 20MB cap", () => {
-    const MAX_BYTES = 20 * 1024 * 1024;
     // Each session = ~7MB (stays under 20MB for 2 sessions but 3 would overflow)
     const bigChunk = "x".repeat(7 * 1024 * 1024); // 7MB string
 

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -7,7 +7,7 @@ import { ToolBlock } from "./ToolBlock";
 import { NorseErrorTablet } from "./NorseErrorTablet";
 import { NorseVerdictInscription, isVerdictMessage } from "./NorseVerdictInscription";
 import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_ICONS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
-import { downloadLog } from "../lib/localStorageLogs";
+
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 
 interface SessionHeaderProps {


### PR DESCRIPTION
## Summary
- Remove unused `downloadLog` import from `LogViewer.tsx`
- Remove unused `MAX_BYTES` variable from `loki-1071-pin-to-cache-gaps.test.ts`

Both cause TS6133 errors that fail the monitor-ui Docker build on main.

## Test plan
- [ ] CI passes (tsc + build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)