### PR TITLE
fix: show friendly agent starting message instead of raw HTTP 400 — issue #1330

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -40,6 +40,8 @@ export function App() {
     streamError,
     replayedFromCache,
     isConnecting,
+    isPodStarting,
+    showPodStartTimeout,
   } = useLogStream();
 
   // Tracks the sessionId we currently have an active WS subscription for.
@@ -200,6 +202,29 @@ export function App() {
     }
   }, [wsState, activeSessionId, send, clearEntries, replayFromTempLog, setLiveSkipCount, jobs]);
 
+  // Auto-retry subscribe when pod is starting up (HTTP 400 returned by kubectl logs).
+  // Retries every 4 seconds. Clears when logs start flowing or after 2-minute timeout.
+  const podStartBeginRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!isPodStarting || !activeSessionId) {
+      podStartBeginRef.current = null;
+      return;
+    }
+    if (podStartBeginRef.current === null) {
+      podStartBeginRef.current = Date.now();
+    }
+    const intervalId = setInterval(() => {
+      const elapsed = Date.now() - (podStartBeginRef.current ?? Date.now());
+      if (elapsed >= 120_000) {
+        clearInterval(intervalId);
+        showPodStartTimeout();
+        return;
+      }
+      send({ type: "subscribe", sessionId: activeSessionId });
+    }, 4000);
+    return () => clearInterval(intervalId);
+  }, [isPodStarting, activeSessionId, send, showPodStartTimeout]);
+
   const activeJob = jobs.find((j) => j.sessionId === activeSessionId) || null;
 
   /** Toggle pin for any session by sessionId. Used by both header and sidebar. */
@@ -281,6 +306,7 @@ export function App() {
             onAvatarClick={setProfileAgent}
             replayedFromCache={replayedFromCache}
             isConnecting={isConnecting}
+            isPodStarting={isPodStarting}
             onSetSpeed={(speed) => {
               if (activeSessionId) {
                 send({ type: "set-speed", sessionId: activeSessionId, speed });

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -208,9 +208,10 @@ interface Props {
   onAvatarClick?: (agentKey: string) => void;
   replayedFromCache?: boolean;
   isConnecting?: boolean;
+  isPodStarting?: boolean;
 }
 
-export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache, isConnecting }: Props) {
+export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache, isConnecting, isPodStarting }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [fixtureSpeed, setFixtureSpeed] = useState(1);
   const [fixturePaused, setFixturePaused] = useState(false);
@@ -352,9 +353,19 @@ export function LogViewer({ entries, activeJob, wsState, isFixture, isTtlExpired
         onScroll={handleScroll}
       >
         {isConnecting && entries.length === 0 && (
-          <div className="session-connecting" aria-label="Connecting to session" aria-live="polite">
-            <span className="connecting-spinner" aria-hidden="true" />
-            <span>Awaiting the Norns\u2026</span>
+          <div
+            className={`session-connecting${isPodStarting ? " pod-starting" : ""}`}
+            aria-label={isPodStarting ? "Agent is starting up" : "Connecting to session"}
+            aria-live="polite"
+          >
+            <span className={isPodStarting ? "pod-starting-rune" : "connecting-spinner"} aria-hidden="true">
+              {isPodStarting ? "\u16C8" : ""}
+            </span>
+            <span>
+              {isPodStarting
+                ? "\u23F3 Agent is starting up \u2014 logs will appear shortly\u2026"
+                : "Awaiting the Norns\u2026"}
+            </span>
           </div>
         )}
         {displayEntries.map((item) => {

--- a/development/monitor-ui/src/hooks/useLogStream.ts
+++ b/development/monitor-ui/src/hooks/useLogStream.ts
@@ -80,6 +80,9 @@ export const TTL_ERROR_PATTERN = /TTL expired|cleaned up/i;
 /** Node-unreachable / kubelet-timeout patterns emitted by friendlyK8sError */
 export const NODE_UNREACHABLE_PATTERN = /Node unreachable|kubelet timeout/i;
 
+/** HTTP 400 / pod-not-yet-ready patterns — pod is initializing, not a real error */
+export const POD_NOT_READY_PATTERN = /HTTP-Code:\s*400|is not running|container.*not running/i;
+
 export function useLogStream() {
   const [entries, setEntries] = useState<LogEntry[]>([]);
   const [activeSessionId, _setActiveSessionId] = useState<string | null>(null);
@@ -92,6 +95,10 @@ export function useLogStream() {
   // the error tablet during the brief connection window (prevents red flash).
   const [isConnecting, _setIsConnecting] = useState(false);
   const isConnectingRef = useRef(false);
+  // isPodStarting: true when HTTP 400 is received (pod not yet ready).
+  // Keeps isConnecting=true and triggers the auto-retry loop in App.tsx.
+  const [isPodStarting, _setIsPodStarting] = useState(false);
+  const isPodStartingRef = useRef(false);
   const replayFromCacheRef = useRef<ReplayFn | null>(null);
   const taskPromptBuffer = useRef<string[]>([]);
   const inTaskPrompt = useRef(false);
@@ -103,6 +110,11 @@ export function useLogStream() {
   const setIsConnecting = useCallback((v: boolean) => {
     isConnectingRef.current = v;
     _setIsConnecting(v);
+  }, []);
+
+  const setIsPodStarting = useCallback((v: boolean) => {
+    isPodStartingRef.current = v;
+    _setIsPodStarting(v);
   }, []);
 
   const setActiveSessionId = useCallback((id: string | null) => {
@@ -120,8 +132,9 @@ export function useLogStream() {
     setStreamError(null);
     setStreamEnded(false);
     setReplayedFromCache(false);
+    setIsPodStarting(false);
     setIsConnecting(true);
-  }, [setIsConnecting]);
+  }, [setIsConnecting, setIsPodStarting]);
 
   /** Expose liveSkipRef setter so callers can set the skip count after replaying cache. */
   const setLiveSkipCount = useCallback((n: number) => {
@@ -399,9 +412,12 @@ export function useLogStream() {
         liveSkipRef.current--;
         return;
       }
-      // First live log-line clears the connecting state
+      // First live log-line clears connecting + pod-starting state
       if (isConnectingRef.current) {
         setIsConnecting(false);
+      }
+      if (isPodStartingRef.current) {
+        setIsPodStarting(false);
       }
       // Persist raw line to localStorage for download / future revisits
       if (activeSessionIdRef.current) {
@@ -410,17 +426,27 @@ export function useLogStream() {
       processRawLogLine(line);
     } else if (msg.type === "stream-error") {
       liveSkipRef.current = 0; // stop skipping on error
-      // Clear connecting state — we now know the stream status
-      if (isConnectingRef.current) {
-        setIsConnecting(false);
-      }
       // If the session has cached data in localStorage, fall back to it immediately
       // rather than showing the error tablet. This handles pinned sessions whose
       // pods have been cleaned up (TTL expired).
       const sessionId = activeSessionIdRef.current;
       if (sessionId && getCachedLog(sessionId)) {
+        if (isConnectingRef.current) {
+          setIsConnecting(false);
+        }
         replayFromCacheRef.current?.(sessionId);
         return;
+      }
+      // HTTP 400: pod is not yet ready — stay in connecting state so the
+      // waiting indicator stays visible. App.tsx will auto-retry the subscribe.
+      if (POD_NOT_READY_PATTERN.test(msg.message)) {
+        // Keep isConnecting=true (don't clear it) so the spinner remains
+        setIsPodStarting(true);
+        return;
+      }
+      // Clear connecting state — we now know the stream status (real error)
+      if (isConnectingRef.current) {
+        setIsConnecting(false);
       }
       setStreamError(msg.message);
       setEntries((prev) => [
@@ -447,7 +473,22 @@ export function useLogStream() {
         { id: nextId(), type: "verdict", verdictResult: msg.result },
       ]);
     }
-  }, [processRawLogLine, setIsConnecting]);
+  }, [processRawLogLine, setIsConnecting, setIsPodStarting]);
+
+  /**
+   * Called by App.tsx after the 2-minute pod-starting timeout.
+   * Clears the waiting state and shows a permanent error.
+   */
+  const showPodStartTimeout = useCallback(() => {
+    setIsPodStarting(false);
+    setIsConnecting(false);
+    const msg = "Agent pod failed to start \u2014 check cluster status";
+    setStreamError(msg);
+    setEntries((prev) => [
+      ...prev,
+      { id: nextId(), type: "error", message: msg },
+    ]);
+  }, [setIsConnecting, setIsPodStarting]);
 
   /**
    * Replay cached JSONL from localStorage for a pinned session (CACHE_PREFIX).
@@ -512,5 +553,7 @@ export function useLogStream() {
     isNodeUnreachable,
     replayedFromCache,
     isConnecting,
+    isPodStarting,
+    showPodStartTimeout,
   };
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -559,6 +559,25 @@ body {
   animation: spin 0.8s linear infinite;
 }
 
+/* Pod-starting waiting state — friendly message while agent initializes */
+.session-connecting.pod-starting {
+  color: var(--gold);
+  font-style: normal;
+  font-size: 0.8rem;
+  padding: 0.8rem 0.4rem;
+  gap: 0.5rem;
+}
+@keyframes rune-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.4; transform: scale(0.85); }
+}
+.pod-starting-rune {
+  display: inline-block; flex-shrink: 0;
+  font-family: 'Cinzel', serif; font-size: 1.1rem;
+  color: var(--gold);
+  animation: rune-pulse 2s ease-in-out infinite;
+}
+
 /* ── Entrypoint lines ──────────────────────────── */
 .ep-header {
   font-family: 'Cinzel', serif; font-size: 0.8rem;


### PR DESCRIPTION
PR for issue: #1330

Replaces raw HTTP 400 error JSON with a friendly 'Agent is starting up' waiting state with auto-retry.

## Changes

- `development/monitor-ui/src/hooks/useLogStream.ts` — `POD_NOT_READY_PATTERN` regex detects HTTP 400; `isPodStarting` state; `showPodStartTimeout` for 2-minute fallback
- `development/monitor-ui/src/App.tsx` — auto-retry `subscribe` every 4s; 2-minute timeout
- `development/monitor-ui/src/components/LogViewer.tsx` — friendly waiting UI with Norse rune animation
- `development/monitor-ui/src/styles/index.css` — CSS for connecting spinner + pod-starting rune with `rune-pulse` keyframes

## Validation

tsc ✓ · build ✓ · frontend Vitest 2020/2020 ✓

Fixes #1330