### PR TITLE
Issue #1463 - fix: wire cancel trigger to running badge in main panel

### DIFF
--- a/development/monitor-ui/src/App.tsx
+++ b/development/monitor-ui/src/App.tsx
@@ -336,6 +336,7 @@ export function App() {
             replayedFromCache={replayedFromCache}
             isConnecting={isConnecting}
             isPodStarting={isPodStarting}
+            onCancelJob={handleOpenCancelDialog}
             onSetSpeed={(speed) => {
               if (activeSessionId) {
                 send({ type: "set-speed", sessionId: activeSessionId, speed });

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -92,9 +92,10 @@ interface SessionHeaderProps {
   onTogglePin?: () => void;
   showPin?: boolean;
   replayedFromCache?: boolean;
+  onCancelJob?: (sessionId: string) => void;
 }
 
-function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, replayedFromCache = false }: SessionHeaderProps) {
+function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, replayedFromCache = false, onCancelJob }: SessionHeaderProps) {
   const displayTitle = resolveSessionTitle(job);
   // Truncate session ID to last 8 chars for display
   const shortId = job.sessionId.length > 8
@@ -138,14 +139,26 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
         </div>
       </div>
       <span className="header-badges">
-        <span
-          className={`job-status-badge${job.status === "running" ? " pulse" : ""}`}
-          style={{ color: STATUS_COLORS[job.status] }}
-          title={`Job status: ${job.status}`}
-          aria-label={`Job status: ${STATUS_LABELS[job.status]}`}
-        >
-          {STATUS_ICONS[job.status]} {STATUS_LABELS[job.status]}
-        </span>
+        {job.status === "running" && onCancelJob ? (
+          <button
+            className="job-status-badge pulse"
+            style={{ color: STATUS_COLORS[job.status], cursor: "pointer", background: "none", border: "none", font: "inherit", padding: 0 }}
+            title="Click to cancel this job"
+            aria-label="Cancel running job"
+            onClick={() => onCancelJob(job.sessionId)}
+          >
+            {STATUS_ICONS[job.status]} {STATUS_LABELS[job.status]}
+          </button>
+        ) : (
+          <span
+            className={`job-status-badge${job.status === "running" ? " pulse" : ""}`}
+            style={{ color: STATUS_COLORS[job.status] }}
+            title={`Job status: ${job.status}`}
+            aria-label={`Job status: ${STATUS_LABELS[job.status]}`}
+          >
+            {STATUS_ICONS[job.status]} {STATUS_LABELS[job.status]}
+          </span>
+        )}
         {replayedFromCache && (
           <span
             className="ws-badge replayed-cache"
@@ -204,9 +217,10 @@ interface Props {
   replayedFromCache?: boolean;
   isConnecting?: boolean;
   isPodStarting?: boolean;
+  onCancelJob?: (sessionId: string) => void;
 }
 
-export function LogViewer({ entries, activeJob, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache, isConnecting, isPodStarting }: Props) {
+export function LogViewer({ entries, activeJob, isFixture, isTtlExpired, isNodeUnreachable, streamError, onSetSpeed, isPinned, onTogglePin, onAvatarClick, replayedFromCache, isConnecting, isPodStarting, onCancelJob }: Props) {
   const termRef = useRef<HTMLDivElement>(null);
   const [fixtureSpeed, setFixtureSpeed] = useState(1);
   const [fixturePaused, setFixturePaused] = useState(false);
@@ -307,6 +321,7 @@ export function LogViewer({ entries, activeJob, isFixture, isTtlExpired, isNodeU
           job={activeJob}
           isPinned={isPinned}
           onTogglePin={onTogglePin}
+          onCancelJob={onCancelJob}
         />
         <NorseErrorTablet sessionId={activeJob.sessionId} message={streamError} />
       </main>
@@ -322,6 +337,7 @@ export function LogViewer({ entries, activeJob, isFixture, isTtlExpired, isNodeU
           isPinned={isPinned}
           onTogglePin={onTogglePin}
           showPin={false}
+          onCancelJob={onCancelJob}
         />
         <NorseErrorTablet sessionId={activeJob.sessionId} message={streamError} variant="node-unreachable" />
       </main>
@@ -335,6 +351,7 @@ export function LogViewer({ entries, activeJob, isFixture, isTtlExpired, isNodeU
         isPinned={isPinned}
         onTogglePin={onTogglePin}
         replayedFromCache={replayedFromCache}
+        onCancelJob={onCancelJob}
       />
       <div
         className="log-terminal"


### PR DESCRIPTION
PR for issue: #1463

Wires the existing RagnarokDialog cancel flow to the pulsing 'running' status badge in the LogViewer main panel. No new cancel machinery — reuses handleOpenCancelDialog from App.tsx.

**Changes:**
- `development/monitor-ui/src/components/LogViewer.tsx` — added onCancelJob prop to Props and SessionHeaderProps; running badge rendered as a clickable button when job is running and onCancelJob is provided
- `development/monitor-ui/src/App.tsx` — passes onCancelJob={handleOpenCancelDialog} to LogViewer

**Verification:**
- Start a running job in Odin's Throne, click the pulsing status badge in the main panel → RagnarokDialog appears
- Confirm cancel in dialog → job cancelled (same behaviour as clicking from session list)