### PR TITLE
fix(infra): disable HTTP on analytics/monitor/n8n ingresses — free global forwarding rule quota

### DIFF
--- a/infrastructure/helm/n8n/templates/ingress.yaml
+++ b/infrastructure/helm/n8n/templates/ingress.yaml
@@ -36,7 +36,7 @@ metadata:
     kubernetes.io/ingress.class: "gce"
     kubernetes.io/ingress.global-static-ip-name: {{ .Values.staticIpName | quote }}
     networking.gke.io/managed-certificates: "n8n-cert"
-    kubernetes.io/ingress.allow-http: "true"
+    kubernetes.io/ingress.allow-http: "false"
     cloud.google.com/backend-config: '{"default":"n8n-backend-config"}'
 spec:
   rules:

--- a/infrastructure/helm/odin-throne/values.yaml
+++ b/infrastructure/helm/odin-throne/values.yaml
@@ -129,7 +129,7 @@ ingress:
     - monitor.fenrirledger.com
   annotations:
     networking.gke.io/managed-certificates: "odin-throne-cert"
-    kubernetes.io/ingress.allow-http: "true"
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: "monitor-ip"
     cloud.google.com/backend-config: '{"default":"odin-throne-ui-backend-config"}'
 

--- a/infrastructure/helm/umami/values-prod.yaml
+++ b/infrastructure/helm/umami/values-prod.yaml
@@ -85,7 +85,7 @@ ingress:
     - analytics.fenrirledger.com
   annotations:
     networking.gke.io/managed-certificates: "umami-cert"
-    kubernetes.io/ingress.allow-http: "true"
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: "umami-ip"
     cloud.google.com/backend-config: '{"default":"umami-backend-config"}'
 

--- a/infrastructure/helm/umami/values.yaml
+++ b/infrastructure/helm/umami/values.yaml
@@ -139,7 +139,7 @@ ingress:
     - analytics.fenrirledger.com
   annotations:
     networking.gke.io/managed-certificates: "umami-cert"
-    kubernetes.io/ingress.allow-http: "true"
+    kubernetes.io/ingress.allow-http: "false"
     kubernetes.io/ingress.global-static-ip-name: "umami-ip"
     cloud.google.com/backend-config: '{"default":"umami-backend-config"}'
 


### PR DESCRIPTION
## Summary

- Hit GCP global forwarding rule quota (limit: 8, all in use)
- The apex HTTP redirect rule (`apex-redirect.tf`) couldn't be created
- Analytics, Odin's Throne, and n8n don't need port 80 — they're HTTPS-only internal tools
- Disabling HTTP on those 3 ingresses frees 3 forwarding rule slots

## Changes

- `umami/values.yaml` + `values-prod.yaml` — `allow-http: false`
- `odin-throne/values.yaml` — `allow-http: false`
- `n8n/templates/ingress.yaml` — `allow-http: false`

## After merge

Re-run `terraform apply` for `apex-redirect.tf` — the HTTP forwarding rule for `fenrirledger.com` will now succeed. Both HTTP and HTTPS apex requests will redirect to `https://www.fenrirledger.com`.

Relates to production outage recovery (cert provisioning fix in #1326).