### PR TITLE
Issue #1245 - fix: color Heimdall badge brown and unknown badge red

### DIFF
--- a/development/monitor-ui/src/lib/constants.ts
+++ b/development/monitor-ui/src/lib/constants.ts
@@ -49,8 +49,9 @@ export const AGENT_COLORS: Record<string, string> = {
   loki: "#a78bfa",
   luna: "#6b8afd",
   freya: "#f0b429",
-  heimdall: "#ef4444",
+  heimdall: "#8B5E3C",
   odin: "#c9920a",
+  unknown: "#ef4444",
 };
 
 export const AGENT_RUNE_NAMES: Record<string, string> = {


### PR DESCRIPTION
PR for issue: #1245

Colors the Heimdall role badge brown and the unknown session badge red in the Hlidskjalf monitor UI for at-a-glance scanning.

**Changes:**
- `development/monitor-ui/src/lib/constants.ts` — change heimdall color from red to brown (`#8B5E3C`), add unknown entry with red (`#ef4444`) in `AGENT_COLORS`

**Verification:**
- Open monitor UI, confirm Heimdall sessions show brown badge
- Confirm sessions with unresolved agent show red badge
- Confirm other agent badges (Luna, FiremanDecko, Loki, Freya) unchanged