### PR TITLE
fix: restore CSP nonce for Next.js RSC inline scripts — issue #1184

### DIFF
--- a/development/frontend/next.config.ts
+++ b/development/frontend/next.config.ts
@@ -6,13 +6,13 @@ import { CACHE_CONTROL } from "./src/lib/cache-headers";
 /**
  * Next.js Configuration
  *
- * Security headers are set as static response headers via headers() so that
- * Cloud CDN can cache HTML pages. Hash-based CSP (pre-computed at build time
- * by scripts/compute-csp-hashes.mjs) keeps the Content-Security-Policy header
- * identical across all requests — a requirement for CDN caching.
+ * Non-CSP security headers are set as static response headers via headers().
+ * CSP is set per-request in middleware (src/middleware.ts) with a nonce for
+ * Next.js RSC inline scripts + hashes for known static inline scripts.
  *
- * Previously, CSP was injected per-request in middleware with a unique nonce.
- * That approach prevented CDN caching (Issue #1144). See ADR for the migration.
+ * Issue #1184: Pure hash-based CSP (Issue #1144) broke Next.js RSC streaming
+ * because dynamic inline <script> tags can't be pre-hashed. Restored nonce
+ * in middleware while keeping hashes for known static scripts.
  */
 
 const nextConfig: NextConfig = {
@@ -24,14 +24,14 @@ const nextConfig: NextConfig = {
   // in parent directories. This is the frontend directory itself.
   outputFileTracingRoot: __dirname,
 
-  // Static security headers — same on every response, enabling CDN caching.
-  // Middleware (src/middleware.ts) handles only canonical redirects.
+  // Non-CSP security headers — static, same on every response.
+  // CSP is set per-request in middleware (needs nonce for RSC scripts).
   async headers() {
     const securityHeaders = buildSecurityHeaders();
     return [
       {
-        // Security headers — apply to all routes except Next.js internals and
-        // static assets. Mirrors the middleware matcher pattern.
+        // Non-CSP security headers — apply to all routes except Next.js internals
+        // and static assets. CSP is set in middleware, not here.
         source:
           "/((?!_next/static|_next/image|favicon.ico|icon.svg|.*\\.(?:svg|png|jpg|jpeg|gif|webp)$).*)",
         headers: securityHeaders,

--- a/development/frontend/src/__tests__/lib/csp-hashes-generated.test.ts
+++ b/development/frontend/src/__tests__/lib/csp-hashes-generated.test.ts
@@ -63,14 +63,10 @@ describe("buildCspDirectives — determinism for CDN caching", () => {
     expect(second).toBe(third);
   });
 
-  it("buildSecurityHeaders CSP value is deterministic across calls", async () => {
-    const { buildSecurityHeaders } = await import("@/lib/csp-headers");
-    const csp1 = buildSecurityHeaders().find(
-      (h) => h.key === "Content-Security-Policy"
-    )!.value;
-    const csp2 = buildSecurityHeaders().find(
-      (h) => h.key === "Content-Security-Policy"
-    )!.value;
+  it("buildCspDirectives with same nonce is deterministic", async () => {
+    const { buildCspDirectives } = await import("@/lib/csp-headers");
+    const csp1 = buildCspDirectives("fixed-nonce").join("; ");
+    const csp2 = buildCspDirectives("fixed-nonce").join("; ");
     expect(csp1).toBe(csp2);
   });
 });
@@ -96,10 +92,8 @@ describe("buildCspDirectives — script-src structure", () => {
   });
 
   it("full CSP string uses semicolons as directive separators", async () => {
-    const { buildSecurityHeaders } = await import("@/lib/csp-headers");
-    const csp = buildSecurityHeaders().find(
-      (h) => h.key === "Content-Security-Policy"
-    )!.value;
+    const { buildCspDirectives } = await import("@/lib/csp-headers");
+    const csp = buildCspDirectives().join("; ");
     // Directives must be '; ' separated for browser compliance
     expect(csp).toContain("; ");
     expect(csp.split("; ").length).toBeGreaterThan(5);

--- a/development/frontend/src/__tests__/lib/csp-headers.test.ts
+++ b/development/frontend/src/__tests__/lib/csp-headers.test.ts
@@ -37,11 +37,18 @@ describe("buildCspDirectives — hash-based CSP", () => {
     expect(scriptSrc).toMatch(/'sha256-[A-Za-z0-9+/=]+=?'/);
   });
 
-  it("script-src does NOT contain 'nonce-' (no per-request nonce)", () => {
+  it("script-src does NOT contain nonce when called without one", () => {
     const scriptSrc = buildCspDirectives().find((d) =>
       d.startsWith("script-src")
     );
     expect(scriptSrc).not.toContain("nonce-");
+  });
+
+  it("script-src contains nonce when one is provided", () => {
+    const scriptSrc = buildCspDirectives("test-nonce-123").find((d) =>
+      d.startsWith("script-src")
+    );
+    expect(scriptSrc).toContain("'nonce-test-nonce-123'");
   });
 
   it("script-src does NOT contain 'unsafe-inline' in production", () => {
@@ -110,17 +117,10 @@ describe("buildSecurityHeaders", () => {
     }
   });
 
-  it("includes Content-Security-Policy header", () => {
+  it("does NOT include Content-Security-Policy (CSP is set per-request in middleware)", () => {
     const headers = buildSecurityHeaders();
     const csp = headers.find((h) => h.key === "Content-Security-Policy");
-    expect(csp).toBeDefined();
-    expect(csp!.value).toContain("default-src 'self'");
-  });
-
-  it("CSP header has no nonce", () => {
-    const headers = buildSecurityHeaders();
-    const csp = headers.find((h) => h.key === "Content-Security-Policy");
-    expect(csp!.value).not.toContain("nonce-");
+    expect(csp).toBeUndefined();
   });
 
   it("includes X-Frame-Options: DENY", () => {

--- a/development/frontend/src/lib/csp-headers.ts
+++ b/development/frontend/src/lib/csp-headers.ts
@@ -39,18 +39,31 @@ const GOOGLE_PICKER_SCRIPT_HASHES = [
  * - data: URIs for fonts (some Google Fonts use data: encoding)
  * - Google Picker inline scripts via SHA-256 hash allowlist (Issue #527)
  */
-export function buildCspDirectives(): string[] {
+export function buildCspDirectives(nonce?: string): string[] {
   return [
     // Default: only same-origin
     "default-src 'self'",
 
-    // Scripts: self + inline script hashes + Google Picker hashes + allowed CDNs
+    // Scripts: self + nonce (for Next.js RSC inline scripts) + hashes (for known
+    // static inline scripts like next-themes) + Google Picker hashes + allowed CDNs.
+    //
+    // Why both nonce AND hashes? (Issue #1184)
+    // Next.js App Router streams RSC data as dynamic inline <script> tags whose
+    // content varies per request — they cannot be pre-hashed. A per-request nonce
+    // covers these. Known static inline scripts (next-themes, GA4 init) use hashes
+    // so they work even if rendered outside middleware (e.g. static generation).
+    //
+    // CDN impact: the nonce makes CSP vary per request, but only for HTML pages.
+    // Static assets (/_next/static/*) bypass middleware and get immutable caching.
+    // Marketing pages get s-maxage via Cache-Control (CDN caches the response body
+    // and strips/replaces CSP on cache hit if configured, or serves origin headers).
+    //
     // In development, Next.js HMR / React Fast Refresh requires 'unsafe-eval'.
-    // Inline script hashes replace the previous per-request nonce (Issue #1144).
     // Google Picker inline script hashes are allowlisted for Issue #527.
     // https://www.googletagmanager.com is required for the external GA4 loader script.
     [
       "script-src 'self'",
+      ...(nonce ? [`'nonce-${nonce}'`] : []),
       ...INLINE_SCRIPT_HASHES,
       ...(process.env.NODE_ENV !== "production" ? ["'unsafe-eval'"] : []),
       ...GOOGLE_PICKER_SCRIPT_HASHES,
@@ -105,16 +118,9 @@ export interface SecurityHeader {
   value: string;
 }
 
-/** Security headers applied to every response. */
+/** Security headers applied to every response (excludes CSP — set by middleware). */
 export function buildSecurityHeaders(): SecurityHeader[] {
-  const cspDirectives = buildCspDirectives();
-  const ContentSecurityPolicy = cspDirectives.join("; ");
-
   return [
-    {
-      key: "Content-Security-Policy",
-      value: ContentSecurityPolicy,
-    },
     {
       key: "X-Frame-Options",
       value: "DENY",

--- a/development/frontend/src/middleware.ts
+++ b/development/frontend/src/middleware.ts
@@ -14,16 +14,20 @@
  *  - The guard verifies the Google id_token JWT against Google's JWKS public keys.
  *  - /api/auth/token is exempt (token exchange endpoint -- no token exists yet).
  *
- * CSP (Issue #1144):
- *  - Nonce-based CSP has been replaced with hash-based CSP for CDN compatibility.
- *  - Security headers are now set as static headers in next.config.ts via headers().
- *  - This middleware no longer generates nonces or sets CSP headers.
+ * CSP (Issue #1184 — fix for #1144):
+ *  - Hybrid nonce + hash CSP. A per-request nonce covers Next.js RSC inline
+ *    scripts (dynamic, can't be pre-hashed). Pre-computed hashes cover known
+ *    static inline scripts (next-themes, GA4 init).
+ *  - The nonce is set on the request headers so Next.js can read it and attach
+ *    it to RSC streaming <script> tags.
+ *  - Non-CSP security headers remain as static headers in next.config.ts.
  *
  * See ADR-005 for the auth architecture. See ADR-008 for API route auth.
  */
 
 import { NextRequest, NextResponse } from "next/server";
 import { getCacheControlForPath } from "@/lib/cache-headers";
+import { buildCspDirectives } from "@/lib/csp-headers";
 
 export function middleware(request: NextRequest) {
   const { hostname, protocol, pathname, search } = request.nextUrl;
@@ -44,16 +48,42 @@ export function middleware(request: NextRequest) {
   }
 
   // -----------------------------------------------------------------------
+  // CSP with per-request nonce — Issue #1184 (fix for #1144)
+  //
+  // Next.js App Router streams RSC data as inline <script> tags whose content
+  // varies per request. These cannot be pre-hashed. A per-request nonce covers
+  // them. Next.js reads the nonce from the request's Content-Security-Policy
+  // header and attaches it to all inline <script> tags it generates.
+  //
+  // Known static inline scripts (next-themes, GA4 init) also get hashes so
+  // they work regardless of nonce presence.
+  // -----------------------------------------------------------------------
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const cspDirectives = buildCspDirectives(nonce);
+  const cspHeaderValue = cspDirectives.join("; ");
+
+  // Set CSP on request headers so Next.js can read the nonce
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("Content-Security-Policy", cspHeaderValue);
+
+  const response = NextResponse.next({
+    request: { headers: requestHeaders },
+  });
+
+  // Set CSP on response headers for the browser to enforce
+  response.headers.set("Content-Security-Policy", cspHeaderValue);
+
+  // -----------------------------------------------------------------------
   // Cache-Control headers — Issue #1145
   // Apply per-route CDN TTL rules. Static asset paths (_next/static,
   // _next/image, ico/svg/png) are excluded from the middleware matcher and
   // get their Cache-Control from next.config.ts headers() instead.
   // -----------------------------------------------------------------------
   const cacheControl = getCacheControlForPath(pathname);
-  const response = NextResponse.next();
   if (cacheControl) {
     response.headers.set("Cache-Control", cacheControl);
   }
+
   return response;
 }
 


### PR DESCRIPTION
PR for issue: #1184

## Summary

Pure hash-based CSP (#1144) broke all page rendering because Next.js App Router streams RSC data as dynamic inline `<script>` tags (`self.__next_f.push(...)`) whose content varies per request — they cannot be pre-hashed. 17/20 E2E tests failed with "element(s) not found" because pages never rendered.

**Fix:** Restore per-request nonce generation in middleware. Hybrid approach:
- **Nonce** (per-request) covers Next.js RSC inline scripts
- **Hashes** (static) cover known inline scripts (next-themes, GA4 init)
- Non-CSP security headers remain as static headers in `next.config.ts`

## Changes

- `src/middleware.ts` — Generate nonce, set CSP on request headers (for Next.js to read) and response headers (for browser enforcement)
- `src/lib/csp-headers.ts` — `buildCspDirectives(nonce?)` accepts optional nonce; `buildSecurityHeaders()` no longer includes CSP
- `next.config.ts` — Removed CSP from static headers (now set per-request in middleware)
- Updated Vitest tests to match new signatures

## Verification

- `tsc` — PASS
- `next build` — PASS (45 routes)
- Vitest — 2073/2073 PASS
- E2E should pass once CI runs (pages will render because RSC scripts get nonce)