### PR TITLE
fix(infra): grant compute.storageAdmin for Redis snapshot policies

### DIFF
--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -111,6 +111,7 @@ locals {
     "roles/monitoring.admin",              # Cloud Monitoring config
     "roles/certificatemanager.editor",     # Managed SSL certs
     "roles/firebaserules.admin",           # Firebase Security Rules (Firestore)
+    "roles/compute.storageAdmin",          # Disk snapshot policies (redis-backup.tf)
   ]
 }
 

--- a/scripts/bootstrap-iam.sh
+++ b/scripts/bootstrap-iam.sh
@@ -50,6 +50,8 @@ ROLES=(
   "roles/logging.admin"
   "roles/monitoring.admin"
   "roles/certificatemanager.editor"
+  "roles/firebaserules.admin"
+  "roles/compute.storageAdmin"
 )
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `roles/compute.storageAdmin` to the deploy SA in `iam.tf` — required for `google_compute_resource_policy` (Redis disk snapshot scheduling)
- Syncs `bootstrap-iam.sh` with `iam.tf` — was missing `roles/firebaserules.admin` and the new `roles/compute.storageAdmin`

## Root cause

`redis-backup.tf` creates a `google_compute_resource_policy` for daily Redis disk snapshots. This requires `compute.resourcePolicies.create`, which is included in `roles/compute.storageAdmin`. The deploy SA didn't have this role.

## Bootstrap step required

**Before merging**, grant the role manually (chicken-and-egg — Terraform can't grant itself a permission it doesn't have):

```bash
gcloud projects add-iam-policy-binding fenrir-ledger-prod \
  --member="serviceAccount:fenrir-deploy@fenrir-ledger-prod.iam.gserviceaccount.com" \
  --role="roles/compute.storageAdmin" --quiet
```

Or re-run `bash scripts/bootstrap-iam.sh` after merging.

## Test plan

- [ ] Grant role manually via gcloud
- [ ] Re-run deploy workflow — terraform apply should succeed
- [ ] Verify snapshot policy created: `gcloud compute resource-policies list --project=fenrir-ledger-prod`

🤖 Generated with [Claude Code](https://claude.com/claude-code)