### PR TITLE
Issue #1108 - fix: consolidate duplicate pin icons in monitor UI

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -52,6 +52,12 @@ export function App() {
 
   const isPinned = pinnedSessionId === activeSessionId && activeSessionId !== null;
 
+  // Set of all pinned sessionIds (for sidebar display across all jobs)
+  const pinnedSessionIds = useMemo(
+    () => new Set(jobs.filter((j) => checkIsPinned(j.sessionId)).map((j) => j.sessionId)),
+    [jobs]
+  );
+
   const onMessage = useCallback(
     (msg: ServerMessage) => {
       handleJobsMessage(msg);
@@ -131,40 +137,50 @@ export function App() {
 
   const activeJob = jobs.find((j) => j.sessionId === activeSessionId) || null;
 
-  /** Toggle pin for the active session. */
-  const handleTogglePin = useCallback(() => {
-    if (!activeSessionId || !activeJob) return;
+  /** Toggle pin for any session by sessionId. Used by both header and sidebar. */
+  const handleTogglePinForSession = useCallback(
+    (sessionId: string) => {
+      const job = jobs.find((j) => j.sessionId === sessionId);
+      if (!job) return;
 
-    if (isPinned) {
-      // Unpin: remove from cache
-      unpinSession(activeSessionId);
-      setPinnedSessionId(null);
-      refreshCached();
-    } else {
-      // Pin: save current log buffer to cache
-      const meta: CachedSessionMeta = {
-        sessionId: activeSessionId,
-        name: activeJob.name,
-        issueNumber: Number(activeJob.issue) || 0,
-        agent: activeJob.agentKey ?? "unknown",
-        step: Number(activeJob.step) || 1,
-        startedAt: activeJob.startTime ? new Date(activeJob.startTime).toISOString() : null,
-        completedAt: activeJob.completionTime ? new Date(activeJob.completionTime).toISOString() : null,
-        issueTitle: activeJob.issueTitle,
-        branchName: activeJob.branchName,
-        pinnedAt: Date.now(),
-      };
-      const ok = pinSession(activeSessionId, meta);
-      if (ok) {
-        setPinnedSessionId(activeSessionId);
+      if (checkIsPinned(sessionId)) {
+        // Unpin: remove from cache
+        unpinSession(sessionId);
+        if (sessionId === activeSessionId) setPinnedSessionId(null);
         refreshCached();
-        if (isCacheNearCap()) {
-          setStorageWarning("Odin\u2019s memory is nearly full \u2014 oldest pins will be evicted.");
-          setTimeout(() => setStorageWarning(null), 5000);
+      } else {
+        // Pin: save log buffer to cache
+        const meta: CachedSessionMeta = {
+          sessionId,
+          name: job.name,
+          issueNumber: Number(job.issue) || 0,
+          agent: job.agentKey ?? "unknown",
+          step: Number(job.step) || 1,
+          startedAt: job.startTime ? new Date(job.startTime).toISOString() : null,
+          completedAt: job.completionTime ? new Date(job.completionTime).toISOString() : null,
+          issueTitle: job.issueTitle,
+          branchName: job.branchName,
+          pinnedAt: Date.now(),
+        };
+        const ok = pinSession(sessionId, meta);
+        if (ok) {
+          if (sessionId === activeSessionId) setPinnedSessionId(sessionId);
+          refreshCached();
+          if (isCacheNearCap()) {
+            setStorageWarning("Odin\u2019s memory is nearly full \u2014 oldest pins will be evicted.");
+            setTimeout(() => setStorageWarning(null), 5000);
+          }
         }
       }
-    }
-  }, [activeSessionId, activeJob, isPinned, refreshCached]);
+    },
+    [jobs, activeSessionId, refreshCached]
+  );
+
+  /** Toggle pin for the currently active session (header shortcut). */
+  const handleTogglePin = useCallback(() => {
+    if (!activeSessionId) return;
+    handleTogglePinForSession(activeSessionId);
+  }, [activeSessionId, handleTogglePinForSession]);
 
   return (
     <ErrorBoundary>
@@ -178,6 +194,8 @@ export function App() {
           onSelectSession={handleSelectSession}
           onAvatarClick={setProfileAgent}
           onOdinClick={() => setProfileAgent("odin")}
+          onTogglePinSession={handleTogglePinForSession}
+          pinnedSessionIds={pinnedSessionIds}
         />
         <ErrorBoundary>
           <LogViewer

--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
 import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_ICONS, STATUS_LABELS } from "../lib/constants";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
@@ -7,9 +8,11 @@ interface Props {
   isActive: boolean;
   onClick: () => void;
   onAvatarClick?: (agentKey: string) => void;
+  isPinned?: boolean;
+  onTogglePin?: () => void;
 }
 
-export function JobCard({ job, isActive, onClick, onAvatarClick }: Props) {
+export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = false, onTogglePin }: Props) {
   const agentColor = AGENT_COLORS[job.agentKey ?? ""] || "#c9920a";
   const avatar = AGENT_AVATARS[job.agentKey ?? ""];
   const sColor = STATUS_COLORS[job.status] || "#606070";
@@ -62,8 +65,74 @@ export function JobCard({ job, isActive, onClick, onAvatarClick }: Props) {
         <span>Step {job.step}</span>
         <span style={{ color: sColor }}>{sLabel}</span>
         {job.fixture && <span className="card-fixture-badge" title="Fixture (replayed log)">ᚠ</span>}
-        {job.status === "cached" && <span className="card-pin-badge" title="Pinned to Odin\u2019s memory">{"\uD83D\uDCCC"}</span>}
+        {onTogglePin && (
+          <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
+        )}
       </div>
     </div>
+  );
+}
+
+function CardPinButton({ isPinned, onTogglePin }: { isPinned: boolean; onTogglePin: () => void }) {
+  const [confirming, setConfirming] = useState(false);
+
+  // Reset confirmation state whenever pin state changes externally
+  useEffect(() => {
+    setConfirming(false);
+  }, [isPinned]);
+
+  if (confirming) {
+    return (
+      <button
+        className="card-pin-btn confirming"
+        onClick={(e) => {
+          e.stopPropagation();
+          onTogglePin();
+          setConfirming(false);
+        }}
+        onBlur={() => setConfirming(false)}
+        title="Confirm: remove from Odin\u2019s memory"
+        aria-label="Confirm unpin"
+      >
+        <span className="card-pin-confirm-text">✕ unpin?</span>
+      </button>
+    );
+  }
+
+  return (
+    <button
+      className={`card-pin-btn${isPinned ? " pinned" : ""}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (isPinned) {
+          setConfirming(true);
+        } else {
+          onTogglePin();
+        }
+      }}
+      title={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
+      aria-label={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
+      aria-pressed={isPinned}
+    >
+      <CardPinIcon filled={isPinned} />
+    </button>
+  );
+}
+
+function CardPinIcon({ filled }: { filled: boolean }) {
+  return (
+    <svg width="11" height="11" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      {filled ? (
+        <>
+          <path d="M10 2L14 6L10.5 9.5L8.5 14L7 12.5L9 8.5L5.5 5L2 3.5L6.5 1.5L10 2Z" fill="currentColor" />
+          <line x1="5" y1="11" x2="2" y2="14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </>
+      ) : (
+        <>
+          <path d="M10 2L14 6L10.5 9.5L8.5 14L7 12.5L9 8.5L5.5 5L2 3.5L6.5 1.5L10 2Z" stroke="currentColor" strokeWidth="1.5" strokeLinejoin="round" />
+          <line x1="5" y1="11" x2="2" y2="14" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+        </>
+      )}
+    </svg>
   );
 }

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -24,6 +24,12 @@ function SessionHeader({ job, wsState, isPinned = false, onTogglePin, showPin = 
   const shortId = job.sessionId.length > 8
     ? job.sessionId.slice(-8)
     : job.sessionId;
+  const [confirmingUnpin, setConfirmingUnpin] = useState(false);
+
+  // Reset confirmation state when pin state changes externally
+  useEffect(() => {
+    setConfirmingUnpin(false);
+  }, [isPinned]);
 
   return (
     <div
@@ -67,15 +73,33 @@ function SessionHeader({ job, wsState, isPinned = false, onTogglePin, showPin = 
         <StatusBadge state={wsState} />
         <CopySessionIdButton sessionId={job.sessionId} />
         {showPin && onTogglePin && (
-          <button
-            className={`pin-btn${isPinned ? " pinned" : ""}`}
-            onClick={onTogglePin}
-            title={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
-            aria-label={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
-            aria-pressed={isPinned}
-          >
-            <PinIcon filled={isPinned} />
-          </button>
+          confirmingUnpin ? (
+            <button
+              className="pin-btn pin-btn-confirming"
+              onClick={() => { onTogglePin(); setConfirmingUnpin(false); }}
+              onBlur={() => setConfirmingUnpin(false)}
+              title="Confirm: remove from Odin\u2019s memory"
+              aria-label="Confirm unpin"
+            >
+              <span className="pin-confirm-label">✕ unpin?</span>
+            </button>
+          ) : (
+            <button
+              className={`pin-btn${isPinned ? " pinned" : ""}`}
+              onClick={() => {
+                if (isPinned) {
+                  setConfirmingUnpin(true);
+                } else {
+                  onTogglePin();
+                }
+              }}
+              title={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
+              aria-label={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
+              aria-pressed={isPinned}
+            >
+              <PinIcon filled={isPinned} />
+            </button>
+          )
         )}
       </span>
     </div>

--- a/development/monitor-ui/src/components/Sidebar.tsx
+++ b/development/monitor-ui/src/components/Sidebar.tsx
@@ -10,9 +10,11 @@ interface Props {
   onSelectSession: (sessionId: string) => void;
   onAvatarClick?: (agentKey: string) => void;
   onOdinClick?: () => void;
+  onTogglePinSession?: (sessionId: string) => void;
+  pinnedSessionIds?: Set<string>;
 }
 
-export function Sidebar({ jobs, activeSessionId, quote, onSelectSession, onAvatarClick, onOdinClick }: Props) {
+export function Sidebar({ jobs, activeSessionId, quote, onSelectSession, onAvatarClick, onOdinClick, onTogglePinSession, pinnedSessionIds }: Props) {
   const { theme, setTheme } = useTheme();
 
   return (
@@ -62,6 +64,8 @@ export function Sidebar({ jobs, activeSessionId, quote, onSelectSession, onAvata
               isActive={job.sessionId === activeSessionId}
               onClick={() => onSelectSession(job.sessionId)}
               onAvatarClick={onAvatarClick}
+              isPinned={pinnedSessionIds?.has(job.sessionId) ?? false}
+              onTogglePin={onTogglePinSession ? () => onTogglePinSession(job.sessionId) : undefined}
             />
           ))
         )}

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -389,9 +389,40 @@ body {
   .pin-btn { min-width: 1.6rem; min-height: 1.6rem; }
 }
 
-/* ── Pin badge in card sidebar ── */
-.card-pin-badge {
-  font-size: 0.7rem; line-height: 1; margin-left: 0.15rem;
+/* ── Pin toggle button in card sidebar ── */
+.card-pin-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 1px 3px; margin-left: auto;
+  background: transparent; border: 1px solid transparent;
+  border-radius: 2px; color: var(--text-void); cursor: pointer;
+  line-height: 1; transition: color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+.card-pin-btn:hover {
+  color: var(--gold-bright); border-color: var(--gold-dim-border);
+}
+.card-pin-btn.pinned {
+  color: var(--gold); border-color: var(--gold-dim-border);
+}
+.card-pin-btn.pinned:hover {
+  color: var(--error-strong); border-color: var(--error-strong);
+}
+.card-pin-btn.confirming {
+  color: var(--error-strong); border-color: var(--error-strong);
+  background: rgba(239, 68, 68, 0.08);
+}
+.card-pin-confirm-text {
+  font-size: 0.55rem; font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap;
+}
+/* ── Header pin confirm label ── */
+.pin-btn-confirming {
+  color: var(--error-strong) !important; border-color: var(--error-strong) !important;
+  background: rgba(239, 68, 68, 0.08) !important;
+}
+.pin-confirm-label {
+  font-size: 0.6rem; font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap;
 }
 .copy-session-btn {
   display: flex; align-items: center; justify-content: center;


### PR DESCRIPTION
PR for issue: #1108

## Summary

- Consolidated duplicate pin indicators (JobCard sidebar + LogViewer header) into single interactive toggle per location
- Pin icon visually toggles between filled (pinned) and outline (unpinned) SVG states
- Two-click unpin confirmation dialog added in both sidebar card and session header
- Pin action works during in-progress (running/pending) jobs — not gated on completion
- `App.tsx` refactored: `handleTogglePinForSession(sessionId)` replaces `handleTogglePin` so any session can be pinned from the sidebar regardless of active selection
- `pinnedSessionIds` Set computed and passed to Sidebar for per-job pin state

## Test plan

- [ ] Pin a session from the sidebar card — icon fills (active state)
- [ ] Pin a session from the session header — icon fills
- [ ] Unpin: click filled pin icon — "✕ unpin?" confirmation appears
- [ ] Confirm unpin — pin removed, icon returns to outline
- [ ] Cancel unpin (click elsewhere / blur) — session stays pinned
- [ ] Pin during in-progress job — icon responds immediately
- [ ] No duplicate pin indicators visible anywhere
- [ ] Multiple pinned sessions each show correct filled state

🤖 Generated with [Claude Code](https://claude.com/claude-code)