### PR TITLE
chore(skills): use AskUserQuestion for bug dispatch prompt

### DIFF
--- a/.claude/skills/file-issue/SKILL.md
+++ b/.claude/skills/file-issue/SKILL.md
@@ -127,12 +127,12 @@ https://github.com/declanshanaghy/fenrir-ledger/issues/534
 
 ### 8. Auto-Dispatch (bugs only)
 
-If the issue type is `bug`, immediately ask the user:
+If the issue type is `bug`, use `AskUserQuestion` to prompt the user:
 
-> **Dispatch agent for #N?** (FiremanDecko → Loki chain)
+> **Dispatch agent for #N — "<title>"?** (FiremanDecko → Loki chain)
 
-If the user confirms (yes, y, do it, go, dispatch, send it, etc.), invoke `/dispatch #N`.
-If the user declines or doesn't respond, stop — the issue is filed and on the board.
+Wait for the user's response via `AskUserQuestion`. If they confirm, invoke `/dispatch #N`.
+If they decline, stop — the issue is filed and on the board.
 
 This step is **skipped** for non-bug types (enhancement, ux, security, documentation).
 


### PR DESCRIPTION
## Summary

- Updates `/file-issue` step 8 to use `AskUserQuestion` tool for the bug auto-dispatch confirmation instead of plain text output, ensuring the prompt actually pauses for user input

## Test plan

- [ ] `/file-issue` for a bug pauses with AskUserQuestion before dispatching

🤖 Generated with [Claude Code](https://claude.com/claude-code)