### PR TITLE
chore: add banned test categories to loki agent def and broaden raw-text ban

### DIFF
--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -94,6 +94,21 @@ machines, auth checks, data transformations — ALL of these are Vitest, never P
 no test infrastructure — no vitest, no testing-library, no `__tests__/` directory.
 All tests are for the main frontend app (`development/frontend/`) only.
 
+### Banned Test Categories (UNBREAKABLE — Do NOT Write)
+
+- GitHub Actions workflows (deploy.yml, ci.yml) — YAML structure
+- Helm charts, Terraform files, Dockerfiles — infrastructure
+- Markdown/docs validation — file counts, README structure
+- Config files (playwright.config, tsconfig, next.config) — static
+- Static page copy/content assertions ("hero has correct text")
+- Component variant exhaustive tests (max 4-6 tests per component)
+- CSP header string matching — middleware internals
+- Marketing page structure tests (section order, heading text)
+- **Any test that reads a file as raw text and asserts on string contents, class names, function names, or string positions** (e.g. reading .mjs/.ts scripts with readFileSync and checking indexOf). This includes YAML, JSON, Markdown, and source code files.
+- Any test that counts files or checks file existence
+
+**Rule of thumb:** If the test breaks when someone edits a config file, copy, infrastructure template, or refactors a script — it should NOT exist. Only test code that RUNS.
+
 ### Rules
 
 1. **Derive every assertion from acceptance criteria** — never from current code behavior

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -58,7 +58,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
   - Static page copy/content assertions ("hero has correct text", "section displays headline")
   - Component variant exhaustive tests (max 4-6 tests per component, not 20+)
   - CSP header string matching — middleware internals, not behavioral
-  - Any test that parses YAML/JSON/Markdown and asserts string contents
+  - Any test that reads a file as raw text (readFileSync, fs.read) and asserts on string contents, class names, function names, or string positions — includes YAML, JSON, Markdown, and source code (.mjs/.ts/.js)
   - Any test that counts files or checks file existence
   - Marketing page structure tests (section order, heading text, badge labels)
 


### PR DESCRIPTION
## Summary
- Add full banned test categories to `.claude/agents/loki.md` (was only in dispatch template — gap that allowed the brittle test)
- Broaden raw-text parsing ban: explicitly includes `.mjs/.ts/.js` source files read with `readFileSync`
- Root cause: `chronicle-agent-decree.test.ts` (PR #1074) read `generate-agent-report.mjs` as raw text and asserted on class names/string positions

## Test plan
- [x] Rules updated in agent definition (canonical source)
- [x] Rules updated in dispatch template

🤖 Generated with [Claude Code](https://claude.com/claude-code)