### PR TITLE
Issue #1118 - fix: deduplicate localStorage cache and add background caching

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -15,6 +15,8 @@ import {
   pinSession,
   unpinSession,
   isCacheNearCap,
+  appendLogLine,
+  migrateRemoveDuplicateLogs,
 } from "./lib/localStorageLogs";
 import type { CachedSessionMeta } from "./lib/localStorageLogs";
 
@@ -36,6 +38,13 @@ export function App() {
   } = useLogStream();
 
   const prevSessionRef = useRef<string | null>(null);
+  // Sessions we kept subscribed in the background for caching after navigation
+  const backgroundSubsRef = useRef<Set<string>>(new Set());
+
+  // Migrate existing duplicate log: entries for pinned sessions on mount
+  useEffect(() => {
+    migrateRemoveDuplicateLogs();
+  }, []);
 
   const [isFixture, setIsFixture] = useState(false);
   const [pinnedSessionId, setPinnedSessionId] = useState<string | null>(null);
@@ -75,6 +84,13 @@ export function App() {
       ) {
         if ("sessionId" in msg && msg.sessionId === activeSessionId) {
           handleLogMessage(msg);
+        } else if ("sessionId" in msg && backgroundSubsRef.current.has(msg.sessionId)) {
+          // Background pinned session: persist log lines to cache, clean up on end
+          if (msg.type === "log-line") {
+            appendLogLine(msg.sessionId, msg.line);
+          } else if (msg.type === "stream-end") {
+            backgroundSubsRef.current.delete(msg.sessionId);
+          }
         }
       }
     },
@@ -85,9 +101,16 @@ export function App() {
 
   const handleSelectSession = useCallback(
     (sessionId: string) => {
-      // Unsubscribe from previous
+      // Handle previous session subscription
       if (prevSessionRef.current && prevSessionRef.current !== sessionId) {
-        send({ type: "unsubscribe", sessionId: prevSessionRef.current });
+        const prev = prevSessionRef.current;
+        if (checkIsPinned(prev)) {
+          // Keep subscription alive so background caching continues
+          backgroundSubsRef.current.add(prev);
+        } else {
+          send({ type: "unsubscribe", sessionId: prev });
+          backgroundSubsRef.current.delete(prev);
+        }
       }
       prevSessionRef.current = sessionId;
       setActiveSessionId(sessionId);
@@ -147,6 +170,11 @@ export function App() {
         // Unpin: remove from cache
         unpinSession(sessionId);
         if (sessionId === activeSessionId) setPinnedSessionId(null);
+        // If we had a background subscription for this session, clean it up
+        if (backgroundSubsRef.current.has(sessionId)) {
+          send({ type: "unsubscribe", sessionId });
+          backgroundSubsRef.current.delete(sessionId);
+        }
         refreshCached();
       } else {
         // Pin: save log buffer to cache
@@ -173,7 +201,7 @@ export function App() {
         }
       }
     },
-    [jobs, activeSessionId, refreshCached]
+    [jobs, activeSessionId, refreshCached, send]
   );
 
   /** Toggle pin for the currently active session (header shortcut). */

--- a/development/monitor-ui/src/lib/localStorageLogs.ts
+++ b/development/monitor-ui/src/lib/localStorageLogs.ts
@@ -1,14 +1,14 @@
 // ── Temporary log buffer (odin-throne:log:<sessionId>) ──────────────────────
-// Written as log-lines arrive for every live session.
-// Separate from the pin cache — these are ephemeral and evict freely.
+// Written as log-lines arrive for live sessions that are NOT pinned.
+// Ephemeral — evicts freely. Pinned sessions skip this buffer entirely.
 
 const LOG_PREFIX = "odin-throne:log:";
 const MAX_LOG_SESSIONS = 10;
 const MAX_LOG_BYTES = 5 * 1024 * 1024; // 5MB
 
 // ── Pin cache (odin-throne:cache:<sessionId>) ────────────────────────────────
-// Written explicitly when the user pins a session.
-// Pinned sessions survive pod reaping and appear in the sidebar as "cached".
+// Single authoritative data store for pinned sessions.
+// When a session is pinned, data flows here only — no log: duplicate.
 
 const CACHE_PREFIX = "odin-throne:cache:";
 const MAX_CACHE_SESSIONS = 10;
@@ -52,6 +52,12 @@ function keysWithPrefix(prefix: string): string[] {
 
 export function appendLogLine(sessionId: string, line: string): void {
   try {
+    // Pinned sessions store data in cache only — no log: duplicate
+    if (isPinned(sessionId)) {
+      appendToCacheRaw(sessionId, line);
+      return;
+    }
+
     const key = LOG_PREFIX + sessionId;
     const existing = localStorage.getItem(key) ?? "";
     const next = existing ? existing + "\n" + line : line;
@@ -76,11 +82,6 @@ export function appendLogLine(sessionId: string, line: string): void {
     }
 
     localStorage.setItem(key, next);
-
-    // If this session is pinned, also append to cache
-    if (isPinned(sessionId)) {
-      appendToCacheRaw(sessionId, line);
-    }
   } catch {
     // localStorage may be full or unavailable — fail silently
   }
@@ -121,6 +122,7 @@ export function isPinned(sessionId: string): boolean {
 
 /**
  * Pin a session: copy current temp-log content to the cache.
+ * Deletes the temp log entry — cache is the single authoritative store.
  * Returns true on success, false if no content available to pin.
  * Evicts oldest cached session if over the cap.
  */
@@ -156,6 +158,10 @@ export function pinSession(sessionId: string, meta: CachedSessionMeta): boolean 
 
     localStorage.setItem(cacheKey, content);
     localStorage.setItem(metaKey, JSON.stringify(meta));
+
+    // Remove the temp log entry — data now lives in cache only (no duplicate)
+    localStorage.removeItem(LOG_PREFIX + sessionId);
+
     return true;
   } catch {
     return false;
@@ -229,5 +235,26 @@ export function isCacheNearCap(): boolean {
     return totalBytes > MAX_CACHE_BYTES * 0.9; // warn at 90%
   } catch {
     return false;
+  }
+}
+
+/**
+ * Migration: remove duplicate log entries for pinned sessions.
+ * Previously both log: and cache: entries were written for pinned sessions.
+ * The cache: entry is authoritative — remove any redundant log: duplicates.
+ * Call once on app load.
+ */
+export function migrateRemoveDuplicateLogs(): void {
+  try {
+    const logKeys = keysWithPrefix(LOG_PREFIX);
+    for (const logKey of logKeys) {
+      const sessionId = logKey.slice(LOG_PREFIX.length);
+      if (isPinned(sessionId)) {
+        // Cache has the authoritative copy — log: is a stale duplicate
+        localStorage.removeItem(logKey);
+      }
+    }
+  } catch {
+    // fail silently
   }
 }


### PR DESCRIPTION
PR for issue: #1118

## Summary
- Consolidated duplicate `odin-throne:log:` + `odin-throne:cache:` entries into a single `cache:` entry per pinned session (~700KB → ~350KB per session)
- Added `migrateRemoveDuplicateLogs()` called on app mount to clean up stale duplicates from existing pinned sessions
- Background caching: pinned sessions keep their WebSocket subscription alive when user navigates away; incoming log lines are persisted to localStorage without updating the UI

## Test plan
- [ ] Pin a session, inspect localStorage — only ONE data entry (`odin-throne:cache:<id>`), no `odin-throne:log:<id>` duplicate
- [ ] Navigate away from a streaming pinned session to another session — come back and confirm all data that arrived while away is present
- [ ] Unpin a session — confirm background WS subscription is cleaned up
- [ ] Reload with pre-existing pinned sessions — migration removes any leftover `log:` duplicates
- [ ] `tsc -b && vite build` passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)