### PR TITLE
fix(infra): adopt pre-existing fenrir-agents resources into Helm

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -397,6 +397,23 @@ jobs:
             --namespace=fenrir-app --dry-run=client -o yaml | kubectl apply -f -
           kubectl annotate serviceaccount fenrir-app-sa --namespace=fenrir-app --overwrite \
             iam.gke.io/gcp-service-account=fenrir-app-workload@${{ secrets.GCP_PROJECT_ID }}.iam.gserviceaccount.com
+          # Adopt pre-existing fenrir-agents resources into Helm management.
+          # If any were created outside Helm (kubectl apply), they lack ownership
+          # metadata and Helm will refuse to install. Label + annotate them so
+          # Helm can adopt and manage them going forward. Errors are suppressed
+          # for first-run when resources don't exist yet.
+          for kind_name in \
+            "namespace/fenrir-agents" \
+            "serviceaccount/fenrir-agents-sa -n fenrir-agents" \
+            "role/fenrir-agents-job-creator -n fenrir-agents" \
+            "rolebinding/fenrir-agents-job-creator-binding -n fenrir-agents" \
+            "resourcequota/agents-quota -n fenrir-agents"; do
+            kubectl label $kind_name \
+              app.kubernetes.io/managed-by=Helm --overwrite 2>/dev/null || true
+            kubectl annotate $kind_name \
+              meta.helm.sh/release-name=fenrir-agents \
+              meta.helm.sh/release-namespace=fenrir-agents --overwrite 2>/dev/null || true
+          done
           helm upgrade --install fenrir-agents infrastructure/helm/agents \
             --namespace fenrir-agents \
             --create-namespace \


### PR DESCRIPTION
## Summary

- Adds a `kubectl label/annotate` loop before `helm upgrade --install` in the deploy workflow to adopt pre-existing `fenrir-agents` namespace resources into Helm management
- Covers: namespace, serviceaccount, role, rolebinding, resourcequota
- Errors suppressed for first-run when resources don't exist yet

## Root cause

The `fenrir-agents` namespace and its resources (SA, RBAC, quota) were created via `kubectl apply` before the Helm chart was introduced. Helm refuses to manage resources it didn't create unless they have `app.kubernetes.io/managed-by=Helm` label and `meta.helm.sh/release-*` annotations.

## Test plan

- [ ] Re-run deploy workflow — Helm install should succeed
- [ ] Verify all fenrir-agents resources have Helm ownership metadata after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)