### PR TITLE
feat: cloud data sync via Firestore — issue #1119

### DIFF
--- a/development/frontend/src/__tests__/sync/sync-hook-advanced.loki.test.ts
+++ b/development/frontend/src/__tests__/sync/sync-hook-advanced.loki.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Loki QA — useCloudSync advanced edge cases (issue #1119)
+ *
+ * Gaps NOT covered by existing hook tests:
+ *   - syncNow() is a no-op when navigator.onLine is false
+ *   - Auto-retry timer fires and calls pushToFirestore after 120s
+ *   - Auto-retry transitions: error → syncing → synced
+ *   - Auto-retry transitions: error → syncing → error (retry fails)
+ *   - fenrir:cards-changed event is ignored when navigator.onLine is false
+ *   - cardCount is null on initial idle (before any sync)
+ *   - lastSyncedAt is null before any successful sync
+ *   - errorMessage is null before any error
+ *   - Multiple fenrir:cards-changed events reset the debounce timer (only one PUT)
+ *   - syncNow() clears pending debounce before pushing
+ *
+ * Issue #1119
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCloudSync, EVT_CARDS_CHANGED } from "@/hooks/useCloudSync";
+import type { Card } from "@/lib/types";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockIsKarlOrTrial = { value: false };
+
+vi.mock("@/hooks/useIsKarlOrTrial", () => ({
+  useIsKarlOrTrial: () => mockIsKarlOrTrial.value,
+}));
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+const mockEnsureFreshToken = vi.fn<[], Promise<string | null>>();
+vi.mock("@/lib/auth/refresh-session", () => ({
+  ensureFreshToken: () => mockEnsureFreshToken(),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  getSession: () => ({ user: { sub: "test-household-adv" } }),
+}));
+
+vi.mock("@/lib/storage", () => ({
+  getCards: vi.fn().mockReturnValue([]),
+  setAllCards: vi.fn(),
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+const TEST_HOUSEHOLD = "test-household-adv";
+
+function setupKarl() {
+  mockIsKarlOrTrial.value = true;
+  mockEnsureFreshToken.mockResolvedValue("test-id-token");
+}
+
+function mockFetchGet(cards: Card[] = []) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      householdId: TEST_HOUSEHOLD,
+      cards,
+      syncedAt: new Date().toISOString(),
+    }),
+  } as Response);
+}
+
+function mockFetchGetFail(code = "forbidden") {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 403,
+    json: async () => ({ error: code }),
+  } as Response);
+}
+
+function mockFetchPut(written = 3) {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      householdId: TEST_HOUSEHOLD,
+      written,
+      skipped: 0,
+      syncedAt: new Date().toISOString(),
+    }),
+  } as Response);
+}
+
+function mockFetchPutFail(code = "server_error") {
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ error: code }),
+  } as Response);
+}
+
+// ── Initial state assertions ───────────────────────────────────────────────────
+
+describe("useCloudSync — initial state (Thrall/idle)", () => {
+  beforeEach(() => {
+    mockIsKarlOrTrial.value = false;
+    global.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("cardCount is null before any sync", () => {
+    const { result } = renderHook(() => useCloudSync());
+    expect(result.current.cardCount).toBeNull();
+  });
+
+  it("lastSyncedAt is null before any sync", () => {
+    const { result } = renderHook(() => useCloudSync());
+    expect(result.current.lastSyncedAt).toBeNull();
+  });
+
+  it("errorMessage is null before any error", () => {
+    const { result } = renderHook(() => useCloudSync());
+    expect(result.current.errorMessage).toBeNull();
+  });
+
+  it("errorCode is null before any error", () => {
+    const { result } = renderHook(() => useCloudSync());
+    expect(result.current.errorCode).toBeNull();
+  });
+
+  it("retryIn is null before any error", () => {
+    const { result } = renderHook(() => useCloudSync());
+    expect(result.current.retryIn).toBeNull();
+  });
+});
+
+// ── syncNow() offline behavior ─────────────────────────────────────────────────
+
+describe("useCloudSync — syncNow() is a no-op when offline", () => {
+  beforeEach(() => {
+    setupKarl();
+    try { localStorage.setItem("fenrir:first-sync-shown", "true"); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // Restore onLine
+    Object.defineProperty(navigator, "onLine", { value: true, configurable: true });
+  });
+
+  it("syncNow() does not fetch when navigator.onLine is false", async () => {
+    // Initial GET succeeds
+    mockFetchGet([]);
+    const { result } = renderHook(() => useCloudSync());
+    await act(async () => {});
+    expect(result.current.status).toBe("synced");
+
+    // Go offline
+    Object.defineProperty(navigator, "onLine", { value: false, configurable: true });
+
+    // Reset fetch spy so we can detect new calls
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock;
+
+    await act(async () => { await result.current.syncNow(); });
+
+    // syncNow() should bail out early — no fetch calls
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── Auto-retry after error ─────────────────────────────────────────────────────
+
+describe("useCloudSync — auto-retry fires after 120s error timeout", () => {
+  beforeEach(() => {
+    setupKarl();
+    vi.useFakeTimers();
+    try { localStorage.setItem("fenrir:first-sync-shown", "true"); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("auto-retry transitions error → syncing → synced after 120s", async () => {
+    // Initial mount fails
+    mockFetchGetFail("forbidden");
+    const { result } = renderHook(() => useCloudSync());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("error");
+
+    // Set up PUT to succeed on retry
+    mockFetchPut(2);
+
+    // Advance past the 120-second retry window
+    await act(async () => {
+      vi.advanceTimersByTime(121_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Should have triggered a push (PUT) and landed in synced
+    const putCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => (c[1] as RequestInit)?.method === "PUT"
+    );
+    expect(putCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("auto-retry transitions error → syncing → error if retry also fails", async () => {
+    // Initial mount fails
+    mockFetchGetFail("permission-denied");
+    const { result } = renderHook(() => useCloudSync());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("error");
+
+    // Retry will also fail
+    mockFetchPutFail("server_error");
+
+    await act(async () => {
+      vi.advanceTimersByTime(121_000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Still in error state after failed retry
+    expect(result.current.status).toBe("error");
+  });
+});
+
+// ── fenrir:cards-changed ignored when offline ──────────────────────────────────
+
+describe("useCloudSync — fenrir:cards-changed ignored when offline", () => {
+  beforeEach(() => {
+    setupKarl();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try { localStorage.setItem("fenrir:first-sync-shown", "true"); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, "onLine", { value: true, configurable: true });
+  });
+
+  it("debounced PUT is not triggered when cards-changed fires while offline", async () => {
+    // Initial GET succeeds
+    mockFetchGet([]);
+    const { result } = renderHook(() => useCloudSync());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(result.current.status).toBe("synced");
+
+    // Go offline
+    Object.defineProperty(navigator, "onLine", { value: false, configurable: true });
+
+    // Count PUT calls before event
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    const callsBefore = fetchMock.mock.calls.filter(
+      (c: unknown[]) => (c[1] as RequestInit)?.method === "PUT"
+    ).length;
+
+    // Fire cards-changed event
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(EVT_CARDS_CHANGED, { detail: { householdId: TEST_HOUSEHOLD } })
+      );
+    });
+
+    // Advance past debounce
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+    });
+
+    const callsAfter = fetchMock.mock.calls.filter(
+      (c: unknown[]) => (c[1] as RequestInit)?.method === "PUT"
+    ).length;
+
+    // No new PUT calls while offline
+    expect(callsAfter).toBe(callsBefore);
+  });
+});
+
+// ── Multiple cards-changed events: only one PUT (debounce) ────────────────────
+
+describe("useCloudSync — multiple fenrir:cards-changed events debounce to one PUT", () => {
+  beforeEach(() => {
+    setupKarl();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    try { localStorage.setItem("fenrir:first-sync-shown", "true"); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it("rapid cards-changed events collapse to a single PUT after debounce", async () => {
+    mockFetchGet([]);
+    renderHook(() => useCloudSync());
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Set up PUT mock
+    mockFetchPut(1);
+
+    // Fire 5 rapid events within the 2s debounce window
+    act(() => {
+      for (let i = 0; i < 5; i++) {
+        window.dispatchEvent(
+          new CustomEvent(EVT_CARDS_CHANGED, { detail: { householdId: TEST_HOUSEHOLD } })
+        );
+      }
+    });
+
+    // Advance past debounce
+    await act(async () => {
+      vi.advanceTimersByTime(3000);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const putCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => (c[1] as RequestInit)?.method === "PUT"
+    );
+
+    // Only 1 PUT despite 5 events
+    expect(putCalls.length).toBe(1);
+  });
+});
+
+// ── onSyncSuccess fields ───────────────────────────────────────────────────────
+
+describe("useCloudSync — sync success sets lastSyncedAt and cardCount", () => {
+  beforeEach(() => {
+    setupKarl();
+    try { localStorage.setItem("fenrir:first-sync-shown", "true"); } catch { /* ignore */ }
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lastSyncedAt is set to a Date after successful sync", async () => {
+    mockFetchGet([]);
+    const { result } = renderHook(() => useCloudSync());
+    await act(async () => {});
+    expect(result.current.lastSyncedAt).toBeInstanceOf(Date);
+  });
+
+  it("cardCount reflects merged card count after GET sync", async () => {
+    const cards = Array.from({ length: 7 }, (_, i) => ({
+      id: `c${i}`,
+      householdId: TEST_HOUSEHOLD,
+      issuerId: "chase",
+      cardName: "Card",
+      openDate: "2025-01-01T00:00:00.000Z",
+      creditLimit: 0,
+      annualFee: 0,
+      annualFeeDate: "",
+      promoPeriodMonths: 0,
+      signUpBonus: null,
+      status: "active" as const,
+      notes: "",
+      createdAt: "2025-01-01T00:00:00.000Z",
+      updatedAt: "2025-01-01T00:00:00.000Z",
+    }));
+    mockFetchGet(cards);
+    const { result } = renderHook(() => useCloudSync());
+    await act(async () => {});
+    expect(result.current.cardCount).toBe(7);
+  });
+
+  it("error fields are cleared after successful syncNow", async () => {
+    // First: fail
+    mockFetchGetFail("forbidden");
+    const { result } = renderHook(() => useCloudSync());
+    await act(async () => {});
+    expect(result.current.status).toBe("error");
+    expect(result.current.errorCode).toBe("forbidden");
+
+    // Now: syncNow succeeds
+    mockFetchPut(4);
+    await act(async () => { await result.current.syncNow(); });
+
+    expect(result.current.status).toBe("synced");
+    expect(result.current.errorCode).toBeNull();
+    expect(result.current.errorMessage).toBeNull();
+    expect(result.current.errorTimestamp).toBeNull();
+    expect(result.current.retryIn).toBeNull();
+  });
+});

--- a/development/frontend/src/__tests__/sync/sync-route-edge-cases.loki.test.ts
+++ b/development/frontend/src/__tests__/sync/sync-route-edge-cases.loki.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Loki QA — /api/sync route edge cases (issue #1119)
+ *
+ * Gaps NOT covered by the main sync.test.ts:
+ *   - PUT /api/sync: 404 when user record not found in Firestore
+ *   - PUT /api/sync: large batch (500+ cards) — all written when all are new
+ *   - PUT /api/sync: large batch mixed (250 newer + 250 older) — correct counts
+ *   - GET /api/sync: response shape includes all required fields
+ *   - PUT /api/sync: empty card array → written:0, skipped:0 (no setCards call)
+ *
+ * Issue #1119
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { NextRequest } from "next/server";
+import type { Card } from "@/lib/types";
+
+// ── Mock requireAuth ───────────────────────────────────────────────────────────
+
+const mockRequireAuth = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/auth/require-auth", () => ({
+  requireAuth: (req: NextRequest) => mockRequireAuth(req),
+}));
+
+// ── Mock Firestore ─────────────────────────────────────────────────────────────
+
+const mockGetUser = vi.hoisted(() => vi.fn());
+const mockGetCards = vi.hoisted(() => vi.fn());
+const mockSetCards = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/firebase/firestore", () => ({
+  getUser: (id: string) => mockGetUser(id),
+  getCards: (hid: string) => mockGetCards(hid),
+  setCards: (cards: Card[]) => mockSetCards(cards),
+}));
+
+// ── Mock entitlement store ─────────────────────────────────────────────────────
+
+const mockGetStripeEntitlement = vi.hoisted(() => vi.fn());
+vi.mock("@/lib/kv/entitlement-store", () => ({
+  getStripeEntitlement: (sub: string) => mockGetStripeEntitlement(sub),
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+
+import { GET, PUT } from "@/app/api/sync/route";
+
+// ── Constants ──────────────────────────────────────────────────────────────────
+
+const TEST_USER_SUB = "google-sub-loki-edge";
+const TEST_HOUSEHOLD_ID = "household-loki-edge";
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+function makeGetRequest(): NextRequest {
+  return new NextRequest("http://localhost/api/sync", { method: "GET" });
+}
+
+function makePutRequest(body: unknown): NextRequest {
+  return new NextRequest("http://localhost/api/sync", {
+    method: "PUT",
+    body: JSON.stringify(body),
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function makeCard(id: string, updatedAt: string, householdId = TEST_HOUSEHOLD_ID): Card {
+  return {
+    id,
+    householdId,
+    issuerId: "amex",
+    cardName: "Gold Card",
+    openDate: "2025-01-01T00:00:00.000Z",
+    creditLimit: 500000,
+    annualFee: 25000,
+    annualFeeDate: "2026-01-01T00:00:00.000Z",
+    promoPeriodMonths: 0,
+    signUpBonus: null,
+    status: "active",
+    notes: "",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt,
+  };
+}
+
+function authSuccess(): void {
+  mockRequireAuth.mockResolvedValue({
+    ok: true,
+    user: { sub: TEST_USER_SUB, email: "loki@test.com", name: "Loki" },
+  });
+}
+
+function karlEntitlement(): void {
+  mockGetStripeEntitlement.mockResolvedValue({ tier: "karl", active: true, stripeCustomerId: "cus_loki" });
+}
+
+function userExists(): void {
+  mockGetUser.mockResolvedValue({
+    clerkUserId: TEST_USER_SUB,
+    householdId: TEST_HOUSEHOLD_ID,
+    email: "loki@test.com",
+    displayName: "Loki",
+    role: "owner",
+    createdAt: "2025-01-01T00:00:00.000Z",
+    updatedAt: "2025-01-01T00:00:00.000Z",
+  });
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  authSuccess();
+  karlEntitlement();
+});
+
+// ── PUT 404: user not found ────────────────────────────────────────────────────
+
+describe("PUT /api/sync — 404 when user not in Firestore", () => {
+  it("returns 404 when getUser returns null", async () => {
+    mockGetUser.mockResolvedValue(null);
+    const res = await PUT(makePutRequest({ cards: [] }));
+    expect(res.status).toBe(404);
+    const body = await res.json() as { error: string };
+    expect(body.error).toBe("user_not_found");
+  });
+
+  it("does not call getCards when user not found", async () => {
+    mockGetUser.mockResolvedValue(null);
+    await PUT(makePutRequest({ cards: [makeCard("c1", "2025-06-01T00:00:00.000Z")] }));
+    expect(mockGetCards).not.toHaveBeenCalled();
+  });
+
+  it("does not call setCards when user not found", async () => {
+    mockGetUser.mockResolvedValue(null);
+    await PUT(makePutRequest({ cards: [makeCard("c1", "2025-06-01T00:00:00.000Z")] }));
+    expect(mockSetCards).not.toHaveBeenCalled();
+  });
+});
+
+// ── Large batch: 500+ cards ────────────────────────────────────────────────────
+
+describe("PUT /api/sync — large batch (500+ cards)", () => {
+  beforeEach(() => {
+    userExists();
+    mockSetCards.mockResolvedValue(undefined);
+  });
+
+  it("writes all 500 new cards when Firestore is empty", async () => {
+    mockGetCards.mockResolvedValue([]); // empty Firestore
+
+    const cards = Array.from({ length: 500 }, (_, i) =>
+      makeCard(`card-${i}`, "2025-06-01T00:00:00.000Z")
+    );
+
+    const res = await PUT(makePutRequest({ cards }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { written: number; skipped: number };
+    expect(body.written).toBe(500);
+    expect(body.skipped).toBe(0);
+    expect(mockSetCards).toHaveBeenCalledTimes(1);
+    // setCards called with all 500 cards
+    const writtenCards = (mockSetCards.mock.calls[0] as [Card[]])[0];
+    expect(writtenCards).toHaveLength(500);
+  });
+
+  it("correctly splits written/skipped in 500-card mixed batch", async () => {
+    const BATCH_SIZE = 500;
+    const NEWER_COUNT = 250;
+    const OLDER_COUNT = 250;
+
+    // Firestore has older versions of all 500 cards
+    const existingCards = Array.from({ length: BATCH_SIZE }, (_, i) =>
+      makeCard(`card-${i}`, "2025-01-01T00:00:00.000Z")
+    );
+    mockGetCards.mockResolvedValue(existingCards);
+
+    // Submit: first 250 are newer (will be written), last 250 are older (will be skipped)
+    const submitted = [
+      ...Array.from({ length: NEWER_COUNT }, (_, i) =>
+        makeCard(`card-${i}`, "2025-12-01T00:00:00.000Z") // newer → write
+      ),
+      ...Array.from({ length: OLDER_COUNT }, (_, i) =>
+        makeCard(`card-${NEWER_COUNT + i}`, "2024-01-01T00:00:00.000Z") // older → skip
+      ),
+    ];
+
+    const res = await PUT(makePutRequest({ cards: submitted }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { written: number; skipped: number };
+    expect(body.written).toBe(NEWER_COUNT);
+    expect(body.skipped).toBe(OLDER_COUNT);
+  });
+
+  it("all 500 cards skipped when all are older than Firestore versions", async () => {
+    const existingCards = Array.from({ length: 500 }, (_, i) =>
+      makeCard(`card-${i}`, "2025-12-01T00:00:00.000Z") // latest in Firestore
+    );
+    mockGetCards.mockResolvedValue(existingCards);
+
+    const submitted = Array.from({ length: 500 }, (_, i) =>
+      makeCard(`card-${i}`, "2024-01-01T00:00:00.000Z") // all older
+    );
+
+    const res = await PUT(makePutRequest({ cards: submitted }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { written: number; skipped: number };
+    expect(body.written).toBe(0);
+    expect(body.skipped).toBe(500);
+    expect(mockSetCards).not.toHaveBeenCalled();
+  });
+});
+
+// ── GET response shape ─────────────────────────────────────────────────────────
+
+describe("GET /api/sync — response shape", () => {
+  beforeEach(() => {
+    userExists();
+  });
+
+  it("response includes householdId, cards, and syncedAt", async () => {
+    mockGetCards.mockResolvedValue([makeCard("c1", "2025-06-01T00:00:00.000Z")]);
+    const res = await GET(makeGetRequest());
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { householdId: string; cards: Card[]; syncedAt: string };
+    expect(typeof body.householdId).toBe("string");
+    expect(Array.isArray(body.cards)).toBe(true);
+    expect(typeof body.syncedAt).toBe("string");
+    expect(new Date(body.syncedAt).getTime()).toBeGreaterThan(0);
+  });
+
+  it("syncedAt is a valid ISO 8601 timestamp", async () => {
+    mockGetCards.mockResolvedValue([]);
+    const res = await GET(makeGetRequest());
+    const body = await res.json() as { syncedAt: string };
+    const ts = new Date(body.syncedAt);
+    expect(isNaN(ts.getTime())).toBe(false);
+    expect(body.syncedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+});
+
+// ── PUT empty card array ───────────────────────────────────────────────────────
+
+describe("PUT /api/sync — empty card array", () => {
+  beforeEach(() => {
+    userExists();
+    mockGetCards.mockResolvedValue([]);
+    mockSetCards.mockResolvedValue(undefined);
+  });
+
+  it("returns 200 with written:0, skipped:0 for empty cards array", async () => {
+    const res = await PUT(makePutRequest({ cards: [] }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json() as { written: number; skipped: number; householdId: string; syncedAt: string };
+    expect(body.written).toBe(0);
+    expect(body.skipped).toBe(0);
+    expect(body.householdId).toBe(TEST_HOUSEHOLD_ID);
+    expect(body.syncedAt).toBeDefined();
+  });
+
+  it("does not call setCards when cards array is empty", async () => {
+    await PUT(makePutRequest({ cards: [] }));
+    expect(mockSetCards).not.toHaveBeenCalled();
+  });
+});
+
+// ── PUT householdId enforcement on large batch ─────────────────────────────────
+
+describe("PUT /api/sync — householdId enforcement on all written cards", () => {
+  beforeEach(() => {
+    userExists();
+    mockGetCards.mockResolvedValue([]);
+    mockSetCards.mockResolvedValue(undefined);
+  });
+
+  it("all written cards have the user's householdId (not the submitted householdId)", async () => {
+    const cards = Array.from({ length: 10 }, (_, i) =>
+      makeCard(`card-${i}`, "2025-06-01T00:00:00.000Z", "wrong-household-from-client")
+    );
+
+    await PUT(makePutRequest({ cards }));
+
+    const writtenCards = (mockSetCards.mock.calls[0] as [Card[]])[0];
+    for (const card of writtenCards) {
+      expect(card.householdId).toBe(TEST_HOUSEHOLD_ID);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

PR for issue: #1119

- GET/PUT `/api/sync` routes: Karl-only gating, last-write-wins via `updatedAt`, householdId enforcement
- `useCloudSync` hook: on-mount pull, `syncNow()`, background push (2s debounce), offline/online state, auto-retry after 120s
- `storage.ts`: write operations dispatch `fenrir:cards-changed`; `setAllCards` does NOT (prevents sync loop)
- Stripe webhook: `checkout.session.completed`, `subscription.updated`, `subscription.deleted` sync `household.tier` to Firestore (best-effort)

## Test Results

**Vitest:** 1871/1871 passing (123 test files)
**New tests (Loki):** 24 new tests in `src/__tests__/sync/`
  - `sync-route-edge-cases.loki.test.ts`: PUT 404 user-not-found, 500+ card batch scenarios, response shape, empty array, householdId enforcement on batch
  - `sync-hook-advanced.loki.test.ts`: initial null state, syncNow() offline no-op, auto-retry (error→synced, error→error), cards-changed ignored when offline, debounce collapse to single PUT, success field clearing

**tsc:** PASS

**QA Finding:** GET/PUT `/api/sync` lack try-catch around Firestore calls — uncaught Firestore errors propagate as unhandled rejections instead of explicit 500 responses. In production Next.js converts these to 500s, but explicit error handling would improve observability.

## Test plan

- [x] Karl user: GET returns Firestore cards; PUT applies last-write-wins
- [x] Thrall user: 403 on both routes
- [x] Unauthenticated: 401 on both routes
- [x] 500+ card batch: correct written/skipped counts
- [x] householdId enforcement on all written cards
- [x] Auto-retry after 120s error window
- [x] syncNow() no-op when offline
- [x] Stripe webhook tier sync: karl→karl, thrall→free, best-effort on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)