### PR TITLE
chore(dispatch): shared per-agent decree templates

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -193,6 +193,7 @@ Determine agent (from `--agent` or inference table), branch (from `--branch` or 
 
 Substitute variables in the template:
 - `{{SANDBOX_PREAMBLE}}` → content of `sandbox-preamble.md`
+- `{{DECREE_TEMPLATE}}` → content of `decree-<agent>.md` (e.g. `decree-firemandecko.md`, `decree-loki.md`)
 - `<NUMBER>` → issue number
 - `<TITLE>` → issue title
 - `<BRANCH>` → branch name

--- a/.claude/skills/fire-next-up/templates/decree-firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/decree-firemandecko.md
@@ -1,0 +1,21 @@
+**Final Step — Decree (UNBREAKABLE):**
+This is your ABSOLUTE LAST output. Emit the block below with ALL angle-bracket placeholders
+replaced by real values. Do NOT narrate this step. Do NOT include the step header in your output.
+Output ONLY what is between (and including) the ᛭᛭᛭ delimiters.
+
+᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
+ISSUE: #<NUMBER>
+VERDICT: DONE
+PR: <actual-pr-url or N/A>
+SUMMARY:
+- <what was implemented — 1 bullet per logical change>
+CHECKS:
+- tsc: PASS or FAIL
+- build: PASS or FAIL
+- vitest: <count> tests, all passing (or N failing)
+SEAL: FiremanDecko · ᚠᛁᚱᛖᛗᚨᚾᛞᛖᚲᚲᛟ · Principal Engineer
+SIGNOFF: Forged in fire, tempered by craft
+᛭᛭᛭ END DECREE ᛭᛭᛭
+
+NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
+This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.

--- a/.claude/skills/fire-next-up/templates/decree-freya.md
+++ b/.claude/skills/fire-next-up/templates/decree-freya.md
@@ -1,0 +1,21 @@
+**Final Step — Decree (UNBREAKABLE):**
+This is your ABSOLUTE LAST output. Emit the block below with ALL angle-bracket placeholders
+replaced by real values. Do NOT narrate this step. Do NOT include the step header in your output.
+Output ONLY what is between (and including) the ᛭᛭᛭ delimiters.
+
+᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
+ISSUE: #<NUMBER>
+VERDICT: APPROVED
+PR: N/A
+SUMMARY:
+- <what was decided/produced — 1 bullet per deliverable>
+CHECKS:
+- product-brief: COMPLETE
+- acceptance-criteria: DEFINED
+- backlog: UPDATED
+SEAL: Freya · ᚠᚱᛖᛃᚨ · Product Owner
+SIGNOFF: Vision cast, priorities set
+᛭᛭᛭ END DECREE ᛭᛭᛭
+
+NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
+This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.

--- a/.claude/skills/fire-next-up/templates/decree-heimdall.md
+++ b/.claude/skills/fire-next-up/templates/decree-heimdall.md
@@ -1,0 +1,21 @@
+**Final Step — Decree (UNBREAKABLE):**
+This is your ABSOLUTE LAST output. Emit the block below with ALL angle-bracket placeholders
+replaced by real values. Do NOT narrate this step. Do NOT include the step header in your output.
+Output ONLY what is between (and including) the ᛭᛭᛭ delimiters.
+
+᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
+ISSUE: #<NUMBER>
+VERDICT: SECURED
+PR: <actual-pr-url or N/A>
+SUMMARY:
+- <what was audited/fixed — 1 bullet per finding area>
+CHECKS:
+- owasp-top10: PASS or FINDINGS
+- requireAuth: PASS or FAIL
+- secrets: PASS or FAIL
+SEAL: Heimdall · ᚺᛖᛁᛗᛞᚨᛚᛚ · Security Specialist
+SIGNOFF: The bridge holds — none shall pass unvetted
+᛭᛭᛭ END DECREE ᛭᛭᛭
+
+NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
+This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.

--- a/.claude/skills/fire-next-up/templates/decree-loki.md
+++ b/.claude/skills/fire-next-up/templates/decree-loki.md
@@ -1,0 +1,22 @@
+**Final Step — Decree (UNBREAKABLE):**
+This is your ABSOLUTE LAST output. Emit the block below with ALL angle-bracket placeholders
+replaced by real values. Do NOT narrate this step. Do NOT include the step header in your output.
+Output ONLY what is between (and including) the ᛭᛭᛭ delimiters.
+
+᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
+ISSUE: #<NUMBER>
+VERDICT: PASS or FAIL
+PR: <actual-pr-url or N/A>
+SUMMARY:
+- <what was validated — 1 bullet per test area>
+CHECKS:
+- tsc: PASS or FAIL
+- build: PASS or FAIL
+- vitest: <count> tests, all passing (or N failing)
+- playwright: <count> tests (if run)
+SEAL: Loki · ᛚᛟᚲᛁ · QA Tester
+SIGNOFF: Break it before the wolf does
+᛭᛭᛭ END DECREE ᛭᛭᛭
+
+NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
+This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.

--- a/.claude/skills/fire-next-up/templates/decree-luna.md
+++ b/.claude/skills/fire-next-up/templates/decree-luna.md
@@ -1,0 +1,21 @@
+**Final Step — Decree (UNBREAKABLE):**
+This is your ABSOLUTE LAST output. Emit the block below with ALL angle-bracket placeholders
+replaced by real values. Do NOT narrate this step. Do NOT include the step header in your output.
+Output ONLY what is between (and including) the ᛭᛭᛭ delimiters.
+
+᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
+ISSUE: #<NUMBER>
+VERDICT: DELIVERED
+PR: N/A
+SUMMARY:
+- <what was designed — 1 bullet per deliverable>
+CHECKS:
+- wireframes: COMPLETE
+- interactions: COMPLETE
+- accessibility: COMPLETE
+SEAL: Luna · ᛚᚢᚾᚨ · UX Designer
+SIGNOFF: Beauty and function, woven as one
+᛭᛭᛭ END DECREE ᛭᛭᛭
+
+NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
+This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -96,23 +96,5 @@ If tsc + build both PASS and handoff comment is posted:
 This dispatches Loki (QA) on the same branch to validate the implementation.
 If ANY verify step FAILED: do NOT run this step — stop and leave the issue for manual triage.
 
-**Step 9 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: DONE
-PR: <pr-url or N/A>
-SUMMARY:
-- <what was implemented — 1 bullet per logical change>
-CHECKS:
-- tsc: PASS or FAIL
-- build: PASS or FAIL
-- vitest: <count> tests, all passing (or N failing)
-SEAL: FiremanDecko · ᚠᛁᚱᛖᛗᚨᚾᛞᛖᚲᚲᛟ · Principal Engineer
-SIGNOFF: Forged in fire, tempered by craft
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```

--- a/.claude/skills/fire-next-up/templates/freya.md
+++ b/.claude/skills/fire-next-up/templates/freya.md
@@ -54,25 +54,7 @@ gh issue comment <NUMBER> --body "## Freya Handoff
 
 **Summary:** <brief summary of research/findings>"
 
-**Step 7 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: APPROVED
-PR: N/A
-SUMMARY:
-- <what was decided/produced — 1 bullet per deliverable>
-CHECKS:
-- product-brief: COMPLETE
-- acceptance-criteria: DEFINED
-- backlog: UPDATED
-SEAL: Freya · ᚠᚱᛖᛃᚨ · Product Owner
-SIGNOFF: Vision cast, priorities set
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```
 
 ## Mode B: Doc Sync (review, update, clean up owned directory)
@@ -146,23 +128,5 @@ gh issue comment <NUMBER> --body "## Freya → Loki Handoff
 
 **Build:** Docs-only — no tsc/build needed. Ready for QA."
 
-**Step 7 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: APPROVED
-PR: N/A
-SUMMARY:
-- <what was decided/produced — 1 bullet per deliverable>
-CHECKS:
-- product-brief: COMPLETE
-- acceptance-criteria: DEFINED
-- backlog: UPDATED
-SEAL: Freya · ᚠᚱᛖᛃᚨ · Product Owner
-SIGNOFF: Vision cast, priorities set
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```

--- a/.claude/skills/fire-next-up/templates/heimdall.md
+++ b/.claude/skills/fire-next-up/templates/heimdall.md
@@ -78,25 +78,7 @@ If tsc + build both PASS and handoff comment is posted:
 This dispatches Loki (QA) on the same branch to validate the security fix.
 If ANY verify step FAILED: do NOT run this step — stop and leave the issue for manual triage.
 
-**Step 9 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: SECURED
-PR: <pr-url or N/A>
-SUMMARY:
-- <what was audited/fixed — 1 bullet per finding area>
-CHECKS:
-- owasp-top10: PASS or FINDINGS
-- requireAuth: PASS or FAIL
-- secrets: PASS or FAIL
-SEAL: Heimdall · ᚺᛖᛁᛗᛞᚨᛚᛚ · Security Specialist
-SIGNOFF: The bridge holds — none shall pass unvetted
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```
 
 ## Mode B: Report / Audit (only writes `.md` files, files issues)

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -133,26 +133,7 @@ If FAIL: do NOT run this step — leave the issue open for manual triage.
 Read that file at the start of Step 3 — it contains budgets, pyramid enforcement,
 locator rules, data isolation patterns, and all UNBREAKABLE test constraints.
 
-**Step 8 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: PASS or FAIL
-PR: <pr-url or N/A>
-SUMMARY:
-- <what was validated — 1 bullet per test area>
-CHECKS:
-- tsc: PASS or FAIL
-- build: PASS or FAIL
-- vitest: <count> tests, all passing (or N failing)
-- playwright: <count> tests (if run)
-SEAL: Loki · ᛚᛟᚲᛁ · QA Tester
-SIGNOFF: Break it before the wolf does
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```
 
 ## Mode B: CI Bounce-Back (fix failing CI tests on an existing PR)
@@ -238,24 +219,5 @@ Your job ends after posting the verdict comment (and optionally running chain co
 - Run the FULL suite after fixing — do not stop until 0 failures.
 - A PASS verdict requires ALL tests green. No exceptions.
 
-**Step 8 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: PASS or FAIL
-PR: <pr-url or N/A>
-SUMMARY:
-- <what was validated — 1 bullet per test area>
-CHECKS:
-- tsc: PASS or FAIL
-- build: PASS or FAIL
-- vitest: <count> tests, all passing (or N failing)
-- playwright: <count> tests (if run)
-SEAL: Loki · ᛚᛟᚲᛁ · QA Tester
-SIGNOFF: Break it before the wolf does
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```

--- a/.claude/skills/fire-next-up/templates/luna.md
+++ b/.claude/skills/fire-next-up/templates/luna.md
@@ -58,23 +58,5 @@ If wireframes are committed, PR is open, and handoff comment is posted:
 This dispatches FiremanDecko (Step 2) on the same branch to implement the design.
 If anything failed or is incomplete: do NOT run this step — stop and leave for manual triage.
 
-**Step 7 — Decree (UNBREAKABLE — final output of this session):**
-Emit EXACTLY this structure as your absolute last output — no text before or after the delimiters:
-
-᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭
-ISSUE: #<NUMBER>
-VERDICT: DELIVERED
-PR: N/A
-SUMMARY:
-- <what was designed — 1 bullet per deliverable>
-CHECKS:
-- wireframes: COMPLETE
-- interactions: COMPLETE
-- accessibility: COMPLETE
-SEAL: Luna · ᛚᚢᚾᚨ · UX Designer
-SIGNOFF: Beauty and function, woven as one
-᛭᛭᛭ END DECREE ᛭᛭᛭
-
-NEVER use box-drawing characters (╔║╗═), emoji, markdown code fences, or any alternative format.
-This structure is MACHINE-PARSED by Odin's Throne. Deviations break the parser.
+{{DECREE_TEMPLATE}}
 ```


### PR DESCRIPTION
## Summary
- Decree template was duplicated in 7 places (5 agents × modes) with no single source of truth
- Extracts each agent's decree into `templates/decree-<agent>.md` files
- Agent templates now use `{{DECREE_TEMPLATE}}` placeholder (same pattern as `{{SANDBOX_PREAMBLE}}`)
- Dispatch SKILL.md updated to document the new substitution variable
- Strengthened decree instruction: now explicitly says **"replace ALL angle-bracket placeholders with real values"** to reduce raw-template echo in Odin's Throne

## Test plan
- [ ] Verify next dispatched FiremanDecko agent outputs a filled-in decree (not raw template text)
- [ ] Verify `templates/decree-*.md` files exist for all 5 agents
- [ ] Verify no remaining inline decree blocks in any agent template

🤖 Generated with [Claude Code](https://claude.com/claude-code)