### PR TITLE
fix: terraform plan on PR + fix infra change detection

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -125,7 +125,7 @@ jobs:
           MONITOR=$(check "^development/monitor/")
           MONITOR_UI=$(check "^development/monitor-ui/")
           HELM_ODIN=$(check "^infrastructure/helm/odin-throne/")
-          INFRA=$(check "^infrastructure/(terraform|monitoring)/")
+          INFRA=$(check "^infrastructure/.*\.tf$|^infrastructure/firestore/")
           REDIS=$(check "^infrastructure/k8s/app/redis-statefulset\.yaml$")
           UMAMI=$(check "^infrastructure/helm/umami/")
           echo "app=$APP" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -1,0 +1,131 @@
+# --------------------------------------------------------------------------
+# Terraform Plan — runs on PRs that touch infrastructure/*.tf or firestore rules
+#
+# Plan-only (no apply). Posts the plan output as a PR comment so reviewers
+# can see exactly what will change before merging to main.
+#
+# Required GitHub Secrets:
+#   GCP_SA_KEY                  — Base64-encoded service account JSON key
+#   GCP_PROJECT_ID              — Google Cloud project ID
+#   GCP_REGION                  — GCP region
+#   GCP_ZONE                    — GCP zone
+#   TF_VAR_BILLING_ACCOUNT_ID   — GCP billing account ID
+#   TF_VAR_UPTIME_CHECK_HOST    — Ingress hostname for uptime checks
+# --------------------------------------------------------------------------
+
+name: Terraform Plan
+
+concurrency:
+  group: terraform-plan-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - "infrastructure/**/*.tf"
+      - "infrastructure/firestore/**"
+  workflow_dispatch:
+
+jobs:
+  plan:
+    name: Terraform Plan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+
+    defaults:
+      run:
+        working-directory: infrastructure
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~> 1.9"
+
+      - name: Terraform Init
+        run: terraform init -input=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan -input=false -no-color 2>&1 | tee /tmp/tf-plan.txt
+        env:
+          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_region: ${{ secrets.GCP_REGION }}
+          TF_VAR_zone: ${{ secrets.GCP_ZONE }}
+          TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
+          TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
+
+      - name: Post plan to PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+            const plan = fs.readFileSync('/tmp/tf-plan.txt', 'utf8');
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+            const marker = '<!-- terraform-plan-comment -->';
+
+            // Truncate if too long (GitHub comment limit is 65536 chars)
+            const maxLen = 60000;
+            const truncated = plan.length > maxLen
+              ? plan.slice(0, maxLen) + '\n\n... (truncated)'
+              : plan;
+
+            const body = [
+              marker,
+              '## Terraform Plan',
+              '',
+              '<details>',
+              '<summary>Click to expand plan output</summary>',
+              '',
+              '```hcl',
+              truncated,
+              '```',
+              '',
+              '</details>',
+              '',
+              `**Commit:** \`${context.sha.slice(0, 7)}\``,
+            ].join('\n');
+
+            const comments = await github.rest.issues.listComments({
+              owner, repo,
+              issue_number: prNumber,
+            });
+            const existing = comments.data.find(c => c.body?.includes(marker));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+      - name: Plan Summary
+        run: |
+          echo "### Terraform Plan" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY
+          tail -20 /tmp/tf-plan.txt >> $GITHUB_STEP_SUMMARY
+          echo '```' >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- **Fix deploy.yml infra detection** — regex `^infrastructure/(terraform|monitoring)/` never matched root `.tf` files like `main.tf`, `iam.tf`, etc. Changed to `^infrastructure/.*\.tf$|^infrastructure/firestore/`
- **Add `terraform-plan.yml`** — new workflow runs `terraform plan` (no apply) on PRs touching `.tf` files or firestore rules, posts plan output as a PR comment for review

## Test plan
- [ ] Verify terraform-plan.yml triggers on PRs that modify `infrastructure/*.tf`
- [ ] Verify deploy.yml terraform job now detects infra changes correctly on main pushes
- [ ] Verify plan output posts as PR comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)