### PR TITLE
Issue #1480 - fix: never truncate IDs in Odin's Spear

### DIFF
--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -97,10 +97,6 @@ interface SessionHeaderProps {
 
 function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, replayedFromCache = false, onCancelJob }: SessionHeaderProps) {
   const displayTitle = resolveSessionTitle(job);
-  // Truncate session ID to last 8 chars for display
-  const shortId = job.sessionId.length > 8
-    ? job.sessionId.slice(-8)
-    : job.sessionId;
   const [confirmingUnpin, setConfirmingUnpin] = useState(false);
 
   // Reset confirmation state when pin state changes externally
@@ -134,7 +130,7 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
             role="text"
             aria-label={`Session ID: ${job.sessionId}`}
           >
-            <span className="session-id-label">Session:</span> {shortId}…
+            <span className="session-id-label">Session:</span> {job.sessionId}
           </span>
         </div>
       </div>
@@ -1043,8 +1039,6 @@ function StartupBlock({ group }: { group: StartupGroup }) {
   const sessionEntry = group.metaEntries.find((e) => /^Session:\s*/.test(e.text ?? ""));
   const model = modelEntry?.text?.replace(/^Model:\s*/, "").trim() ?? "";
   const session = sessionEntry?.text?.replace(/^Session:\s*/, "").trim() ?? "";
-  const shortSession = session.length > 24 ? session.slice(0, 24) + "…" : session;
-
   return (
     <div className={`ep-group ${open ? "open" : ""}`}>
       <div className="ep-group-header" onClick={() => setOpen(!open)} role="button" tabIndex={0} aria-expanded={open} onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); setOpen((o) => !o); } }}>
@@ -1052,7 +1046,7 @@ function StartupBlock({ group }: { group: StartupGroup }) {
         <span className="ep-group-title">Starting Claude Code</span>
         <span className="ep-group-meta">
           {model && <span className="ep-group-meta-item"><span className="ep-group-meta-key">Model:</span> {model}</span>}
-          {shortSession && <span className="ep-group-meta-item"><span className="ep-group-meta-key">Session:</span> {shortSession}</span>}
+          {session && <span className="ep-group-meta-item"><span className="ep-group-meta-key">Session:</span> {session}</span>}
         </span>
       </div>
       <div className="ep-group-body-wrap">

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -360,8 +360,7 @@ body {
 .card-minimal-issue {
   font-family: 'JetBrains Mono', monospace; font-size: 0.6rem;
   font-weight: 700; color: var(--text-saga);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  max-width: 56px; text-align: center;
+  white-space: nowrap; text-align: center;
 }
 .card-avatar-btn--minimal {
   padding: 0; border: none; background: transparent; cursor: pointer;
@@ -471,6 +470,7 @@ body {
 .session-id-chip {
   font-family: 'JetBrains Mono', monospace; font-size: 0.65rem;
   font-style: italic; color: var(--text-void); cursor: help;
+  word-break: break-all;
 }
 .session-id-label {
   /* Hidden on mobile (≤600px) via responsive rules below */
@@ -751,10 +751,9 @@ body {
   display: flex; gap: 0.75rem; flex-wrap: wrap;
   font-family: 'JetBrains Mono', monospace; font-size: 0.65rem;
   color: var(--text-rune); margin-left: 0.5rem;
-  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
   flex: 1; min-width: 0;
 }
-.ep-group-meta-item { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.ep-group-meta-item { white-space: nowrap; }
 .ep-group-meta-key { color: var(--gold); font-weight: 600; margin-right: 0.2rem; }
 .ep-group-error { border-color: var(--error-border-dim); }
 .ep-group-error .ep-group-title { color: var(--error-strong); }
@@ -2674,9 +2673,7 @@ body {
   font-size: 0.8rem;
   color: #c9920a;
   font-weight: 600;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-break: break-word;
 }
 .rdk-session-id {
   font-size: 0.68rem;


### PR DESCRIPTION
PR for issue: #1480

Remove all ID truncation from Odin's Spear (monitor-ui). Session IDs, job names, GKE job IDs, and any other identifiers must always display in full.

**Changes:**
- `development/monitor-ui/src/components/LogViewer.tsx` — removed JS truncation of sessionId (was showing last 8 chars only); removed JS truncation of session string in EntrypointGroup (was slicing to 24 chars)
- `development/monitor-ui/src/styles/index.css` — removed `text-overflow: ellipsis` and `max-width` from `.card-minimal-issue` (issue numbers in collapsed sidebar cards); removed `overflow: hidden; text-overflow: ellipsis; white-space: nowrap` from `.ep-group-meta` and `.ep-group-meta-item` (session ID in entrypoint group header); removed `text-overflow: ellipsis; white-space: nowrap; overflow: hidden` from `.rdk-job-label-text` (job name in Ragnarok cancel dialog); added `word-break: break-all` to `.session-id-chip` so long session IDs wrap instead of overflowing

**Verification:**
- All IDs in Odin's Spear display in full with no clipping or ellipsis
- tsc: PASS
- build: PASS
- Vitest: 2547 tests PASS