### PR TITLE
fix(infra): switch to official n8n Helm chart — fixes deploy 404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -804,7 +804,7 @@ jobs:
   # Namespace: fenrir-marketing
   # n8n workflow automation at marketing.fenrirledger.com.
   # Two Helm installs:
-  #   1. oci://ghcr.io/8gears/n8n   — n8n app (external chart, n8n-app-values.yaml)
+  #   1. oci://ghcr.io/n8n-io/n8n-helm-chart/n8n — official n8n chart (n8n-app-values.yaml)
   #   2. infrastructure/helm/n8n/   — infra chart (oauth2-proxy, cert, BackendConfig, ingress)
   # ============================================================================
 
@@ -863,7 +863,8 @@ jobs:
 
       - name: Helm deploy n8n app
         run: |
-          helm upgrade --install n8n oci://ghcr.io/8gears/n8n \
+          helm upgrade --install n8n oci://ghcr.io/n8n-io/n8n-helm-chart/n8n \
+            --version 1.1.0 \
             --namespace=fenrir-marketing \
             --create-namespace \
             -f infrastructure/helm/n8n/n8n-app-values.yaml \

--- a/infrastructure/helm/n8n/Chart.yaml
+++ b/infrastructure/helm/n8n/Chart.yaml
@@ -4,7 +4,7 @@ description: >
   Fenrir Ledger — Marketing Engine infrastructure.
   Manages the fenrir-marketing namespace, oauth2-proxy, GKE ManagedCertificate,
   BackendConfig, and GCE Ingress for marketing.fenrirledger.com.
-  The n8n application is deployed separately via oci://ghcr.io/8gears/n8n
+  The n8n application is deployed separately via oci://ghcr.io/n8n-io/n8n-helm-chart/n8n
   using n8n-app-values.yaml in this same directory.
 type: application
 version: 0.1.0

--- a/infrastructure/helm/n8n/n8n-app-values.yaml
+++ b/infrastructure/helm/n8n/n8n-app-values.yaml
@@ -1,25 +1,32 @@
 # --------------------------------------------------------------------------
 # n8n Application Helm Values
-# Chart: oci://ghcr.io/8gears/n8n
+# Chart: oci://ghcr.io/n8n-io/n8n-helm-chart/n8n (official)
 # Namespace: fenrir-marketing
 #
 # Deploy:
-#   helm upgrade --install n8n oci://ghcr.io/8gears/n8n \
+#   helm upgrade --install n8n oci://ghcr.io/n8n-io/n8n-helm-chart/n8n \
+#     --version 1.1.0 \
 #     -n fenrir-marketing \
 #     -f infrastructure/helm/n8n/n8n-app-values.yaml
 # --------------------------------------------------------------------------
 
-n8n:
-  host: "marketing.fenrirledger.com"
-  protocol: "https"
-  port: 5678
-  editorBaseUrl: "https://marketing.fenrirledger.com/"
-  webhookTunnelUrl: "https://marketing.fenrirledger.com/"
+# Standalone mode (no queue, no Redis, no external Postgres)
+queueMode:
+  enabled: false
 
-db:
+# SQLite database (standalone mode)
+database:
   type: sqlite
+  useExternal: false
 
-env:
+# Redis not needed in standalone mode
+redis:
+  enabled: false
+  useExternal: false
+
+# n8n configuration
+config:
+  timezone: UTC
   N8N_HOST: "marketing.fenrirledger.com"
   N8N_PROTOCOL: "https"
   N8N_PORT: "5678"
@@ -29,40 +36,40 @@ env:
   N8N_DIAGNOSTICS_ENABLED: "false"
   N8N_VERSION_NOTIFICATIONS_ENABLED: "false"
 
-extraEnvFrom:
-  - secretRef:
-      name: n8n-secrets
+# Secrets from K8s secret
+secretRefs:
+  existingSecret: "n8n-secrets"
 
+# Persistence for SQLite data
 persistence:
   enabled: true
-  storageClass: standard-rwo
+  accessModes: ["ReadWriteOnce"]
   size: 1Gi
-  mountPath: /home/node/.n8n
-  accessModes:
-    - ReadWriteOnce
+  storageClassName: standard-rwo
 
+# Resources
 resources:
-  requests:
-    cpu: "250m"
-    memory: "512Mi"
-    ephemeral-storage: "128Mi"
-  limits:
-    cpu: "250m"
-    memory: "512Mi"
-    ephemeral-storage: "256Mi"
+  main:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+      ephemeral-storage: "128Mi"
+    limits:
+      cpu: "250m"
+      memory: "512Mi"
+      ephemeral-storage: "256Mi"
 
+# Service
 service:
   type: ClusterIP
-  port: 80
-  targetPort: 5678
+  port: 5678
 
 # Ingress managed by n8n-infra Helm chart (infrastructure/helm/n8n/)
 ingress:
   enabled: false
 
-replicaCount: 1
-
+# Image
 image:
-  repository: n8nio/n8n
-  tag: latest
+  repository: docker.n8n.io/n8nio/n8n
+  tag: "2.11.2"
   pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary
8gears chart at `oci://ghcr.io/8gears/n8n` returns 404 (silently moved registries, stale since 2023).

Switched to official n8n chart: `oci://ghcr.io/n8n-io/n8n-helm-chart/n8n` v1.1.0 (app 2.11.2).

- Standalone mode (SQLite, no Redis/Postgres)
- Values rewritten for official chart schema
- Pinned chart version

## Test plan
- [ ] CI deploy job succeeds
- [ ] n8n pod starts in fenrir-marketing namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)