### PR TITLE
fix(dispatch): use --prompt-file to prevent heredoc truncation

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -225,18 +225,20 @@ If `--prompt-extra`, append after the issue body:
 ```bash
 REPO_ROOT=$(git rev-parse --show-toplevel) && \
 SESSION_ID="issue-<N>-step<S>-<agent>-$(uuidgen | cut -c1-8 | tr A-Z a-z)" && \
+PROMPT_FILE=$(mktemp /tmp/agent-prompt-XXXXXX.md) && \
+cat > "$PROMPT_FILE" <<'AGENT_PROMPT_EOF'
+<composed prompt content here>
+AGENT_PROMPT_EOF
 bash "$REPO_ROOT/infrastructure/k8s/agents/dispatch-job.sh" \
   --session-id "$SESSION_ID" \
   --branch "<BRANCH>" \
   --model "<MODEL>" \
-  --prompt "$(cat <<'PROMPT'
-<composed prompt content here>
-PROMPT
-)" && \
+  --prompt-file "$PROMPT_FILE" && \
 node "$REPO_ROOT/.claude/skills/fire-next-up/scripts/pack-status.mjs" --move <N> in-progress
+rm -f "$PROMPT_FILE"
 ```
 
-**Key:** Use a `<<'PROMPT'` heredoc (single-quoted delimiter) to avoid all shell expansion issues. The `$(cat ...)` wrapping passes the heredoc content as a single string argument to `--prompt`.
+**Key:** Write the prompt to a temp file with `cat >` and pass via `--prompt-file`. This avoids the heredoc-in-subshell pattern (`$(cat <<'DELIM'...DELIM)`) which silently truncates the prompt if the content happens to contain the delimiter word on its own line. The delimiter `AGENT_PROMPT_EOF` is chosen to be unlikely in prompt content. Single-quoted delimiter (`<<'...'`) prevents shell expansion.
 
 **Job naming:** The dispatch script generates DNS-compatible job names from the session ID.
 

--- a/infrastructure/agent-sandbox-validation.test.ts
+++ b/infrastructure/agent-sandbox-validation.test.ts
@@ -290,6 +290,11 @@ describe('Agent Sandbox Infrastructure (Issue #681)', () => {
       expect(dispatchScript).toContain('IMAGE_TAG="latest"');
     });
 
+    it('should support --prompt-file flag for reliable prompt delivery', () => {
+      expect(dispatchScript).toContain('--prompt-file');
+      expect(dispatchScript).toContain('PROMPT_FILE');
+    });
+
     it('should validate required arguments', () => {
       expect(dispatchScript).toContain('required');
       expect(dispatchScript).toContain('exit 1');

--- a/infrastructure/k8s/agents/dispatch-job.sh
+++ b/infrastructure/k8s/agents/dispatch-job.sh
@@ -19,9 +19,11 @@
 #   --session-id  Unique session identifier
 #   --branch      Git branch name
 #   --model       Claude model identifier
-#   --prompt      Task prompt text
+#   --prompt      Task prompt text (use --prompt-file for reliability)
 #
 # Optional:
+#   --prompt-file Path to a file containing the task prompt (preferred
+#                 over --prompt — avoids heredoc/shell escaping issues)
 #   --image-tag   Container image tag (default: latest)
 #   --dry-run     Print generated manifest without applying
 # --------------------------------------------------------------------------
@@ -34,6 +36,7 @@ SESSION_ID=""
 BRANCH=""
 MODEL=""
 PROMPT=""
+PROMPT_FILE=""
 IMAGE_TAG="latest"
 DRY_RUN=false
 ISSUE_NUMBER=""
@@ -44,6 +47,7 @@ while [[ $# -gt 0 ]]; do
     --branch)        BRANCH="$2"; shift 2 ;;
     --model)         MODEL="$2"; shift 2 ;;
     --prompt)        PROMPT="$2"; shift 2 ;;
+    --prompt-file)   PROMPT_FILE="$2"; shift 2 ;;
     --image-tag)     IMAGE_TAG="$2"; shift 2 ;;
     --issue-number)  ISSUE_NUMBER="$2"; shift 2 ;;
     --dry-run)       DRY_RUN=true; shift ;;
@@ -54,9 +58,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# --------------------------------------------------------------------------
+# Resolve prompt: --prompt-file takes precedence over --prompt
+# --------------------------------------------------------------------------
+if [ -n "$PROMPT_FILE" ]; then
+  if [ ! -f "$PROMPT_FILE" ]; then
+    echo "Error: --prompt-file '${PROMPT_FILE}' does not exist." >&2
+    exit 1
+  fi
+  PROMPT=$(cat "$PROMPT_FILE")
+fi
+
 # Validate required arguments
 if [ -z "$SESSION_ID" ] || [ -z "$BRANCH" ] || [ -z "$MODEL" ] || [ -z "$PROMPT" ]; then
-  echo "Error: --session-id, --branch, --model, and --prompt are all required." >&2
+  echo "Error: --session-id, --branch, --model, and --prompt (or --prompt-file) are all required." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Adds `--prompt-file` flag to `dispatch-job.sh` — reads prompt from a file instead of a shell argument, eliminating heredoc delimiter collision that silently truncated agent prompts
- Updates dispatch SKILL.md to prescribe the temp-file pattern (`cat > file <<'AGENT_PROMPT_EOF'`) instead of the fragile `$(cat <<'PROMPT'...PROMPT)` subshell pattern
- Adds validation test for `--prompt-file` support

## Root cause

The old pattern used `--prompt "$(cat <<'PROMPT'...PROMPT)"`. If the composed prompt text contained the word `PROMPT` on its own line, the heredoc terminated early — silently truncating the prompt. The agent received a garbled task and failed.

## Test plan

- [ ] Dispatch an agent with `--prompt-file` and verify the full prompt arrives in the K8s Job
- [ ] Verify `--prompt` (inline) still works for backward compatibility
- [ ] Verify `--prompt-file` with a nonexistent path exits with error

🤖 Generated with [Claude Code](https://claude.com/claude-code)