### PR TITLE
chore: Fenrir theme on all coverage reports + Loki's decree

### DIFF
--- a/quality/scripts/coverage.mjs
+++ b/quality/scripts/coverage.mjs
@@ -23,7 +23,7 @@
  */
 
 import { execSync, spawn } from "node:child_process";
-import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, readdirSync, readFileSync, writeFileSync, copyFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -203,6 +203,54 @@ function generateReports() {
   log(`  - LCOV:  ${relDir}/lcov.info`);
 }
 
+/**
+ * Post-process Istanbul HTML reports (vitest, playwright) to inject Fenrir theme.
+ * Istanbul generates reports with base.css — we copy our coverage.css alongside
+ * and inject a <link> after base.css in every HTML file.
+ */
+function applyFenrirTheme(reportDir) {
+  const cssSource = path.join(__dirname, "coverage.css");
+  if (!existsSync(cssSource) || !existsSync(reportDir)) return;
+
+  // Copy CSS to the report directory
+  copyFileSync(cssSource, path.join(reportDir, "fenrir-theme.css"));
+
+  // Walk all HTML files and inject the link
+  function walkAndInject(dir) {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walkAndInject(fullPath);
+      } else if (entry.name.endsWith(".html")) {
+        let html = readFileSync(fullPath, "utf8");
+        if (html.includes("fenrir-theme.css")) continue; // already injected
+
+        // Compute relative path to the report root where fenrir-theme.css lives
+        const relToRoot = path.relative(dir, reportDir).replace(/\\/g, "/");
+        const cssHref = relToRoot ? `${relToRoot}/fenrir-theme.css` : "fenrir-theme.css";
+
+        // Inject after base.css link (Istanbul pattern)
+        if (html.includes('href="base.css"')) {
+          html = html.replace(
+            /(<link[^>]*href="[^"]*base\.css"[^>]*>)/,
+            `$1\n    <link rel="stylesheet" href="${cssHref}" />`,
+          );
+        } else {
+          // Fallback: inject before </head>
+          html = html.replace(
+            "</head>",
+            `    <link rel="stylesheet" href="${cssHref}" />\n</head>`,
+          );
+        }
+        writeFileSync(fullPath, html);
+      }
+    }
+  }
+
+  walkAndInject(reportDir);
+  log(`Fenrir theme applied to ${path.relative(REPO_ROOT, reportDir)}`);
+}
+
 function runCombine() {
   log("Merging Vitest + Playwright coverage via coverage-combine.mjs...");
   const combineScript = path.join(__dirname, "coverage-combine.mjs");
@@ -247,6 +295,7 @@ function runUnitCoverage() {
   const vitestReportsDir = path.join(REPORTS_DIR, "vitest");
   mkdirSync(vitestReportsDir, { recursive: true });
   run("npm run test:unit:coverage", { cwd: FRONTEND_DIR });
+  applyFenrirTheme(vitestReportsDir);
   log(`Vitest coverage reports written to ${vitestReportsDir}`);
   log("  - HTML:  quality/reports/coverage/vitest/index.html");
   log("  - LCOV:  quality/reports/coverage/vitest/lcov.info");
@@ -282,6 +331,7 @@ async function main() {
       const vitestReportsDir = path.join(REPORTS_DIR, "vitest");
       mkdirSync(vitestReportsDir, { recursive: true });
       run("npm run test:unit:coverage", { cwd: FRONTEND_DIR });
+      applyFenrirTheme(vitestReportsDir);
       log("Vitest coverage complete.");
     }
 
@@ -301,6 +351,7 @@ async function main() {
   }
 
   generateReports();
+  applyFenrirTheme(path.join(REPORTS_DIR, "playwright"));
 
   // Phase 3: Merge coverage reports
   if (combined) {

--- a/quality/scripts/quality-report.mjs
+++ b/quality/scripts/quality-report.mjs
@@ -383,6 +383,104 @@ async function main() {
 
   L.push(`---`);
   L.push(``);
+
+  // ── 4. LOKI'S DECREE ───────────────────────────────────────────────────────
+  const combinedLinePct = lcovCombined ? parseFloat(lcovCombined.lines.pct) : (lcovVitest ? parseFloat(lcovVitest.lines.pct) : 0);
+  const isClean = bullshitFiles.length === 0;
+  const isCoverageHealthy = combinedLinePct >= 50;
+  const isShieldSecure = isClean && isCoverageHealthy;
+
+  L.push(`## ᛉ Loki's Decree`);
+  L.push(``);
+
+  if (isShieldSecure) {
+    L.push(`\`\`\``);
+    L.push(`╔══════════════════════════════════════════════════════════════╗`);
+    L.push(`║                                                              ║`);
+    L.push(`║     ᛉ   R U N I C   S E A L   O F   Q U A L I T Y   ᛉ      ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  The shield wall stands unbroken. ${String(totalTests).padStart(4)} tests guard the        ║`);
+    L.push(`║  realm. ${String(totalFiles).padStart(3)} files carry the weight. No hollow              ║`);
+    L.push(`║  assertions defile the count.                                ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  Combined line coverage: ${String(combinedLinePct.toFixed(1) + '%').padEnd(7)}                          ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  I, Loki Laufeyson, QA Tester of Fenrir Ledger,             ║`);
+    L.push(`║  do hereby declare: THE SHIELD WALL IS SECURE.              ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  The chains hold. The wolf sleeps.                           ║`);
+    L.push(`║  No change order is required at this time.                   ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║                               Signed: ᛚᛟᚲᛁ                   ║`);
+    L.push(`║                               Loki Laufeyson                 ║`);
+    L.push(`║                               QA Tester, Fenrir Ledger       ║`);
+    L.push(`║                               ${new Date().toISOString().split('T')[0]}                       ║`);
+    L.push(`║                                                              ║`);
+    L.push(`╚══════════════════════════════════════════════════════════════╝`);
+    L.push(`\`\`\``);
+  } else {
+    const issues = [];
+    if (!isClean) issues.push(`${bullshitFiles.length} hollow test file${bullshitFiles.length !== 1 ? 's' : ''} (${totalBullshitTests} tests) poisoning the suite`);
+    if (!isCoverageHealthy) issues.push(`combined line coverage at ${combinedLinePct.toFixed(1)}% — below the 50% minimum threshold`);
+
+    L.push(`\`\`\``);
+    L.push(`╔══════════════════════════════════════════════════════════════╗`);
+    L.push(`║                                                              ║`);
+    L.push(`║   ᚦ  F O R M A L   C H A N G E   O R D E R   ᚦ             ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  TO: Odin, All-Father and Project Owner                      ║`);
+    L.push(`║  FROM: Loki Laufeyson, QA Tester                             ║`);
+    L.push(`║  RE: Test Quality Deficiencies — Immediate Action Required   ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  The shield wall has been inspected and found WANTING.        ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║  DEFICIENCIES:                                               ║`);
+    for (const issue of issues) {
+      // Word-wrap to fit inside the box (max 52 chars per content line)
+      const words = issue.split(' ');
+      const lines = [];
+      let cur = '';
+      for (const w of words) {
+        if (cur && (cur.length + 1 + w.length) > 52) {
+          lines.push(cur);
+          cur = w;
+        } else {
+          cur = cur ? `${cur} ${w}` : w;
+        }
+      }
+      if (cur) lines.push(cur);
+      for (let i = 0; i < lines.length; i++) {
+        const prefix = i === 0 ? '- ' : '  ';
+        L.push(`║    ${prefix}${lines[i].padEnd(54)}║`);
+      }
+    }
+    L.push(`║                                                              ║`);
+    L.push(`║  REQUIRED ACTIONS:                                           ║`);
+    if (!isClean) {
+      L.push(`║    1. Delete all flagged hollow test files                   ║`);
+      L.push(`║    2. Replace with behavioural tests that guard logic        ║`);
+    }
+    if (!isCoverageHealthy) {
+      L.push(`║    ${isClean ? '1' : '3'}. Increase coverage to ≥50% combined lines              ║`);
+      L.push(`║    ${isClean ? '2' : '4'}. Priority: auth flows, sync engine, import pipeline     ║`);
+    }
+    L.push(`║                                                              ║`);
+    L.push(`║  This decree is BINDING until the deficiencies are           ║`);
+    L.push(`║  resolved and a subsequent quality report issues a           ║`);
+    L.push(`║  Runic Seal of Quality.                                      ║`);
+    L.push(`║                                                              ║`);
+    L.push(`║                               Signed: ᛚᛟᚲᛁ                   ║`);
+    L.push(`║                               Loki Laufeyson                 ║`);
+    L.push(`║                               QA Tester, Fenrir Ledger       ║`);
+    L.push(`║                               ${new Date().toISOString().split('T')[0]}                       ║`);
+    L.push(`║                                                              ║`);
+    L.push(`╚══════════════════════════════════════════════════════════════╝`);
+    L.push(`\`\`\``);
+  }
+
+  L.push(``);
+  L.push(`---`);
+  L.push(``);
   L.push(`*Generated by \`quality/scripts/quality-report.mjs\` · [Coverage index](coverage/index.html)*`);
 
   mkdirSync(path.dirname(OUTPUT_PATH), { recursive: true });


### PR DESCRIPTION
## Summary
- **Fenrir theme**: All three coverage HTML reports (vitest, playwright, combined) now use the void-black + gold Fenrir CSS. Previously only combined (genhtml) was themed.
- **Loki's Decree**: Quality report now ends with an official decree from Loki Laufeyson:
  - **Runic Seal of Quality** (clean suite + ≥50% coverage) — shield wall is secure
  - **Formal Change Order** (bullshit tests or low coverage) — binding action items for Odin

## Test plan
- [x] `node quality/scripts/quality-report.mjs` generates decree
- [x] Vitest HTML reports contain `fenrir-theme.css` link
- [x] Word-wrap works for long deficiency lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)