### PR TITLE
Issue #1217 - docs: sync Heimdall security documentation

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -12,8 +12,9 @@ This directory contains all security documentation for the Fenrir Ledger project
 - **Stripe webhook**: SHA-256 HMAC via `stripe.webhooks.constructEvent()`.
 - **CSP**: Includes all required Google and Stripe domains.
 - **KV store**: Upstash Redis, configured via `KV_REST_API_URL` and `KV_REST_API_TOKEN`.
-- **Firestore sync (NEW — issue #1126)**: **2 CRITICAL IDOR vulnerabilities** in `/api/sync/pull` and `/api/sync/push` — client-supplied `householdId` not verified against auth'd user's household. Issues filed. See report below.
-- **Open findings**: 3 LOW (distributed rate limiting, webhook deduplication, email validation), 3 INFO (trust chain comment, KV delete race, publishable key monitoring).
+- **Firestore sync (issue #1126)**: ~~2 CRITICAL IDOR vulnerabilities~~ → **RESOLVED**. IDOR in `/api/sync/pull` (PR #1203) and `/api/sync/push` (PR #1207) fixed — both routes now derive `householdId` from the server-side user record, not the client. See report below.
+- **Open findings (Firestore audit)**: 1 HIGH (invite validate PII leakage), 3 MEDIUM (no rate limiting on invite/sync routes, Admin SDK bypasses rules), 3 LOW (error handling, entropy docs, tier disclosure), 3 INFO (emulator-only rules, soft-delete, no collection group).
+- **Open findings (older reports)**: 3 LOW (distributed rate limiting, webhook deduplication, email validation), 3 INFO (trust chain comment, KV delete race, publishable key monitoring), plus external pentest CRITICAL (Next.js CVEs #475) and HIGH (SheetJS #476).
 
 ---
 
@@ -21,7 +22,7 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Date | Scope | Risk Summary | Status | Path |
 |------|-------|-------------|--------|------|
-| 2026-03-17 | **Firestore Sync & Household Data Access** (issue #1126) | **2C / 1H / 3M / 3L / 3I** | **[Active] CRITICAL IDOR in sync/pull + sync/push — requires immediate fix** | [reports/2026-03-17-firestore-sync-audit.md](reports/2026-03-17-firestore-sync-audit.md) |
+| 2026-03-17 | **Firestore Sync & Household Data Access** (issue #1126) | **2C / 1H / 3M / 3L / 3I** | **[Active] CRITICAL IDOR fixed in PRs #1203 + #1207; HIGH + MEDIUM findings open** | [reports/2026-03-17-firestore-sync-audit.md](reports/2026-03-17-firestore-sync-audit.md) |
 | 2026-03-10 | **Comprehensive External Pen Test** — Consolidated from 4 parallel audits (#470–473) | **1C / 1H / 3M / 3L / 5I** | **[Active] CRITICAL Next.js CVEs require immediate patching; HIGH SheetJS unpatched — see issues** | [reports/2026-03-09-external-pentest.md](reports/2026-03-09-external-pentest.md) |
 | 2026-03-02 | Google API Integration | 0C / 3H / 3M / 3L / 3I | Active — findings partially open | [reports/2026-03-02-google-api-integration.md](reports/2026-03-02-google-api-integration.md) |
 | 2026-03-04 | Stripe Direct Integration | 0C / 0H / 0M / 3L / 3I | Active — CRITICAL/MEDIUM resolved | [reports/2026-03-04-stripe-direct-integration.md](reports/2026-03-04-stripe-direct-integration.md) |
@@ -64,10 +65,10 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Document | Description | Last Reviewed |
 |----------|-------------|---------------|
-| [architecture/auth-architecture.md](architecture/auth-architecture.md) | Full OAuth 2.0 PKCE flow, session storage model, token expiration, incremental Drive consent, trust boundaries, JWKS verification, and Stripe subscription auth model | 2026-03-14 |
-| [architecture/data-flow-diagrams.md](architecture/data-flow-diagrams.md) | Security-focused data flow diagrams for OAuth PKCE, URL import (Path A), CSV upload (Path C), Google Picker (Path B), and Stripe checkout; marks trust boundaries, SSRF surfaces, and injection points | 2026-03-14 |
-| [architecture/trust-boundaries.md](architecture/trust-boundaries.md) | Five trust zones (browser, GKE server, Google infra, Stripe infra, Upstash Redis); secret locations; what data crosses each boundary; localStorage XSS implications and mitigations | 2026-03-14 |
-| [architecture/threat-model.md](architecture/threat-model.md) | Assets, threat actors, attack surfaces, mitigations in place, and residual risks; updated for GKE Autopilot | 2026-03-14 |
+| [architecture/auth-architecture.md](architecture/auth-architecture.md) | Full OAuth 2.0 PKCE flow, session storage model, token expiration, incremental Drive consent, trust boundaries, JWKS verification, Stripe subscription auth model, and Firestore sync authorization model | 2026-03-17 |
+| [architecture/data-flow-diagrams.md](architecture/data-flow-diagrams.md) | Security-focused data flow diagrams for OAuth PKCE, URL import (Path A), CSV upload (Path C), Google Picker (Path B), Stripe checkout, and Firestore sync pull/push; marks trust boundaries, SSRF surfaces, and injection points | 2026-03-17 |
+| [architecture/trust-boundaries.md](architecture/trust-boundaries.md) | Six trust zones (browser, GKE server, Google infra, Stripe infra, Upstash Redis, Firestore); secret locations; what data crosses each boundary; localStorage XSS implications and Firestore householdId constraints | 2026-03-17 |
+| [architecture/threat-model.md](architecture/threat-model.md) | Assets, threat actors, attack surfaces, mitigations in place, and residual risks; includes Firestore sync attack surfaces and IDOR mitigations | 2026-03-17 |
 
 ---
 
@@ -75,8 +76,8 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Document | Description | Last Reviewed |
 |----------|-------------|---------------|
-| [checklists/api-route-checklist.md](checklists/api-route-checklist.md) | Pre-merge checklist for adding or modifying API routes: requireAuth pattern, input validation, error handling, secret hygiene, SSRF prevention; includes Stripe webhook exemption | 2026-03-14 |
-| [checklists/deployment-security.md](checklists/deployment-security.md) | Pre-deployment checklist for GKE Autopilot: secret hygiene, CSP verification, OAuth config, Stripe config, dependency audit, build verification, post-deployment checks | 2026-03-14 |
+| [checklists/api-route-checklist.md](checklists/api-route-checklist.md) | Pre-merge checklist for adding or modifying API routes: requireAuth pattern, Firestore householdId validation, input validation, error handling, secret hygiene, SSRF prevention; includes Stripe webhook exemption | 2026-03-17 |
+| [checklists/deployment-security.md](checklists/deployment-security.md) | Pre-deployment checklist for GKE Autopilot: secret hygiene (including Firestore env vars), CSP verification, OAuth config, Stripe config, dependency audit, build verification, post-deployment checks | 2026-03-17 |
 
 ---
 
@@ -90,12 +91,23 @@ None to date.
 
 The following findings from active reports remain open. Assign to FiremanDecko for remediation.
 
-### Critical (2026-03-10 External Pen Test)
+### Firestore Sync (2026-03-17 Audit)
 
 | ID | Report | Severity | Title | Status | Issue |
 |----|--------|----------|-------|--------|-------|
-| **CRITICAL-001** | **2026-03-09-external-pentest** | **CRITICAL** | **Next.js Multiple Critical CVEs (GHSA-3h52, GHSA-g5qg, GHSA-xv57, GHSA-4342, GHSA-9g9p, GHSA-f82v)** | **[URGENT] File issues immediately** | #475 |
-| **HIGH-001** | **2026-03-09-external-pentest** | **HIGH** | **SheetJS Unpatched Prototype Pollution & ReDoS (GHSA-4r6h, GHSA-5pgg)** | **[URGENT] File issues immediately** | #476 |
+| ~~SEV-001~~ | ~~2026-03-17-firestore-sync-audit~~ | ~~CRITICAL~~ | ~~IDOR: `/api/sync/pull` reads any household's cards~~ | **RESOLVED — PR #1203** | #1192 |
+| ~~SEV-002~~ | ~~2026-03-17-firestore-sync-audit~~ | ~~CRITICAL~~ | ~~IDOR: `/api/sync/push` reads/overwrites any household's cards~~ | **RESOLVED — PR #1207** | #1193 |
+| SEV-003 | 2026-03-17-firestore-sync-audit | HIGH | PII leakage: member emails in invite validate response | Open | — |
+| SEV-004 | 2026-03-17-firestore-sync-audit | MEDIUM | No rate limiting on invite validate/join endpoints | Open | — |
+| SEV-005 | 2026-03-17-firestore-sync-audit | MEDIUM | No rate limiting on sync push/pull endpoints | Open | — |
+| SEV-006 | 2026-03-17-firestore-sync-audit | MEDIUM | Admin SDK bypasses Firestore security rules (defense-in-depth gap) | Open | — |
+
+### External Pen Test (2026-03-10)
+
+| ID | Report | Severity | Title | Status | Issue |
+|----|--------|----------|-------|--------|-------|
+| **CRITICAL-001** | **2026-03-09-external-pentest** | **CRITICAL** | **Next.js Multiple Critical CVEs (GHSA-3h52, GHSA-g5qg, GHSA-xv57, GHSA-4342, GHSA-9g9p, GHSA-f82v)** | **Open** | #475 |
+| **HIGH-001** | **2026-03-09-external-pentest** | **HIGH** | **SheetJS Unpatched Prototype Pollution & ReDoS (GHSA-4r6h, GHSA-5pgg)** | Open | #476 |
 | MEDIUM-001 | 2026-03-09-external-pentest | MEDIUM | CSP allows unsafe-inline scripts/styles | Open | #477 |
 | MEDIUM-002 | 2026-03-09-external-pentest | MEDIUM | CSV fetch follows redirects without validation (SSRF) | Open | #478 |
 | MEDIUM-003 | 2026-03-09-external-pentest | MEDIUM | CSV sanitization regex bypass via Unicode | Open | #479 |

--- a/security/architecture/auth-architecture.md
+++ b/security/architecture/auth-architecture.md
@@ -1,7 +1,7 @@
 # Auth Architecture — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-14 (updated for GKE Autopilot — replaced Vercel references)
+**Last reviewed**: 2026-03-17 (added Firestore sync auth model — Section 10)
 **References**: ADR-005, ADR-006, ADR-008, ADR-010
 
 ---
@@ -431,6 +431,55 @@ used by Odin's Throne (removed in issue #933).
 | Cookie flags | `secure=true`, `samesite=lax` |
 | Health check bypass | `--skip-auth-route` per service (e.g. `/healthz`) |
 | No custom session tokens | Removed handrolled HMAC-SHA256 sessions (issue #933) |
+
+---
+
+## 10. Firestore Cloud Sync Authorization Model
+
+### 10.1 Overview
+
+Cloud card sync was introduced in issue #1119. Karl-tier users can sync their card portfolio
+across devices via Firestore. All Firestore access is through the Firebase Admin SDK from
+the Next.js server — the browser has no direct Firestore access.
+
+**Critical constraint:** The Admin SDK bypasses Firestore security rules entirely.
+All authorization is enforced at the API route layer. This means a broken access control bug
+in an API route has no database-layer backstop.
+
+### 10.2 Sync Routes
+
+| Route | Method | Auth | Household ID Source |
+|---|---|---|---|
+| `/api/sync` | GET / PUT | requireAuth + Karl tier | Server: `getUser(googleSub).householdId` |
+| `/api/sync/pull` | GET | requireAuth + Karl tier | **Server** (fixed in PR #1203 — was client-supplied) |
+| `/api/sync/push` | POST | requireAuth + Karl tier | **Server** (fixed in PR #1207 — was client-supplied) |
+| `/api/household/invite` | GET | requireAuth + owner role | Server: `user.householdId` |
+| `/api/household/invite/validate` | GET | requireAuth | Derived from invite code lookup |
+| `/api/household/join` | POST | requireAuth | Derived from invite code lookup |
+| `/api/household/members` | GET | requireAuth | Server: `user.householdId` |
+
+### 10.3 Mandatory Pattern for Firestore Sync Routes
+
+```typescript
+// REQUIRED pattern — never trust householdId from request body or query params:
+const auth = await requireAuth(request);
+if (!auth.ok) return auth.response;
+
+const user = await getUser(auth.user.sub);  // fetch from Firestore via Admin SDK
+if (!user) return NextResponse.json({ error: "user_not_found" }, { status: 404 });
+
+// Use server-derived householdId ONLY:
+const cards = await getCards(user.householdId);
+```
+
+Any route that accepts a `householdId` from the client (query param or request body) MUST
+validate it against `user.householdId` and return 403 if they differ, or simply ignore the
+client value and use `user.householdId` exclusively.
+
+### 10.4 Tier Enforcement
+
+Sync routes check `getStripeEntitlement(googleSub)` from Upstash Redis and return 403 with
+`{ error: "karl_required", current_tier: "thrall" }` for non-Karl users.
 
 ---
 

--- a/security/architecture/data-flow-diagrams.md
+++ b/security/architecture/data-flow-diagrams.md
@@ -1,7 +1,7 @@
 # Security Data Flow Diagrams — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-14 (updated for GKE Autopilot — replaced Vercel references)
+**Last reviewed**: 2026-03-17 (added Firestore sync flows — sections 7 and 8)
 
 Trust boundary notation:
 - `[TB]` — Trust boundary crossing (browser ↔ server)
@@ -268,3 +268,59 @@ Browser (authenticated)
 | Stripe checkout | None (Stripe SDK) | None | None | requireAuth |
 | Stripe webhook | None | None | None | N/A (SHA-256 HMAC) |
 | Stripe membership | None | None | None (KV only) | requireAuth |
+| Firestore sync pull | None | None | None (Firestore) | requireAuth + Karl tier |
+| Firestore sync push | None | None (Zod validated) | None (Firestore) | requireAuth + Karl tier |
+
+---
+
+## 7. Firestore Cloud Sync — Pull Flow (`GET /api/sync/pull`)
+
+```
+Browser (Karl-tier, authenticated)
+  │
+  ├─ GET /api/sync/pull?householdId=<IGNORED>  [TB]
+  │    Authorization: Bearer <id_token>
+  │    requireAuth() → verified Google user { sub }
+  │    Karl tier check via getStripeEntitlement(sub) → Upstash Redis
+  │    if not Karl → 403
+  │
+  │    getUser(sub)           ← Admin SDK, Firestore Zone 6
+  │    user.householdId       ← server-authoritative; client-supplied householdId IGNORED
+  │
+  │    getAllFirestoreCards(user.householdId)  ← Admin SDK reads cards collection
+  │
+  └─ return { cards: FirestoreCard[] } → browser
+```
+
+**Trust boundary crossings**: 1 (browser → API route)
+**IDOR protection**: `householdId` derived server-side from `getUser(sub)` — not from request params (fixed PR #1203)
+**Auth check**: requireAuth + Karl tier check
+
+---
+
+## 8. Firestore Cloud Sync — Push Flow (`POST /api/sync/push`)
+
+```
+Browser (Karl-tier, authenticated)
+  │
+  ├─ POST /api/sync/push  [TB]
+  │    Authorization: Bearer <id_token>
+  │    Body: { cards: Card[] }      ← householdId in body IGNORED
+  │    requireAuth() → verified Google user { sub }
+  │    Karl tier check via getStripeEntitlement(sub) → Upstash Redis
+  │    if not Karl → 403
+  │
+  │    getUser(sub)           ← Admin SDK
+  │    user.householdId       ← server-authoritative
+  │
+  │    getAllFirestoreCards(user.householdId)   ← read remote state
+  │    mergeCardsWithStats(localCards, remoteCards)  ← 3-way merge
+  │    merged cards have householdId overridden to user.householdId
+  │    setCards(merged)        ← Admin SDK batch write
+  │
+  └─ return { cards: merged, stats } → browser
+```
+
+**Trust boundary crossings**: 1 (browser → API route)
+**IDOR protection**: `householdId` derived server-side; cards' `householdId` overridden before write (fixed PR #1207)
+**Injection surface**: Card array validated via Zod before merge

--- a/security/architecture/threat-model.md
+++ b/security/architecture/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-14 (updated for GKE Autopilot — replaced Vercel references)
+**Last reviewed**: 2026-03-17 (added Firestore sync assets and attack surfaces)
 **Methodology**: STRIDE-lite with OWASP Top 10 mapping
 
 ---
@@ -22,6 +22,8 @@
 | Card portfolio data | MEDIUM | localStorage per-user | Financial metadata exposure (no PAN/CVV stored) |
 | User PII (email, name, picture) | MEDIUM | localStorage["fenrir:auth"].user | Identity exposure |
 | Stripe entitlements in KV | MEDIUM | Upstash Redis | Attacker can grant or revoke subscription tier |
+| Card portfolio in Firestore | HIGH | Firestore per-household collection | Attacker can read/overwrite any household's full card portfolio if IDOR present |
+| Household membership in Firestore | MEDIUM | Firestore households collection | Attacker can enumerate members, manipulate household composition |
 
 ---
 
@@ -116,13 +118,24 @@
 | Drive token theft via XSS | Information Disclosure | CSP | Medium — stored in localStorage |
 | Malicious spreadsheet content | Tampering | Zod validation, LLM security rules | Low |
 
-### 3.5 Stripe Subscription
+### 3.5 Firestore Cloud Sync
+
+| Attack | STRIDE | Mitigation | Residual Risk |
+|--------|--------|-----------|---------------|
+| IDOR: read other household's cards | Information Disclosure | `householdId` derived from `getUser(sub)` server-side (fixed PR #1203, #1207) | Low |
+| IDOR: overwrite other household's cards | Tampering | `householdId` enforced server-side before write (fixed PR #1207) | Low |
+| PII leakage via invite validate | Information Disclosure | None currently — `email` returned to invite holders (SEV-003 open) | Medium |
+| Rate-limit bypass on sync routes | DoS / Cost amplification | None currently (SEV-005 open) | Medium |
+| Admin SDK bypasses Firestore rules | Elevation of Privilege | Defense-in-depth gap; mitigated by API-layer auth checks | Medium |
+| Invite code enumeration | Spoofing | 32^6 ≈ 1B combinations; rate limiting absent (SEV-004 open) | Low |
+
+### 3.6 Stripe Subscription
 
 | Attack | STRIDE | Mitigation | Residual Risk |
 |--------|--------|-----------|---------------|
 | Webhook forgery | Spoofing | SHA-256 HMAC via `stripe.webhooks.constructEvent()` | Low |
 | Webhook replay | Tampering | Not implemented (open — SEV-005 from 2026-03-04 report) | Low (KV writes idempotent currently) |
-| Open redirect post-checkout | Tampering | `APP_BASE_URL`/`VERCEL_URL` only (fixed SEV-002) | Low |
+| Open redirect post-checkout | Tampering | `APP_BASE_URL` only (fixed SEV-002) | Low |
 | Unlimited checkout session creation | DoS | In-memory rate limit (10/min) | Medium — not distributed (SEV-004) |
 | Entitlement tampering via KV error | Tampering | Partial-delete race condition (SEV-008) | Low (non-blocking) |
 | STRIPE_SECRET_KEY exposure | Information Disclosure | Server env only, never logged or serialized | Low |

--- a/security/architecture/trust-boundaries.md
+++ b/security/architecture/trust-boundaries.md
@@ -1,7 +1,7 @@
 # Trust Boundaries — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-14 (updated for GKE Autopilot — replaced Vercel references)
+**Last reviewed**: 2026-03-17 (updated for Firestore sync — added Zone 6)
 
 ---
 
@@ -71,6 +71,23 @@ is trusted for payment processing and subscription lifecycle events.
 │  Accessed only from ZONE 2 (server). Browser has no direct   │
 │  access. No user credentials stored in KV.                   │
 └──────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────┐
+│  ZONE 6: Google Firestore (Trusted Persistent Store)         │
+│                                                              │
+│  - households/{householdId}/cards → FirestoreCard[]          │
+│  - users/{googleSub}              → UserRecord               │
+│  - households/{householdId}       → HouseholdRecord          │
+│                                                              │
+│  Accessed via Firebase Admin SDK from ZONE 2 only. Admin SDK │
+│  bypasses Firestore security rules — all authorization is    │
+│  enforced at the API route layer. Browser has no direct      │
+│  Firestore access.                                           │
+│                                                              │
+│  CRITICAL CONSTRAINT: householdId MUST be derived from the  │
+│  server-side user record (getUser(googleSub).householdId),   │
+│  never from client-supplied request parameters.             │
+└──────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -90,6 +107,8 @@ is trusted for payment processing and subscription lifecycle events.
 | `GOOGLE_PICKER_API_KEY` | `process.env` (server) | Yes — served on request | Auth-gated; GCP referrer restriction required |
 | `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | `process.env` (public) | Yes — by design | OAuth Client ID is public; embedded in auth URL |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | `process.env` (public) | Yes — by design | Stripe publishable key is safe for client exposure |
+| `FIRESTORE_PROJECT_ID` | `process.env` (server) | No | GCP project ID for Admin SDK |
+| `FIRESTORE_DATABASE_ID` | `process.env` (server) | No | Firestore database name for Admin SDK |
 | Google `access_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; ~1-hour TTL |
 | Google `id_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; used as API Bearer token |
 | Google `refresh_token` | `localStorage["fenrir:auth"]` | Yes — same-origin JS | XSS risk; long-lived (no TTL) |

--- a/security/checklists/api-route-checklist.md
+++ b/security/checklists/api-route-checklist.md
@@ -1,7 +1,7 @@
 # API Route Security Checklist — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-14 (updated for GKE Autopilot — replaced Vercel references)
+**Last reviewed**: 2026-03-17 (added Firestore householdId validation rule)
 
 Use this checklist whenever adding, modifying, or reviewing an API route under
 `development/frontend/src/app/api/`.
@@ -87,6 +87,23 @@ Every route handler MUST pass all items in this section before merge.
 
 - [ ] **Routes that call external services (LLM, Google APIs) are rate-limited**
   - Consider per-user rate limits (keyed on `auth.user.sub`) in addition to per-IP
+
+### 5a. Firestore / Household Authorization
+
+Routes that access Firestore on behalf of the authenticated user MUST derive the `householdId`
+from the server-side user record, never from client-supplied inputs.
+
+- [ ] **Routes accessing Firestore household data derive `householdId` from `getUser(auth.user.sub)`**
+  - Pattern:
+    ```typescript
+    const user = await getUser(auth.user.sub);
+    if (!user) return NextResponse.json({ error: "user_not_found" }, { status: 404 });
+    // Use user.householdId — never request.nextUrl.searchParams.get("householdId")
+    ```
+  - If the route receives a `householdId` parameter (e.g., for validation), compare it against
+    `user.householdId` and return 403 if they differ
+  - Override any client-supplied `householdId` on write payloads (e.g., card objects) with the
+    server-derived value before writing to Firestore
 
 ### 6. SSRF Prevention
 

--- a/security/checklists/deployment-security.md
+++ b/security/checklists/deployment-security.md
@@ -1,7 +1,7 @@
 # Deployment Security Checklist — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-14 (updated for GKE Autopilot — replaced Vercel references)
+**Last reviewed**: 2026-03-17 (added Firestore env vars to required list)
 
 Run this checklist before every production deployment. Items marked [AUTOMATED] are
 covered by the Playwright test suite or CI. Items marked [MANUAL] require human review.
@@ -37,6 +37,7 @@ covered by the Playwright test suite or CI. Items marked [MANUAL] require human 
   - `KV_REST_API_URL`, `KV_REST_API_TOKEN`
   - `APP_BASE_URL` (production URL for Stripe redirects)
   - `UPTIME_CHECK_HOST` (Google Cloud Monitoring uptime check target)
+  - `FIRESTORE_PROJECT_ID`, `FIRESTORE_DATABASE_ID` (Firestore cloud sync)
 
 - [ ] [MANUAL] **No server secrets use `NEXT_PUBLIC_` prefix**
   ```


### PR DESCRIPTION
PR for issue: #1217

## Summary

- **README.md**: marked Firestore IDOR findings resolved (PRs #1203 + #1207); split Open Findings Tracker into Firestore and external pentest sections; updated open findings summary
- **auth-architecture.md**: added Section 10 documenting Firestore sync auth model — mandatory `getUser(sub).householdId` pattern, sync route table, tier enforcement, Admin SDK bypass constraint
- **data-flow-diagrams.md**: added Sections 7–8 for Firestore sync pull/push flows; added Firestore rows to attack surface summary table
- **trust-boundaries.md**: added Zone 6 (Google Firestore) to trust zone diagram; added `FIRESTORE_PROJECT_ID` and `FIRESTORE_DATABASE_ID` to secrets table
- **threat-model.md**: added Firestore card portfolio and household membership as assets; added Section 3.5 (Firestore sync attack surfaces)
- **api-route-checklist.md**: added Section 5a — Firestore householdId validation pattern (mandatory server-side derivation)
- **deployment-security.md**: added `FIRESTORE_PROJECT_ID`/`FIRESTORE_DATABASE_ID` to required env vars

## Test plan

- [ ] Verify no broken links in `security/README.md`
- [ ] Verify architecture docs accurately describe the post-IDOR-fix sync routes
- [ ] Confirm `.sync-report.md` is gitignored (not in this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)