### PR TITLE
fix(e2e): remove redundant goto in CSRF mismatch test

### DIFF
--- a/quality/test-suites/auth/auth-callback.spec.ts
+++ b/quality/test-suites/auth/auth-callback.spec.ts
@@ -157,7 +157,8 @@ test.describe("Auth Callback — CSRF State Mismatch", () => {
   }) => {
     // Spec: auth/callback/page.tsx — pkceData.state !== stateParam →
     //       "State mismatch — possible CSRF attack. Please sign in again."
-    await page.goto("/ledger");
+    // Note: beforeEach already lands on /ledger — seed sessionStorage directly
+    // without a second goto to avoid an extra API request burst that prevents networkidle.
     // Seed PKCE session with a known state
     await page.evaluate(() => {
       sessionStorage.setItem(


### PR DESCRIPTION
## Root Cause

`beforeEach` navigates to `/ledger` and clears storage. The CSRF test then navigated to `/ledger` a second time to seed sessionStorage — triggering a fresh burst of API requests (`/api/trial/status` etc.). When the next `page.goto` to the callback URL fired, those requests were still in-flight. `waitUntil: "networkidle"` on the callback page never settled before the 30s timeout.

## Fix

Remove the redundant `goto("/ledger")`. Since `beforeEach` already lands on `/ledger`, just call `page.evaluate` directly to seed sessionStorage — no extra navigation needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)