### PR TITLE
Issue #1471 - feat: harden agent rules — ban tests on over-tested sources

### DIFF
--- a/.claude/agents/fireman-decko.md
+++ b/.claude/agents/fireman-decko.md
@@ -189,6 +189,15 @@ These patterns were found and deleted from this repo (issue #1253):
 `chronicles/chronicle-agent-css.test.ts` (CSS string), `gke/gke-api-routes.test.ts` (vacuous),
 `components/marketing-navbar.test.tsx` (static copy), `chronicles/chronicle-1050-mdx-heckler.test.ts` (CSS string).
 
+### Over-Tested Sources — Do Not Add Tests (UNBREAKABLE)
+
+See `.claude/agents/loki.md` § "Over-Tested Sources — Do Not Add Tests" for the full list
+of 12 files with 37×+ average LCOV hit count.
+
+If your new Vitest test primarily exercises a file in that list, stop. Redirect coverage
+effort to zero/low-coverage code instead. Test budget is finite — do not waste it on
+already-saturated files. The rule is absolute: no new tests targeting those files.
+
 ## GitHub Actions Authoring
 
 FiremanDecko owns the CI/CD implementation. When writing or modifying `.github/workflows/` files:

--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -109,6 +109,30 @@ All tests are for the main frontend app (`development/frontend/`) only.
 
 **Rule of thumb:** If the test breaks when someone edits a config file, copy, infrastructure template, or refactors a script — it should NOT exist. Only test code that RUNS.
 
+### Over-Tested Sources — Do Not Add Tests (UNBREAKABLE)
+
+The following 12 files have an average LCOV hit count exceeding 37× — already saturated by
+existing tests. **If your new test primarily exercises any file in this list, stop.**
+Redirect coverage effort to zero/low-coverage files instead.
+
+| File | Avg Hit × | Coverage |
+|------|----------:|---------|
+| `src/components/marketing/MarketingNavLinks.tsx` | 274× | 87.5% |
+| `src/app/api/sync/route.ts` | 214× | 100.0% |
+| `src/lib/firebase/firestore-types.ts` | 145× | 88.2% |
+| `src/lib/sync/sync-engine.ts` | 67× | 100.0% |
+| `src/components/ui/button.tsx` | 62× | 100.0% |
+| `src/components/easter-eggs/HeilungModal.tsx` | 61× | 97.1% |
+| `src/hooks/useCloudSync.ts` | 61× | 92.6% |
+| `src/lib/trial-utils.ts` | 60× | 81.3% |
+| `src/lib/realm-utils.ts` | 56× | 50.0% |
+| `src/components/layout/LedgerTopBar.tsx` | 52× | 82.1% |
+| `src/app/ledger/settings/page.tsx` | 46× | 97.0% |
+| `src/lib/chronicles.ts` | 37× | 100.0% |
+
+These files are transitive deps or have multiple test owners — they are covered by proxy.
+Adding direct tests here is noise, not signal. Test budget must go toward uncovered code.
+
 ### Banned Pattern Examples (learned from cull — do NOT recreate)
 
 The following pattern types were found in this repo and deleted (issue #1253). If you are about


### PR DESCRIPTION
PR for issue: #1471

Add Over-Tested Sources rules to loki.md and fireman-decko.md agent definitions. Agents must not add new tests that primarily exercise the 12 listed files (37x+ avg hit count). Redirect coverage effort to zero/low-coverage files instead.

Changes:
- .claude/agents/loki.md - added Over-Tested Sources section with 12 files + hit counts
- .claude/agents/fireman-decko.md - added reference to loki.md Over-Tested Sources section

Verification:
- Static content change - build verification only, no Vitest tests needed
- tsc: PASS
- build: PASS