### PR TITLE
Issue #1231 - feat: DNS record + TLS cert for marketing.fenrirledger.com

### DIFF
--- a/infrastructure/dns.tf
+++ b/infrastructure/dns.tf
@@ -116,6 +116,18 @@ resource "google_dns_record_set" "analytics" {
   rrdatas = [google_compute_global_address.umami_ip.address]
 }
 
+resource "google_dns_record_set" "marketing" {
+  name         = "marketing.${var.domain}."
+  managed_zone = google_dns_managed_zone.app.name
+  project      = var.project_id
+  type         = "A"
+  # TTL lowered to 60s pre-CDN for fast DNS-level rollback.
+  # Raise to 3600s after CDN stability is confirmed (issue #1209).
+  ttl = 60
+
+  rrdatas = [google_compute_global_address.app_ip.address]
+}
+
 # --------------------------------------------------------------------------
 # Static Global IP — Odin's Throne (monitor.fenrirledger.com)
 # --------------------------------------------------------------------------

--- a/infrastructure/k8s/app/ingress.yaml
+++ b/infrastructure/k8s/app/ingress.yaml
@@ -65,6 +65,16 @@ spec:
                 name: fenrir-app
                 port:
                   number: 80
+    - host: marketing.fenrirledger.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: fenrir-app
+                port:
+                  number: 80
 
 ---
 # --------------------------------------------------------------------------
@@ -83,6 +93,7 @@ spec:
     - fenrirledger.com
     - www.fenrirledger.com
     - analytics.fenrirledger.com
+    - marketing.fenrirledger.com
 
 ---
 # --------------------------------------------------------------------------


### PR DESCRIPTION
PR for issue: #1231

Fixes #1231

Add DNS A-record and TLS certificate for marketing.fenrirledger.com — the hostname for n8n marketing automation on GKE.

**Changes:**
- `infrastructure/dns.tf` — A-record for marketing.fenrirledger.com pointing to shared `app_ip` (GKE Ingress IP)
- `infrastructure/k8s/app/ingress.yaml` — ManagedCertificate updated with marketing.fenrirledger.com SAN; Ingress rules updated with marketing.fenrirledger.com host

**Verification:**
- terraform plan shows only DNS + cert changes, no regressions
- SAN count: 3 → 4 (well under 100-domain limit)
- tsc PASS, build PASS (45 routes), Vitest PASS (2219 tests across 145 files)

**QA:** PASS — Loki validated 2026-03-17