### PR TITLE
fix(infra): allow GCP LB health check probers in NetworkPolicy

### DIFF
--- a/infrastructure/helm/fenrir-bootstrap/templates/networkpolicies.yaml
+++ b/infrastructure/helm/fenrir-bootstrap/templates/networkpolicies.yaml
@@ -21,6 +21,15 @@ spec:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: gke-managed-system
+    # Allow GCP Load Balancer health check probers
+    - from:
+        - ipBlock:
+            cidr: 130.211.0.0/22
+        - ipBlock:
+            cidr: 35.191.0.0/16
+      ports:
+        - protocol: TCP
+          port: 3000
     # Block traffic from fenrir-agents (implicit deny for unlisted namespaces)
 ---
 # Restrict agent pods to egress-only: DNS + 80/443


### PR DESCRIPTION
## Summary

The `deny-from-agents` NetworkPolicy applied by the bootstrap Helm chart blocked GCP Load Balancer health check probers (`130.211.0.0/22`, `35.191.0.0/16`). Both `fenrir-app` backends went UNHEALTHY → production served 502s on all routes including `/ledger`.

- Fixed live by patching the NetworkPolicy directly in the cluster
- This PR persists the fix so the next bootstrap deploy doesn't regress

## Changes

- `infrastructure/helm/fenrir-bootstrap/templates/networkpolicies.yaml` — added ingress rule for GCP LB health check IP ranges on port 3000

## Test plan

- [ ] Bootstrap deploy re-applies the policy without breaking LB health
- [ ] Both backends remain HEALTHY after next Helm upgrade

🤖 Generated with [Claude Code](https://claude.com/claude-code)