### PR TITLE
fix(ci): authenticate to GHCR before pulling n8n Helm chart

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -783,6 +783,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: read
 
     steps:
       - uses: actions/checkout@v5
@@ -818,6 +819,9 @@ jobs:
             --namespace=fenrir-marketing \
             --from-literal=emails.txt="declanshanaghy@gmail.com" \
             --dry-run=client -o yaml | kubectl apply -f -
+
+      - name: Login to GHCR for n8n chart
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Helm deploy n8n app
         run: |


### PR DESCRIPTION
## Summary
- Add `helm registry login ghcr.io` step before pulling the n8n OCI chart
- Add `packages: read` permission to the `marketing-engine` job so `GITHUB_TOKEN` can authenticate to GHCR
- Root cause: GHCR returns 403 on public OCI charts without auth

## Test plan
- [ ] Trigger deploy workflow — marketing-engine job should pull and install the n8n chart successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)