### PR TITLE
fix(ci): reorder pre-deploy steps — build before unit tests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -343,11 +343,11 @@ jobs:
       - name: TypeScript check
         run: bash quality/scripts/verify.sh --step tsc
 
-      - name: Unit tests
-        run: bash quality/scripts/verify.sh --step unit
-
       - name: Build check
         run: bash quality/scripts/verify.sh --step build
+
+      - name: Unit tests
+        run: bash quality/scripts/verify.sh --step unit
 
       - name: Upload reports on failure
         if: failure()


### PR DESCRIPTION
## Summary
- Swapped build and unit test steps in `app-pre-deploy-tests`: tsc → build → vitest
- No point running Vitest if the build is broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)