### PR TITLE
fix: reload dashboard cards after cloud sync writes to localStorage

### DIFF
--- a/development/frontend/src/app/ledger/page.tsx
+++ b/development/frontend/src/app/ledger/page.tsx
@@ -114,6 +114,13 @@ function DashboardPageContent() {
     }
   }, [canImport]);
 
+  // Reload cards when cloud sync writes to localStorage (fenrir:sync fired by setAllCards).
+  // Without this, the dashboard stays empty after migration/pull downloads cards from Firestore.
+  useEffect(() => {
+    window.addEventListener("fenrir:sync", refreshCards);
+    return () => window.removeEventListener("fenrir:sync", refreshCards);
+  }, [refreshCards]);
+
   // Listen for custom event from EmptyState's "Import from Google Sheets" button
   useEffect(() => {
     function handleOpenWizard() {


### PR DESCRIPTION
## Root Cause

The dashboard loads cards once on mount from localStorage. When cloud sync (migration download or pull) runs **after** the initial load, it calls `setAllCards()` which writes to localStorage and dispatches `"fenrir:sync"`. But the dashboard page had no listener for this event — so it stayed empty.

## Fix

Add a `fenrir:sync` listener that calls `refreshCards()`. One listener, 5 lines.

## Reproduces as

- Sign in as a Karl user on a fresh browser/device
- Settings shows "N cards backed up" 
- Dashboard shows no cards

## Test plan

- [ ] Sign in as Karl user with existing cloud cards
- [ ] Dashboard populates with cards after sync completes
- [ ] No duplicate renders / infinite loop (fenrir:sync fires on saveCard too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)