### PR TITLE
Issue #1407 - feat: collapsible session list minimal mode

### DIFF
--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -11,9 +11,10 @@ interface Props {
   isPinned?: boolean;
   onTogglePin?: () => void;
   onCancelJob?: (sessionId: string) => void;
+  collapsed?: boolean;
 }
 
-export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = false, onTogglePin, onCancelJob }: Props) {
+export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = false, onTogglePin, onCancelJob, collapsed = false }: Props) {
   const agentColor = AGENT_COLORS[job.agentKey ?? ""] || "#c9920a";
   const avatar = AGENT_AVATARS[job.agentKey ?? ""];
   const sColor = STATUS_COLORS[job.status] || "#606070";
@@ -25,6 +26,42 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
   const cardTitle = job.issueTitle
     ? `#${job.issue} \u2013 ${job.issueTitle}`
     : displayTitle;
+
+  if (collapsed) {
+    return (
+      <div
+        className={`card card--minimal${isActive ? " active" : ""}`}
+        role="listitem"
+        aria-label={`Job: Issue ${job.issue} – ${job.agentName} – ${sLabel}`}
+        onClick={onClick}
+        title={cardTitle}
+      >
+        <span className={`card-status${pulse}`} style={{ color: sColor }} aria-hidden="true">
+          {sIcon}
+        </span>
+        <span className="card-minimal-issue" aria-label={`Issue ${job.issue}`}>
+          #{job.issue}
+        </span>
+        {avatar ? (
+          <button
+            className="card-avatar-btn card-avatar-btn--minimal"
+            onClick={(e) => {
+              e.stopPropagation();
+              onAvatarClick?.(job.agentKey ?? "");
+            }}
+            aria-label={`View ${job.agentName} profile`}
+            title={`View ${job.agentName} profile`}
+          >
+            <img className="card-avatar card-avatar--minimal" src={avatar} alt={job.agentName} />
+          </button>
+        ) : (
+          <span className="card-minimal-agent-initial" style={{ color: agentColor }} aria-label={job.agentName}>
+            {job.agentName?.[0] ?? "?"}
+          </span>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div

--- a/development/monitor-ui/src/components/Sidebar.tsx
+++ b/development/monitor-ui/src/components/Sidebar.tsx
@@ -1,8 +1,27 @@
+import { useState, useCallback } from "react";
 import type { DisplayJob } from "../lib/types";
 import { useTheme } from "../hooks/useTheme";
 import { JobCard } from "./JobCard";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 import { StatusBadge } from "./StatusBadge";
+
+const COLLAPSE_KEY = "hlidskjalf:sidebar-collapsed";
+
+function loadCollapsed(): boolean {
+  try {
+    return localStorage.getItem(COLLAPSE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function saveCollapsed(value: boolean): void {
+  try {
+    localStorage.setItem(COLLAPSE_KEY, String(value));
+  } catch {
+    // private browsing — ignore
+  }
+}
 
 interface Props {
   jobs: DisplayJob[];
@@ -19,9 +38,18 @@ interface Props {
 
 export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession, onAvatarClick, onOdinClick, onTogglePinSession, pinnedSessionIds, onCancelJob }: Props) {
   const { theme, setTheme } = useTheme();
+  const [collapsed, setCollapsed] = useState<boolean>(loadCollapsed);
+
+  const handleToggleCollapse = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      saveCollapsed(next);
+      return next;
+    });
+  }, []);
 
   return (
-    <nav className="sidebar" aria-label="Agent sessions">
+    <nav className={`sidebar${collapsed ? " sidebar--collapsed" : ""}`} aria-label="Agent sessions">
       <div className="sidebar-header">
         <div className="brand">
           <button
@@ -35,33 +63,50 @@ export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession
               alt="Odin"
             />
           </button>
-          <h1>Hlidskjalf</h1>
-          <span className="brand-wss-badge">
-            <StatusBadge state={wsState} />
-          </span>
+          {!collapsed && <h1>Hlidskjalf</h1>}
+          {!collapsed && (
+            <span className="brand-wss-badge">
+              <StatusBadge state={wsState} />
+            </span>
+          )}
+          <button
+            className="sidebar-collapse-btn"
+            onClick={handleToggleCollapse}
+            aria-label={collapsed ? "Expand session list" : "Collapse session list"}
+            title={collapsed ? "Expand session list" : "Collapse session list"}
+            aria-expanded={!collapsed}
+          >
+            <CollapseChevron collapsed={collapsed} />
+          </button>
         </div>
-        <div className="quote" role="note">
-          &ldquo;{quote}&rdquo;
-        </div>
-        <div className="count-row">
-          <div className="count" aria-live="polite">
-            {jobs.length} session{jobs.length !== 1 ? "s" : ""}
-          </div>
-          <ThemeSwitcher theme={theme} setTheme={setTheme} />
-        </div>
+        {!collapsed && (
+          <>
+            <div className="quote" role="note">
+              &ldquo;{quote}&rdquo;
+            </div>
+            <div className="count-row">
+              <div className="count" aria-live="polite">
+                {jobs.length} session{jobs.length !== 1 ? "s" : ""}
+              </div>
+              <ThemeSwitcher theme={theme} setTheme={setTheme} />
+            </div>
+          </>
+        )}
       </div>
       <div className="card-list" role="list" aria-label="Job sessions">
         {jobs.length === 0 ? (
-          <div
-            style={{
-              padding: "1rem",
-              fontSize: "0.8rem",
-              color: "var(--text-void)",
-              fontStyle: "italic",
-            }}
-          >
-            No agent jobs found
-          </div>
+          !collapsed && (
+            <div
+              style={{
+                padding: "1rem",
+                fontSize: "0.8rem",
+                color: "var(--text-void)",
+                fontStyle: "italic",
+              }}
+            >
+              No agent jobs found
+            </div>
+          )
         ) : (
           jobs.map((job) => (
             <JobCard
@@ -73,10 +118,33 @@ export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession
               isPinned={pinnedSessionIds?.has(job.sessionId) ?? false}
               onTogglePin={onTogglePinSession ? () => onTogglePinSession(job.sessionId) : undefined}
               onCancelJob={onCancelJob}
+              collapsed={collapsed}
             />
           ))
         )}
       </div>
     </nav>
+  );
+}
+
+function CollapseChevron({ collapsed }: { collapsed: boolean }) {
+  return (
+    <svg
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      fill="none"
+      aria-hidden="true"
+      className={`collapse-chevron${collapsed ? " collapse-chevron--collapsed" : ""}`}
+    >
+      <polyline
+        points={collapsed ? "4,2 8,6 4,10" : "8,2 4,6 8,10"}
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        fill="none"
+      />
+    </svg>
   );
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -263,6 +263,77 @@ body {
 }
 .card-list { flex: 1; overflow-y: auto; padding: 0.5rem; }
 
+/* ── Sidebar collapse ──────────────────────────── */
+.sidebar {
+  transition: width 0.2s ease, min-width 0.2s ease;
+}
+.sidebar--collapsed {
+  width: 72px; min-width: 72px;
+  overflow-x: hidden;
+}
+.sidebar--collapsed .sidebar-header {
+  padding: 0.6rem 0.5rem;
+}
+.sidebar--collapsed .card-list {
+  padding: 0.25rem 0.3rem;
+}
+.sidebar--collapsed .brand {
+  flex-direction: column; gap: 0.4rem; margin-bottom: 0;
+  align-items: center;
+}
+.sidebar--collapsed .odin-avatar-btn img {
+  width: 32px; height: 32px;
+}
+.sidebar-collapse-btn {
+  display: flex; align-items: center; justify-content: center;
+  background: transparent; border: 1px solid var(--rune-border);
+  border-radius: 3px; padding: 3px; cursor: pointer;
+  color: var(--text-void); flex-shrink: 0;
+  transition: background 0.15s, color 0.15s;
+}
+.sidebar-collapse-btn:hover {
+  background: var(--chain); color: var(--text-saga);
+}
+.sidebar--collapsed .sidebar-collapse-btn {
+  margin-top: 0.25rem;
+}
+.collapse-chevron {
+  display: block; transition: none;
+}
+
+/* ── Minimal (collapsed) card ──────────────────── */
+.card--minimal {
+  display: flex; align-items: center; justify-content: center;
+  flex-direction: column; gap: 4px;
+  padding: 0.45rem 0.3rem; border-radius: 4px; cursor: pointer;
+  margin-bottom: 2px; border-left: 3px solid transparent;
+  transition: background 0.15s;
+}
+.card--minimal:hover { background: var(--chain); }
+.card--minimal.active { background: var(--chain); border-left-color: var(--gold); }
+.card-minimal-issue {
+  font-family: 'JetBrains Mono', monospace; font-size: 0.6rem;
+  font-weight: 700; color: var(--text-saga);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 56px; text-align: center;
+}
+.card-avatar-btn--minimal {
+  padding: 0; border: none; background: transparent; cursor: pointer;
+}
+.card-avatar--minimal {
+  width: 26px; height: 26px; border-radius: 50%;
+  border: 1px solid var(--rune-border); object-fit: cover;
+}
+.card-minimal-agent-initial {
+  font-family: 'Cinzel', serif; font-size: 0.75rem; font-weight: 700;
+  width: 26px; height: 26px; border-radius: 50%;
+  border: 1px solid var(--rune-border);
+  display: flex; align-items: center; justify-content: center;
+}
+.card--minimal .card-status {
+  font-size: 0.7rem; margin-left: 0;
+}
+
 /* ── Job cards ─────────────────────────────────── */
 .card {
   padding: 0.6rem 0.75rem; border-radius: 4px; cursor: pointer;


### PR DESCRIPTION
Fixes #1407

## Summary
- Added collapse/expand toggle to Sidebar header with chevron SVG, aria-expanded, aria-label
- Collapsed state persists via localStorage (hlidskjalf:sidebar-collapsed) with try/catch for private browsing
- JobCard renders minimal view (status icon + issue # + agent avatar/initial) when collapsed prop is true
- Empty session list suppressed in collapsed mode
- CSS transitions: sidebar width 0.2s ease, card background 0.15s; no layout jank

## Test plan
- tsc PASS
- build PASS (45 routes)
- N/A Vitest (monitor-ui has no test infrastructure)
- E2E: CI