### PR TITLE
fix: switch agent GH_TOKEN to classic PAT for Projects API

### DIFF
--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -67,11 +67,11 @@ const SECRETS = [
 
   // --- GitHub → K8s agent secrets (deploy workflow creates agent-secrets) ---
   { name: "CLAUDE_CODE_OAUTH_TOKEN", dest: "github", group: "Agent Sandbox", secretsVar: "CLAUDE_CODE_OAUTH_TOKEN" },
-  { name: "GH_TOKEN_AGENTS",         dest: "github", group: "Agent Sandbox", secretsVar: "GITHUB_TOKEN_PAT_FINE_GRAINED" },
+  { name: "GH_TOKEN_AGENTS",         dest: "github", group: "Agent Sandbox", secretsVar: "GITHUB_TOKEN_PAT_CLASSIC" },
 
   // --- K8s agent-secrets (fenrir-agents namespace) ---
   { name: "anthropic-api-key",   dest: "k8s-agents", group: "K8s Agent Secrets", envVar: "FENRIR_ANTHROPIC_API_KEY", k8sSecret: "agent-secrets" },
-  { name: "gh-token",            dest: "k8s-agents", group: "K8s Agent Secrets", secretsVar: "GITHUB_TOKEN_PAT_FINE_GRAINED",  k8sSecret: "agent-secrets" },
+  { name: "gh-token",            dest: "k8s-agents", group: "K8s Agent Secrets", secretsVar: "GITHUB_TOKEN_PAT_CLASSIC",  k8sSecret: "agent-secrets" },
   { name: "claude-oauth-token",  dest: "k8s-agents", group: "K8s Agent Secrets", secretsVar: "CLAUDE_CODE_OAUTH_TOKEN",  k8sSecret: "agent-secrets" },
 
   // --- K8s n8n-secrets (fenrir-marketing namespace) ---


### PR DESCRIPTION
## Summary
- Fine-grained PATs lack GitHub Projects API scope — agents can't move issues on the board
- Switched `gh-token` and `GH_TOKEN_AGENTS` from `GITHUB_TOKEN_PAT_FINE_GRAINED` to `GITHUB_TOKEN_PAT_CLASSIC`
- Secret already pushed to K8s `agent-secrets` and GitHub Actions secrets

## Test plan
- [x] `manage-secrets --push gh-token` succeeded
- [x] `manage-secrets --push GH_TOKEN_AGENTS` succeeded
- [ ] Next agent dispatch verifies board moves work from inside sandbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)