### PR TITLE
Issue #1149 - fix: eliminate red error flash on monitor session load

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -39,6 +39,7 @@ export function App() {
     isNodeUnreachable,
     streamError,
     replayedFromCache,
+    isConnecting,
   } = useLogStream();
 
   // Tracks the sessionId we currently have an active WS subscription for.
@@ -279,6 +280,7 @@ export function App() {
             onTogglePin={handleTogglePin}
             onAvatarClick={setProfileAgent}
             replayedFromCache={replayedFromCache}
+            isConnecting={isConnecting}
             onSetSpeed={(speed) => {
               if (activeSessionId) {
                 send({ type: "set-speed", sessionId: activeSessionId, speed });

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -177,9 +177,10 @@ interface Props {
   onTogglePin?: () => void;
   onAvatarClick?: (agentKey: string) => void;
   replayedFromCache?: boolean;
+  isConnecting?: boolean;
 }
 
-export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache }: Props) {
+export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache, isConnecting }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [fixtureSpeed, setFixtureSpeed] = useState(1);
   const [fixturePaused, setFixturePaused] = useState(false);
@@ -269,9 +270,11 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
   }
 
   // TTL-expired sessions get the full-pane Norse error tablet — unless we have
-  // cached data to display instead (replayedFromCache), in which case fall through
-  // to the normal log terminal.
-  if (isTtlExpired && streamError && !replayedFromCache) {
+  // cached data to display instead (replayedFromCache) or the connection is still
+  // being established (isConnecting), in which case fall through to the log terminal.
+  // Guarding on !isConnecting prevents a red flash on the frame(s) before the first
+  // log-line or cache replay arrives.
+  if (isTtlExpired && streamError && !replayedFromCache && !isConnecting) {
     return (
       <main className="content" aria-label="Log viewer">
         <SessionHeader
@@ -286,7 +289,7 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
   }
 
   // Node-unreachable / kubelet-timeout errors get the same Norse error tablet treatment
-  if (isNodeUnreachable && streamError && !replayedFromCache) {
+  if (isNodeUnreachable && streamError && !replayedFromCache && !isConnecting) {
     return (
       <main className="content" aria-label="Log viewer">
         <SessionHeader
@@ -318,6 +321,12 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
         aria-label="Session logs"
         onScroll={handleScroll}
       >
+        {isConnecting && entries.length === 0 && (
+          <div className="session-connecting" aria-label="Connecting to session" aria-live="polite">
+            <span className="connecting-spinner" aria-hidden="true" />
+            <span>Awaiting the Norns\u2026</span>
+          </div>
+        )}
         {displayEntries.map((item) => {
           if ("_collapsed" in item) {
             return (

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -87,6 +87,11 @@ export function useLogStream() {
   const [streamError, setStreamError] = useState<string | null>(null);
   const [streamEnded, setStreamEnded] = useState(false);
   const [replayedFromCache, setReplayedFromCache] = useState(false);
+  // isConnecting: true from the moment clearEntries() is called (session selected)
+  // until the first WS data arrives or cache replay begins. Used to suppress
+  // the error tablet during the brief connection window (prevents red flash).
+  const [isConnecting, _setIsConnecting] = useState(false);
+  const isConnectingRef = useRef(false);
   const replayFromCacheRef = useRef<ReplayFn | null>(null);
   const taskPromptBuffer = useRef<string[]>([]);
   const inTaskPrompt = useRef(false);
@@ -94,6 +99,11 @@ export function useLogStream() {
   // Tracks how many live log-line messages to skip after a cache replay.
   // Set to N after replaying N cached lines so the re-streamed duplicates are ignored.
   const liveSkipRef = useRef(0);
+
+  const setIsConnecting = useCallback((v: boolean) => {
+    isConnectingRef.current = v;
+    _setIsConnecting(v);
+  }, []);
 
   const setActiveSessionId = useCallback((id: string | null) => {
     activeSessionIdRef.current = id;
@@ -110,7 +120,8 @@ export function useLogStream() {
     setStreamError(null);
     setStreamEnded(false);
     setReplayedFromCache(false);
-  }, []);
+    setIsConnecting(true);
+  }, [setIsConnecting]);
 
   /** Expose liveSkipRef setter so callers can set the skip count after replaying cache. */
   const setLiveSkipCount = useCallback((n: number) => {
@@ -388,6 +399,10 @@ export function useLogStream() {
         liveSkipRef.current--;
         return;
       }
+      // First live log-line clears the connecting state
+      if (isConnectingRef.current) {
+        setIsConnecting(false);
+      }
       // Persist raw line to localStorage for download / future revisits
       if (activeSessionIdRef.current) {
         appendLogLine(activeSessionIdRef.current, line);
@@ -395,6 +410,10 @@ export function useLogStream() {
       processRawLogLine(line);
     } else if (msg.type === "stream-error") {
       liveSkipRef.current = 0; // stop skipping on error
+      // Clear connecting state — we now know the stream status
+      if (isConnectingRef.current) {
+        setIsConnecting(false);
+      }
       // If the session has cached data in localStorage, fall back to it immediately
       // rather than showing the error tablet. This handles pinned sessions whose
       // pods have been cleaned up (TTL expired).
@@ -410,6 +429,10 @@ export function useLogStream() {
       ]);
     } else if (msg.type === "stream-end") {
       liveSkipRef.current = 0; // stop skipping on end
+      // Clear connecting state on stream end
+      if (isConnectingRef.current) {
+        setIsConnecting(false);
+      }
       setStreamEnded(true);
       setEntries((prev) => {
         // Mark any open batch as complete before adding stream-end
@@ -424,7 +447,7 @@ export function useLogStream() {
         { id: nextId(), type: "verdict", verdictResult: msg.result },
       ]);
     }
-  }, [processRawLogLine]);
+  }, [processRawLogLine, setIsConnecting]);
 
   /**
    * Replay cached JSONL from localStorage for a pinned session (CACHE_PREFIX).
@@ -435,6 +458,10 @@ export function useLogStream() {
   const replayFromCache = useCallback((sessionId: string) => {
     const content = getCachedLog(sessionId);
     if (!content) return;
+    // Cache replay provides content immediately — clear connecting state
+    if (isConnectingRef.current) {
+      setIsConnecting(false);
+    }
     setReplayedFromCache(true);
     const lines = content.split("\n");
     for (const line of lines) {
@@ -446,7 +473,7 @@ export function useLogStream() {
       ...prev,
       { id: nextId(), type: "system", detail: "replayed from Odin\u2019s memory (pinned cache)" },
     ]);
-  }, [processRawLogLine]);
+  }, [processRawLogLine, setIsConnecting]);
 
   // Keep ref in sync so handleMessage can invoke replayFromCache without
   // a circular useCallback dependency.
@@ -484,5 +511,6 @@ export function useLogStream() {
     isTtlExpired,
     isNodeUnreachable,
     replayedFromCache,
+    isConnecting,
   };
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -542,6 +542,23 @@ body {
 .empty-state .empty-title { font-family: 'Cinzel', serif; font-size: 1.2rem; }
 .empty-state .empty-sub { font-size: 0.85rem; font-style: italic; }
 
+/* ── Session connecting / loading state ──────────── */
+.session-connecting {
+  display: flex; align-items: center; gap: 0.6rem;
+  padding: 0.6rem 0.2rem;
+  color: var(--text-void); font-size: 0.75rem; font-style: italic;
+}
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+.connecting-spinner {
+  display: inline-block; width: 12px; height: 12px; flex-shrink: 0;
+  border: 2px solid var(--rune-border);
+  border-top-color: var(--gold);
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+}
+
 /* ── Entrypoint lines ──────────────────────────── */
 .ep-header {
   font-family: 'Cinzel', serif; font-size: 0.8rem;


### PR DESCRIPTION
PR for issue: #1149

Fixes red error flash on monitor session load by gating error tablets behind isConnecting state.

Loki QA: tsc + build PASS. Monitor-ui change — no Vitest tests applicable.