### PR TITLE
fix: grant deploy SA firebaserules.admin for Firestore rules

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -110,6 +110,7 @@ locals {
     "roles/logging.admin",                 # Cloud Logging config
     "roles/monitoring.admin",              # Cloud Monitoring config
     "roles/certificatemanager.editor",     # Managed SSL certs
+    "roles/firebaserules.admin",           # Firebase Security Rules (Firestore)
   ]
 }
 


### PR DESCRIPTION
## Summary
- Terraform apply failed with `Error creating Ruleset: 403 The caller does not have permission` — the deploy SA needs `roles/firebaserules.admin` to manage Firebase Security Rules
- Role pre-granted via `gcloud` to unblock (chicken-and-egg: Terraform can't grant itself a missing role)
- Added to `iam.tf` deploy_roles so Terraform manages it going forward

## Test plan
- [ ] Terraform plan shows the new IAM binding
- [ ] Terraform apply succeeds after merge (Firestore database + rules created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)