### PR TITLE
fix(e2e): use waitUntil load for corrupt PKCE test to avoid timeout

### DIFF
--- a/quality/test-suites/auth/auth-callback.spec.ts
+++ b/quality/test-suites/auth/auth-callback.spec.ts
@@ -200,8 +200,11 @@ test.describe("Auth Callback — Corrupt PKCE Data", () => {
       sessionStorage.setItem("fenrir:pkce", "this-is-not-valid-json{{{{");
     });
 
+    // Use "load" not "networkidle": corrupt PKCE is detected client-side before
+    // the token exchange completes. A fake code causes /api/auth/token to hang
+    // server-side, preventing networkidle from ever settling within 30s.
     await page.goto("/ledger/auth/callback?code=fake_code&state=any-state", {
-      waitUntil: "networkidle",
+      waitUntil: "load",
     });
 
     await expect(


### PR DESCRIPTION
## Summary
The "Corrupt PKCE Data" E2E test was timing out at 30s in CI. The test navigates to `/ledger/auth/callback?code=fake_code&state=any-state` with `waitUntil: "networkidle"`. The fake code triggers a `/api/auth/token` server call which hangs, preventing networkidle from settling.

The corrupt PKCE error is a pure client-side check (JSON.parse throws on the invalid sessionStorage value) — it does not need the network to settle. Switching to `waitUntil: "load"` lets the error render immediately.

## Test plan
- [ ] CI: "shows corrupt PKCE error when sessionStorage contains invalid JSON" passes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)