### PR TITLE
Issue #1117 - fix: collapse repeated tool entries in monitor UI

### DIFF
--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -1,5 +1,52 @@
 import React, { useEffect, useRef, useState, useCallback, useMemo } from "react";
 
+/** Groups consecutive identical entries for collapse rendering */
+interface CollapsedGroup {
+  _collapsed: true;
+  key: string;
+  count: number;
+  representative: LogEntry;
+}
+type DisplayEntry = LogEntry | CollapsedGroup;
+
+/** Returns a collapse key for entries that can be grouped, or null if not collapsible */
+function collapseKey(entry: LogEntry): string | null {
+  if (entry.type === "tool-use" && entry.toolName) {
+    return `tool-use:${entry.toolName}`;
+  }
+  if (entry.type === "system" && entry.detail) {
+    return `system:${entry.detail}`;
+  }
+  return null;
+}
+
+/** Pre-processes entries: groups consecutive same-key entries into CollapsedGroup */
+function groupConsecutiveEntries(entries: LogEntry[]): DisplayEntry[] {
+  const result: DisplayEntry[] = [];
+  let i = 0;
+  while (i < entries.length) {
+    const entry = entries[i]!;
+    const key = collapseKey(entry);
+    if (!key) {
+      result.push(entry);
+      i++;
+      continue;
+    }
+    let j = i + 1;
+    while (j < entries.length && collapseKey(entries[j]!) === key) {
+      j++;
+    }
+    const count = j - i;
+    if (count === 1) {
+      result.push(entry);
+    } else {
+      result.push({ _collapsed: true, key, count, representative: entries[j - 1]! });
+    }
+    i = j;
+  }
+  return result;
+}
+
 import type { LogEntry } from "../hooks/useLogStream";
 import type { DisplayJob } from "../lib/types";
 import { StatusBadge } from "./StatusBadge";
@@ -195,6 +242,9 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
     return null;
   }, [entries]);
 
+  // Pre-process: collapse consecutive identical tool-use / system entries
+  const displayEntries = useMemo(() => groupConsecutiveEntries(entries), [entries]);
+
   if (!activeJob) {
     return (
       <main className="content" aria-label="Log viewer">
@@ -253,18 +303,35 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
         aria-label="Session logs"
         onScroll={handleScroll}
       >
-        {entries.map((entry) => (
-          <LogLine
-            key={entry.id}
-            entry={entry}
-            {...(activeJob?.agentKey ? { agentKey: activeJob.agentKey } : {})}
-            {...(activeJob?.agentName ? { agentName: activeJob.agentName } : {})}
-            isLastAssistantText={entry.id === lastAssistantTextId}
-            autoScroll={autoScroll}
-            isLatestBatch={entry.type === "tool-batch" && entry.id === lastToolBatchId}
-            onAvatarClick={onAvatarClick}
-          />
-        ))}
+        {displayEntries.map((item) => {
+          if ("_collapsed" in item) {
+            return (
+              <LogLine
+                key={item.representative.id}
+                entry={item.representative}
+                {...(activeJob?.agentKey ? { agentKey: activeJob.agentKey } : {})}
+                {...(activeJob?.agentName ? { agentName: activeJob.agentName } : {})}
+                isLastAssistantText={false}
+                autoScroll={autoScroll}
+                isLatestBatch={item.representative.type === "tool-batch" && item.representative.id === lastToolBatchId}
+                onAvatarClick={onAvatarClick}
+                collapseCount={item.count}
+              />
+            );
+          }
+          return (
+            <LogLine
+              key={item.id}
+              entry={item}
+              {...(activeJob?.agentKey ? { agentKey: activeJob.agentKey } : {})}
+              {...(activeJob?.agentName ? { agentName: activeJob.agentName } : {})}
+              isLastAssistantText={item.id === lastAssistantTextId}
+              autoScroll={autoScroll}
+              isLatestBatch={item.type === "tool-batch" && item.id === lastToolBatchId}
+              onAvatarClick={onAvatarClick}
+            />
+          );
+        })}
       </div>
       <div className="log-controls">
         {isFixture && (
@@ -309,12 +376,16 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
   );
 }
 
-function LogLine({ entry, agentKey, agentName, isLastAssistantText, autoScroll, isLatestBatch, onAvatarClick }: { entry: LogEntry; agentKey?: string; agentName?: string; isLastAssistantText?: boolean; autoScroll?: boolean; isLatestBatch?: boolean; onAvatarClick?: (agentKey: string) => void }) {
+function LogLine({ entry, agentKey, agentName, isLastAssistantText, autoScroll, isLatestBatch, onAvatarClick, collapseCount }: { entry: LogEntry; agentKey?: string; agentName?: string; isLastAssistantText?: boolean; autoScroll?: boolean; isLatestBatch?: boolean; onAvatarClick?: (agentKey: string) => void; collapseCount?: number }) {
   switch (entry.type) {
     case "system":
       return (
         <div className="ev-system">
-          <span className="ev-label">system</span> {entry.detail}
+          <span className="ev-label">system</span>
+          {collapseCount != null && collapseCount > 1 && (
+            <span className="ev-collapse-count" title={`${collapseCount} consecutive identical entries collapsed`}>×{collapseCount}</span>
+          )}
+          {" "}{entry.detail}
         </div>
       );
     case "turn-divider":
@@ -335,7 +406,7 @@ function LogLine({ entry, agentKey, agentName, isLastAssistantText, autoScroll, 
         />
       );
     case "tool-use":
-      return <ToolBlock entry={entry} />;
+      return <ToolBlock entry={entry} {...(collapseCount != null && collapseCount > 1 ? { collapseCount } : {})} />;
     case "entrypoint-group":
       return <EntrypointGroup entry={entry} />;
     case "entrypoint-header":

--- a/development/monitor-ui/src/components/ToolBlock.tsx
+++ b/development/monitor-ui/src/components/ToolBlock.tsx
@@ -4,9 +4,10 @@ import { toolBadgeClass, toolPreview } from "../lib/constants";
 
 interface Props {
   entry: LogEntry;
+  collapseCount?: number;
 }
 
-export function ToolBlock({ entry }: Props) {
+export function ToolBlock({ entry, collapseCount }: Props) {
   const [open, setOpen] = useState(false);
   const cls = toolBadgeClass(entry.toolName || "");
   let parsedInput: Record<string, unknown> | undefined;
@@ -23,6 +24,9 @@ export function ToolBlock({ entry }: Props) {
     <div className={`ev-tool${open ? " open" : ""}${entry.toolIsError ? " ev-tool-error" : ""}`}>
       <div className="ev-tool-header" onClick={() => setOpen(!open)}>
         <span className={`ev-tool-badge ${cls}`}>{entry.toolName}</span>
+        {collapseCount != null && collapseCount > 1 && (
+          <span className="ev-collapse-count" title={`${collapseCount} consecutive identical calls collapsed`}>×{collapseCount}</span>
+        )}
         <span className="ev-tool-preview">{preview}</span>
         <span className="ev-tool-chevron">{"\u203A"}</span>
       </div>

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -931,6 +931,7 @@ body {
   animation: fadeIn 0.2s ease;
 }
 .ev-system .ev-label { color: var(--gold); font-weight: 600; }
+.ev-system .ev-collapse-count { display: inline-block; margin: 0 0.3rem; vertical-align: middle; }
 
 /* ── JSONL events — assistant (Mayo) ───────────── */
 .ev-assistant-text {
@@ -1109,6 +1110,17 @@ body {
 .ev-tool-badge.edit,
 .ev-tool-badge.write { background: var(--write-badge-bg); color: var(--write-badge-text); }
 .ev-tool-badge.agent { background: var(--mayo-red-dim); color: #fca5a5; }
+.ev-collapse-count {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem; font-weight: 700;
+  padding: 0.1rem 0.35rem;
+  border-radius: 10px;
+  background: var(--text-void);
+  color: var(--bg-void);
+  opacity: 0.65;
+  letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
 .ev-tool-preview {
   font-family: 'JetBrains Mono', monospace;
   font-size: 0.65rem; color: var(--text-rune); opacity: 0.6;


### PR DESCRIPTION
PR for issue: #1117

Collapses consecutive identical WebSearch and system task_progress entries into single entries with count badges.

## What changed

- **`LogViewer.tsx`**: Added `collapseKey()` and `groupConsecutiveEntries()` helpers that pre-process the entries array via `useMemo` before rendering. Consecutive entries with the same `tool-use:${toolName}` or `system:${detail}` key are folded into a `CollapsedGroup` — the last entry in the run is the representative displayed with a `×N` badge.
- **`ToolBlock.tsx`**: Added optional `collapseCount` prop; renders an `×N` pill between the tool badge and preview when count > 1.
- **`LogLine`**: Updated `system` case to show the same `×N` pill inline.
- **`index.css`**: Added `.ev-collapse-count` pill styles (monospace, pill shape, subdued opacity).

## Acceptance criteria

- [x] Consecutive identical tool calls (same `toolName`) collapsed with `×N` count badge
- [x] Last entry in collapsed sequence is the representative (expandable via click)
- [x] Non-consecutive or different tool types render normally
- [x] `system task_progress` entries collapsed when repeated
- [x] Single-occurrence entries unaffected
- [x] tsc + vite build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)