### PR TITLE
feat(dispatch): add --no-spot flag for on-demand agent nodes

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -41,6 +41,7 @@ If issue data + agent template are already in context, that's **1 tool call** (s
 | `--local` | No | Local worktree instead of Depot. |
 | `--parallel` | No | Dispatch multiple issues simultaneously. |
 | `--prompt-extra <text>` | No | Extra context injected after issue body. |
+| `--no-spot` | No | Use on-demand nodes instead of Spot (avoids preemption). Check memory for current default mode. |
 | `--dry-run` | No | Show composed prompt without spawning. |
 | `--skip-board-move` | No | Don't move to In Progress. |
 
@@ -233,12 +234,15 @@ bash "$REPO_ROOT/infrastructure/k8s/agents/dispatch-job.sh" \
   --session-id "$SESSION_ID" \
   --branch "<BRANCH>" \
   --model "<MODEL>" \
-  --prompt-file "$PROMPT_FILE" && \
+  --prompt-file "$PROMPT_FILE" \
+  [--no-spot] && \
 node "$REPO_ROOT/.claude/skills/fire-next-up/scripts/pack-status.mjs" --move <N> in-progress
 rm -f "$PROMPT_FILE"
 ```
 
 **Key:** Write the prompt to a temp file with `cat >` and pass via `--prompt-file`. This avoids the heredoc-in-subshell pattern (`$(cat <<'DELIM'...DELIM)`) which silently truncates the prompt if the content happens to contain the delimiter word on its own line. The delimiter `AGENT_PROMPT_EOF` is chosen to be unlikely in prompt content. Single-quoted delimiter (`<<'...'`) prevents shell expansion.
+
+**Spot vs on-demand:** Default is Spot (cheap, but pods can be preempted). Pass `--no-spot` to use on-demand nodes for stability. Check the `project_agent_spot_mode.md` memory file for the current default — if Odin has switched to on-demand mode, pass `--no-spot` on every dispatch until told otherwise.
 
 **Job naming:** The dispatch script generates DNS-compatible job names from the session ID.
 

--- a/infrastructure/agent-sandbox-validation.test.ts
+++ b/infrastructure/agent-sandbox-validation.test.ts
@@ -295,6 +295,11 @@ describe('Agent Sandbox Infrastructure (Issue #681)', () => {
       expect(dispatchScript).toContain('PROMPT_FILE');
     });
 
+    it('should support --no-spot flag for on-demand nodes', () => {
+      expect(dispatchScript).toContain('--no-spot');
+      expect(dispatchScript).toContain('USE_SPOT');
+    });
+
     it('should validate required arguments', () => {
       expect(dispatchScript).toContain('required');
       expect(dispatchScript).toContain('exit 1');

--- a/infrastructure/k8s/agents/dispatch-job.sh
+++ b/infrastructure/k8s/agents/dispatch-job.sh
@@ -24,6 +24,7 @@
 # Optional:
 #   --prompt-file Path to a file containing the task prompt (preferred
 #                 over --prompt — avoids heredoc/shell escaping issues)
+#   --no-spot     Use on-demand nodes instead of Spot (avoids preemption)
 #   --image-tag   Container image tag (default: latest)
 #   --dry-run     Print generated manifest without applying
 # --------------------------------------------------------------------------
@@ -40,6 +41,7 @@ PROMPT_FILE=""
 IMAGE_TAG="latest"
 DRY_RUN=false
 ISSUE_NUMBER=""
+USE_SPOT=true
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -50,6 +52,7 @@ while [[ $# -gt 0 ]]; do
     --prompt-file)   PROMPT_FILE="$2"; shift 2 ;;
     --image-tag)     IMAGE_TAG="$2"; shift 2 ;;
     --issue-number)  ISSUE_NUMBER="$2"; shift 2 ;;
+    --no-spot)       USE_SPOT=false; shift ;;
     --dry-run)       DRY_RUN=true; shift ;;
     *)
       echo "Unknown argument: $1" >&2
@@ -105,6 +108,23 @@ if [ ! -f "$TEMPLATE" ]; then
 fi
 
 # --------------------------------------------------------------------------
+# Build Spot/on-demand config block
+# --------------------------------------------------------------------------
+if [ "$USE_SPOT" = true ]; then
+  SPOT_CONFIG="      # Use Spot/preemptible pods for cost savings (up to 70% cheaper)
+      nodeSelector:
+        cloud.google.com/gke-spot: \"true\"
+      # Tolerate Spot eviction
+      tolerations:
+        - key: cloud.google.com/gke-spot
+          operator: Equal
+          value: \"true\"
+          effect: NoSchedule"
+else
+  SPOT_CONFIG="      # On-demand nodes (no Spot) — stable, no preemption"
+fi
+
+# --------------------------------------------------------------------------
 # Substitute placeholders
 # --------------------------------------------------------------------------
 # Simple placeholders are substituted via sed.
@@ -114,7 +134,18 @@ fi
 PROMPT_B64=$(printf '%s' "$PROMPT" | base64 | tr -d '\n')
 
 TMPFILE=$(mktemp /tmp/agent-job-XXXXXX.yaml)
+SPOT_TMPFILE=$(mktemp /tmp/agent-spot-XXXXXX.yaml)
 
+# First pass: replace {{SPOT_CONFIG}} with the multi-line block (sed can't do this)
+awk -v spot_config="$SPOT_CONFIG" '{
+  if ($0 ~ /\{\{SPOT_CONFIG\}\}/) {
+    print spot_config
+  } else {
+    print
+  }
+}' "$TEMPLATE" > "$SPOT_TMPFILE"
+
+# Second pass: substitute all other placeholders
 awk \
   -v job_name="$JOB_NAME" \
   -v session_id="$SESSION_ID" \
@@ -134,7 +165,9 @@ awk \
     gsub(/\{\{ISSUE_TITLE\}\}/, issue_title)
     gsub(/\{\{PR_TITLE\}\}/, pr_title)
     print
-  }' "$TEMPLATE" > "$TMPFILE"
+  }' "$SPOT_TMPFILE" > "$TMPFILE"
+
+rm -f "$SPOT_TMPFILE"
 
 # --------------------------------------------------------------------------
 # Apply or dry-run
@@ -146,11 +179,13 @@ if [ "$DRY_RUN" = true ]; then
   exit 0
 fi
 
+SPOT_LABEL=$( [ "$USE_SPOT" = true ] && echo "spot" || echo "on-demand" )
 echo "Creating K8s Job: ${JOB_NAME}"
 echo "  Namespace: fenrir-agents"
 echo "  Branch: ${BRANCH}"
 echo "  Model: ${MODEL}"
 echo "  Image: agent-sandbox:${IMAGE_TAG}"
+echo "  Node type: ${SPOT_LABEL}"
 
 kubectl apply -f "$TMPFILE" -n fenrir-agents
 

--- a/infrastructure/k8s/agents/job-template.yaml
+++ b/infrastructure/k8s/agents/job-template.yaml
@@ -49,18 +49,7 @@ spec:
     spec:
       serviceAccountName: fenrir-agents-sa
 
-      # Use Spot/preemptible pods for cost savings (up to 70% cheaper)
-      # GKE Autopilot supports Spot via node selector
-      nodeSelector:
-        cloud.google.com/gke-spot: "true"
-
-      # Tolerate Spot eviction
-      tolerations:
-        - key: cloud.google.com/gke-spot
-          operator: Equal
-          value: "true"
-          effect: NoSchedule
-
+{{SPOT_CONFIG}}
       # Grace period for eviction cleanup (commit WIP before pod dies)
       terminationGracePeriodSeconds: 30
 


### PR DESCRIPTION
## Summary

- Adds `--no-spot` flag to `dispatch-job.sh` — dispatches agent jobs to on-demand GKE Autopilot nodes instead of Spot, avoiding preemption
- Makes Spot config in `job-template.yaml` dynamic via `{{SPOT_CONFIG}}` placeholder
- Updates `/dispatch` SKILL.md with the new flag and memory-based mode tracking
- Default remains Spot; orchestrator checks `project_agent_spot_mode.md` memory to determine current mode

## How it works

- **Default (Spot):** Jobs get `nodeSelector: cloud.google.com/gke-spot: "true"` + matching toleration — cheap but can be preempted
- **`--no-spot`:** Jobs get no Spot selector — GKE Autopilot provisions stable on-demand nodes
- **Mode memory:** `project_agent_spot_mode.md` tracks current default. Odin says "switch to on-demand" → memory updated → all future dispatches use `--no-spot`

## Test plan

- [ ] `dispatch-job.sh --dry-run` without `--no-spot` → manifest has Spot nodeSelector
- [ ] `dispatch-job.sh --dry-run --no-spot` → manifest has no Spot nodeSelector
- [ ] Dispatch an agent with `--no-spot` → pod runs on on-demand node

🤖 Generated with [Claude Code](https://claude.com/claude-code)