### PR TITLE
Issue #1169 - fix: Odin profile image and theme in monitor popup

### DIFF
--- a/development/monitor-ui/src/lib/constants.ts
+++ b/development/monitor-ui/src/lib/constants.ts
@@ -27,12 +27,12 @@ export const AGENT_TITLES: Record<string, string> = {
 };
 
 export const AGENT_AVATARS: Record<string, string> = {
-  firemandecko: "/agents/fireman-decko-dark.png",
-  loki: "/agents/loki-dark.png",
-  luna: "/agents/luna-dark.png",
-  freya: "/agents/freya-dark.png",
-  heimdall: "/agents/heimdall-dark.png",
-  odin: "/agents/odin-dark.png",
+  firemandecko: "/profiles/fireman-decko-dark.png",
+  loki: "/profiles/loki-dark.png",
+  luna: "/profiles/luna-dark.png",
+  freya: "/profiles/freya-dark.png",
+  heimdall: "/profiles/heimdall-dark.png",
+  odin: "/profiles/odin-dark.png",
 };
 
 export const AGENT_LIGHT_AVATARS: Record<string, string> = {


### PR DESCRIPTION
PR for issue: #1169

Fix Odin agent popup: correct profile image and add light/dark theme adaptation.

## Root Cause

`AGENT_AVATARS` in `constants.ts` pointed to `/agents/*-dark.png` (placeholder runic circle art) instead of `/profiles/*-dark.png` (the actual profile artwork). `AGENT_LIGHT_AVATARS` already used the correct `/profiles/` path. The theme-switching logic in `AgentProfileModal` and CSS variable adaptation were already correct — only the asset paths were wrong.

## What Changed

- `development/monitor-ui/src/lib/constants.ts` — updated all 6 `AGENT_AVATARS` entries from `/agents/*-dark.png` → `/profiles/*-dark.png`

## Verification

- Click Odin agent in monitor UI — correct profile image shown (not the runic circle placeholder)
- Toggle theme — popup background and image adapt to light/dark (CSS variables already handled this)
- All other agent popups (FiremanDecko, Loki, Luna, Freya, Heimdall) now also show correct dark profile images

**Build:** tsc PASS + next build PASS (43 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)