### PR TITLE
fix(odins-spear): REPL fills full terminal window on launch and resize (#1440)

### DIFF
--- a/development/frontend/scripts/odins-spear.mjs
+++ b/development/frontend/scripts/odins-spear.mjs
@@ -28,7 +28,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import React, { useState, useEffect, useCallback } from "react";
-import { render, Box, Text, useInput, useApp } from "ink";
+import { render, Box, Text, useInput, useApp, useStdout } from "ink";
 
 // ── Stripe ───────────────────────────────────────────────────────────────────
 
@@ -3258,6 +3258,24 @@ function MainContent({ activeTab, onJumpToHousehold, setInputCaptured }) {
 /** Root TUI application. */
 function SpearApp({ connectionStatus, counts }) {
   const { exit } = useApp();
+  const { stdout } = useStdout();
+
+  // Track terminal dimensions and reflow on resize
+  const [termSize, setTermSize] = useState({
+    columns: stdout?.columns ?? process.stdout.columns ?? 80,
+    rows:    stdout?.rows    ?? process.stdout.rows    ?? 24,
+  });
+  useEffect(() => {
+    function onResize() {
+      setTermSize({
+        columns: stdout?.columns ?? process.stdout.columns ?? 80,
+        rows:    stdout?.rows    ?? process.stdout.rows    ?? 24,
+      });
+    }
+    process.stdout.on("resize", onResize);
+    return () => process.stdout.off("resize", onResize);
+  }, [stdout]);
+
   const [activeTab, setActiveTab]         = useState(0);
   const [showHelp, setShowHelp]           = useState(false);
   const [inputCaptured, setInputCaptured] = useState(false); // true when a tab holds input (e.g. text prompt)
@@ -3405,7 +3423,7 @@ function SpearApp({ connectionStatus, counts }) {
     mainArea = h(MainContent, { activeTab, onJumpToHousehold, setInputCaptured });
   }
 
-  return h(Box, { flexDirection: "column", height: "100%" },
+  return h(Box, { flexDirection: "column", width: termSize.columns, height: termSize.rows },
     h(TopBar, { activeTab, onTabChange: setActiveTab }),
     mainArea,
     ...(cmdStatusMsg ? [
@@ -3427,7 +3445,7 @@ const connectionStatus = {
   stripe: await getStripeKey().then(Boolean).catch(() => false),
 };
 
-const { waitUntilExit } = render(h(SpearApp, { connectionStatus, counts: initialCounts }));
+const { waitUntilExit } = render(h(SpearApp, { connectionStatus, counts: initialCounts }), { fullscreen: true });
 await waitUntilExit();
 cleanupPortForward();
 await redis.quit().catch(() => {});

--- a/development/frontend/src/__tests__/odins-spear-terminal-fill.test.ts
+++ b/development/frontend/src/__tests__/odins-spear-terminal-fill.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Vitest — Odin's Spear: REPL fills full terminal window
+ * Issue #1440: Terminal size detection and resize handling
+ *
+ * odins-spear.mjs uses top-level await with side-effects and cannot be imported.
+ * Tests mirror the terminal-size logic with injectable dependencies.
+ *
+ * Suites:
+ *   1. Terminal size initialization — stdout.columns/rows with fallback chain
+ *   2. Resize handler — updates dimensions from stdout or process.stdout
+ *   3. Resize handler cleanup — removes listener on unmount
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ─── Terminal size helpers (mirroring SpearApp initialisation) ─────────────────
+//
+// Mirrors:
+//   const [termSize, setTermSize] = useState({
+//     columns: stdout?.columns ?? process.stdout.columns ?? 80,
+//     rows:    stdout?.rows    ?? process.stdout.rows    ?? 24,
+//   });
+
+interface MockStdout {
+  columns?: number;
+  rows?: number;
+  on: (event: string, fn: () => void) => void;
+  off: (event: string, fn: () => void) => void;
+}
+
+function getInitialTermSize(
+  stdout: MockStdout | null,
+  processStdout: { columns?: number; rows?: number }
+): { columns: number; rows: number } {
+  return {
+    columns: stdout?.columns ?? processStdout?.columns ?? 80,
+    rows:    stdout?.rows    ?? processStdout?.rows    ?? 24,
+  };
+}
+
+function buildResizeHandler(
+  stdout: MockStdout | null,
+  processStdout: { columns?: number; rows?: number },
+  setTermSize: (size: { columns: number; rows: number }) => void
+): () => void {
+  return function onResize() {
+    setTermSize({
+      columns: stdout?.columns ?? processStdout?.columns ?? 80,
+      rows:    stdout?.rows    ?? processStdout?.rows    ?? 24,
+    });
+  };
+}
+
+// ─── 1. Terminal size initialization ─────────────────────────────────────────
+
+describe("terminal size initialization — stdout.columns/rows fallback chain (issue #1440)", () => {
+  it("uses stdout.columns and stdout.rows when both are provided", () => {
+    const stdout: MockStdout = { columns: 220, rows: 55, on: vi.fn(), off: vi.fn() };
+    const size = getInitialTermSize(stdout, { columns: 80, rows: 24 });
+    expect(size).toEqual({ columns: 220, rows: 55 });
+  });
+
+  it("falls back to process.stdout values when stdout is null", () => {
+    const size = getInitialTermSize(null, { columns: 132, rows: 40 });
+    expect(size).toEqual({ columns: 132, rows: 40 });
+  });
+
+  it("falls back to defaults (80x24) when both stdout and process.stdout are undefined", () => {
+    const size = getInitialTermSize(null, {});
+    expect(size).toEqual({ columns: 80, rows: 24 });
+  });
+
+  it("falls back to process.stdout when stdout.columns is undefined", () => {
+    const stdout: MockStdout = { rows: 50, on: vi.fn(), off: vi.fn() };
+    const size = getInitialTermSize(stdout, { columns: 100, rows: 30 });
+    // columns falls back to process.stdout.columns; rows taken from stdout.rows
+    expect(size.columns).toBe(100);
+    expect(size.rows).toBe(50);
+  });
+
+  it("falls back to process.stdout when stdout.rows is undefined", () => {
+    const stdout: MockStdout = { columns: 200, on: vi.fn(), off: vi.fn() };
+    const size = getInitialTermSize(stdout, { columns: 80, rows: 35 });
+    expect(size.columns).toBe(200);
+    expect(size.rows).toBe(35);
+  });
+
+  it("uses default 80 columns when stdout is null and process.stdout.columns is undefined", () => {
+    const size = getInitialTermSize(null, { rows: 30 });
+    expect(size.columns).toBe(80);
+  });
+
+  it("uses default 24 rows when stdout is null and process.stdout.rows is undefined", () => {
+    const size = getInitialTermSize(null, { columns: 100 });
+    expect(size.rows).toBe(24);
+  });
+});
+
+// ─── 2. Resize handler — updates dimensions ────────────────────────────────
+
+describe("resize handler — reflects new terminal dimensions (issue #1440)", () => {
+  it("calls setTermSize with stdout dimensions on resize", () => {
+    const stdout: MockStdout = { columns: 300, rows: 80, on: vi.fn(), off: vi.fn() };
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(stdout, {}, setTermSize);
+    onResize();
+    expect(setTermSize).toHaveBeenCalledOnce();
+    expect(setTermSize).toHaveBeenCalledWith({ columns: 300, rows: 80 });
+  });
+
+  it("falls back to process.stdout on resize when stdout is null", () => {
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(null, { columns: 120, rows: 40 }, setTermSize);
+    onResize();
+    expect(setTermSize).toHaveBeenCalledWith({ columns: 120, rows: 40 });
+  });
+
+  it("uses defaults on resize when both sources are undefined", () => {
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(null, {}, setTermSize);
+    onResize();
+    expect(setTermSize).toHaveBeenCalledWith({ columns: 80, rows: 24 });
+  });
+
+  it("reflects updated stdout dimensions across multiple resize events", () => {
+    const stdout: MockStdout = { columns: 100, rows: 30, on: vi.fn(), off: vi.fn() };
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(stdout, {}, setTermSize);
+
+    onResize();
+    stdout.columns = 200;
+    stdout.rows = 60;
+    onResize();
+
+    expect(setTermSize).toHaveBeenCalledTimes(2);
+    expect(setTermSize.mock.calls[0][0]).toEqual({ columns: 100, rows: 30 });
+    expect(setTermSize.mock.calls[1][0]).toEqual({ columns: 200, rows: 60 });
+  });
+});
+
+// ─── 3. Resize handler cleanup ────────────────────────────────────────────────
+//
+// Mirrors:
+//   process.stdout.on("resize", onResize);
+//   return () => process.stdout.off("resize", onResize);
+
+describe("resize handler cleanup — removes listener on unmount (issue #1440)", () => {
+  let onListeners: Map<string, Set<() => void>>;
+  let mockProcessStdout: { on: (event: string, fn: () => void) => void; off: (event: string, fn: () => void) => void };
+
+  beforeEach(() => {
+    onListeners = new Map();
+    mockProcessStdout = {
+      on: vi.fn((event: string, fn: () => void) => {
+        if (!onListeners.has(event)) onListeners.set(event, new Set());
+        onListeners.get(event)!.add(fn);
+      }),
+      off: vi.fn((event: string, fn: () => void) => {
+        onListeners.get(event)?.delete(fn);
+      }),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a 'resize' listener on mount", () => {
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(null, {}, setTermSize);
+    mockProcessStdout.on("resize", onResize);
+    expect(mockProcessStdout.on).toHaveBeenCalledWith("resize", onResize);
+  });
+
+  it("removes the 'resize' listener on cleanup", () => {
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(null, {}, setTermSize);
+    mockProcessStdout.on("resize", onResize);
+
+    // Simulate unmount cleanup
+    mockProcessStdout.off("resize", onResize);
+    expect(mockProcessStdout.off).toHaveBeenCalledWith("resize", onResize);
+    expect(onListeners.get("resize")?.has(onResize)).toBe(false);
+  });
+
+  it("cleanup does not call setTermSize after removal", () => {
+    const setTermSize = vi.fn();
+    const onResize = buildResizeHandler(null, { columns: 80, rows: 24 }, setTermSize);
+    mockProcessStdout.on("resize", onResize);
+    mockProcessStdout.off("resize", onResize);
+
+    // No more resize events should fire setTermSize
+    onListeners.get("resize")?.forEach((fn) => fn());
+    expect(setTermSize).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
PR for issue: #1440

Fix Odin's Spear REPL to detect and fill full terminal dimensions at launch and on resize.

## Changes

- `development/frontend/scripts/odins-spear.mjs`
  - Import `useStdout` from Ink
  - Track terminal dimensions (`columns` × `rows`) in component state, initialized from `stdout` with fallback to `process.stdout` and hardcoded defaults (80×24)
  - Add `process.stdout` `resize` listener that updates state; cleaned up on unmount
  - Pass explicit `width`/`height` to root `Box` so layout always fills the full screen
  - Enable `fullscreen: true` in `render()` to use the alternate screen buffer

- `development/frontend/src/__tests__/odins-spear-terminal-fill.test.ts` _(new)_
  - 14 Vitest tests covering: initialization fallback chain, resize dimension updates, multi-resize tracking, listener registration and cleanup

## Verification

- tsc: PASS
- build: PASS (45 routes)
- Vitest: 2361 tests across 154 files — all passing

**Manual test:** Launch `just frontend odins-spear`, verify it fills the full terminal. Resize the terminal window and verify the UI reflows with no dead space.