### PR TITLE
Issue #1405 - feat: dual GitHub PAT strategy — classic for agents, fine-grained for CI

### DIFF
--- a/.github/workflows/auto-add-to-project.yml
+++ b/.github/workflows/auto-add-to-project.yml
@@ -9,8 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add issue to Fenrir Ledger Triage project
+        # Requires classic PAT — gh project item-add needs project scope (not available on fine-grained PATs)
         env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN_PAT_CLASSIC }}
         run: |
           gh project item-add 1 \
             --owner declanshanaghy \

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -81,6 +81,9 @@ jobs:
 
       - name: Upsert PR comment with CI results
         if: always() && github.event_name == 'push'
+        # Fine-grained PAT is sufficient for PR comment writes (pull-requests: write)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN_PAT_FINE_GRAINED }}
         uses: actions/github-script@v8
         with:
           script: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@
 #   FENRIR_ANTHROPIC_API_KEY, ENTITLEMENT_ENCRYPTION_KEY
 #   STRIPE_SECRET_KEY, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID
 #   TF_VAR_BILLING_ACCOUNT_ID, TF_VAR_UPTIME_CHECK_HOST
-#   CLAUDE_CODE_OAUTH_TOKEN, GH_TOKEN_AGENTS
+#   CLAUDE_CODE_OAUTH_TOKEN, GITHUB_TOKEN_PAT_CLASSIC, GITHUB_TOKEN_PAT_FINE_GRAINED
 #   UMAMI_OAUTH2_PROXY_COOKIE_SECRET  — 32-byte cookie secret for Umami oauth2-proxy
 #   MONITOR_OAUTH2_PROXY_COOKIE_SECRET — 32-byte cookie secret for Odin's Throne oauth2-proxy
 #   ODINS_THRONE_CLIENT_ID, ODINS_THRONE_CLIENT_SECRET
@@ -439,12 +439,16 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync agent secrets
+        # Dual-PAT strategy — see infrastructure/k8s/agents/README.md for token usage table.
+        # gh-token-classic: classic PAT with repo+project scopes — agent write ops
+        # gh-token-fine-grained: fine-grained repo-scoped PAT — read-only / CI checks
         run: |
           kubectl create secret generic agent-secrets \
             --namespace=fenrir-agents \
             --from-literal=anthropic-api-key="${{ secrets.FENRIR_ANTHROPIC_API_KEY }}" \
             --from-literal=claude-oauth-token="${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}" \
-            --from-literal=gh-token="${{ secrets.GH_TOKEN_AGENTS }}" \
+            --from-literal=gh-token-classic="${{ secrets.GITHUB_TOKEN_PAT_CLASSIC }}" \
+            --from-literal=gh-token-fine-grained="${{ secrets.GITHUB_TOKEN_PAT_FINE_GRAINED }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Resolve image tag

--- a/infrastructure/k8s/agents/README.md
+++ b/infrastructure/k8s/agents/README.md
@@ -2,6 +2,25 @@
 
 Ephemeral Kubernetes Jobs for running Claude Code agent tasks on GKE Autopilot.
 
+## GitHub PAT Token Strategy
+
+Two tokens are used. Both live in `.secrets` and are synced to K8s via the `Sync agent secrets`
+step in `deploy.yml`. Agent pods receive `GH_TOKEN` set to the classic PAT.
+
+| Secret Name | K8s Key | Env Var | Use Case |
+|---|---|---|---|
+| `GITHUB_TOKEN_PAT_CLASSIC` | `gh-token-classic` | `GH_TOKEN` (agents) | `gh pr edit`, `gh issue comment`, `gh project item-add`, `git push` — any write operation |
+| `GITHUB_TOKEN_PAT_FINE_GRAINED` | `gh-token-fine-grained` | `GITHUB_TOKEN` (CI) | `gh pr view`, `gh issue view`, CI status checks, PR comment upserts — read-only / low-privilege |
+
+**Why classic for agents?** Fine-grained PATs do not support GitHub Projects v2 (`project` scope)
+or certain PR edit operations. Agents need full write access; the classic PAT has `repo` + `project`.
+
+**Why fine-grained for CI?** CI workflows only read PRs/issues and post comments. The fine-grained
+PAT is repo-scoped and can be rotated independently without affecting agent dispatch.
+
+**Fail-fast guarantee:** `entrypoint.sh` exits immediately with `[FATAL]` if `GH_TOKEN` is unset,
+preventing silent fallback to an incorrect or missing token.
+
 ## Architecture
 
 ```
@@ -42,12 +61,15 @@ docker push us-central1-docker.pkg.dev/fenrir-ledger-prod/fenrir-images/agent-sa
 kubectl create secret generic agent-secrets \
   --namespace fenrir-agents \
   --from-literal=anthropic-api-key="<your-anthropic-key>" \
-  --from-literal=gh-token="<fine-grained-pat>" \
+  --from-literal=gh-token-classic="<classic-pat-with-repo-and-project-scopes>" \
+  --from-literal=gh-token-fine-grained="<fine-grained-pat-scoped-to-this-repo>" \
   --from-literal=claude-oauth-token="<claude-code-oauth-token>"
 ```
 
-**Note:** `gh-token` must be a **fine-grained PAT** (not classic) scoped to this repo with
-Contents, Pull requests, Issues, Workflows, and Metadata permissions.
+**Note:** `gh-token-classic` must be a **classic PAT** with `repo` and `project` scopes — required
+for `gh pr edit`, `gh issue comment`, `gh project item-add`, and `git push`.
+`gh-token-fine-grained` is a **fine-grained PAT** scoped to this repo for read-only CI operations.
+See the PAT Token Strategy table above for the full routing breakdown.
 
 ### 3. Dispatch an agent
 

--- a/infrastructure/k8s/agents/job-template.yaml
+++ b/infrastructure/k8s/agents/job-template.yaml
@@ -96,8 +96,10 @@ spec:
                 secretKeyRef:
                   name: agent-secrets
                   key: claude-oauth-token
+            # Classic PAT — required for write ops: gh pr edit, gh issue comment,
+            # gh project item-add, git push. See infrastructure/k8s/agents/README.md.
             - name: GH_TOKEN
               valueFrom:
                 secretKeyRef:
                   name: agent-secrets
-                  key: gh-token
+                  key: gh-token-classic


### PR DESCRIPTION
PR for issue: #1405

## Summary

Dual GitHub PAT strategy — classic PAT for agent write operations, fine-grained PAT for CI read operations.

### Changes

- `infrastructure/k8s/agents/job-template.yaml` — `GH_TOKEN` sourced from `gh-token-classic` K8s secret key
- `.github/workflows/deploy.yml` — Syncs both `gh-token-classic` and `gh-token-fine-grained` to K8s
- `.github/workflows/auto-add-to-project.yml` — `GH_TOKEN` set to `GITHUB_TOKEN_PAT_CLASSIC`
- `.github/workflows/ci-tests.yml` — PR comment upsert uses `GITHUB_TOKEN_PAT_FINE_GRAINED`
- `scripts/sync-secrets.mjs` — K8s agent-secrets SECRETS list cleaned up
- `infrastructure/k8s/agents/README.md` — Full dual PAT strategy table documented

Fixes #1405