### PR TITLE
chore: add no-monitor-ui-tests rule to dispatch templates

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -129,6 +129,11 @@ Loki runs only his NEW feature tests, not the full suite.
   cd /workspace/repo && bash quality/scripts/verify.sh --step build
 On failure: fix, commit+push, re-run that step. Repeat until green.
 
+NO MONITOR-UI TESTS (UNBREAKABLE):
+NEVER write tests for `development/monitor-ui/` (Odin's Throne). It has NO test
+infrastructure — no vitest, no testing-library, no __tests__/ directory. All tests
+target `development/frontend/` only. For monitor-ui issues, validate via tsc + build only.
+
 STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,
 declare things "done", or add commentary beyond your handoff step.

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -47,6 +47,8 @@ Then create your todo list via TodoWrite. Every todo below is required:
 - Run: `cd <REPO_ROOT>/development/frontend && npx vitest run src/__tests__/<feature>/ --reporter=verbose`
 - Commit+push tests with implementation.
 - Loki will add E2E tests later — you own Vitest tests.
+- **NEVER write tests for monitor-ui (Odin's Throne).** `development/monitor-ui/` has NO test
+  infrastructure — no vitest, no testing-library, no __tests__/ directory. Tests are frontend-only.
 
 **Step 4 — Full verify: tsc + build (each = separate Bash tool call + separate todo):**
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -64,6 +64,11 @@ Then create your todo list via TodoWrite. Every todo below is required:
 
   **Rule of thumb:** If the test breaks when someone edits a config file, copy,
   or infrastructure template — it should NOT exist. Only test code that RUNS.
+
+- **NEVER write tests for monitor-ui (Odin's Throne).** `development/monitor-ui/` has NO test
+  infrastructure — no vitest, no testing-library, no __tests__/ directory. All tests target
+  `development/frontend/` only. If the issue is a monitor-ui change, skip Vitest entirely and
+  validate via tsc + build only.
 - Follow ALL Test Standards from the agent definition — budgets, pyramid, locators, data isolation.
 - Use the handoff's "How to verify" and "Edge cases" to guide test design.
 - **Commit+push tests before running them:**


### PR DESCRIPTION
## Summary
- Add "NO MONITOR-UI TESTS" unbreakable rule to sandbox preamble in dispatch SKILL.md
- Add prohibition to FiremanDecko template (Step 3b)
- Add prohibition to Loki template (banned categories)

Ensures all dispatched agents know monitor-ui has no test infrastructure.

## Test plan
- [ ] Templates render correctly in dispatched prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)