### PR TITLE
chore(dispatch): default to on-demand nodes, make Spot opt-in

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -41,7 +41,7 @@ If issue data + agent template are already in context, that's **1 tool call** (s
 | `--local` | No | Local worktree instead of Depot. |
 | `--parallel` | No | Dispatch multiple issues simultaneously. |
 | `--prompt-extra <text>` | No | Extra context injected after issue body. |
-| `--no-spot` | No | Use on-demand nodes instead of Spot (avoids preemption). Check memory for current default mode. |
+| `--spot` | No | Use Spot nodes (cheaper but preemptible). Default is on-demand — Spot is opt-in only. |
 | `--dry-run` | No | Show composed prompt without spawning. |
 | `--skip-board-move` | No | Don't move to In Progress. |
 
@@ -234,15 +234,14 @@ bash "$REPO_ROOT/infrastructure/k8s/agents/dispatch-job.sh" \
   --session-id "$SESSION_ID" \
   --branch "<BRANCH>" \
   --model "<MODEL>" \
-  --prompt-file "$PROMPT_FILE" \
-  [--no-spot] && \
+  --prompt-file "$PROMPT_FILE" && \
 node "$REPO_ROOT/.claude/skills/fire-next-up/scripts/pack-status.mjs" --move <N> in-progress
 rm -f "$PROMPT_FILE"
 ```
 
 **Key:** Write the prompt to a temp file with `cat >` and pass via `--prompt-file`. This avoids the heredoc-in-subshell pattern (`$(cat <<'DELIM'...DELIM)`) which silently truncates the prompt if the content happens to contain the delimiter word on its own line. The delimiter `AGENT_PROMPT_EOF` is chosen to be unlikely in prompt content. Single-quoted delimiter (`<<'...'`) prevents shell expansion.
 
-**Spot vs on-demand:** Default is Spot (cheap, but pods can be preempted). Pass `--no-spot` to use on-demand nodes for stability. Check the `project_agent_spot_mode.md` memory file for the current default — if Odin has switched to on-demand mode, pass `--no-spot` on every dispatch until told otherwise.
+**Spot vs on-demand:** Default is **on-demand** (stable, no preemption). Pass `--spot` to opt-in to Spot nodes (cheaper but pods can be preempted). Spot is effectively deprecated for agents — too disruptive.
 
 **Job naming:** The dispatch script generates DNS-compatible job names from the session ID.
 

--- a/infrastructure/k8s/agents/dispatch-job.sh
+++ b/infrastructure/k8s/agents/dispatch-job.sh
@@ -24,7 +24,8 @@
 # Optional:
 #   --prompt-file Path to a file containing the task prompt (preferred
 #                 over --prompt — avoids heredoc/shell escaping issues)
-#   --no-spot     Use on-demand nodes instead of Spot (avoids preemption)
+#   --spot        Use Spot nodes (cheaper but can be preempted; default is on-demand)
+#   --no-spot     Explicitly use on-demand nodes (this is already the default)
 #   --image-tag   Container image tag (default: latest)
 #   --dry-run     Print generated manifest without applying
 # --------------------------------------------------------------------------
@@ -41,7 +42,7 @@ PROMPT_FILE=""
 IMAGE_TAG="latest"
 DRY_RUN=false
 ISSUE_NUMBER=""
-USE_SPOT=true
+USE_SPOT=false
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -52,6 +53,7 @@ while [[ $# -gt 0 ]]; do
     --prompt-file)   PROMPT_FILE="$2"; shift 2 ;;
     --image-tag)     IMAGE_TAG="$2"; shift 2 ;;
     --issue-number)  ISSUE_NUMBER="$2"; shift 2 ;;
+    --spot)          USE_SPOT=true; shift ;;
     --no-spot)       USE_SPOT=false; shift ;;
     --dry-run)       DRY_RUN=true; shift ;;
     *)


### PR DESCRIPTION
## Summary

- Flips `dispatch-job.sh` default from Spot (`USE_SPOT=true`) to on-demand (`USE_SPOT=false`)
- Adds `--spot` flag to opt-in to Spot nodes (inverse of `--no-spot`)
- `--no-spot` remains for backward compat but is now a no-op (already default)
- Updates dispatch SKILL.md — Spot is deprecated for agents, on-demand is the permanent default

Spot was causing 4-5 pod failures per job from preemptions, burning more setup time (clone + npm ci + checkout) than it saved in compute costs.

## Test plan

- [ ] `dispatch-job.sh --dry-run` → manifest has no Spot nodeSelector (on-demand)
- [ ] `dispatch-job.sh --dry-run --spot` → manifest has Spot nodeSelector
- [ ] Next agent dispatch runs on on-demand node without `--no-spot` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)