### PR TITLE
Issue #1139 - fix: monitor session streaming lifecycle

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -17,6 +17,7 @@ import {
   isCacheNearCap,
   appendLogLine,
   migrateRemoveDuplicateLogs,
+  evictExpiredLogs,
 } from "./lib/localStorageLogs";
 import type { CachedSessionMeta } from "./lib/localStorageLogs";
 
@@ -32,19 +33,25 @@ export function App() {
     clearEntries,
     handleMessage: handleLogMessage,
     replayFromCache,
+    replayFromTempLog,
+    setLiveSkipCount,
     isTtlExpired,
     isNodeUnreachable,
     streamError,
     replayedFromCache,
   } = useLogStream();
 
-  const prevSessionRef = useRef<string | null>(null);
+  // Tracks the sessionId we currently have an active WS subscription for.
+  // Distinct from activeSessionId (display state) — this is the wire-protocol state.
+  const subscribedSessionRef = useRef<string | null>(null);
   // Sessions we kept subscribed in the background for caching after navigation
   const backgroundSubsRef = useRef<Set<string>>(new Set());
 
   // Migrate existing duplicate log: entries for pinned sessions on mount
+  // and evict non-pinned temp logs older than the 1-hour TTL
   useEffect(() => {
     migrateRemoveDuplicateLogs();
+    evictExpiredLogs();
   }, []);
 
   const [isFixture, setIsFixture] = useState(false);
@@ -102,34 +109,66 @@ export function App() {
 
   const handleSelectSession = useCallback(
     (sessionId: string) => {
-      // Handle previous session subscription
-      if (prevSessionRef.current && prevSessionRef.current !== sessionId) {
-        const prev = prevSessionRef.current;
-        if (checkIsPinned(prev)) {
+      const currentSub = subscribedSessionRef.current;
+
+      // Unsubscribe / move to background for the current active subscription
+      if (currentSub !== null && currentSub !== sessionId) {
+        if (checkIsPinned(currentSub)) {
           // Keep subscription alive so background caching continues
-          backgroundSubsRef.current.add(prev);
+          backgroundSubsRef.current.add(currentSub);
         } else {
-          send({ type: "unsubscribe", sessionId: prev });
-          backgroundSubsRef.current.delete(prev);
+          send({ type: "unsubscribe", sessionId: currentSub });
+          backgroundSubsRef.current.delete(currentSub);
         }
       }
-      prevSessionRef.current = sessionId;
+
       setActiveSessionId(sessionId);
       setIsFixture(false);
       clearEntries();
 
-      // Determine if this session is cached-only (no live pod)
+      // Determine if this session is cached-only (pinned, no live pod)
       const selectedJob = jobs.find((j) => j.sessionId === sessionId);
       if (selectedJob?.status === "cached") {
-        // Replay from localStorage — do NOT subscribe to server
+        // Replay from pinned localStorage cache — do NOT subscribe to server
+        subscribedSessionRef.current = null;
         // Use setTimeout to let clearEntries flush before replay
         setTimeout(() => replayFromCache(sessionId), 0);
+      } else if (currentSub === sessionId) {
+        // Revisiting the session we're already subscribed to (e.g. user clicks
+        // the same session again). Replay temp log for instant display — the live
+        // stream is still active and will continue from where it left off.
+        const cachedLineCount = replayFromTempLog(sessionId);
+        if (cachedLineCount > 0) {
+          setLiveSkipCount(cachedLineCount);
+        }
+        // subscribedSessionRef stays the same — still subscribed
       } else {
+        // New session: load from temp log for instant display, then subscribe
+        const cachedLineCount = replayFromTempLog(sessionId);
+        subscribedSessionRef.current = sessionId;
+        if (cachedLineCount > 0) {
+          // Tell handleMessage to skip the first N live lines (server re-streams
+          // from beginning, these are duplicates of what we just showed from cache)
+          setLiveSkipCount(cachedLineCount);
+        }
         send({ type: "subscribe", sessionId });
       }
     },
-    [send, setActiveSessionId, clearEntries, replayFromCache, jobs]
+    [send, setActiveSessionId, clearEntries, replayFromCache, replayFromTempLog, setLiveSkipCount, jobs]
   );
+
+  // Send unsubscribe when App unmounts (e.g. browser navigation away from the SPA).
+  // Also covers backgroundSubsRef sessions so the server cleans up cleanly.
+  useEffect(() => {
+    return () => {
+      if (subscribedSessionRef.current) {
+        send({ type: "unsubscribe", sessionId: subscribedSessionRef.current });
+      }
+      for (const sessionId of backgroundSubsRef.current) {
+        send({ type: "unsubscribe", sessionId });
+      }
+    };
+  }, [send]);
 
   // Re-subscribe only on actual reconnect (wsState transitions to "open").
   // Skip re-subscribe if the session ended with a TTL-expired or node-unreachable
@@ -140,7 +179,6 @@ export function App() {
   const isNodeUnreachableRef = useRef(isNodeUnreachable);
   isNodeUnreachableRef.current = isNodeUnreachable;
   const prevWsState = useRef(wsState);
-  const lastSubscribedRef = useRef<string | null>(null);
   useEffect(() => {
     const wasDisconnected = prevWsState.current !== "open";
     prevWsState.current = wsState;
@@ -149,15 +187,17 @@ export function App() {
       const activeJob = jobs.find((j) => j.sessionId === activeSessionId);
       if (activeJob?.status === "cached") return;
 
-      // On reconnect to the SAME session, clear entries first to avoid
-      // duplicate log replay stacking on top of existing entries.
-      if (lastSubscribedRef.current === activeSessionId) {
-        clearEntries();
+      // On reconnect: clear stale entries, replay temp log for instant display,
+      // then re-subscribe. Set skip count so duplicates from re-stream are ignored.
+      clearEntries();
+      const cachedLineCount = replayFromTempLog(activeSessionId);
+      if (cachedLineCount > 0) {
+        setLiveSkipCount(cachedLineCount);
       }
-      lastSubscribedRef.current = activeSessionId;
+      subscribedSessionRef.current = activeSessionId;
       send({ type: "subscribe", sessionId: activeSessionId });
     }
-  }, [wsState, activeSessionId, send, clearEntries, jobs]);
+  }, [wsState, activeSessionId, send, clearEntries, replayFromTempLog, setLiveSkipCount, jobs]);
 
   const activeJob = jobs.find((j) => j.sessionId === activeSessionId) || null;
 

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -2,7 +2,7 @@ import { useState, useCallback, useRef } from "react";
 import type { ServerMessage, JsonEvent, ContentBlock } from "../lib/types";
 import { parseJsonlLine } from "../lib/jsonl";
 import { batchSummary } from "../lib/constants";
-import { appendLogLine, getCachedLog } from "../lib/localStorageLogs";
+import { appendLogLine, getCachedLog, getLog } from "../lib/localStorageLogs";
 
 // Ref type for cache-fallback invoke — avoids circular useCallback dependency
 type ReplayFn = (sessionId: string) => void;
@@ -91,6 +91,9 @@ export function useLogStream() {
   const taskPromptBuffer = useRef<string[]>([]);
   const inTaskPrompt = useRef(false);
   const inEntrypoint = useRef(false);
+  // Tracks how many live log-line messages to skip after a cache replay.
+  // Set to N after replaying N cached lines so the re-streamed duplicates are ignored.
+  const liveSkipRef = useRef(0);
 
   const setActiveSessionId = useCallback((id: string | null) => {
     activeSessionIdRef.current = id;
@@ -100,6 +103,7 @@ export function useLogStream() {
   const clearEntries = useCallback(() => {
     setEntries([]);
     entryCounter = 0;
+    liveSkipRef.current = 0;
     taskPromptBuffer.current = [];
     inTaskPrompt.current = false;
     inEntrypoint.current = false;
@@ -108,113 +112,9 @@ export function useLogStream() {
     setReplayedFromCache(false);
   }, []);
 
-  const handleMessage = useCallback((msg: ServerMessage) => {
-    if (msg.type === "log-line") {
-      const line = msg.line;
-      // Persist raw line to localStorage for download
-      if (activeSessionIdRef.current) {
-        appendLogLine(activeSessionIdRef.current, line);
-      }
-      const ev = parseJsonlLine(line);
-      if (!ev) {
-        if (line.trim()) {
-          // Strip kubectl timestamp prefix (e.g. "2026-03-15T19:58:07Z ")
-          const stripped = stripTimestamp(line.trim());
-
-          // Task prompt buffering (happens after "Starting Claude Code")
-          if (/^---\s*TASK PROMPT\s*---$/.test(stripped)) {
-            inTaskPrompt.current = true;
-            taskPromptBuffer.current = [];
-            return;
-          }
-          if (/^---\s*END PROMPT\s*---$/.test(stripped)) {
-            inTaskPrompt.current = false;
-            const fullPrompt = taskPromptBuffer.current.join("\n");
-            taskPromptBuffer.current = [];
-            setEntries((prev) => [
-              ...prev,
-              { id: nextId(), type: "entrypoint-task", text: fullPrompt },
-            ]);
-            return;
-          }
-          if (inTaskPrompt.current) {
-            taskPromptBuffer.current.push(stripped);
-            return;
-          }
-
-          // Entrypoint section start marker
-          if (/^===\s*Agent Sandbox Entrypoint\s*===/.test(stripped)) {
-            inEntrypoint.current = true;
-            setEntries((prev) => [...prev, parseEntrypointLine(stripped)]);
-            return;
-          }
-
-          // Entrypoint section end marker — collapse all pre-Claude entries into a group.
-          // Collects entrypoint-typed entries AND raw lines (pre-entrypoint output like
-          // "Waiting for DNS...", "Cloning...") into the group's children.
-          // Preserves any non-entrypoint, non-raw entries (e.g. task prompts) at root.
-          if (/^===\s*Starting Claude Code\s*===/.test(stripped)) {
-            inEntrypoint.current = false;
-            setEntries((prev) => {
-              const groupTypes = new Set(["entrypoint-header", "entrypoint-ok", "entrypoint-info", "entrypoint-fatal", "raw"]);
-              const epChildren: LogEntry[] = [];
-              const rest: LogEntry[] = [];
-              for (const e of prev) {
-                if (groupTypes.has(e.type)) epChildren.push(e);
-                else rest.push(e);
-              }
-              const group: LogEntry = {
-                id: nextId(),
-                type: "entrypoint-group",
-                text: "Agent Sandbox Setup",
-                children: epChildren,
-              };
-              return [...rest, group, parseEntrypointLine(stripped)];
-            });
-            return;
-          }
-
-          // Inside entrypoint section — parse with structured types
-          if (inEntrypoint.current) {
-            setEntries((prev) => [...prev, parseEntrypointLine(stripped)]);
-            return;
-          }
-
-          // Outside entrypoint — render as raw (dimmed) text
-          setEntries((prev) => [...prev, { id: nextId(), type: "raw", text: stripped }]);
-        }
-        return;
-      }
-      processEvent(ev);
-    } else if (msg.type === "stream-error") {
-      // If the session has cached data in localStorage, fall back to it immediately
-      // rather than showing the error tablet. This handles pinned sessions whose
-      // pods have been cleaned up (TTL expired).
-      const sessionId = activeSessionIdRef.current;
-      if (sessionId && getCachedLog(sessionId)) {
-        replayFromCacheRef.current?.(sessionId);
-        return;
-      }
-      setStreamError(msg.message);
-      setEntries((prev) => [
-        ...prev,
-        { id: nextId(), type: "error", message: msg.message },
-      ]);
-    } else if (msg.type === "stream-end") {
-      setStreamEnded(true);
-      setEntries((prev) => {
-        // Mark any open batch as complete before adding stream-end
-        const updated = prev.map((e) =>
-          e.type === "tool-batch" && !e.complete ? { ...e, complete: true } : e
-        );
-        return [...updated, { id: nextId(), type: "stream-end", reason: msg.reason }];
-      });
-    } else if (msg.type === "verdict") {
-      setEntries((prev) => [
-        ...prev,
-        { id: nextId(), type: "verdict", verdictResult: msg.result },
-      ]);
-    }
+  /** Expose liveSkipRef setter so callers can set the skip count after replaying cache. */
+  const setLiveSkipCount = useCallback((n: number) => {
+    liveSkipRef.current = n;
   }, []);
 
   const processEvent = useCallback((ev: JsonEvent) => {
@@ -403,42 +303,46 @@ export function useLogStream() {
   }, []);
 
   /**
-   * Replay cached JSONL from localStorage for a pinned session.
-   * Processes every stored line through the same pipeline as live log-lines,
-   * but skips re-persisting to localStorage.
-   * Call AFTER clearEntries() and INSTEAD OF (or as fallback to) subscribing to the server.
+   * Process a single raw log line through the parser pipeline.
+   * Used by both the live handleMessage path and the cache replay paths.
+   * Does NOT call appendLogLine — callers handle persistence separately.
    */
-  const replayFromCache = useCallback((sessionId: string) => {
-    const content = getCachedLog(sessionId);
-    if (!content) return;
-    setReplayedFromCache(true);
-    const lines = content.split("\n");
-    for (const line of lines) {
-      if (!line.trim()) continue;
-      const ev = parseJsonlLine(line);
-      if (!ev) {
+  const processRawLogLine = useCallback((line: string) => {
+    const ev = parseJsonlLine(line);
+    if (!ev) {
+      if (line.trim()) {
+        // Strip kubectl timestamp prefix (e.g. "2026-03-15T19:58:07Z ")
         const stripped = stripTimestamp(line.trim());
+
+        // Task prompt buffering (happens after "Starting Claude Code")
         if (/^---\s*TASK PROMPT\s*---$/.test(stripped)) {
           inTaskPrompt.current = true;
           taskPromptBuffer.current = [];
-          continue;
+          return;
         }
         if (/^---\s*END PROMPT\s*---$/.test(stripped)) {
           inTaskPrompt.current = false;
           const fullPrompt = taskPromptBuffer.current.join("\n");
           taskPromptBuffer.current = [];
-          setEntries((prev) => [...prev, { id: nextId(), type: "entrypoint-task", text: fullPrompt }]);
-          continue;
+          setEntries((prev) => [
+            ...prev,
+            { id: nextId(), type: "entrypoint-task", text: fullPrompt },
+          ]);
+          return;
         }
         if (inTaskPrompt.current) {
           taskPromptBuffer.current.push(stripped);
-          continue;
+          return;
         }
+
+        // Entrypoint section start marker
         if (/^===\s*Agent Sandbox Entrypoint\s*===/.test(stripped)) {
           inEntrypoint.current = true;
           setEntries((prev) => [...prev, parseEntrypointLine(stripped)]);
-          continue;
+          return;
         }
+
+        // Entrypoint section end marker — collapse all pre-Claude entries into a group.
         if (/^===\s*Starting Claude Code\s*===/.test(stripped)) {
           inEntrypoint.current = false;
           setEntries((prev) => {
@@ -449,30 +353,119 @@ export function useLogStream() {
               if (groupTypes.has(e.type)) epChildren.push(e);
               else rest.push(e);
             }
-            const group: LogEntry = { id: nextId(), type: "entrypoint-group", text: "Agent Sandbox Setup", children: epChildren };
+            const group: LogEntry = {
+              id: nextId(),
+              type: "entrypoint-group",
+              text: "Agent Sandbox Setup",
+              children: epChildren,
+            };
             return [...rest, group, parseEntrypointLine(stripped)];
           });
-          continue;
+          return;
         }
+
+        // Inside entrypoint section — parse with structured types
         if (inEntrypoint.current) {
           setEntries((prev) => [...prev, parseEntrypointLine(stripped)]);
-          continue;
+          return;
         }
+
+        // Outside entrypoint — render as raw (dimmed) text
         setEntries((prev) => [...prev, { id: nextId(), type: "raw", text: stripped }]);
-      } else {
-        processEvent(ev);
       }
+      return;
+    }
+    processEvent(ev);
+  }, [processEvent]);
+
+  const handleMessage = useCallback((msg: ServerMessage) => {
+    if (msg.type === "log-line") {
+      const line = msg.line;
+      // If we recently replayed from cache, skip lines that were already shown.
+      // The server re-streams from the beginning after subscribe, so the first N
+      // live lines are duplicates of what we displayed from the temp log.
+      if (liveSkipRef.current > 0) {
+        liveSkipRef.current--;
+        return;
+      }
+      // Persist raw line to localStorage for download / future revisits
+      if (activeSessionIdRef.current) {
+        appendLogLine(activeSessionIdRef.current, line);
+      }
+      processRawLogLine(line);
+    } else if (msg.type === "stream-error") {
+      liveSkipRef.current = 0; // stop skipping on error
+      // If the session has cached data in localStorage, fall back to it immediately
+      // rather than showing the error tablet. This handles pinned sessions whose
+      // pods have been cleaned up (TTL expired).
+      const sessionId = activeSessionIdRef.current;
+      if (sessionId && getCachedLog(sessionId)) {
+        replayFromCacheRef.current?.(sessionId);
+        return;
+      }
+      setStreamError(msg.message);
+      setEntries((prev) => [
+        ...prev,
+        { id: nextId(), type: "error", message: msg.message },
+      ]);
+    } else if (msg.type === "stream-end") {
+      liveSkipRef.current = 0; // stop skipping on end
+      setStreamEnded(true);
+      setEntries((prev) => {
+        // Mark any open batch as complete before adding stream-end
+        const updated = prev.map((e) =>
+          e.type === "tool-batch" && !e.complete ? { ...e, complete: true } : e
+        );
+        return [...updated, { id: nextId(), type: "stream-end", reason: msg.reason }];
+      });
+    } else if (msg.type === "verdict") {
+      setEntries((prev) => [
+        ...prev,
+        { id: nextId(), type: "verdict", verdictResult: msg.result },
+      ]);
+    }
+  }, [processRawLogLine]);
+
+  /**
+   * Replay cached JSONL from localStorage for a pinned session (CACHE_PREFIX).
+   * Processes every stored line through the same pipeline as live log-lines,
+   * but skips re-persisting to localStorage.
+   * Call AFTER clearEntries() and INSTEAD OF subscribing to the server.
+   */
+  const replayFromCache = useCallback((sessionId: string) => {
+    const content = getCachedLog(sessionId);
+    if (!content) return;
+    setReplayedFromCache(true);
+    const lines = content.split("\n");
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      processRawLogLine(line);
     }
     // System marker at end of replay
     setEntries((prev) => [
       ...prev,
       { id: nextId(), type: "system", detail: "replayed from Odin\u2019s memory (pinned cache)" },
     ]);
-  }, [processEvent]);
+  }, [processRawLogLine]);
 
   // Keep ref in sync so handleMessage can invoke replayFromCache without
   // a circular useCallback dependency.
   replayFromCacheRef.current = replayFromCache;
+
+  /**
+   * Replay the non-pinned temp log (LOG_PREFIX) for a session.
+   * Returns the number of lines replayed so the caller can set the live skip count.
+   * Call AFTER clearEntries() and BEFORE subscribing to the server for instant display.
+   */
+  const replayFromTempLog = useCallback((sessionId: string): number => {
+    const content = getLog(sessionId);
+    if (!content) return 0;
+    const lines = content.split("\n").filter((l) => l.trim());
+    for (const line of lines) {
+      processRawLogLine(line);
+    }
+    return lines.length;
+  }, [processRawLogLine]);
 
   const isTtlExpired = streamEnded && streamError !== null && TTL_ERROR_PATTERN.test(streamError);
   const isNodeUnreachable = streamEnded && streamError !== null && NODE_UNREACHABLE_PATTERN.test(streamError);
@@ -484,6 +477,8 @@ export function useLogStream() {
     clearEntries,
     handleMessage,
     replayFromCache,
+    replayFromTempLog,
+    setLiveSkipCount,
     streamError,
     streamEnded,
     isTtlExpired,

--- a/development/monitor-ui/src/lib/localStorageLogs.ts
+++ b/development/monitor-ui/src/lib/localStorageLogs.ts
@@ -3,6 +3,9 @@
 // Ephemeral — evicts freely. Pinned sessions skip this buffer entirely.
 
 const LOG_PREFIX = "odin-throne:log:";
+const LOG_TTL_PREFIX = "odin-throne:log-ttl:";
+/** TTL for non-pinned session temp logs — 1 hour */
+export const LOG_CACHE_TTL_MS = 60 * 60 * 1000;
 const MAX_LOG_SESSIONS = 10;
 const MAX_LOG_BYTES = 5 * 1024 * 1024; // 5MB
 
@@ -82,6 +85,8 @@ export function appendLogLine(sessionId: string, line: string): void {
     }
 
     localStorage.setItem(key, next);
+    // Update TTL timestamp so the entry stays fresh while actively streaming
+    localStorage.setItem(LOG_TTL_PREFIX + sessionId, String(Date.now()));
   } catch {
     // localStorage may be full or unavailable — fail silently
   }
@@ -235,6 +240,26 @@ export function isCacheNearCap(): boolean {
     return totalBytes > MAX_CACHE_BYTES * 0.9; // warn at 90%
   } catch {
     return false;
+  }
+}
+
+/**
+ * Evict non-pinned temp log entries older than ttlMs (default 1 hour).
+ * Call once on app mount to clean up stale session data.
+ */
+export function evictExpiredLogs(ttlMs: number = LOG_CACHE_TTL_MS): void {
+  try {
+    const ttlKeys = keysWithPrefix(LOG_TTL_PREFIX);
+    for (const ttlKey of ttlKeys) {
+      const sessionId = ttlKey.slice(LOG_TTL_PREFIX.length);
+      const ts = localStorage.getItem(ttlKey);
+      if (ts && Date.now() - Number(ts) > ttlMs) {
+        localStorage.removeItem(LOG_PREFIX + sessionId);
+        localStorage.removeItem(ttlKey);
+      }
+    }
+  } catch {
+    // fail silently
   }
 }
 


### PR DESCRIPTION
PR for issue: #1139

Fix session streaming in monitor UI: send `unsubscribe` on navigate-away, persist all log data to localStorage as it streams, load from cache on revisit for instant display, background streaming for pinned sessions, TTL expiration for non-pinned caches, and deduplicate subscribes.

## Changes

- **`localStorageLogs.ts`** — add `LOG_CACHE_TTL_MS` (1 hour), touch TTL timestamp on every `appendLogLine` write, add `evictExpiredLogs()` to prune stale non-pinned entries on startup
- **`useLogStream.ts`** — extract `processRawLogLine` shared parser (eliminates duplication between live and cache replay paths), add `liveSkipRef` to skip already-shown lines when live stream re-delivers cached content after subscribe, add `replayFromTempLog()` for instant display on session revisit, add `setLiveSkipCount()` so App can coordinate skip count before subscribe, `clearEntries()` resets `liveSkipRef`, refactor `replayFromCache` to use `processRawLogLine`
- **`App.tsx`** — rename `prevSessionRef` → `subscribedSessionRef` (tracks wire-protocol subscription state), add unmount `useEffect` to send `unsubscribe` for active + background subscriptions, `handleSelectSession` loads temp log + sets skip count before subscribe, handles same-session revisit (no re-subscribe, just replay + skip), reconnect effect replays temp log + sets skip count on WS reconnect, calls `evictExpiredLogs()` on mount

## Verification

- Navigate to session → away → back: data loads instantly from cache, stream resumes, single subscribe in WS frames
- Navigate away mid-stream: `unsubscribe` message visible in WS frames
- Pin a session, navigate away: background subscription keeps caching log lines
- WS reconnect: temp log displayed instantly, no duplicate log lines
- Non-pinned session cache expires after 1 hour (TTL evicted on next app load)
- tsc: PASS, build: PASS (37 routes)