### PR TITLE
chore: agents must run full Vitest suite before handoff

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -121,13 +121,14 @@ After every logical chunk of implementation work (~5-10 min or 1-3 files changed
 Do NOT batch all changes into one commit at the end. Sessions can die at any time —
 uncommitted work is lost work.
 
-VERIFY — tsc + build ONLY (UNBREAKABLE):
-Agents run tsc and build. The FULL test suite runs via CI on every PR push.
-Do NOT run `verify.sh --step test` for the full suite — CI is the authority.
-Loki runs only his NEW feature tests, not the full suite.
+VERIFY — tsc + build + Vitest (UNBREAKABLE):
+All agents run tsc, build, AND the full Vitest suite before handoff.
+Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
   cd /workspace/repo && bash quality/scripts/verify.sh --step tsc
   cd /workspace/repo && bash quality/scripts/verify.sh --step build
+  cd /workspace/repo/development/frontend && npx vitest run --reporter=verbose
 On failure: fix, commit+push, re-run that step. Repeat until green.
+Do NOT proceed to handoff with ANY failing Vitest tests.
 
 NO MONITOR-UI TESTS (UNBREAKABLE):
 NEVER write tests for `development/monitor-ui/` (Odin's Throne). It has NO test

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -50,11 +50,13 @@ Then create your todo list via TodoWrite. Every todo below is required:
 - **NEVER write tests for monitor-ui (Odin's Throne).** `development/monitor-ui/` has NO test
   infrastructure — no vitest, no testing-library, no __tests__/ directory. Tests are frontend-only.
 
-**Step 4 — Full verify: tsc + build (each = separate Bash tool call + separate todo):**
+**Step 4 — Full verify: tsc + build + Vitest (each = separate Bash tool call + separate todo):**
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step tsc
   cd <REPO_ROOT> && bash quality/scripts/verify.sh --step build
-On failure: fix, commit+push, re-run that step. Repeat until green.
-Do NOT run tests — the full test suite runs via CI on PR push.
+  cd <REPO_ROOT>/development/frontend && npx vitest run --reporter=verbose
+On failure: fix ALL failing tests (yours AND pre-existing), commit+push, re-run.
+Do NOT proceed to handoff with ANY failing Vitest tests.
+Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
 Update each verify todo as you complete it.
 
 **Step 5 — Rebase + final push:**

--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -30,13 +30,14 @@ After every logical chunk of implementation work (~5-10 min or 1-3 files changed
 Do NOT batch all changes into one commit at the end. Sessions can die at any time —
 uncommitted work is lost work.
 
-VERIFY — tsc + build ONLY (UNBREAKABLE):
-Agents run tsc and build. The FULL test suite runs via CI on every PR push.
-Do NOT run `verify.sh --step test` for the full suite — CI is the authority.
-Loki runs only his NEW feature tests, not the full suite.
+VERIFY — tsc + build + Vitest (UNBREAKABLE):
+All agents run tsc, build, AND the full Vitest suite before handoff.
+Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
   cd /workspace/repo && bash quality/scripts/verify.sh --step tsc
   cd /workspace/repo && bash quality/scripts/verify.sh --step build
+  cd /workspace/repo/development/frontend && npx vitest run --reporter=verbose
 On failure: fix, commit+push, re-run that step. Repeat until green.
+Do NOT proceed to handoff with ANY failing Vitest tests.
 
 STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,


### PR DESCRIPTION
## Summary
- All agents now run the full Vitest suite (not just tsc + build) before handoff
- Prevents runtime test failures from reaching CI after FiremanDecko hands off to Loki
- Playwright E2E still banned from agent sessions (runs via CI only)
- Updated: sandbox preamble, FiremanDecko template, dispatch SKILL.md embedded preamble

🤖 Generated with [Claude Code](https://claude.com/claude-code)