### PR TITLE
fix: remove invalid cdn.googleapis.com API — unblocks Terraform

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -50,7 +50,6 @@ resource "google_project_service" "apis" {
     "dns.googleapis.com",                  # Cloud DNS
     "firestore.googleapis.com",            # Firestore
     "firebaserules.googleapis.com",        # Firebase Security Rules
-    "cdn.googleapis.com",                  # Cloud CDN
   ])
 
   project            = var.project_id


### PR DESCRIPTION
## Summary
- `cdn.googleapis.com` is not a real GCP API — Cloud CDN is part of `compute.googleapis.com`. The CDN PR (#1142) added it incorrectly, causing `terraform apply` to fail with `SERVICE_CONFIG_NOT_FOUND_OR_PERMISSION_DENIED`.

## Test plan
- [ ] Terraform plan succeeds (check the plan comment on this PR)
- [ ] Re-run deploy workflow after merge — Terraform apply should pass and provision Firestore

🤖 Generated with [Claude Code](https://claude.com/claude-code)