### PR TITLE
Issue #1135 - fix: fall back to cache for pinned sessions when pod is cleaned up

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -35,6 +35,7 @@ export function App() {
     isTtlExpired,
     isNodeUnreachable,
     streamError,
+    replayedFromCache,
   } = useLogStream();
 
   const prevSessionRef = useRef<string | null>(null);
@@ -237,6 +238,7 @@ export function App() {
             isPinned={isPinned}
             onTogglePin={handleTogglePin}
             onAvatarClick={setProfileAgent}
+            replayedFromCache={replayedFromCache}
             onSetSpeed={(speed) => {
               if (activeSessionId) {
                 send({ type: "set-speed", sessionId: activeSessionId, speed });

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -63,9 +63,10 @@ interface SessionHeaderProps {
   isPinned?: boolean;
   onTogglePin?: () => void;
   showPin?: boolean;
+  replayedFromCache?: boolean;
 }
 
-function SessionHeader({ job, wsState, isPinned = false, onTogglePin, showPin = true }: SessionHeaderProps) {
+function SessionHeader({ job, wsState, isPinned = false, onTogglePin, showPin = true, replayedFromCache = false }: SessionHeaderProps) {
   const displayTitle = resolveSessionTitle(job);
   // Truncate session ID to last 8 chars for display
   const shortId = job.sessionId.length > 8
@@ -117,7 +118,17 @@ function SessionHeader({ job, wsState, isPinned = false, onTogglePin, showPin = 
         >
           {STATUS_ICONS[job.status]} {STATUS_LABELS[job.status]}
         </span>
-        <StatusBadge state={wsState} />
+        {replayedFromCache ? (
+          <span
+            className="ws-badge replayed-cache"
+            title="Pod cleaned up — showing cached logs"
+            aria-label="Replayed from cache"
+          >
+            ᛗ replayed from cache
+          </span>
+        ) : (
+          <StatusBadge state={wsState} />
+        )}
         <CopySessionIdButton sessionId={job.sessionId} />
         {showPin && onTogglePin && (
           confirmingUnpin ? (
@@ -165,9 +176,10 @@ interface Props {
   isPinned?: boolean;
   onTogglePin?: () => void;
   onAvatarClick?: (agentKey: string) => void;
+  replayedFromCache?: boolean;
 }
 
-export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick }: Props) {
+export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [fixtureSpeed, setFixtureSpeed] = useState(1);
   const [fixturePaused, setFixturePaused] = useState(false);
@@ -256,8 +268,10 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
     );
   }
 
-  // TTL-expired sessions get the full-pane Norse error tablet instead of the log terminal
-  if (isTtlExpired && streamError) {
+  // TTL-expired sessions get the full-pane Norse error tablet — unless we have
+  // cached data to display instead (replayedFromCache), in which case fall through
+  // to the normal log terminal.
+  if (isTtlExpired && streamError && !replayedFromCache) {
     return (
       <main className="content" aria-label="Log viewer">
         <SessionHeader
@@ -272,7 +286,7 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
   }
 
   // Node-unreachable / kubelet-timeout errors get the same Norse error tablet treatment
-  if (isNodeUnreachable && streamError) {
+  if (isNodeUnreachable && streamError && !replayedFromCache) {
     return (
       <main className="content" aria-label="Log viewer">
         <SessionHeader
@@ -294,6 +308,7 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
         wsState={wsState}
         isPinned={isPinned}
         onTogglePin={onTogglePin}
+        replayedFromCache={replayedFromCache}
       />
       <div
         className="log-terminal"

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -4,6 +4,9 @@ import { parseJsonlLine } from "../lib/jsonl";
 import { batchSummary } from "../lib/constants";
 import { appendLogLine, getCachedLog } from "../lib/localStorageLogs";
 
+// Ref type for cache-fallback invoke — avoids circular useCallback dependency
+type ReplayFn = (sessionId: string) => void;
+
 export interface LogEntry {
   id: string;
   type: "system" | "turn-divider" | "assistant-text" | "tool-use" | "tool-result" | "tool-batch" | "raw" | "error" | "warning" | "stream-end" | "verdict" | "entrypoint-header" | "entrypoint-ok" | "entrypoint-info" | "entrypoint-task" | "entrypoint-group" | "entrypoint-fatal";
@@ -83,6 +86,8 @@ export function useLogStream() {
   const activeSessionIdRef = useRef<string | null>(null);
   const [streamError, setStreamError] = useState<string | null>(null);
   const [streamEnded, setStreamEnded] = useState(false);
+  const [replayedFromCache, setReplayedFromCache] = useState(false);
+  const replayFromCacheRef = useRef<ReplayFn | null>(null);
   const taskPromptBuffer = useRef<string[]>([]);
   const inTaskPrompt = useRef(false);
   const inEntrypoint = useRef(false);
@@ -100,6 +105,7 @@ export function useLogStream() {
     inEntrypoint.current = false;
     setStreamError(null);
     setStreamEnded(false);
+    setReplayedFromCache(false);
   }, []);
 
   const handleMessage = useCallback((msg: ServerMessage) => {
@@ -181,6 +187,14 @@ export function useLogStream() {
       }
       processEvent(ev);
     } else if (msg.type === "stream-error") {
+      // If the session has cached data in localStorage, fall back to it immediately
+      // rather than showing the error tablet. This handles pinned sessions whose
+      // pods have been cleaned up (TTL expired).
+      const sessionId = activeSessionIdRef.current;
+      if (sessionId && getCachedLog(sessionId)) {
+        replayFromCacheRef.current?.(sessionId);
+        return;
+      }
       setStreamError(msg.message);
       setEntries((prev) => [
         ...prev,
@@ -392,11 +406,12 @@ export function useLogStream() {
    * Replay cached JSONL from localStorage for a pinned session.
    * Processes every stored line through the same pipeline as live log-lines,
    * but skips re-persisting to localStorage.
-   * Call AFTER clearEntries() and INSTEAD OF subscribing to the server.
+   * Call AFTER clearEntries() and INSTEAD OF (or as fallback to) subscribing to the server.
    */
   const replayFromCache = useCallback((sessionId: string) => {
     const content = getCachedLog(sessionId);
     if (!content) return;
+    setReplayedFromCache(true);
     const lines = content.split("\n");
     for (const line of lines) {
       if (!line.trim()) continue;
@@ -455,6 +470,10 @@ export function useLogStream() {
     ]);
   }, [processEvent]);
 
+  // Keep ref in sync so handleMessage can invoke replayFromCache without
+  // a circular useCallback dependency.
+  replayFromCacheRef.current = replayFromCache;
+
   const isTtlExpired = streamEnded && streamError !== null && TTL_ERROR_PATTERN.test(streamError);
   const isNodeUnreachable = streamEnded && streamError !== null && NODE_UNREACHABLE_PATTERN.test(streamError);
 
@@ -469,5 +488,6 @@ export function useLogStream() {
     streamEnded,
     isTtlExpired,
     isNodeUnreachable,
+    replayedFromCache,
   };
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -438,10 +438,11 @@ body {
   padding: 0.15rem 0.5rem; border-radius: 3px;
   border: 1px solid var(--rune-border); flex-shrink: 0;
 }
-.ws-badge.connecting { color: var(--gold-bright); border-color: var(--gold-bright); }
-.ws-badge.open       { color: var(--teal-asgard); border-color: var(--teal-asgard); }
-.ws-badge.closed     { color: var(--text-void); border-color: var(--rune-border); }
-.ws-badge.error      { color: var(--error-strong); border-color: var(--error-strong); }
+.ws-badge.connecting      { color: var(--gold-bright); border-color: var(--gold-bright); }
+.ws-badge.open            { color: var(--teal-asgard); border-color: var(--teal-asgard); }
+.ws-badge.closed          { color: var(--text-void); border-color: var(--rune-border); }
+.ws-badge.error           { color: var(--error-strong); border-color: var(--error-strong); }
+.ws-badge.replayed-cache  { color: var(--gold); border-color: var(--gold); opacity: 0.85; }
 
 /* ── Log terminal ──────────────────────────────── */
 .log-terminal {


### PR DESCRIPTION
PR for issue: #1135

## Summary

- On `stream-error` (TTL expired/pod cleaned up), `useLogStream` now checks `localStorage` for cached data before showing the error tablet
- If cached data exists, it replays immediately via `replayFromCache` and sets a `replayedFromCache` flag — no error state is set
- `LogViewer` skips the Norse error tablet when `replayedFromCache` is true and shows a gold "ᛗ replayed from cache" badge in the header instead of the WebSocket status badge
- Live sessions with no cache still show the error tablet as before

## Test plan

- [ ] Pin a running/completed session, wait for pod TTL to expire (or simulate by sending `stream-error` from server), click session → should show cached logs with "ᛗ replayed from cache" badge, not the error tablet
- [ ] Unpinned session whose pod is cleaned up → still shows Norse error tablet ("unavailable")
- [ ] Live session streams normally — no regression
- [ ] `cached`-status sessions (sidebar) still replay via the existing path in `handleSelectSession`
- [ ] tsc + vite build PASS ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)