### PR TITLE
fix: dark SVG seal background

### DIFF
--- a/quality/scripts/quality-report-html.mjs
+++ b/quality/scripts/quality-report-html.mjs
@@ -103,7 +103,7 @@ function gaugeRing(pct, label, size = 100) {
 function lokiSealSvg(dateStr, isSecure) {
   const glowColor = isSecure ? "#4ade80" : "#ef4444";
   const runeGlow = isSecure ? "drop-shadow(0 0 6px #4ade8060)" : "drop-shadow(0 0 6px #ef444460)";
-  return `<svg width="320" height="160" viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg">
+  return `<svg width="320" height="160" viewBox="0 0 320 160" xmlns="http://www.w3.org/2000/svg" style="background:#07070d;border-radius:8px">
     <defs>
       <linearGradient id="seal-border" x1="0" y1="0" x2="1" y2="1">
         <stop offset="0%" stop-color="#c9920a"/>
@@ -112,16 +112,17 @@ function lokiSealSvg(dateStr, isSecure) {
       </linearGradient>
       <filter id="glow"><feGaussianBlur stdDeviation="2" result="blur"/><feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge></filter>
     </defs>
+    <rect x="0" y="0" width="320" height="160" rx="8" fill="#07070d"/>
     <rect x="2" y="2" width="316" height="156" rx="8" fill="#07070d" stroke="url(#seal-border)" stroke-width="1.5"/>
     <rect x="5" y="5" width="310" height="150" rx="6" fill="none" stroke="#c9920a" stroke-width="0.3" opacity="0.2"/>
     <line x1="30" y1="42" x2="290" y2="42" stroke="#c9920a" stroke-width="0.4" opacity="0.2"/>
     <text x="160" y="32" text-anchor="middle" font-family="serif" font-size="20" letter-spacing="10" fill="#c9920a" opacity="0.8" filter="url(#glow)">ᛚ ᛟ ᚲ ᛁ</text>
     <text x="160" y="64" text-anchor="middle" font-family="serif" font-size="14" fill="#c9920a" opacity="0.9" letter-spacing="2">Loki Laufeyson</text>
-    <text x="160" y="84" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#555">QA Tester</text>
-    <text x="160" y="104" text-anchor="middle" font-family="monospace" font-size="10" fill="#444">${dateStr}</text>
+    <text x="160" y="84" text-anchor="middle" font-family="sans-serif" font-size="11" fill="#8b8680">QA Tester</text>
+    <text x="160" y="104" text-anchor="middle" font-family="monospace" font-size="10" fill="#666">${dateStr}</text>
     <line x1="30" y1="115" x2="290" y2="115" stroke="#c9920a" stroke-width="0.3" opacity="0.15"/>
     <text x="160" y="138" text-anchor="middle" font-family="serif" font-size="12" letter-spacing="4" fill="${glowColor}" opacity="0.5" style="filter: ${runeGlow}">ᚠ ᛖ ᚾ ᚱ ᛁ ᚱ</text>
-    <text x="160" y="153" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#333" letter-spacing="2">OFFICIAL SEAL</text>
+    <text x="160" y="153" text-anchor="middle" font-family="sans-serif" font-size="7" fill="#555" letter-spacing="2">OFFICIAL SEAL</text>
   </svg>`;
 }
 


### PR DESCRIPTION
SVG seal was rendering with light background. Added explicit background + full-bleed rect + brighter text.