### PR TITLE
Issue #1308 - feat: sandbox preamble chain continuation

### DIFF
--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -53,4 +53,17 @@ STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,
 declare things "done", or add commentary beyond your handoff step.
 If something is ambiguous, comment on the issue asking for clarification — don't guess.
+
+CHAIN CONTINUATION (UNBREAKABLE):
+Every agent template includes a final chain continuation step. It is MANDATORY when
+conditions are met (success verdict) and FORBIDDEN when they are not (failure/partial).
+
+- Non-final agents (Luna, FiremanDecko, Heimdall): run `/fire-next-up --resume #<NUMBER>`
+  as the final step ONLY when all verify steps pass and the handoff comment is posted.
+  This dispatches the next agent in the chain on the same branch.
+- Final agent (Loki): merge and close ONLY on a clean PASS verdict:
+  `gh pr merge <PR_NUMBER> --squash --delete-branch && gh issue close <NUMBER>`
+- If verdict is FAIL or any verify step failed: do NOT run chain continuation.
+  Stop immediately and leave the issue open for manual triage.
+- Chain continuation is the ONLY authorized merge path — do not merge any other way.
 ```


### PR DESCRIPTION
PR for issue: #1308

Syncs `sandbox-preamble.md` (the standalone template file) with the embedded preamble in `dispatch/SKILL.md`, which already contained the CHAIN CONTINUATION section from prior work.

**Changes:**
- `.claude/skills/fire-next-up/templates/sandbox-preamble.md` — added CHAIN CONTINUATION (UNBREAKABLE) section after STRICT SCOPE, matching the embedded preamble in dispatch/SKILL.md

**Verification:**
- Both preamble sources (embedded in dispatch/SKILL.md and standalone sandbox-preamble.md) now contain identical CHAIN CONTINUATION instructions
- All agent templates (firemandecko.md, loki.md Mode A+B) already have explicit chain continuation steps from PR #1312 — this preamble layer provides universal coverage regardless of template
- Markdown content is valid (no build step needed)