### PR TITLE
fix: parse session ID for title when branch has no issue metadata (#1220)

### DIFF
--- a/development/monitor-ui/src/lib/resolveSessionTitle.ts
+++ b/development/monitor-ui/src/lib/resolveSessionTitle.ts
@@ -25,17 +25,43 @@ export function parseBranchTitle(branch: string, step: string): string {
 }
 
 /**
+ * Parse a session ID into a human-readable title.
+ * Session IDs follow the pattern: issue-<N>-step<S>-<agent>-<uuid>
+ *
+ * Examples:
+ *   "issue-1200-step1-firemandecko-fe9c6b6d" → "Issue #1200 – Step 1"
+ *   "issue-987-step2-luna-abc12345"           → "Issue #987 – Step 2"
+ *
+ * Returns null if the session ID does not match the expected pattern.
+ */
+export function parseSessionIdTitle(sessionId: string): string | null {
+  const match = /^issue-(\d+)-step(\d+)-/i.exec(sessionId);
+  if (!match) return null;
+  return `Issue #${match[1]} – Step ${match[2]}`;
+}
+
+/**
  * Resolve the display title for a session using priority order:
  *   1. issueTitle (from K8s annotation fenrir/pr-title or fenrir/issue-title)
- *   2. branchName parse fallback
- *   3. Raw sessionId (existing behavior, graceful degradation)
+ *   2. branchName parse (only if branch contains an issue pattern)
+ *   3. sessionId parse (issue-<N>-step<S>-<agent>-<uuid> pattern)
+ *   4. Raw branchName or sessionId (graceful degradation)
  */
 export function resolveSessionTitle(job: DisplayJob): string {
   if (job.issueTitle) {
     return `Issue #${job.issue} – ${job.issueTitle} – Step ${job.step}`;
   }
   if (job.branchName) {
-    return parseBranchTitle(job.branchName, job.step);
+    const fromBranch = parseBranchTitle(job.branchName, job.step);
+    // parseBranchTitle returns the raw branch name when no issue pattern found
+    if (fromBranch !== job.branchName) {
+      return fromBranch;
+    }
   }
-  return job.sessionId;
+  // Branch had no issue pattern — try to extract from session ID
+  const fromSessionId = parseSessionIdTitle(job.sessionId);
+  if (fromSessionId) {
+    return fromSessionId;
+  }
+  return job.branchName ?? job.sessionId;
 }


### PR DESCRIPTION
## Summary
- `resolveSessionTitle` now falls back to parsing the **session ID** (`issue-<N>-step<S>-<agent>-<uuid>`) when the branch name (e.g. `main`) contains no issue pattern
- Adds `parseSessionIdTitle(sessionId)` — extracts issue number and step from the session ID convention
- Priority order preserved: K8s `issueTitle` annotation → branch parse → session ID parse → raw branch/session ID

## Root Cause
`parseBranchTitle("main", step)` found no `issue-(\d+)` match and returned the raw string `"main"`, which was then displayed as the session title. The session ID already had the correct issue info but was never consulted.

## Test Plan
- [x] `tsc -b` passes with zero errors
- [x] `vite build` produces a clean production bundle
- Session `issue-1200-step1-firemandecko-fe9c6b6d` with `branchName: "main"` → title now shows **"Issue #1200 – Step 1"**
- Session with a proper `fix/issue-987-picker-gate` branch → title unchanged: **"Issue #987 – picker gate – Step 1"**
- Session with K8s `issueTitle` annotation → unchanged, highest priority

Closes #1220

🤖 Generated with [Claude Code](https://claude.com/claude-code)