### PR TITLE
Issue #1406 - fix: standardize Karl tab styling across pages

### DIFF
--- a/development/frontend/src/__tests__/karl-bling/settings-tab-bling-1406.test.tsx
+++ b/development/frontend/src/__tests__/karl-bling/settings-tab-bling-1406.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Settings page tabs — karl-bling-tab class (Issue #1406)
+ *
+ * Validates that all Settings page tab buttons carry the `karl-bling-tab` CSS
+ * class. The karl-bling.css cascade fires on this class:
+ *
+ *   [data-tier="karl"]  .karl-bling-tab[aria-selected="true"] { color: var(--karl-gold); ... }
+ *   [data-tier="trial"] .karl-bling-tab[aria-selected="true"] { color: rgba(212,165,32,0.80); ... }
+ *
+ * This ensures active Settings tabs render gold text for Karl/trial users —
+ * matching the Cards page (Dashboard) where active tabs use `text-gold`.
+ *
+ * @see app/karl-bling.css  — .karl-bling-tab rules
+ * @see app/ledger/settings/page.tsx  — tab buttons
+ * @see Issue #1406
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SettingsPage from "@/app/ledger/settings/page";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/analytics/track", () => ({ track: vi.fn() }));
+
+vi.mock("@/components/entitlement/StripeSettings", () => ({
+  StripeSettings: () => <div data-testid="stripe-settings" />,
+}));
+
+vi.mock("@/components/trial/TrialSettingsSection", () => ({
+  TrialSettingsSection: () => <div data-testid="trial-section" />,
+}));
+
+vi.mock("@/components/household/HouseholdSettingsSection", () => ({
+  HouseholdSettingsSection: () => <div data-testid="household-section" />,
+}));
+
+vi.mock("@/components/sync/SyncSettingsSection", () => ({
+  SyncSettingsSection: () => <div data-testid="sync-section" />,
+}));
+
+vi.mock("@/components/easter-eggs/EasterEggModal", () => ({
+  EasterEggModal: () => null,
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Settings page tabs — karl-bling-tab class (Issue #1406)", () => {
+  it("all tab buttons carry the karl-bling-tab class for Karl gold cascade", () => {
+    render(<SettingsPage />);
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+    for (const tab of tabs) {
+      expect(tab.className).toContain("karl-bling-tab");
+    }
+  });
+
+  it("active tab button has aria-selected=true and karl-bling-tab class", () => {
+    render(<SettingsPage />);
+    const accountTab = screen.getByRole("tab", { name: /^Account$/i });
+    expect(accountTab.getAttribute("aria-selected")).toBe("true");
+    expect(accountTab.className).toContain("karl-bling-tab");
+  });
+
+  it("inactive tab buttons carry karl-bling-tab class for hover bling", () => {
+    render(<SettingsPage />);
+    const householdTab = screen.getByRole("tab", { name: /^Household$/i });
+    const settingsTab = screen.getByRole("tab", { name: /^Settings$/i });
+    expect(householdTab.getAttribute("aria-selected")).toBe("false");
+    expect(settingsTab.getAttribute("aria-selected")).toBe("false");
+    expect(householdTab.className).toContain("karl-bling-tab");
+    expect(settingsTab.className).toContain("karl-bling-tab");
+  });
+});

--- a/development/frontend/src/app/karl-bling.css
+++ b/development/frontend/src/app/karl-bling.css
@@ -492,6 +492,7 @@
 [data-tier="karl"] .karl-bling-tab[aria-selected="true"] {
   border-bottom: 2px solid #d4a520;
   box-shadow: 0 2px 10px rgba(212, 165, 32, 0.35);
+  color: var(--karl-gold);
 }
 
 [data-tier="karl"] .karl-bling-tab:hover {
@@ -502,6 +503,7 @@
 [data-tier="trial"] .karl-bling-tab[aria-selected="true"] {
   border-bottom: 2px solid rgba(212, 165, 32, 0.55);
   box-shadow: 0 2px 8px rgba(212, 165, 32, 0.18);
+  color: rgba(212, 165, 32, 0.80);
 }
 
 [data-tier="trial"] .karl-bling-tab:hover {


### PR DESCRIPTION
PR for issue: #1406

Unifies Karl-tier tab bling styling between Cards and Settings pages.

## Root Cause

The `.karl-bling-tab` CSS rule for `[aria-selected="true"]` applied gold border and glow shadow but **omitted text color**. The Cards page (Dashboard) active tabs use `text-gold` inline Tailwind class, so their active tab text is always gold. Settings page tabs used `text-foreground` inline and only received the gold border from the CSS cascade — not gold text.

## Changes

- `src/app/karl-bling.css`: Added `color: var(--karl-gold)` to `[data-tier="karl"] .karl-bling-tab[aria-selected="true"]` and `color: rgba(212,165,32,0.80)` to the trial rule — matching the `text-gold` active tab treatment on the Cards page
- `src/__tests__/karl-bling/settings-tab-bling-1406.test.tsx`: New test file verifying all Settings tab buttons carry the `karl-bling-tab` class (enabling the CSS cascade for Karl/trial tiers)

## Verification

- tsc: PASS
- build: PASS (45 routes)
- Vitest: 2200 tests across 148 files — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)