### PR TITLE
Issue #1307 - feat: agent chain auto-continuation

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -149,6 +149,19 @@ STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,
 declare things "done", or add commentary beyond your handoff step.
 If something is ambiguous, comment on the issue asking for clarification — don't guess.
+
+CHAIN CONTINUATION (UNBREAKABLE):
+Every agent template includes a final chain continuation step. It is MANDATORY when
+conditions are met (success verdict) and FORBIDDEN when they are not (failure/partial).
+
+- Non-final agents (Luna, FiremanDecko, Heimdall): run `/fire-next-up --resume #<NUMBER>`
+  as the final step ONLY when all verify steps pass and the handoff comment is posted.
+  This dispatches the next agent in the chain on the same branch.
+- Final agent (Loki): merge and close ONLY on a clean PASS verdict:
+  `gh pr merge <PR_NUMBER> --squash --delete-branch && gh issue close <NUMBER>`
+- If verdict is FAIL or any verify step failed: do NOT run chain continuation.
+  Stop immediately and leave the issue open for manual triage.
+- Chain continuation is the ONLY authorized merge path — do not merge any other way.
 ```
 
 ---

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -90,4 +90,9 @@ gh issue comment <NUMBER> --body "## FiremanDecko → Loki Handoff
 - <Tricky scenarios>
 
 **Build:** tsc + build PASS. Ready for QA."
+**Step 8 — Chain continuation (DONE only):**
+If tsc + build both PASS and handoff comment is posted:
+  /fire-next-up --resume #<NUMBER>
+This dispatches Loki (QA) on the same branch to validate the implementation.
+If ANY verify step FAILED: do NOT run this step — stop and leave the issue for manual triage.
 ```

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -71,6 +71,12 @@ gh issue comment <NUMBER> --body "## Heimdall → Loki Handoff
 - <What to test: input validation, auth checks, error handling>
 
 **Build:** tsc + build PASS. Ready for QA."
+
+**Step 8 — Chain continuation (security fix only):**
+If tsc + build both PASS and handoff comment is posted:
+  /fire-next-up --resume #<NUMBER>
+This dispatches Loki (QA) on the same branch to validate the security fix.
+If ANY verify step FAILED: do NOT run this step — stop and leave the issue for manual triage.
 ```
 
 ## Mode B: Report / Audit (only writes `.md` files, files issues)
@@ -129,4 +135,10 @@ gh issue comment <NUMBER> --body "## Heimdall Handoff
 **Summary:** <brief summary of findings/work>
 
 **Severity counts:** CRITICAL: N, HIGH: N, MEDIUM: N, LOW: N, INFO: N"
+
+**Step 7 — Chain continuation (report/audit):**
+If work is complete, PR is open, and handoff comment is posted:
+  /fire-next-up --resume #<NUMBER>
+This dispatches the next agent (if any) on the same branch.
+If work is incomplete or blocked: do NOT run this step — stop and leave for manual triage.
 ```

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -120,6 +120,13 @@ gh issue comment <NUMBER> --body "## Loki QA Verdict
 <If PASS: Ready for merge — awaiting orchestrator + CI green.>
 <If FAIL: Blocked — see failures above.>"
 
+**Step 7 — Chain continuation (PASS only):**
+If your verdict is PASS (all tests green, tsc + build PASS):
+  gh pr view <BRANCH> --json number --jq '.number'
+  gh pr merge <PR_NUMBER> --squash --delete-branch
+  gh issue close <NUMBER>
+If FAIL: do NOT run this step — leave the issue open for manual triage.
+
 ---
 
 **Test Standards:** Canonical source is `.claude/agents/loki.md` § "Test Standards (UNBREAKABLE)".
@@ -193,9 +200,16 @@ gh issue comment <NUMBER> --body "## Loki QA Verdict (Revised)
 <If all tests pass: All CI failures resolved. Ready for merge — awaiting orchestrator.>
 <If still failing: FAIL — <what is still broken>.>"
 
-**IMPORTANT — DO NOT MERGE:**
-You do NOT have merge authority. Only the orchestrator (via Odin's approval) merges PRs.
-Your job ends after posting the verdict comment. Do NOT run `gh pr merge` or any merge command.
+**Step 7 — Chain continuation (PASS only):**
+If your verdict is PASS (ALL tests green):
+  gh pr view <BRANCH> --json number --jq '.number'
+  gh pr merge <PR_NUMBER> --squash --delete-branch
+  gh issue close <NUMBER>
+If still FAIL: do NOT run this step — leave the issue open for manual triage.
+
+**IMPORTANT — DO NOT MERGE (unless chain continuation above applies):**
+The chain continuation step above is the only authorized merge path. Only run it on a clean PASS.
+Your job ends after posting the verdict comment (and optionally running chain continuation).
 
 **Key reminders:**
 - EVERY bash command must start with cd <REPO_ROOT>.

--- a/.claude/skills/fire-next-up/templates/luna.md
+++ b/.claude/skills/fire-next-up/templates/luna.md
@@ -51,4 +51,10 @@ gh issue comment <NUMBER> --body "## Luna → FiremanDecko Handoff
 - <Component suggestions, patterns to reuse, edge cases>
 
 Ready for implementation."
+
+**Step 6 — Chain continuation:**
+If wireframes are committed, PR is open, and handoff comment is posted:
+  /fire-next-up --resume #<NUMBER>
+This dispatches FiremanDecko (Step 2) on the same branch to implement the design.
+If anything failed or is incomplete: do NOT run this step — stop and leave for manual triage.
 ```


### PR DESCRIPTION
PR for issue: #1307

Adds a chain continuation step to all agent dispatch templates so the agent chain advances automatically on success without manual orchestration.

**Changes:**
- `.claude/skills/fire-next-up/templates/firemandecko.md` — Step 8: run `/fire-next-up --resume` on DONE
- `.claude/skills/fire-next-up/templates/luna.md` — Step 6: run `/fire-next-up --resume` on completion
- `.claude/skills/fire-next-up/templates/heimdall.md` — Step 8 (Mode A) / Step 7 (Mode B): run `/fire-next-up --resume`
- `.claude/skills/fire-next-up/templates/loki.md` — Step 7 (both modes): `gh pr merge --squash --delete-branch && gh issue close` on PASS
- `.claude/skills/dispatch/SKILL.md` — sandbox preamble: CHAIN CONTINUATION (UNBREAKABLE) rule

**Verification:**
- Open any template file and confirm the final step contains chain continuation
- Confirm Loki's step merges and closes; non-final agents dispatch next step via `/fire-next-up --resume`
- Confirm chain continuation is gated on success (DONE/PASS) — FAIL stops the chain