### PR TITLE
fix: add FIRESTORE_PROJECT_ID to Helm — fixes 500 on household API

### DIFF
--- a/infrastructure/helm/fenrir-app/values.yaml
+++ b/infrastructure/helm/fenrir-app/values.yaml
@@ -23,6 +23,8 @@ app:
     NODE_ENV: "production"
     PORT: "3000"
     HOSTNAME: "0.0.0.0"
+    FIRESTORE_PROJECT_ID: "fenrir-ledger-prod"
+    NEXT_PUBLIC_UMAMI_WEBSITE_ID: "ce25059e-57c4-44f9-ad92-389d2bd15e4d"
 
   resources:
     requests:


### PR DESCRIPTION
## Summary
- Pods were missing `FIRESTORE_PROJECT_ID` env var — it was in the raw `deployment.yaml` but not in the Helm chart `values.yaml`. All Firestore-backed API routes (`/api/household/*`) returned 500.
- Also added `NEXT_PUBLIC_UMAMI_WEBSITE_ID` for consistency.

## Test plan
- [ ] After deploy, `GET /api/household/members` returns 200 (not 500)
- [ ] Pod env includes `FIRESTORE_PROJECT_ID=fenrir-ledger-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)