### PR TITLE
Issue #1219 - fix: wrap sync-hook-advanced tests in AuthProvider

### DIFF
--- a/development/frontend/src/__tests__/sync/sync-hook-advanced.loki.test.ts
+++ b/development/frontend/src/__tests__/sync/sync-hook-advanced.loki.test.ts
@@ -23,10 +23,18 @@ import type { Card } from "@/lib/types";
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
-const mockIsKarlOrTrial = { value: false };
+const mockEntitlement = { tier: "thrall" as string, isActive: false };
 
-vi.mock("@/hooks/useIsKarlOrTrial", () => ({
-  useIsKarlOrTrial: () => mockIsKarlOrTrial.value,
+vi.mock("@/hooks/useEntitlement", () => ({
+  useEntitlement: () => mockEntitlement,
+}));
+
+// Issue #1172: useCloudSync gates on auth status — mock AuthContext to avoid
+// "useAuthContext must be used within <AuthProvider>" in unit tests
+const mockAuthContext = { status: "authenticated" as string };
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuthContext: () => mockAuthContext,
 }));
 
 vi.mock("sonner", () => ({
@@ -46,7 +54,7 @@ vi.mock("@/lib/auth/session", () => ({
 }));
 
 vi.mock("@/lib/storage", () => ({
-  getCards: vi.fn().mockReturnValue([]),
+  getRawAllCards: vi.fn().mockReturnValue([]),
   setAllCards: vi.fn(),
 }));
 
@@ -54,18 +62,25 @@ vi.mock("@/lib/storage", () => ({
 
 const TEST_HOUSEHOLD = "test-household-adv";
 
+const FAKE_SESSION = {
+  id_token: "test-id-token-adv",
+  user: { sub: TEST_HOUSEHOLD },
+};
+
 function setupKarl() {
-  mockIsKarlOrTrial.value = true;
+  mockEntitlement.tier = "karl";
+  mockEntitlement.isActive = true;
   mockEnsureFreshToken.mockResolvedValue("test-id-token");
+  localStorage.setItem("fenrir:auth", JSON.stringify(FAKE_SESSION));
 }
 
+// The hook POSTs to /api/sync/push and expects { cards, syncedCount } in the response.
 function mockFetchGet(cards: Card[] = []) {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({
-      householdId: TEST_HOUSEHOLD,
       cards,
-      syncedAt: new Date().toISOString(),
+      syncedCount: cards.length,
     }),
   } as Response);
 }
@@ -78,14 +93,12 @@ function mockFetchGetFail(code = "forbidden") {
   } as Response);
 }
 
-function mockFetchPut(written = 3) {
+function mockFetchPut(syncedCount = 3) {
   global.fetch = vi.fn().mockResolvedValue({
     ok: true,
     json: async () => ({
-      householdId: TEST_HOUSEHOLD,
-      written,
-      skipped: 0,
-      syncedAt: new Date().toISOString(),
+      cards: [],
+      syncedCount,
     }),
   } as Response);
 }
@@ -102,7 +115,8 @@ function mockFetchPutFail(code = "server_error") {
 
 describe("useCloudSync — initial state (Thrall/idle)", () => {
   beforeEach(() => {
-    mockIsKarlOrTrial.value = false;
+    mockEntitlement.tier = "thrall";
+    mockEntitlement.isActive = false;
     global.fetch = vi.fn();
   });
 
@@ -206,11 +220,11 @@ describe("useCloudSync — auto-retry fires after 120s error timeout", () => {
       await Promise.resolve();
     });
 
-    // Should have triggered a push (PUT) and landed in synced
-    const putCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (c: unknown[]) => (c[1] as RequestInit)?.method === "PUT"
+    // Should have triggered a retry (POST to /api/sync/push)
+    const postCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => (c[1] as RequestInit)?.method === "POST"
     );
-    expect(putCalls.length).toBeGreaterThanOrEqual(1);
+    expect(postCalls.length).toBeGreaterThanOrEqual(1);
   });
 
   it("auto-retry transitions error → syncing → error if retry also fails", async () => {
@@ -319,7 +333,7 @@ describe("useCloudSync — multiple fenrir:cards-changed events debounce to one 
     // Set up PUT mock
     mockFetchPut(1);
 
-    // Fire 5 rapid events within the 2s debounce window
+    // Fire 5 rapid events within the debounce window
     act(() => {
       for (let i = 0; i < 5; i++) {
         window.dispatchEvent(
@@ -328,19 +342,21 @@ describe("useCloudSync — multiple fenrir:cards-changed events debounce to one 
       }
     });
 
-    // Advance past debounce
+    // Advance past AUTO_SYNC_DEBOUNCE_MS (10s) to trigger the debounced push
     await act(async () => {
-      vi.advanceTimersByTime(3000);
+      vi.advanceTimersByTime(11_000);
       await Promise.resolve();
       await Promise.resolve();
     });
 
-    const putCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
-      (c: unknown[]) => (c[1] as RequestInit)?.method === "PUT"
+    const postCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.filter(
+      (c: unknown[]) => (c[1] as RequestInit)?.method === "POST"
     );
 
-    // Only 1 PUT despite 5 events
-    expect(putCalls.length).toBe(1);
+    // Only 1 POST despite 5 events (initial sync POST + 1 debounced POST = 2 total,
+    // but the initial sync already ran before mockFetchPut was set — count POST calls
+    // made AFTER the events, which should be exactly 1)
+    expect(postCalls.length).toBe(1);
   });
 });
 

--- a/development/frontend/src/hooks/useCloudSync.ts
+++ b/development/frontend/src/hooks/useCloudSync.ts
@@ -80,6 +80,9 @@ const EVT_CLOUD_SYNC_COMPLETE = "fenrir:cloud-sync-complete";
  */
 const EVT_CLOUD_SYNC_ERROR = "fenrir:cloud-sync-error";
 
+/** Custom event name fired when cards change — triggers debounced cloud push */
+export const EVT_CARDS_CHANGED = "fenrir:cards-changed";
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -184,6 +187,7 @@ export function useCloudSync(): CloudSyncState {
     setStatus("syncing");
     setErrorMessage(null);
     setErrorCode(null);
+    setErrorTimestamp(null);
     setRetryIn(null);
 
     // Cancel any pending retry
@@ -478,9 +482,9 @@ export function useCloudSync(): CloudSyncState {
       }, AUTO_SYNC_DEBOUNCE_MS);
     };
 
-    window.addEventListener("fenrir:cards-changed", handleCardsChanged);
+    window.addEventListener(EVT_CARDS_CHANGED, handleCardsChanged);
     return () => {
-      window.removeEventListener("fenrir:cards-changed", handleCardsChanged);
+      window.removeEventListener(EVT_CARDS_CHANGED, handleCardsChanged);
       if (autoSyncTimerRef.current) {
         clearTimeout(autoSyncTimerRef.current);
         autoSyncTimerRef.current = null;


### PR DESCRIPTION
PR for issue: #1219

Fix 13 failing Vitest tests by adding missing context mocks and correcting test/hook logic.

## Changes

**`sync-hook-advanced.loki.test.ts`** — test fixes:
- Add `vi.mock("@/contexts/AuthContext")` — resolves `useAuthContext must be used within <AuthProvider>` on all 13 tests
- Replace incorrect `useIsKarlOrTrial` mock with `useEntitlement` (what the hook actually imports)
- Fix `setupKarl()` to set `mockEntitlement.tier/isActive` and write session to `localStorage`
- Fix storage mock: `getCards` → `getRawAllCards` to match hook's actual import
- Fix mock response shape: `{ cards, syncedCount }` instead of `{ householdId, written, syncedAt }`
- Fix assertions: hook uses POST not PUT; advance 11s not 3s for 10s debounce

**`useCloudSync.ts`** — hook fixes:
- Export `EVT_CARDS_CHANGED` constant (was used in test import but never exported, resolved to `undefined`)
- Use `EVT_CARDS_CHANGED` constant for `addEventListener`/`removeEventListener` calls
- Add `setErrorTimestamp(null)` to sync-start cleanup (was missing, causing `errorTimestamp` to persist after successful retry)

## Verification

- All 13 tests in `sync-hook-advanced.loki.test.ts` pass
- Full Vitest suite: **2219 tests across 145 files — all pass**
- `tsc --noEmit`: PASS
- `next build`: PASS (45 routes)