### PR TITLE
fix(marketing): correct n8n upstream service name n8n → n8n-main

### DIFF
--- a/infrastructure/helm/n8n/values.yaml
+++ b/infrastructure/helm/n8n/values.yaml
@@ -8,7 +8,7 @@ staticIpName: marketing-ip
 
 oauth2Proxy:
   image: quay.io/oauth2-proxy/oauth2-proxy:v7.6.0
-  upstream: http://n8n.fenrir-marketing.svc.cluster.local:5678
+  upstream: http://n8n-main.fenrir-marketing.svc.cluster.local:5678
   redirectUrl: https://marketing.fenrirledger.com/oauth2/callback
   cookieDomain: marketing.fenrirledger.com
   secretsSecretName: n8n-oauth2-proxy-secrets


### PR DESCRIPTION
oauth2-proxy configured with `upstream: http://n8n...` but the n8n Helm chart names the service `n8n-main`. DNS lookup failed causing 502 bad gateway after auth.