### PR TITLE
fix(monitor-ui): ws-badge-icon border regression from .ws-badge base class — issue:1469

### DIFF
--- a/development/monitor-ui/src/components/StatusBadge.tsx
+++ b/development/monitor-ui/src/components/StatusBadge.tsx
@@ -54,7 +54,7 @@ export function StatusBadge({ state }: Props) {
   const color = STATE_COLORS[state];
   return (
     <span
-      className={`ws-badge ws-badge-icon ${state}`}
+      className={`ws-badge-icon ${state}`}
       title={`WebSocket: ${state}`}
       aria-label={`WebSocket: ${state}`}
       role="status"

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -200,14 +200,9 @@ body {
 }
 .ws-badge-icon {
   display: flex; align-items: center; justify-content: center;
-  padding: 0.15rem; border-radius: 3px;
-  border: 1px solid transparent; flex-shrink: 0;
-  cursor: default;
+  border: none; padding: 0; border-radius: 0;
+  flex-shrink: 0; cursor: default;
 }
-.ws-badge-icon.open    { border-color: #22c55e33; }
-.ws-badge-icon.connecting { border-color: #eab30833; }
-.ws-badge-icon.closed  { border-color: var(--rune-border); }
-.ws-badge-icon.error   { border-color: #ef444433; }
 .sidebar-header img {
   width: 40px; height: 40px; border-radius: 50%;
   border: 2px solid var(--gold);


### PR DESCRIPTION
PR for issue: #1469

## Root Cause

`StatusBadge.tsx` applied both `ws-badge` and `ws-badge-icon` classes to the icon span. The `.ws-badge` rule (defined later in `index.css`) had higher cascade priority than `.ws-badge-icon`'s `border: 1px solid transparent`, causing the solid `border: 1px solid var(--rune-border)` — and state-specific colored variants — to bleed through onto the icon.

## Changes

- `development/monitor-ui/src/components/StatusBadge.tsx` — removed `ws-badge` base class from icon span (only needed by text badges)
- `development/monitor-ui/src/styles/index.css` — reset `.ws-badge-icon` to `border: none; padding: 0; border-radius: 0` and removed now-redundant state border-color overrides; color is communicated via SVG fill alone

## Verification

- WSS icon in sidebar header renders with no visible border or bounding box
- Color alone communicates state (open=green, connecting=yellow, closed=red, error=red)
- Text badge variant (`.ws-badge` without `.ws-badge-icon`) unaffected — still renders border correctly
- Mobile rule `.ws-badge:not(.ws-badge-icon)` unaffected

## Build

- tsc: PASS
- next build: PASS (45 routes)
- vitest: 2429 tests, 148 files — all passing

Closes #1469