### PR TITLE
fix(tests): update redirect test to match apex→www canonical direction

### DIFF
--- a/development/frontend/src/__tests__/lib/cache-headers-middleware.loki.test.ts
+++ b/development/frontend/src/__tests__/lib/cache-headers-middleware.loki.test.ts
@@ -69,10 +69,24 @@ describe("middleware — Cache-Control applied on normal HTTPS apex requests", (
 });
 
 // ── 301 redirects must NOT carry Cache-Control ────────────────────────────
+// www.fenrirledger.com is canonical. Apex (fenrirledger.com) → www. HTTP → HTTPS.
+
+/** Build a request to fenrirledger.com (the apex domain) for redirect tests. */
+function apexCanonicalRequest(pathname: string, { http = false } = {}): NextRequest {
+  const proto = http ? "http" : "https";
+  const host = "fenrirledger.com";
+  return new NextRequest(`${proto}://${host}${pathname}`, {
+    method: "GET",
+    headers: {
+      host,
+      ...(http ? { "x-forwarded-proto": "http" } : {}),
+    },
+  });
+}
 
 describe("middleware — 301 redirect responses must NOT carry Cache-Control", () => {
-  it("www → apex redirect has no Cache-Control header", () => {
-    const req = apexRequest("/", { www: true });
+  it("apex → www redirect has no Cache-Control header", () => {
+    const req = apexCanonicalRequest("/");
     const response = middleware(req);
     expect(response.status).toBe(301);
     expect(response.headers.get("Cache-Control")).toBeNull();
@@ -85,8 +99,8 @@ describe("middleware — 301 redirect responses must NOT carry Cache-Control", (
     expect(response.headers.get("Cache-Control")).toBeNull();
   });
 
-  it("www + HTTP combined redirect has no Cache-Control header", () => {
-    const req = apexRequest("/about", { www: true, http: true });
+  it("apex + HTTP combined redirect has no Cache-Control header", () => {
+    const req = apexCanonicalRequest("/about", { http: true });
     const response = middleware(req);
     expect(response.status).toBe(301);
     expect(response.headers.get("Cache-Control")).toBeNull();


### PR DESCRIPTION
## Summary
The redirect direction changed from `www→apex` to `apex→www` in #1304. The unit test `cache-headers-middleware.loki.test.ts` still asserted the old `www→apex` behavior, causing a CI failure.

## Changes
- Add `apexCanonicalRequest()` helper using `fenrirledger.com` (the apex domain our middleware actually checks)
- Rename test: "www → apex redirect" → "apex → www redirect"
- Update combined HTTP+redirect test to use apex domain

## Test plan
- [ ] `npx vitest run src/__tests__/lib/cache-headers-middleware.loki.test.ts` — 11/11 pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)