### PR TITLE
Issue #1384 - fix: show trial status box for anonymous users

### DIFF
--- a/development/frontend/src/__tests__/trial/trial-settings-section-render.test.tsx
+++ b/development/frontend/src/__tests__/trial/trial-settings-section-render.test.tsx
@@ -125,13 +125,36 @@ describe("TrialSettingsSection — Subscribe price button visibility (Issue #103
     expect(container.firstChild).toBeNull();
   });
 
-  // AC: Subscribe button with price shown for Thrall (free) users with no trial
-  it("renders nothing for Thrall users with no trial (none) — section hidden", () => {
+  // AC: Anonymous / no-trial users see the "not started" box (issue #1384)
+  it("renders the anonymous trial-not-started box for status 'none'", () => {
+    setStatus("none");
+    renderSection();
+
+    const section = screen.getByRole("region", { name: "Trial Status" });
+    expect(section).toBeDefined();
+  });
+
+  it("shows Norse-themed 'not started' copy for status 'none'", () => {
     setStatus("none");
     const { container } = renderSection();
 
-    // TrialSettingsSection returns null for none; price button does not appear
-    expect(container.firstChild).toBeNull();
+    expect(container.textContent).toContain("Thy trial hath not yet begun");
+  });
+
+  it("shows sign-in CTA link for status 'none'", () => {
+    setStatus("none");
+    renderSection();
+
+    const cta = screen.getByRole("link", { name: /sign in to begin thy karl trial/i });
+    expect(cta).toBeDefined();
+  });
+
+  it("does not render subscribe price button for status 'none'", () => {
+    setStatus("none");
+    renderSection();
+
+    const priceButton = screen.queryByRole("button", { name: PRICE_BUTTON_ARIA });
+    expect(priceButton).toBeNull();
   });
 
   // AC: Section renders during active trial (section itself not hidden)

--- a/development/frontend/src/__tests__/trial/trial-settings-section.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-settings-section.test.ts
@@ -59,10 +59,10 @@ function computePlanLabel(status: string, remainingDays: number): string {
 
 /**
  * Determines if the settings section should render.
+ * Anonymous users (status "none") now see a "not started" box (issue #1384).
  */
 function shouldShowSettingsSection(status: string, isLoading: boolean): boolean {
   if (isLoading) return false;
-  if (status === "none") return false;
   if (status === "converted") return false;
   return true;
 }
@@ -189,8 +189,8 @@ describe("TrialSettingsSection helpers", () => {
       expect(shouldShowSettingsSection("none", true)).toBe(false);
     });
 
-    it("returns false when status is 'none'", () => {
-      expect(shouldShowSettingsSection("none", false)).toBe(false);
+    it("returns true when status is 'none' — anonymous users see the not-started box (issue #1384)", () => {
+      expect(shouldShowSettingsSection("none", false)).toBe(true);
     });
 
     it("returns false when status is 'converted'", () => {

--- a/development/frontend/src/components/trial/TrialSettingsSection.tsx
+++ b/development/frontend/src/components/trial/TrialSettingsSection.tsx
@@ -88,9 +88,47 @@ export function TrialSettingsSection() {
     }
   }, [subscribeStripe]);
 
-  // Don't render if no trial or already converted
-  if (isLoading || status === "none" || status === "converted") {
+  // Don't render while loading or for paid subscribers (already converted)
+  if (isLoading || status === "converted") {
     return null;
+  }
+
+  // Anonymous / no-trial state: show Norse-themed "not started" box
+  if (status === "none") {
+    return (
+      <section
+        className="relative border border-border p-5 flex flex-col gap-3"
+        aria-label="Trial Status"
+      >
+        <h2 className="text-sm font-heading font-bold uppercase tracking-[0.08em] text-foreground">
+          Trial Status
+        </h2>
+        <div className="border border-muted/20 bg-muted/5 p-3 flex flex-col gap-1.5">
+          <p className="text-[13px] font-heading font-semibold text-foreground">
+            Thy trial hath not yet begun, wanderer
+          </p>
+          <p className="text-[12px] text-muted-foreground font-body leading-relaxed">
+            Sign in or add a credit card to begin thy 30&#8209;day Karl Trial — free
+            to start, no charge until thou subscribest.
+          </p>
+        </div>
+        <a
+          href="/ledger/sign-in"
+          className={[
+            "inline-flex items-center justify-center gap-2",
+            "min-h-[44px] md:min-h-[40px] px-5 py-2",
+            "text-base font-heading font-semibold tracking-wide",
+            "bg-gold text-primary-foreground",
+            "hover:brightness-110 transition-colors",
+            "border border-gold rounded-sm",
+            "self-start",
+          ].join(" ")}
+          aria-label="Sign in to begin thy Karl Trial"
+        >
+          Sign in to begin
+        </a>
+      </section>
+    );
   }
 
   const planLabel =


### PR DESCRIPTION
Fixes #1384

## Summary
- Removed \`status === "none"\` from the early-return guard in \`TrialSettingsSection\`
- Added dedicated anonymous render branch showing Norse-themed "trial not started" box
- Box includes CTA link to \`/ledger/sign-in\` with proper aria labels for accessibility

## What Changed
| File | Change |
|---|---|
| \`src/components/trial/TrialSettingsSection.tsx\` | Core fix — anonymous render branch |
| \`src/__tests__/trial/trial-settings-section-render.test.tsx\` | Updated: status=none expects section content; 4 new assertions |
| \`src/__tests__/trial/trial-settings-section.test.ts\` | Updated: shouldShowSettingsSection("none") now returns true |

## Test Results
- tsc: ✅ PASS
- build: ✅ PASS (45 routes)
- Vitest: ✅ 2075 tests / 141 files — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)