### PR TITLE
fix(monitor-ui): remove copy:profiles scripts breaking Docker build

### DIFF
--- a/development/monitor-ui/package.json
+++ b/development/monitor-ui/package.json
@@ -4,9 +4,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "copy:profiles": "cp -r ../../.claude/agents/profiles/*.png public/profiles/",
-    "prebuild": "mkdir -p public/profiles && npm run copy:profiles",
-    "predev": "mkdir -p public/profiles && npm run copy:profiles",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview"


### PR DESCRIPTION
## Summary
- PR #1092 added `prebuild`/`predev`/`copy:profiles` scripts to copy profile PNGs from `../../.claude/agents/profiles/` — a path outside the Docker build context
- The same PR already committed all 12 profile images directly to `public/profiles/`, making the copy scripts redundant
- Removes the 3 broken scripts; the Dockerfile's `COPY public/ ./public/` already handles it

## Test plan
- [x] `npm run build` passes locally
- [ ] CI Docker build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)