### PR TITLE
fix(security): remove --email-domain=* from oauth2-proxy, use shared emails secret

### DIFF
--- a/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
@@ -27,7 +27,7 @@ spec:
       volumes:
         - name: oauth2-proxy-emails
           secret:
-            secretName: odin-throne-oauth2-proxy-secrets
+            secretName: oauth2-proxy-emails
             items:
               - key: emails.txt
                 path: emails.txt
@@ -67,7 +67,6 @@ spec:
             - --client-id=$(GOOGLE_CLIENT_ID)
             - --client-secret=$(GOOGLE_CLIENT_SECRET)
             - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
-            - --email-domain=*
             - --authenticated-emails-file=/etc/oauth2-proxy/emails.txt
             - --upstream=http://localhost:80
             - --http-address=0.0.0.0:{{ .Values.oauth2Proxy.port }}

--- a/infrastructure/helm/odin-throne/templates/deployment.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
       volumes:
         - name: oauth2-proxy-emails
           secret:
-            secretName: odin-throne-oauth2-proxy-secrets
+            secretName: oauth2-proxy-emails
             items:
               - key: emails.txt
                 path: emails.txt
@@ -62,7 +62,6 @@ spec:
             - --client-id=$(GOOGLE_CLIENT_ID)
             - --client-secret=$(GOOGLE_CLIENT_SECRET)
             - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
-            - --email-domain=*
             - --authenticated-emails-file=/etc/oauth2-proxy/emails.txt
             - --upstream=http://localhost:{{ .Values.service.containerPort }}
             - --http-address=0.0.0.0:{{ .Values.oauth2Proxy.port }}

--- a/infrastructure/helm/umami/templates/deployment.yaml
+++ b/infrastructure/helm/umami/templates/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       volumes:
         - name: oauth2-proxy-emails
           secret:
-            secretName: umami-oauth2-proxy-secrets
+            secretName: oauth2-proxy-emails
             items:
               - key: emails.txt
                 path: emails.txt
@@ -63,7 +63,6 @@ spec:
             - --client-id=$(GOOGLE_CLIENT_ID)
             - --client-secret=$(GOOGLE_CLIENT_SECRET)
             - --cookie-secret=$(OAUTH2_PROXY_COOKIE_SECRET)
-            - --email-domain=*
             - --authenticated-emails-file=/etc/oauth2-proxy/emails.txt
             - --upstream=http://localhost:{{ .Values.service.containerPort }}
             - --http-address=0.0.0.0:{{ .Values.oauth2Proxy.port }}


### PR DESCRIPTION
## Summary
- Remove `--email-domain=*` from all 3 oauth2-proxy deployment templates (odin-throne, odin-throne-ui, umami)
- This flag was overriding `--authenticated-emails-file`, allowing ANY Google account to access monitor and analytics
- Switch emails volume to shared `oauth2-proxy-emails` secret (one per namespace, same content)
- Shared secret already created in `fenrir-monitor` and `fenrir-analytics` namespaces

## Test plan
- [ ] After helm upgrade: freyafenrir78@gmail.com should be BLOCKED from monitor.fenrirledger.com
- [ ] declanshanaghy@gmail.com should still have access
- [ ] Same for analytics.fenrirledger.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)