### PR TITLE
fix(infra+auth): restore backend timeout + accept Google sub as householdId

### DIFF
--- a/development/frontend/src/__tests__/auth/authz.test.ts
+++ b/development/frontend/src/__tests__/auth/authz.test.ts
@@ -241,6 +241,23 @@ describe("requireAuthz", () => {
     expect(result.ok).toBe(true);
   });
 
+  it("returns ok:true when supplied householdId matches user's Google sub (legacy client compat)", async () => {
+    vi.mocked(requireAuth).mockReturnValue(makeAuthSuccess(KARL_USER));
+    vi.mocked(getUser).mockResolvedValue(FIRESTORE_USER);
+    vi.mocked(getStripeEntitlement).mockResolvedValue(KARL_ENTITLEMENT);
+
+    // Client sends session.user.sub as householdId (localStorage key pattern).
+    // This differs from firestoreUser.householdId but should be accepted
+    // because it matches the authenticated user's own Google sub.
+    const result = await requireAuthz(makeRequest(), {
+      householdId: KARL_USER.sub, // "google-sub-karl" !== "household-abc"
+      tier: "karl",
+    });
+
+    expect(result.ok).toBe(true);
+    expect(log.warn).not.toHaveBeenCalled();
+  });
+
   it("returns 403 when supplied householdId does not match", async () => {
     vi.mocked(requireAuth).mockReturnValue(makeAuthSuccess(KARL_USER));
     vi.mocked(getUser).mockResolvedValue(FIRESTORE_USER);

--- a/development/frontend/src/lib/auth/authz.ts
+++ b/development/frontend/src/lib/auth/authz.ts
@@ -102,8 +102,14 @@ export async function requireAuthz(
   }
 
   // ── Step 3: Household membership check ───────────────────────────────────
+  // Legacy client compat: the client sends session.user.sub (Google sub) as
+  // householdId for localStorage keying. Accept it as "my own household"
+  // since the authenticated user's identity is already verified. The server
+  // still uses firestoreUser.householdId for all Firestore operations, so
+  // IDOR protection is intact.
   if (requirement?.householdId !== undefined) {
-    if (requirement.householdId !== firestoreUser.householdId) {
+    const isOwnSub = requirement.householdId === googleSub;
+    if (!isOwnSub && requirement.householdId !== firestoreUser.householdId) {
       log.warn("requireAuthz: access denied", {
         reason: "household_mismatch",
         googleSub,

--- a/infrastructure/helm/fenrir-app/values.yaml
+++ b/infrastructure/helm/fenrir-app/values.yaml
@@ -99,7 +99,7 @@ ingress:
       type: HTTP
       requestPath: /api/health
       port: 3000
-    timeoutSec: 30
+    timeoutSec: 3600
     connectionDraining:
       drainingTimeoutSec: 15
     cdn:


### PR DESCRIPTION
## Summary
- **Blank page fix**: BackendConfig `timeoutSec` was 30s in Helm values (should be 3600s). PR #1243 (bootstrap) deployed the Helm value, replacing the raw manifests that had 3600s. GCP LB kills RSC stream after 30s → React can't hydrate → blank page.
- **Sync fix**: Client sends `session.user.sub` as `householdId` but Firestore now stores a UUID. `requireAuthz` rejects with `household_mismatch`. Accept user's own Google sub as valid self-reference — IDOR protection intact since server uses `firestoreUser.householdId` for all Firestore ops.
- **Test**: Added test for Google sub legacy client compat (22/22 pass).

## Test plan
- [ ] CI green (Vitest + build)
- [ ] Deploy to GKE — verify /ledger loads (not blank)
- [ ] Verify sync/push no longer returns 403 household_mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)