### PR TITLE
feat: DNS TTL optimization and CDN cutover validation (#1148)

### DIFF
--- a/infrastructure/SMOKE-TEST.md
+++ b/infrastructure/SMOKE-TEST.md
@@ -66,6 +66,109 @@ gcloud monitoring uptime-check-configs list --project=fenrir-ledger-prod
 gcloud alpha monitoring policies list --project=fenrir-ledger-prod
 ```
 
+## 7. CDN Verification
+
+After Cloud CDN is enabled (see `infrastructure/cdn.tf`), validate edge serving:
+
+```bash
+# Run the CDN validation script against production
+node infrastructure/scripts/validate-cdn.mjs
+
+# Or target a specific domain (e.g. staging)
+node infrastructure/scripts/validate-cdn.mjs --base-url https://fenrirledger.com
+```
+
+### What the script checks
+
+| URL | Expected `x-goog-cache-status` |
+|-----|-------------------------------|
+| `fenrirledger.com/` | `HIT` (after warm request) |
+| `fenrirledger.com/_next/static/chunks/main.js` | `HIT` |
+| `fenrirledger.com/_next/static/css/app.css` | `HIT` |
+| `fenrirledger.com/api/health` | `MISS` / absent (uncacheable) |
+| `fenrirledger.com/api/auth/token` | `MISS` / absent (uncacheable) |
+
+Possible `x-goog-cache-status` values from Google Cloud CDN:
+
+| Value | Meaning |
+|-------|---------|
+| `HIT` | Served from CDN edge cache |
+| `MISS` | Cache miss — fetched from origin |
+| `REVALIDATED` | Stale entry revalidated with origin |
+| `STALE` | Served stale while revalidating in background |
+
+### Manual header inspection
+
+```bash
+# Check a single URL
+curl -sI https://fenrirledger.com/ | grep -i x-goog-cache-status
+
+# Check static asset (replace BUILD_ID with output of: kubectl exec ... -- cat /app/.next/BUILD_ID)
+curl -sI "https://fenrirledger.com/_next/static/chunks/main.js" | grep -i x-goog-cache-status
+
+# API route must NOT show HIT
+curl -sI https://fenrirledger.com/api/health | grep -i x-goog-cache-status
+```
+
+---
+
+## CDN Rollback Runbook
+
+If CDN is causing issues (stale content, incorrect caching, errors), follow these steps:
+
+### Option A — Disable CDN in Helm (recommended, fastest)
+
+```bash
+# 1. Edit the Helm values to disable CDN
+#    Set cdn.enabled: false in infrastructure/k8s/helm/values.yaml
+
+# 2. Apply the Helm upgrade
+helm upgrade fenrir-app infrastructure/k8s/helm/ \
+  --namespace fenrir-app \
+  --reuse-values \
+  --set cdn.enabled=false
+
+# 3. Verify BackendConfig no longer has CDN block
+kubectl get backendconfig -n fenrir-app -o yaml | grep -A5 cdn
+```
+
+### Option B — Edit BackendConfig directly (emergency)
+
+```bash
+# Patch the BackendConfig to remove CDN settings
+kubectl patch backendconfig fenrir-app -n fenrir-app \
+  --type=json \
+  -p='[{"op": "remove", "path": "/spec/cdn"}]'
+
+# Confirm the patch applied
+kubectl get backendconfig fenrir-app -n fenrir-app -o yaml
+```
+
+### Option C — DNS-level rollback (nuclear, last resort)
+
+Because DNS TTLs are set to 60s (pre-CDN safety setting), DNS propagates within ~1 minute.
+
+```bash
+# 1. Update dns.tf to point to a backup IP or remove CDN-fronted IP
+# 2. Apply Terraform
+cd infrastructure && terraform apply -target=google_dns_record_set.apex -target=google_dns_record_set.www
+
+# 3. Wait ~60s for TTL expiry, then verify
+sleep 60 && curl -sI https://fenrirledger.com/ | grep x-goog-cache-status
+```
+
+### Post-rollback validation
+
+```bash
+# Confirm CDN is no longer serving (no HIT headers)
+node infrastructure/scripts/validate-cdn.mjs
+
+# Verify app is still serving correctly
+curl -sk https://fenrirledger.com/api/health | jq .
+```
+
+---
+
 ## Troubleshooting
 
 | Symptom | Check |
@@ -74,3 +177,5 @@ gcloud alpha monitoring policies list --project=fenrir-ledger-prod
 | Pods CrashLoopBackOff | `kubectl logs -n fenrir-app <pod> --previous` |
 | 502 Bad Gateway | Pods not ready yet, or health check path wrong |
 | SSL errors | Expected with IP-based access (no cert for IP); use `-k` flag |
+| CDN serving stale content | Run Option A rollback above, then re-enable after fix |
+| API routes returning `HIT` | Check BackendConfig cache rules — API paths must be excluded |

--- a/infrastructure/dns.tf
+++ b/infrastructure/dns.tf
@@ -68,7 +68,9 @@ resource "google_dns_record_set" "apex" {
   managed_zone = google_dns_managed_zone.app.name
   project      = var.project_id
   type         = "A"
-  ttl          = 300
+  # TTL lowered to 60s pre-CDN for fast DNS-level rollback.
+  # Raise to 3600s after CDN stability is confirmed (issue #1209).
+  ttl = 60
 
   rrdatas = [google_compute_global_address.app_ip.address]
 }
@@ -78,7 +80,9 @@ resource "google_dns_record_set" "www" {
   managed_zone = google_dns_managed_zone.app.name
   project      = var.project_id
   type         = "A"
-  ttl          = 300
+  # TTL lowered to 60s pre-CDN for fast DNS-level rollback.
+  # Raise to 3600s after CDN stability is confirmed (issue #1209).
+  ttl = 60
 
   rrdatas = [google_compute_global_address.app_ip.address]
 }
@@ -105,7 +109,9 @@ resource "google_dns_record_set" "analytics" {
   managed_zone = google_dns_managed_zone.app.name
   project      = var.project_id
   type         = "A"
-  ttl          = 300
+  # TTL lowered to 60s pre-CDN for fast DNS-level rollback.
+  # Raise to 3600s after CDN stability is confirmed (issue #1209).
+  ttl = 60
 
   rrdatas = [google_compute_global_address.umami_ip.address]
 }
@@ -126,7 +132,9 @@ resource "google_dns_record_set" "monitor" {
   managed_zone = google_dns_managed_zone.app.name
   project      = var.project_id
   type         = "A"
-  ttl          = 300
+  # TTL lowered to 60s pre-CDN for fast DNS-level rollback.
+  # Raise to 3600s after CDN stability is confirmed (issue #1209).
+  ttl = 60
 
   rrdatas = [google_compute_global_address.monitor_ip.address]
 }

--- a/infrastructure/scripts/validate-cdn.mjs
+++ b/infrastructure/scripts/validate-cdn.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * validate-cdn.mjs — CDN edge serving validation for Fenrir Ledger
+ *
+ * Checks that Cloud CDN is serving correctly by inspecting the
+ * `x-goog-cache-status` response header for a set of test URLs.
+ *
+ * Expected behaviour:
+ *   - HTML pages        → HIT (after first warm request)
+ *   - Static JS/CSS     → HIT
+ *   - API routes        → MISS or no cache header (uncacheable)
+ *
+ * Usage:
+ *   node infrastructure/scripts/validate-cdn.mjs [--base-url https://fenrirledger.com]
+ *
+ * Exit codes:
+ *   0 — all checks passed
+ *   1 — one or more checks failed
+ */
+
+// --------------------------------------------------------------------------
+// Configuration
+// --------------------------------------------------------------------------
+
+const DEFAULT_BASE_URL = "https://fenrirledger.com";
+
+/** x-goog-cache-status values that indicate a CDN cache hit. */
+const HIT_VALUES = new Set(["HIT", "REVALIDATED", "STALE"]);
+
+/**
+ * @typedef {"HIT" | "MISS" | "UNCACHEABLE"} ExpectedCache
+ *
+ * @typedef {Object} CheckSpec
+ * @property {string}        path          - URL path relative to base URL
+ * @property {ExpectedCache} expected      - Required cache behaviour
+ * @property {string}        description   - Human-readable label for output
+ */
+
+/** @type {CheckSpec[]} */
+const CHECKS = [
+  {
+    path: "/",
+    expected: "HIT",
+    description: "Homepage HTML — should be cached after warm request",
+  },
+  {
+    // Next.js emits a build-ID-stamped manifest; any static chunk works.
+    // The path does not need to exist on disk — CDN serves from GCS/origin.
+    path: "/_next/static/chunks/main.js",
+    expected: "HIT",
+    description: "Static JS chunk — should always be cached",
+  },
+  {
+    path: "/_next/static/css/app.css",
+    expected: "HIT",
+    description: "Static CSS — should always be cached",
+  },
+  {
+    path: "/api/health",
+    expected: "UNCACHEABLE",
+    description: "API health endpoint — must NOT be cached",
+  },
+  {
+    path: "/api/auth/token",
+    expected: "UNCACHEABLE",
+    description: "Auth token endpoint — must NOT be cached",
+  },
+];
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/**
+ * Parse CLI args for --base-url flag.
+ * @returns {string}
+ */
+function resolveBaseUrl() {
+  const idx = process.argv.indexOf("--base-url");
+  if (idx !== -1 && process.argv[idx + 1]) {
+    return process.argv[idx + 1].replace(/\/$/, "");
+  }
+  return DEFAULT_BASE_URL;
+}
+
+/**
+ * Classify a raw x-goog-cache-status header value.
+ * @param {string | null} raw
+ * @returns {ExpectedCache}
+ */
+function classify(raw) {
+  if (!raw) return "UNCACHEABLE";
+  const upper = raw.toUpperCase();
+  return HIT_VALUES.has(upper) ? "HIT" : upper === "MISS" ? "MISS" : "UNCACHEABLE";
+}
+
+/**
+ * Fetch a URL with a warm-up request followed by the validation request.
+ * We do two requests so HTML pages get a chance to be cached on first load.
+ *
+ * @param {string} url
+ * @returns {Promise<{status: number, cacheHeader: string | null, classification: ExpectedCache}>}
+ */
+async function probe(url) {
+  const opts = {
+    method: "GET",
+    redirect: "follow",
+    headers: { "User-Agent": "fenrir-cdn-validator/1.0" },
+  };
+
+  // Warm-up — prime the CDN cache
+  await fetch(url, opts).catch(() => null);
+
+  // Validation request
+  const res = await fetch(url, opts);
+  const cacheHeader = res.headers.get("x-goog-cache-status");
+
+  return {
+    status: res.status,
+    cacheHeader,
+    classification: classify(cacheHeader),
+  };
+}
+
+/**
+ * Check whether the actual classification satisfies the expectation.
+ * UNCACHEABLE expectation accepts MISS or absent header (both mean no caching).
+ *
+ * @param {ExpectedCache} expected
+ * @param {ExpectedCache} actual
+ * @returns {boolean}
+ */
+function passes(expected, actual) {
+  if (expected === "UNCACHEABLE") return actual === "UNCACHEABLE" || actual === "MISS";
+  if (expected === "HIT") return actual === "HIT";
+  if (expected === "MISS") return actual === "MISS";
+  return false;
+}
+
+// --------------------------------------------------------------------------
+// Runner
+// --------------------------------------------------------------------------
+
+async function main() {
+  const baseUrl = resolveBaseUrl();
+  console.log(`\nFenrir CDN Validation — target: ${baseUrl}\n`);
+  console.log("=".repeat(60));
+
+  let failures = 0;
+
+  for (const check of CHECKS) {
+    const url = `${baseUrl}${check.path}`;
+    process.stdout.write(`  Checking ${check.path} … `);
+
+    let result;
+    try {
+      result = await probe(url);
+    } catch (/** @type {unknown} */ err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`ERROR — ${msg}`);
+      failures++;
+      continue;
+    }
+
+    const ok = passes(check.expected, result.classification);
+    const icon = ok ? "✓" : "✗";
+    const raw = result.cacheHeader ?? "(none)";
+    const label = ok ? "PASS" : "FAIL";
+
+    console.log(
+      `${icon} ${label} [HTTP ${result.status}] ` +
+        `x-goog-cache-status: ${raw} (expected: ${check.expected}, got: ${result.classification})`
+    );
+
+    if (!ok) {
+      console.log(`    └─ ${check.description}`);
+      failures++;
+    }
+  }
+
+  console.log("=".repeat(60));
+
+  if (failures === 0) {
+    console.log(`\n✓ All ${CHECKS.length} CDN checks passed.\n`);
+    process.exit(0);
+  } else {
+    console.error(`\n✗ ${failures} of ${CHECKS.length} CDN checks failed.\n`);
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Lower all DNS A record TTLs from 300s → **60s** across apex, www, analytics, and monitor records — enables fast DNS-level rollback during CDN cutover window (TTLs will be raised to 3600s after stability is confirmed, tracked in issue #1209)
- Add `infrastructure/scripts/validate-cdn.mjs` — probes `x-goog-cache-status` response headers across HTML, static assets, and API routes; exits non-zero on any failure
- Update `infrastructure/SMOKE-TEST.md` with CDN verification section and full rollback runbook covering Helm disable, kubectl patch, and DNS-level options

## Test plan

- [ ] `node infrastructure/scripts/validate-cdn.mjs` runs without error (node 20+, no deps)
- [ ] Script output shows PASS for static assets (HIT) and FAIL-correctly for API routes (UNCACHEABLE/MISS)
- [ ] `terraform plan` on `infrastructure/dns.tf` shows TTL change 300 → 60 for all 4 A records
- [ ] `SMOKE-TEST.md` CDN section is readable and rollback steps are complete
- [ ] `tsc --noEmit`: PASS
- [ ] `next build`: PASS

## Closes

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)