### PR TITLE
fix: PostgreSQL PVC reclaim policy Retain + remove namespace from Helm — issue #1337

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -720,6 +720,28 @@ jobs:
             -f ./infrastructure/helm/umami/values-prod.yaml \
             --wait --timeout=5m
 
+      - name: Patch PostgreSQL PV reclaim policy to Retain
+        # Belt-and-suspenders: the StorageClass already sets reclaimPolicy=Retain
+        # for new PVCs. This step also patches any pre-existing PV that was
+        # provisioned with the old standard-rwo (Delete) policy — issue #1337.
+        run: |
+          PV_NAME=$(kubectl get pvc postgresql-data-postgresql-0 \
+            -n fenrir-analytics \
+            -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)
+          if [ -n "$PV_NAME" ]; then
+            CURRENT_POLICY=$(kubectl get pv "$PV_NAME" \
+              -o jsonpath='{.spec.persistentVolumeReclaimPolicy}' 2>/dev/null || true)
+            if [ "$CURRENT_POLICY" != "Retain" ]; then
+              echo "Patching PV $PV_NAME: $CURRENT_POLICY → Retain"
+              kubectl patch pv "$PV_NAME" \
+                -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+            else
+              echo "PV $PV_NAME already has reclaimPolicy=Retain — no patch needed"
+            fi
+          else
+            echo "PVC postgresql-data-postgresql-0 not found yet — skipping PV patch"
+          fi
+
       - name: Verify rollout
         run: |
           echo "### Analytics Deploy" >> $GITHUB_STEP_SUMMARY

--- a/infrastructure/SMOKE-TEST.md
+++ b/infrastructure/SMOKE-TEST.md
@@ -169,6 +169,123 @@ curl -sk https://fenrirledger.com/api/health | jq .
 
 ---
 
+---
+
+## PostgreSQL (Umami Analytics) — Backup & Restore
+
+### Background
+
+Issue #1337: the `fenrir-bootstrap` Helm release previously owned the
+`fenrir-analytics` namespace. Uninstalling it cascaded and deleted the PVC
+(reclaim policy was `Delete`), permanently destroying the Umami database.
+
+**Protections now in place:**
+
+1. `fenrir-analytics` namespace created imperatively by CI — never owned by Helm.
+2. StorageClass `standard-rwo-retain` (`reclaimPolicy: Retain`) — disk survives PVC deletion.
+3. CI patches any pre-existing PV to `Retain` on every deploy.
+4. Daily GCP disk snapshots via `infrastructure/postgresql-backup.tf` (03:00 UTC, 7-day retention).
+
+---
+
+### Verify PV reclaim policy
+
+```bash
+PV_NAME=$(kubectl get pvc postgresql-data-postgresql-0 \
+  -n fenrir-analytics -o jsonpath='{.spec.volumeName}')
+kubectl get pv "$PV_NAME" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}'
+# Expected: Retain
+```
+
+If output is `Delete`, patch it manually:
+
+```bash
+kubectl patch pv "$PV_NAME" \
+  -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+```
+
+---
+
+### Attach GCP snapshot policy (post initial deploy)
+
+After the PV exists, obtain the underlying GCE disk name and apply Terraform:
+
+```bash
+# 1. Get PV name
+PV_NAME=$(kubectl get pvc postgresql-data-postgresql-0 \
+  -n fenrir-analytics -o jsonpath='{.spec.volumeName}')
+
+# 2. Get GCE disk name from the PV (CSI volumeHandle is "projects/.../zones/.../disks/<name>")
+DISK_HANDLE=$(kubectl get pv "$PV_NAME" -o jsonpath='{.spec.csi.volumeHandle}')
+# volumeHandle format: projects/PROJECT/zones/ZONE/disks/DISK_NAME
+DISK_NAME=$(echo "$DISK_HANDLE" | awk -F'/' '{print $NF}')
+echo "Disk name: $DISK_NAME"
+
+# 3. Apply Terraform to attach the snapshot policy
+cd infrastructure
+terraform apply -var="postgresql_disk_name=$DISK_NAME"
+```
+
+---
+
+### Verify snapshot policy is attached
+
+```bash
+DISK_NAME=<disk-name-from-above>
+gcloud compute disks describe "$DISK_NAME" \
+  --zone=us-central1-a \
+  --project=fenrir-ledger-prod \
+  --format='value(resourcePolicies)'
+# Expected: .../resourcePolicies/postgresql-daily-snapshot
+```
+
+---
+
+### Restore from GCP snapshot
+
+```bash
+# 1. List available snapshots
+gcloud compute snapshots list \
+  --filter="sourceDisk~postgresql" \
+  --project=fenrir-ledger-prod \
+  --sort-by="~creationTimestamp" \
+  --limit=10
+
+# 2. Create a new disk from the desired snapshot
+SNAPSHOT_NAME=<snapshot-name>
+gcloud compute disks create postgresql-restored \
+  --source-snapshot="$SNAPSHOT_NAME" \
+  --zone=us-central1-a \
+  --project=fenrir-ledger-prod \
+  --type=pd-balanced
+
+# 3. Scale down PostgreSQL StatefulSet
+kubectl scale statefulset postgresql -n fenrir-analytics --replicas=0
+
+# 4. Delete the existing PVC (PV is Retain — underlying disk is NOT deleted)
+kubectl delete pvc postgresql-data-postgresql-0 -n fenrir-analytics
+
+# 5. Manually create a PV pointing to the restored disk, then a PVC binding to it.
+#    Patch the PV claimRef to point to the new PVC, then re-scale:
+kubectl scale statefulset postgresql -n fenrir-analytics --replicas=1
+
+# 6. Verify
+kubectl get pods -n fenrir-analytics
+kubectl logs statefulset/postgresql -n fenrir-analytics --tail=20
+```
+
+---
+
+### Re-create Umami admin account (post data-loss recovery only)
+
+If Umami data was lost and the database is empty:
+
+1. Visit https://analytics.fenrirledger.com/setup
+2. Create the admin account
+3. Re-add tracked sites and copy the tracking scripts
+
+---
+
 ## Troubleshooting
 
 | Symptom | Check |

--- a/infrastructure/helm/umami/templates/storageclass.yaml
+++ b/infrastructure/helm/umami/templates/storageclass.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.postgresql.enabled }}
+# --------------------------------------------------------------------------
+# StorageClass: standard-rwo-retain
+#
+# Identical to the GKE default standard-rwo StorageClass but with
+# reclaimPolicy: Retain so that the underlying GCE PersistentDisk survives
+# PVC or namespace deletion. This prevents analytics data loss if Helm or
+# kubectl uninstall/delete cascades to the namespace.
+#
+# Issue #1337: previously used standard-rwo (reclaimPolicy: Delete) which
+# caused permanent data loss when the fenrir-bootstrap release was removed.
+# --------------------------------------------------------------------------
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard-rwo-retain
+  labels:
+    {{- include "umami.labels" . | nindent 4 }}
+provisioner: pd.csi.storage.gke.io
+parameters:
+  type: pd-balanced
+reclaimPolicy: Retain
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{- end }}

--- a/infrastructure/helm/umami/values-prod.yaml
+++ b/infrastructure/helm/umami/values-prod.yaml
@@ -60,7 +60,8 @@ postgresql:
   persistence:
     enabled: true
     size: 1Gi
-    storageClass: standard-rwo
+    # standard-rwo-retain: reclaimPolicy=Retain — disk survives PVC/NS deletion (issue #1337)
+    storageClass: standard-rwo-retain
 
   resources:
     requests:

--- a/infrastructure/helm/umami/values.yaml
+++ b/infrastructure/helm/umami/values.yaml
@@ -86,7 +86,10 @@ postgresql:
   persistence:
     enabled: true
     size: 1Gi
-    storageClass: standard-rwo
+    # standard-rwo-retain is defined in templates/storageclass.yaml.
+    # It matches standard-rwo (pd-balanced) but sets reclaimPolicy: Retain so
+    # the underlying GCE disk survives PVC or namespace deletion (issue #1337).
+    storageClass: standard-rwo-retain
     mountPath: /var/lib/postgresql/data
 
   resources:

--- a/infrastructure/postgresql-backup.tf
+++ b/infrastructure/postgresql-backup.tf
@@ -1,0 +1,76 @@
+# --------------------------------------------------------------------------
+# PostgreSQL Disk Snapshot Policy — Fenrir Ledger
+#
+# Schedules daily snapshots of the PostgreSQL persistent disk backing the
+# Umami analytics StatefulSet in the fenrir-analytics namespace.
+#
+# Background: issue #1337 — the previous reclaimPolicy=Delete caused permanent
+# data loss when the fenrir-bootstrap Helm release was uninstalled. These
+# snapshots provide a second layer of protection alongside reclaimPolicy=Retain.
+#
+# Disk name: obtained from the GKE-provisioned PV at deploy time.
+# Variable: postgresql_disk_name — set in CI via:
+#   kubectl get pv <pv-name> -o jsonpath='{.spec.csi.volumeHandle}'
+# where <pv-name> comes from:
+#   kubectl get pvc postgresql-data-postgresql-0 -n fenrir-analytics \
+#     -o jsonpath='{.spec.volumeName}'
+# --------------------------------------------------------------------------
+
+variable "postgresql_disk_name" {
+  description = "Name of the GCE persistent disk backing the PostgreSQL PVC in fenrir-analytics (from kubectl get pv -o jsonpath='{.spec.csi.volumeHandle}'). Set at apply time by CI."
+  type        = string
+  default     = ""
+}
+
+# --------------------------------------------------------------------------
+# Snapshot resource policy — daily at 03:00 UTC, 7-day retention
+# Offset from Redis (02:00) to avoid concurrent snapshot I/O.
+# --------------------------------------------------------------------------
+
+resource "google_compute_resource_policy" "postgresql_daily_snapshot" {
+  name    = "postgresql-daily-snapshot"
+  project = var.project_id
+  region  = var.region
+
+  snapshot_schedule_policy {
+    schedule {
+      daily_schedule {
+        days_in_cycle = 1
+        start_time    = "03:00" # 03:00 UTC — off-peak, offset from Redis at 02:00
+      }
+    }
+
+    retention_policy {
+      max_retention_days    = 7
+      on_source_disk_delete = "KEEP_AUTO_SNAPSHOTS"
+    }
+
+    snapshot_properties {
+      labels = {
+        managed-by  = "terraform"
+        environment = "production"
+        component   = "postgresql"
+        purpose     = "analytics-backup"
+      }
+      storage_locations = [var.region]
+    }
+  }
+
+  depends_on = [google_project_service.apis["compute.googleapis.com"]]
+}
+
+# --------------------------------------------------------------------------
+# Attach snapshot policy to the PostgreSQL disk
+#
+# Only created when postgresql_disk_name is provided (set by CI after PV exists).
+# Usage: terraform apply -var="postgresql_disk_name=<disk-name>"
+# --------------------------------------------------------------------------
+
+resource "google_compute_disk_resource_policy_attachment" "postgresql_snapshot_attachment" {
+  count = var.postgresql_disk_name != "" ? 1 : 0
+
+  name    = google_compute_resource_policy.postgresql_daily_snapshot.name
+  disk    = var.postgresql_disk_name
+  project = var.project_id
+  zone    = var.zone
+}


### PR DESCRIPTION
PR for issue: #1337

Prevents repeat of the analytics DB wipeout: sets PVC reclaim policy to Retain and removes `fenrir-analytics` namespace from Helm management.

## Root causes addressed

1. **Namespace managed by Helm** — deleting a release that owns a namespace cascades to all resources including PVCs. Namespace is now created imperatively by CI and never owned by Helm.
2. **PVC reclaim policy was `Delete`** — upgraded to `Retain` via a dedicated `standard-rwo-retain` StorageClass so the underlying GCE disk survives PVC or namespace deletion.

## Changes

- `infrastructure/helm/umami/templates/storageclass.yaml` — new `standard-rwo-retain` StorageClass (`reclaimPolicy: Retain`, `pd-balanced`)
- `infrastructure/helm/umami/values.yaml` + `values-prod.yaml` — `storageClass: standard-rwo-retain` for PostgreSQL persistence
- `.github/workflows/deploy.yml` — `fenrir-analytics` namespace created imperatively before `helm upgrade --install`; post-deploy step patches any pre-existing PV to `Retain`
- `infrastructure/postgresql-backup.tf` — GCP `google_compute_resource_policy` for daily snapshots (03:00 UTC, 7-day retention) + disk attachment resource
- `infrastructure/SMOKE-TEST.md` — backup/restore procedure, PV verification, snapshot attachment steps, Umami admin recovery

## Verification

- `fenrir-analytics` namespace: NOT in any Helm chart template (no `namespace.yaml`)
- `deploy.yml`: namespace created with `kubectl create namespace ... --dry-run=client -o yaml | kubectl apply -f -` before helm upgrade
- PV reclaim policy: patched to `Retain` on every deploy (belt-and-suspenders alongside StorageClass)
- GCP snapshot policy: `postgresql-daily-snapshot` resource policy, attached via Terraform after PV exists

## Testing

- tsc: PASS
- build: PASS (45 routes)
- Vitest: 2020/2020 PASS