### PR TITLE
fix: make www.fenrirledger.com the canonical domain

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -4,7 +4,7 @@
 # Runs on every push to PR branches and workflow_dispatch:
 #   1. TypeScript type-checking (tsc --noEmit)
 #   2. Vitest unit tests
-#   3. Playwright E2E tests against https://fenrirledger.com
+#   3. Playwright E2E tests against https://www.fenrirledger.com
 #   4. Upload test artifacts + upsert PR comment with results
 #
 # Replaces the former Vercel-deployment-based CI workflow (Issue #734).
@@ -68,7 +68,7 @@ jobs:
       - name: Run Playwright E2E tests
         id: e2e
         env:
-          SERVER_URL: https://fenrirledger.com
+          SERVER_URL: https://www.fenrirledger.com
         run: npx playwright test
 
       - name: Upload Playwright report
@@ -114,7 +114,7 @@ jobs:
               '',
               `**Commit:** \`${sha.slice(0, 7)}\``,
               `**Run:** [View details](${runUrl})`,
-              `**Target:** https://fenrirledger.com`,
+              `**Target:** https://www.fenrirledger.com`,
             ].join('\n');
 
             // Upsert: find existing comment or create new

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -500,7 +500,7 @@ jobs:
             --from-literal=GOOGLE_PICKER_API_KEY="${{ secrets.GOOGLE_PICKER_API_KEY }}" \
             --from-literal=FENRIR_ANTHROPIC_API_KEY="${{ secrets.FENRIR_ANTHROPIC_API_KEY }}" \
             --from-literal=ENTITLEMENT_ENCRYPTION_KEY="${{ secrets.ENTITLEMENT_ENCRYPTION_KEY }}" \
-            --from-literal=APP_BASE_URL="https://fenrirledger.com" \
+            --from-literal=APP_BASE_URL="https://www.fenrirledger.com" \
             --from-literal=STRIPE_SECRET_KEY="${{ secrets.STRIPE_SECRET_KEY }}" \
             --from-literal=NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}" \
             --from-literal=STRIPE_WEBHOOK_SECRET="${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
@@ -579,7 +579,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}
-      SERVER_URL: https://fenrirledger.com
+      SERVER_URL: https://www.fenrirledger.com
 
     steps:
       - name: Checkout

--- a/development/frontend/src/app/(marketing)/terms/page.tsx
+++ b/development/frontend/src/app/(marketing)/terms/page.tsx
@@ -59,10 +59,10 @@ export default function TermsPage() {
         Fenrir Ledger is a credit card rewards tracking application operated by
         Declan Shanaghy (&ldquo;we&rdquo;, &ldquo;us&rdquo;, &ldquo;our&rdquo;). The Service is available at{" "}
         <a
-          href="https://fenrirledger.com"
+          href="https://www.fenrirledger.com"
           className="text-gold underline hover:brightness-110 transition-colors"
         >
-          fenrirledger.com
+          www.fenrirledger.com
         </a>
         .
       </p>

--- a/development/frontend/src/middleware.ts
+++ b/development/frontend/src/middleware.ts
@@ -33,15 +33,16 @@ export function middleware(request: NextRequest) {
   const { hostname, protocol, pathname, search } = request.nextUrl;
 
   // -----------------------------------------------------------------------
-  // Canonical domain redirect: www → apex, HTTP → HTTPS
+  // Canonical domain redirect: apex → www, HTTP → HTTPS
+  // www.fenrirledger.com is canonical. Apex and HTTP requests redirect here.
   // Skip in development (localhost) and health check endpoint (GCP probes use HTTP)
   // -----------------------------------------------------------------------
   if (hostname !== "localhost" && hostname !== "127.0.0.1" && pathname !== "/api/health") {
-    const isWww = hostname.startsWith("www.");
+    const isApex = !hostname.startsWith("www.") && hostname.includes("fenrirledger.com");
     const isHttp = protocol === "http:" || request.headers.get("x-forwarded-proto") === "http";
 
-    if (isWww || isHttp) {
-      const canonicalHost = hostname.replace(/^www\./, "");
+    if (isApex || isHttp) {
+      const canonicalHost = isApex ? `www.${hostname}` : hostname;
       const url = `https://${canonicalHost}${pathname}${search}`;
       return NextResponse.redirect(url, 301);
     }

--- a/infrastructure/helm/fenrir-app/values.yaml
+++ b/infrastructure/helm/fenrir-app/values.yaml
@@ -124,7 +124,7 @@ secrets:
   # When enabled, creates the Secret resource with placeholder values.
   # In production, secrets are injected by the CD pipeline via kubectl.
   enabled: false
-  appBaseUrl: "https://fenrirledger.com"
+  appBaseUrl: "https://www.fenrirledger.com"
 
 # -- Redis -----------------------------------------------------------------
 redis:


### PR DESCRIPTION
## Summary
- Flips redirect direction: apex → www (previously www → apex)
- `www.fenrirledger.com` is canonical — all `fenrirledger.com` traffic 301s there
- Fixes #1302 — users on apex had isolated localStorage → 0 cards shown

## Changes
- `middleware.ts` — redirect apex → www; HTTP → HTTPS; leave www unchanged
- `deploy.yml` — `APP_BASE_URL` + E2E `SERVER_URL` → `https://www.fenrirledger.com`
- `ci-tests.yml` — `SERVER_URL` → `https://www.fenrirledger.com`
- `infrastructure/helm/fenrir-app/values.yaml` — `appBaseUrl` default updated
- `terms/page.tsx` — href + display text updated

## Test plan
- [ ] `https://fenrirledger.com` → 301 → `https://www.fenrirledger.com`
- [ ] `http://fenrirledger.com` → 301 → `https://www.fenrirledger.com`
- [ ] `https://www.fenrirledger.com` — no redirect, loads directly
- [ ] Cards visible on `www` (localStorage intact)
- [ ] Subdomains unaffected (`analytics.*`, `monitoring.*`, `marketing.*`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)