### PR TITLE
Issue #1446 - feat: wire Production GKE badge to deploy workflow status

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   </tr>
   <tr>
     <td colspan="4">
-      <a href="https://app.fenrirledger.com"><img src="https://img.shields.io/badge/Production-GKE-c9920a?style=for-the-badge&logo=googlecloud&logoColor=white&labelColor=07070d" alt="Production"></a>
+      <a href="https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/deploy.yml"><img src="https://github.com/declanshanaghy/fenrir-ledger/actions/workflows/deploy.yml/badge.svg?branch=main" alt="Production: GKE"></a>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
PR for issue: #1446

Replaces the static Production GKE shield badge in README.md with the live GitHub Actions workflow status badge for deploy.yml on main.

**Changes:**
- `README.md` — badge src swapped to GitHub Actions workflow badge URL

**Verification:**
- Badge at the top of README shows live deploy.yml pass/fail status
- Clicking badge navigates to the workflow runs page