### PR TITLE
fix(odins-spear): handle already-canceled subscriptions in cancel-sub

### DIFF
--- a/development/frontend/scripts/odins-spear.mjs
+++ b/development/frontend/scripts/odins-spear.mjs
@@ -737,6 +737,16 @@ const commands = {
       console.log(`${DIM}Use "stripe-subs" to list subscription IDs.${RESET}`);
       return;
     }
+    // Retrieve first to check current status before attempting cancellation
+    const sub = await stripe("GET", `/subscriptions/${id}`);
+    if (!sub) {
+      console.log(`\n  ${RED}Subscription not found:${RESET} ${id}\n`);
+      return;
+    }
+    if (sub.status === "canceled") {
+      console.log(`\n  ${DIM}Subscription ${id} is already canceled.${RESET}\n`);
+      return;
+    }
     // Stripe API is source of truth — cancel there, webhooks sync Redis
     const data = await stripe("DELETE", `/subscriptions/${id}`);
     if (!data) return;


### PR DESCRIPTION
Closes #1378

## Summary
- Retrieve subscription via `GET /subscriptions/{id}` before attempting `DELETE`
- If status is `canceled`, print "already canceled" and return — no Stripe error
- If subscription not found (null), print clear "not found" message
- Active subscriptions still cancel normally via the DELETE call

## Test plan
- [ ] `cancel-sub sub_xxx` on an already-canceled sub → "Subscription is already canceled"
- [ ] `cancel-sub sub_xxx` on a non-existent sub → "Subscription not found"
- [ ] `cancel-sub sub_xxx` on an active sub → cancels and prints status as before
- [ ] tsc + build pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)