### PR TITLE
fix(dispatch): add bypassPermissions mode to local agent spawns

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -251,7 +251,7 @@ rm -f "$PROMPT_FILE"
 
 #### Local (`--local`)
 
-Launch via Agent tool with `isolation: "worktree"`, `run_in_background: true`, using the composed prompt as the agent task.
+Launch via Agent tool with `isolation: "worktree"`, `run_in_background: true`, `mode: "bypassPermissions"`, using the composed prompt as the agent task.
 
 ### Phase 3 — Board Move (MANDATORY)
 


### PR DESCRIPTION
## Summary

- Add `mode: "bypassPermissions"` to local worktree Agent tool invocation in dispatch SKILL.md
- Prevents local agents from prompting for file edit approval on every operation

## Test plan

- [ ] Dispatch an agent with `--local` and confirm it runs fully autonomously without permission prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)