### PR TITLE
feat(infra): deploy n8n to GKE Autopilot in analytics namespace — issue #1232

### DIFF
--- a/infrastructure/k8s/n8n/README.md
+++ b/infrastructure/k8s/n8n/README.md
@@ -1,0 +1,90 @@
+# n8n — GKE Autopilot Deployment
+
+n8n workflow automation platform deployed in the `fenrir-analytics` namespace
+via Helm. Uses SQLite on a 1Gi PVC for persistence. Accessible at
+`marketing.fenrirledger.com` (DNS + TLS from issue #1231).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `values.yaml` | Helm values for `oci://ghcr.io/8gears/n8n` |
+| `namespace.yaml` | `fenrir-analytics` namespace (created by bootstrap, emergency fallback) |
+| `managed-certificate.yaml` | GKE ManagedCertificate for `marketing.fenrirledger.com` |
+| `ingress-patch.yaml` | GCE Ingress + BackendConfig routing to n8n service |
+
+## Deploy / Upgrade
+
+```bash
+# 1. Ensure namespace exists (idempotent — bootstrap chart usually creates it)
+kubectl apply -f infrastructure/k8s/n8n/namespace.yaml
+
+# 2. Apply GKE ManagedCertificate (TLS provisioning starts immediately)
+kubectl apply -f infrastructure/k8s/n8n/managed-certificate.yaml -n fenrir-analytics
+
+# 3. Deploy n8n via Helm
+helm upgrade --install n8n oci://ghcr.io/8gears/n8n \
+  -n fenrir-analytics \
+  -f infrastructure/k8s/n8n/values.yaml
+
+# 4. Apply GCE Ingress + BackendConfig (may override Helm-managed ingress)
+kubectl apply -f infrastructure/k8s/n8n/ingress-patch.yaml -n fenrir-analytics
+```
+
+## Verify
+
+```bash
+# Pod health
+kubectl get pods -n fenrir-analytics -l app.kubernetes.io/name=n8n
+
+# Ingress + IP allocation
+kubectl get ingress -n fenrir-analytics
+
+# Certificate provisioning status (may take 10–20 min on first deploy)
+kubectl describe managedcertificate n8n-cert -n fenrir-analytics
+
+# PVC bound
+kubectl get pvc -n fenrir-analytics
+
+# Service endpoint
+kubectl get svc n8n -n fenrir-analytics
+```
+
+## Architecture
+
+```
+marketing.fenrirledger.com (DNS A → fenrir-app-ip)
+  └── GCE Ingress (fenrir-app-ip static IP)
+        └── GKE ManagedCertificate (n8n-cert) — TLS termination
+              └── n8n Service (ClusterIP :80 → pod :5678)
+                    └── n8n Pod (n8nio/n8n)
+                          └── PVC (1Gi standard-rwo) → /home/node/.n8n (SQLite)
+```
+
+## Configuration
+
+- **Namespace:** `fenrir-analytics`
+- **Static IP:** `fenrir-app-ip` (shared with main app, `marketing.` DNS points here)
+- **Storage:** SQLite on 1Gi PVC (`standard-rwo` StorageClass)
+- **Resources:** 250m CPU / 512Mi memory (requests = limits)
+- **Host:** `marketing.fenrirledger.com`
+- **Protocol:** `https`
+
+## Environment Variables
+
+Key n8n env vars set via `values.yaml`:
+
+| Var | Value |
+|---|---|
+| `N8N_HOST` | `marketing.fenrirledger.com` |
+| `N8N_PROTOCOL` | `https` |
+| `N8N_PORT` | `5678` |
+| `N8N_EDITOR_BASE_URL` | `https://marketing.fenrirledger.com/` |
+| `WEBHOOK_URL` | `https://marketing.fenrirledger.com/` |
+| `N8N_USER_FOLDER` | `/home/node/.n8n` (PVC mount) |
+
+## Related Issues
+
+- **#1232** — This deployment (n8n Helm + GKE)
+- **#1231** — DNS A-record + TLS cert for `marketing.fenrirledger.com`
+- **#1230** — n8n workflow git backup

--- a/infrastructure/k8s/n8n/ingress-patch.yaml
+++ b/infrastructure/k8s/n8n/ingress-patch.yaml
@@ -1,0 +1,77 @@
+# --------------------------------------------------------------------------
+# n8n — GCE Ingress (standalone, applied separately from Helm)
+#
+# This ingress routes marketing.fenrirledger.com → n8n ClusterIP service.
+# It uses the shared fenrir-app-ip static IP (same IP used by the main
+# Fenrir Ledger app + marketing DNS A-record from issue #1231).
+#
+# Use this file if the 8gears Helm chart's built-in ingress does not support
+# GKE-specific annotations, or as an override/patch on top of the Helm-managed
+# ingress.
+#
+# Apply:
+#   kubectl apply -f infrastructure/k8s/n8n/managed-certificate.yaml -n fenrir-analytics
+#   kubectl apply -f infrastructure/k8s/n8n/ingress-patch.yaml -n fenrir-analytics
+#
+# Verify:
+#   kubectl get ingress -n fenrir-analytics
+#   kubectl describe managedcertificate n8n-cert -n fenrir-analytics
+# --------------------------------------------------------------------------
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: n8n
+  namespace: fenrir-analytics
+  labels:
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/part-of: fenrir-ledger
+    app.kubernetes.io/component: analytics
+  annotations:
+    # Shared static IP — marketing.fenrirledger.com DNS points here (issue #1231)
+    kubernetes.io/ingress.global-static-ip-name: "fenrir-app-ip"
+    # GKE ManagedCertificate for TLS (see managed-certificate.yaml)
+    networking.gke.io/managed-certificates: "n8n-cert"
+    # Allow HTTP during cert provisioning; GKE redirects to HTTPS once cert is active
+    kubernetes.io/ingress.allow-http: "true"
+    # BackendConfig for health check tuning
+    cloud.google.com/backend-config: '{"default":"n8n-backend-config"}'
+    kubernetes.io/ingress.class: "gce"
+spec:
+  rules:
+    - host: marketing.fenrirledger.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                # Service name matches Helm release name (helm install n8n ...)
+                name: n8n
+                port:
+                  number: 80
+---
+# --------------------------------------------------------------------------
+# BackendConfig — health check tuning for n8n
+# n8n serves HTTP on port 5678; /healthz is available after startup.
+# --------------------------------------------------------------------------
+apiVersion: cloud.google.com/v1
+kind: BackendConfig
+metadata:
+  name: n8n-backend-config
+  namespace: fenrir-analytics
+  labels:
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/part-of: fenrir-ledger
+    app.kubernetes.io/component: analytics
+spec:
+  healthCheck:
+    checkIntervalSec: 15
+    timeoutSec: 5
+    healthyThreshold: 1
+    unhealthyThreshold: 3
+    type: HTTP
+    requestPath: /healthz
+    port: 5678
+  timeoutSec: 30
+  connectionDraining:
+    drainingTimeoutSec: 60

--- a/infrastructure/k8s/n8n/managed-certificate.yaml
+++ b/infrastructure/k8s/n8n/managed-certificate.yaml
@@ -1,0 +1,24 @@
+# --------------------------------------------------------------------------
+# n8n — GKE ManagedCertificate
+#
+# Provisions a Google-managed TLS certificate for marketing.fenrirledger.com.
+# Referenced by the GCE Ingress via annotation:
+#   networking.gke.io/managed-certificates: "n8n-cert"
+#
+# DNS prerequisite: marketing.fenrirledger.com A-record must point to
+# fenrir-app-ip before cert provisioning will succeed (issue #1231 — done).
+#
+# Apply: kubectl apply -f infrastructure/k8s/n8n/managed-certificate.yaml -n fenrir-analytics
+# --------------------------------------------------------------------------
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: n8n-cert
+  namespace: fenrir-analytics
+  labels:
+    app.kubernetes.io/name: n8n
+    app.kubernetes.io/part-of: fenrir-ledger
+    app.kubernetes.io/component: analytics
+spec:
+  domains:
+    - marketing.fenrirledger.com

--- a/infrastructure/k8s/n8n/namespace.yaml
+++ b/infrastructure/k8s/n8n/namespace.yaml
@@ -1,0 +1,19 @@
+# --------------------------------------------------------------------------
+# n8n — Namespace Reference
+#
+# The fenrir-analytics namespace is created by the fenrir-bootstrap Helm
+# chart (infrastructure/helm/fenrir-bootstrap/). This file documents the
+# namespace spec and can be used to create it manually if the bootstrap
+# chart has not yet been applied.
+#
+# Normal path: namespace already exists from bootstrap.
+# Emergency path: kubectl apply -f infrastructure/k8s/n8n/namespace.yaml
+# --------------------------------------------------------------------------
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: fenrir-analytics
+  labels:
+    app.kubernetes.io/part-of: fenrir-ledger
+    app.kubernetes.io/component: analytics
+    app.kubernetes.io/managed-by: helm

--- a/infrastructure/k8s/n8n/values.yaml
+++ b/infrastructure/k8s/n8n/values.yaml
@@ -1,0 +1,97 @@
+# --------------------------------------------------------------------------
+# n8n Workflow Automation — Helm Values
+#
+# Chart: oci://ghcr.io/8gears/n8n
+# Namespace: fenrir-analytics
+#
+# Deploy:
+#   helm upgrade --install n8n oci://ghcr.io/8gears/n8n \
+#     -n fenrir-analytics \
+#     -f infrastructure/k8s/n8n/values.yaml
+#
+# GKE supplementary resources (apply separately before/after helm install):
+#   kubectl apply -f infrastructure/k8s/n8n/namespace.yaml
+#   kubectl apply -f infrastructure/k8s/n8n/managed-certificate.yaml
+# --------------------------------------------------------------------------
+
+# -- n8n Application Config -----------------------------------------------
+# Maps to N8N_* environment variables injected into the n8n container.
+n8n:
+  host: "marketing.fenrirledger.com"
+  protocol: "https"
+  port: 5678
+  editorBaseUrl: "https://marketing.fenrirledger.com/"
+  webhookTunnelUrl: "https://marketing.fenrirledger.com/"
+
+# -- Database (SQLite) -----------------------------------------------------
+# n8n defaults to SQLite when no external DB is configured.
+# SQLite DB file lives in N8N_USER_FOLDER (/home/node/.n8n), persisted via PVC.
+db:
+  type: sqlite
+
+# -- Environment Variables -------------------------------------------------
+# Explicit N8N_* env vars — these supplement n8n.* config above.
+env:
+  N8N_HOST: "marketing.fenrirledger.com"
+  N8N_PROTOCOL: "https"
+  N8N_PORT: "5678"
+  N8N_EDITOR_BASE_URL: "https://marketing.fenrirledger.com/"
+  WEBHOOK_URL: "https://marketing.fenrirledger.com/"
+  N8N_USER_FOLDER: "/home/node/.n8n"
+  # Disable diagnostics/telemetry in production
+  N8N_DIAGNOSTICS_ENABLED: "false"
+  N8N_VERSION_NOTIFICATIONS_ENABLED: "false"
+
+# -- Persistence (1Gi PVC for SQLite DB + workflow storage) ----------------
+persistence:
+  enabled: true
+  storageClass: standard-rwo
+  size: 1Gi
+  mountPath: /home/node/.n8n
+  accessModes:
+    - ReadWriteOnce
+
+# -- Resources (mirrors Umami analytics pattern) ---------------------------
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+    ephemeral-storage: "128Mi"
+  limits:
+    cpu: "250m"
+    memory: "512Mi"
+    ephemeral-storage: "256Mi"
+
+# -- Service ---------------------------------------------------------------
+service:
+  type: ClusterIP
+  port: 80
+  targetPort: 5678
+
+# -- Ingress ---------------------------------------------------------------
+# GCE Ingress uses the shared fenrir-app-ip static IP (marketing.fenrirledger.com
+# DNS A-record already points to this IP via infrastructure/dns.tf).
+# ManagedCertificate is created separately in managed-certificate.yaml.
+ingress:
+  enabled: true
+  className: "gce"
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: "fenrir-app-ip"
+    networking.gke.io/managed-certificates: "n8n-cert"
+    kubernetes.io/ingress.allow-http: "true"
+    cloud.google.com/backend-config: '{"default":"n8n-backend-config"}'
+  hosts:
+    - host: marketing.fenrirledger.com
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []  # TLS handled by GKE ManagedCertificate (n8n-cert)
+
+# -- Replica ---------------------------------------------------------------
+replicaCount: 1
+
+# -- Image -----------------------------------------------------------------
+image:
+  repository: n8nio/n8n
+  tag: latest
+  pullPolicy: IfNotPresent


### PR DESCRIPTION
PR for issue: #1232\n\nDeploy n8n to GKE Autopilot analytics namespace via Helm. SQLite on 1Gi PVC, marketing.fenrirledger.com hostname.\n\n**Changes:**\n- infrastructure/k8s/n8n/values.yaml — Helm values\n- infrastructure/k8s/n8n/managed-certificate.yaml — TLS cert\n- infrastructure/k8s/n8n/ingress-patch.yaml — Ingress routing\n- infrastructure/k8s/n8n/namespace.yaml — namespace ref\n- infrastructure/k8s/n8n/README.md — deploy docs\n\n**Verification:** tsc PASS, build PASS, Vitest 2253/2253 PASS (infra-only change)