### PR TITLE
fix: rename Firestore database to fenrir-ledger-prod

### DIFF
--- a/development/frontend/src/lib/firebase/firestore.ts
+++ b/development/frontend/src/lib/firebase/firestore.ts
@@ -48,7 +48,8 @@ export function getFirestore(): Firestore {
     );
   }
 
-  _firestore = new Firestore({ projectId });
+  const databaseId = process.env.FIRESTORE_DATABASE_ID || "(default)";
+  _firestore = new Firestore({ projectId, databaseId });
   return _firestore;
 }
 

--- a/infrastructure/firestore.tf
+++ b/infrastructure/firestore.tf
@@ -9,9 +9,9 @@
 # are version-controlled alongside the rest of the infrastructure.
 # --------------------------------------------------------------------------
 
-resource "google_firestore_database" "default" {
+resource "google_firestore_database" "main" {
   project     = var.project_id
-  name        = "(default)"
+  name        = "fenrir-ledger-prod"
   location_id = var.region
   type        = "FIRESTORE_NATIVE"
 
@@ -60,5 +60,5 @@ resource "google_firebaserules_release" "firestore" {
   name         = "cloud.firestore"
   ruleset_name = google_firebaserules_ruleset.firestore.name
 
-  depends_on = [google_firestore_database.default]
+  depends_on = [google_firestore_database.main]
 }

--- a/infrastructure/helm/fenrir-app/values.yaml
+++ b/infrastructure/helm/fenrir-app/values.yaml
@@ -24,6 +24,7 @@ app:
     PORT: "3000"
     HOSTNAME: "0.0.0.0"
     FIRESTORE_PROJECT_ID: "fenrir-ledger-prod"
+    FIRESTORE_DATABASE_ID: "fenrir-ledger-prod"
     NEXT_PUBLIC_UMAMI_WEBSITE_ID: "ce25059e-57c4-44f9-ad92-389d2bd15e4d"
 
   resources:

--- a/infrastructure/k8s/app/deployment.yaml
+++ b/infrastructure/k8s/app/deployment.yaml
@@ -58,6 +58,8 @@ spec:
               value: "redis://redis.fenrir-app.svc.cluster.local:6379"
             - name: FIRESTORE_PROJECT_ID
               value: "fenrir-ledger-prod"
+            - name: FIRESTORE_DATABASE_ID
+              value: "fenrir-ledger-prod"
             # Umami analytics — public website ID (non-secret, safe for NEXT_PUBLIC_).
             # Set to the UUID from https://analytics.fenrirledger.com → Websites.
             # Leave empty or unset to disable analytics in this environment.

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -65,7 +65,7 @@ output "dns_nameservers" {
 
 output "firestore_database_name" {
   description = "Firestore database name"
-  value       = google_firestore_database.default.name
+  value       = google_firestore_database.main.name
 }
 
 output "firestore_project_id" {


### PR DESCRIPTION
## Summary
- Renamed Firestore database from `(default)` to `fenrir-ledger-prod`
- Deleted old `(default)` database via gcloud CLI (was empty, created today)
- Created new `fenrir-ledger-prod` database via gcloud CLI
- Updated Terraform, Helm values, deployment.yaml, and Firestore client
- Client falls back to `(default)` if `FIRESTORE_DATABASE_ID` is unset

## Test plan
- [ ] Verify `gcloud firestore databases list --project=fenrir-ledger-prod` shows `fenrir-ledger-prod`
- [ ] Verify app pods pick up `FIRESTORE_DATABASE_ID` env var after deploy
- [ ] Verify Firestore operations work with named database

🤖 Generated with [Claude Code](https://claude.com/claude-code)