### PR TITLE
Issue #1490 - fix: scale Odin's Throne to 2 replicas + add PDB

### DIFF
--- a/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
@@ -23,6 +23,14 @@ spec:
         {{- include "odin-throne.labels" (dict "component" "monitor-ui") | nindent 8 }}
     spec:
       terminationGracePeriodSeconds: 15
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: odin-throne
+              app.kubernetes.io/component: monitor-ui
       {{- if .Values.oauth2Proxy.enabled }}
       volumes:
         - name: oauth2-proxy-emails

--- a/infrastructure/helm/odin-throne/templates/deployment.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment.yaml
@@ -20,6 +20,14 @@ spec:
     spec:
       serviceAccountName: {{ .Values.app.serviceAccountName }}
       terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: odin-throne
+              app.kubernetes.io/component: monitor
       volumes:
         - name: oauth2-proxy-emails
           secret:

--- a/infrastructure/helm/odin-throne/templates/pdb.yaml
+++ b/infrastructure/helm/odin-throne/templates/pdb.yaml
@@ -1,0 +1,31 @@
+{{- if ge (int .Values.app.replicaCount) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: odin-throne-pdb
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "odin-throne.labels" (dict "component" "monitor") | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: odin-throne
+      app.kubernetes.io/component: monitor
+---
+{{- end }}
+{{- if ge (int .Values.ui.replicaCount) 2 }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: odin-throne-ui-pdb
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "odin-throne.labels" (dict "component" "monitor-ui") | nindent 4 }}
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: odin-throne
+      app.kubernetes.io/component: monitor-ui
+{{- end }}

--- a/infrastructure/helm/odin-throne/values-prod.yaml
+++ b/infrastructure/helm/odin-throne/values-prod.yaml
@@ -10,7 +10,7 @@
 namespace: fenrir-monitor
 
 app:
-  replicaCount: 1
+  replicaCount: 2
 
   resources:
     requests:
@@ -23,7 +23,7 @@ app:
       ephemeral-storage: "256Mi"
 
 ui:
-  replicaCount: 1
+  replicaCount: 2
 
 ingress:
   enabled: true

--- a/infrastructure/helm/odin-throne/values.yaml
+++ b/infrastructure/helm/odin-throne/values.yaml
@@ -10,7 +10,7 @@ namespace: fenrir-monitor
 
 # -- App Deployment --------------------------------------------------------
 app:
-  replicaCount: 1
+  replicaCount: 2
   revisionHistoryLimit: 3
 
   image:
@@ -75,7 +75,7 @@ app:
 
 # -- UI Deployment ---------------------------------------------------------
 ui:
-  replicaCount: 1
+  replicaCount: 2
   revisionHistoryLimit: 3
 
   image:


### PR DESCRIPTION
PR for issue: #1490

## Summary
- Scale odin-throne and odin-throne-ui deployments to 2 replicas (was 1)
- Add PodDisruptionBudget (minAvailable: 1) for both deployments, guarded by replicaCount >= 2
- Add topologySpreadConstraints (maxSkew:1, kubernetes.io/hostname, DoNotSchedule) to both deployments ensuring pods land on different nodes
- Update values.yaml and values-prod.yaml with replicaCount: 2 for app + ui

## Test plan
- tsc: PASS
- next build: PASS (45 routes)
- Helm chart templates validated — PDB guarded by ge replicaCount 2, topology spread configured
- values-prod.yaml confirms replicaCount: 2 for both app and ui in production
- Vitest skipped — all changes are Helm/infrastructure + monitor-ui (no test infrastructure)

Closes #1490

Generated with Claude Code