### PR TITLE
chore: bump agent job deadline from 60m to 120m

### DIFF
--- a/infrastructure/k8s/agents/job-template.yaml
+++ b/infrastructure/k8s/agents/job-template.yaml
@@ -33,8 +33,8 @@ spec:
   # Auto-delete completed/failed Jobs after 30 minutes
   ttlSecondsAfterFinished: 1800
 
-  # Max runtime: 60 minutes — prevents runaway agents
-  activeDeadlineSeconds: 3600
+  # Max runtime: 120 minutes — prevents runaway agents
+  activeDeadlineSeconds: 7200
 
   # Retry on failure — covers transient scheduling delays (Autopilot node scale-up)
   # Exponential backoff: 10s, 20s, 40s, 80s, 160s (~5 min total)


### PR DESCRIPTION
Jobs were hitting `activeDeadlineSeconds: 3600` on long Vitest runs. Issue #1239 was killed at 62 minutes while running the full test suite.

**Change:** `activeDeadlineSeconds: 3600 → 7200`