### PR TITLE
fix: resolve marketing.fenrirledger.com 403 error

### DIFF
--- a/infrastructure/helm/n8n/values.yaml
+++ b/infrastructure/helm/n8n/values.yaml
@@ -8,7 +8,7 @@ staticIpName: marketing-ip
 
 oauth2Proxy:
   image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
-  upstream: http://n8n.fenrir-marketing.svc.cluster.local:80
+  upstream: http://n8n.fenrir-marketing.svc.cluster.local:5678
   redirectUrl: https://marketing.fenrirledger.com/oauth2/callback
   cookieDomain: marketing.fenrirledger.com
   secretsSecretName: n8n-oauth2-proxy-secrets


### PR DESCRIPTION
Fixes #1320

## Root cause

`infrastructure/helm/n8n/values.yaml` had the oauth2-proxy `upstream` pointing to port **80** but n8n's ClusterIP service exposes port **5678**. Every proxied request failed with an upstream connection refused error, surfacing as 403 at marketing.fenrirledger.com.

## Fix

Changed upstream port from `80` → `5678` in `infrastructure/helm/n8n/values.yaml`.

## Loki QA Validation

- **tsc** — PASS
- **next build** — PASS (45 routes)
- **vitest run** — 136 files / 2007 tests PASS
- **Tests written:** 0 (infrastructure-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)