### PR TITLE
Issue #1339 - fix: Redis PVC Retain + AOF persistence + GCP snapshots

### DIFF
--- a/infrastructure/helm/fenrir-app/templates/redis.yaml
+++ b/infrastructure/helm/fenrir-app/templates/redis.yaml
@@ -1,4 +1,19 @@
 {{- if .Values.redis.enabled }}
+# Custom StorageClass with Retain reclaim policy — prevents PV deletion on PVC removal.
+# GKE default StorageClasses use Delete; this ensures Redis data survives namespace teardown.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: redis-retain
+  labels:
+    {{- include "fenrir-app.redisLabels" . | nindent 4 }}
+provisioner: pd.csi.storage.gke.io
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  type: pd-standard
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -51,6 +66,7 @@ spec:
         name: redis-data
       spec:
         accessModes: [{{ .Values.redis.persistence.accessMode | quote }}]
+        storageClassName: {{ .Values.redis.persistence.storageClassName | quote }}
         resources:
           requests:
             storage: {{ .Values.redis.persistence.size }}

--- a/infrastructure/helm/fenrir-app/values-prod.yaml
+++ b/infrastructure/helm/fenrir-app/values-prod.yaml
@@ -31,3 +31,5 @@ ingress:
 
 redis:
   enabled: true
+  persistence:
+    storageClassName: "redis-retain"

--- a/infrastructure/helm/fenrir-app/values.yaml
+++ b/infrastructure/helm/fenrir-app/values.yaml
@@ -144,6 +144,9 @@ redis:
   persistence:
     size: 1Gi
     accessMode: ReadWriteOnce
+    # Custom StorageClass with reclaimPolicy: Retain — PV survives PVC deletion.
+    # Defined in templates/redis.yaml. Prevents cloud sync data loss on redeploy.
+    storageClassName: "redis-retain"
 
   service:
     port: 6379

--- a/infrastructure/redis-backup.tf
+++ b/infrastructure/redis-backup.tf
@@ -1,0 +1,73 @@
+# --------------------------------------------------------------------------
+# Redis Disk Snapshot Policy — Fenrir Ledger
+#
+# Schedules daily snapshots of the Redis persistent disk.
+# Redis is the cloud sync backend for Karl-tier user card data.
+# Snapshots ensure point-in-time recovery even if the PV is corrupted.
+#
+# The Redis PV reclaim policy is now set to Retain (see Helm StorageClass
+# redis-retain), so the underlying GCE disk survives PVC/namespace deletion.
+# These snapshots add a second layer of protection.
+#
+# Disk name: obtained from the GKE-provisioned PV at deploy time.
+# Variable: redis_disk_name — set in CI via:
+#   kubectl get pv <pv-name> -o jsonpath='{.spec.csi.volumeHandle}'
+# --------------------------------------------------------------------------
+
+variable "redis_disk_name" {
+  description = "Name of the GCE persistent disk backing the Redis PVC (from kubectl get pv -o jsonpath='{.spec.csi.volumeHandle}'). Set at apply time by CI."
+  type        = string
+  default     = ""
+}
+
+# --------------------------------------------------------------------------
+# Snapshot resource policy — daily at 02:00 UTC, 7-day retention
+# --------------------------------------------------------------------------
+
+resource "google_compute_resource_policy" "redis_daily_snapshot" {
+  name    = "redis-daily-snapshot"
+  project = var.project_id
+  region  = var.region
+
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "02:00" # 02:00 UTC — off-peak for US users
+      }
+    }
+
+    retention_policy {
+      max_retention_days    = 7
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+
+    snapshot_properties {
+      labels = {
+        managed-by  = "terraform"
+        environment = "production"
+        component   = "redis"
+        purpose     = "cloud-sync-backup"
+      }
+      storage_locations = [var.region]
+    }
+  }
+
+  depends_on = [google_project_service.apis["compute.googleapis.com"]]
+}
+
+# --------------------------------------------------------------------------
+# Attach snapshot policy to the Redis disk
+#
+# Only created when redis_disk_name is provided (set by CI after PV exists).
+# Usage: terraform apply -var="redis_disk_name=<disk-name>"
+# --------------------------------------------------------------------------
+
+resource "google_compute_disk_resource_policy_attachment" "redis_snapshot_attachment" {
+  count = var.redis_disk_name != "" ? 1 : 0
+
+  name    = google_compute_resource_policy.redis_daily_snapshot.name
+  disk    = var.redis_disk_name
+  project = var.project_id
+  zone    = var.zone
+}


### PR DESCRIPTION
Fixes #1339

## Summary

- Added custom `StorageClass` (`redis-retain`) with `reclaimPolicy: Retain` to `templates/redis.yaml` — prevents PV deletion when PVC is removed
- Set `storageClassName: redis-retain` in `values.yaml` and `values-prod.yaml` so all future Redis PVC recreations use the Retain policy
- Added `infrastructure/redis-backup.tf` with daily GCP disk snapshot policy (`google_compute_resource_policy`) and conditional disk attachment — 7-day retention, 02:00 UTC schedule
- Confirmed `--appendonly yes` in Redis `args` (AOF persistence already configured in `values.yaml`)

## Test plan

- [x] tsc PASS
- [x] build PASS (45 routes)
- [x] Vitest suite PASS (135 files, 1994 tests)
- [ ] CI E2E (runs via CI pipeline)

Infrastructure-only changes (Helm + Terraform). No Vitest tests written per banned categories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)