### PR TITLE
fix(loki): PASS criteria must not require tests for monitor-ui or static changes

### DIFF
--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -166,7 +166,10 @@ When in a worktree: run tests against the provided port (not 9653), read
 ```
 
 PASS requires: code review passes, build passes, tsc passes, GH Actions pass,
-AND new Playwright tests written and passing.
+AND new Playwright tests written and passing — EXCEPT:
+- **monitor-ui changes** (`development/monitor-ui/`): tsc + build only, no tests. PASS with 0 tests.
+- **Static/CSS-only changes** (no logic, no behaviour): build verification only, no tests. PASS with 0 tests.
+Do NOT FAIL an issue solely because no Playwright tests were written if the change falls into one of these exception categories.
 
 ## GitHub Actions Authoring
 


### PR DESCRIPTION
## Summary

- Loki was FAILing issues like #1443 (CSS-only monitor-ui change) because PASS criteria unconditionally required new Playwright tests
- Added explicit exceptions to line 169: monitor-ui changes (tsc+build only) and static/CSS-only changes (build verification only) are both PASS with 0 tests
- The exceptions were already stated later in the file (`### No Tests for Monitor UI`, `Static/content-only changes`) — this aligns the PASS criteria with those rules

## Test plan
- [ ] Read `.claude/agents/loki.md` line ~169 — PASS criteria now includes the two exception cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)