### PR TITLE
feat: epic-manager skill + plan-w-team epic graph output

### DIFF
--- a/.claude/commands/epic-manager.md
+++ b/.claude/commands/epic-manager.md
@@ -1,0 +1,174 @@
+---
+description: >
+  Monitor epic progress and dispatch next ready stories. Reads tmp/epics/<N>.json,
+  cross-references live GitHub issue states and active GKE K8s jobs, prints a
+  wave-by-wave dashboard, and identifies what's ready to dispatch next.
+  Use when the user says 'epic status', 'epic manager', 'what's next in epic',
+  '/epic-manager <N>', or provides a root issue number to track.
+argument-hint: "<root-issue-number> [--dispatch]"
+---
+
+# Epic Manager
+
+Monitor an epic's dependency graph against live GitHub + K8s state and prepare
+the next wave of stories for dispatch.
+
+## Input
+
+```
+/epic-manager <root-issue-number> [--dispatch]
+```
+
+| Arg | Required | Description |
+|-----|----------|-------------|
+| `<N>` | Yes | Root issue number — reads `tmp/epics/<N>.json` |
+| `--dispatch` | No | Print ready `/dispatch` commands after the dashboard |
+
+## Speed Rules (UNBREAKABLE)
+
+1. **One tool call.** Run the MJS script directly — no pre-fetching, no narration between calls.
+2. **Never re-fetch what the script already fetches.** The script queries GitHub and K8s itself.
+3. **If the epic file is missing**, tell Odin to run `/plan-w-team` or check the issue number.
+
+## Execution
+
+```bash
+node .claude/scripts/epic-manager.mjs <N> [--dispatch]
+```
+
+That is the entire execution. No other tool calls needed unless the output requires
+follow-up action (e.g., closing a duplicate, dispatching a ready story).
+
+## What the Script Does
+
+### Phase 1 — Load epic graph
+Reads `tmp/epics/<N>.json`. Fails with a clear message if missing.
+
+### Phase 2 — GitHub state sync
+For every issue number in the graph (stories + their blockers), calls:
+```
+gh issue view <N> --json number,state,title
+```
+Results are keyed by issue number. State is `OPEN` or `CLOSED`.
+
+### Phase 3 — K8s job sync
+Queries active GKE jobs in `fenrir-agents` namespace:
+```
+kubectl get jobs -n fenrir-agents -o json
+```
+Extracts issue numbers from:
+- `fenrir.dev/session-id` label (format: `issue-<N>-step<S>-<agent>-<uuid>`)
+- Job name (format: `agent-issue-<N>-step<S>-<agent>-<uuid>`)
+
+Only jobs with `status.active > 0` are counted as running (completed/failed are ignored).
+
+### Phase 4 — Status computation
+Each story gets one of these statuses (in priority order):
+
+| Status | Condition |
+|--------|-----------|
+| `done` | GitHub state = CLOSED |
+| `running` | Active K8s job found for this issue |
+| `blocked` | One or more `blocked_by` issues are still OPEN |
+| `duplicate` | Story has `duplicate_of` set — needs manual close |
+| `ready` | None of the above — all blockers closed, not running |
+
+### Phase 5 — Dashboard output
+Wave-by-wave table with icons:
+
+```
+══════════════════════════════════════════════════════════════════════════
+  EPIC #1386 — Odin's Spear TUI
+══════════════════════════════════════════════════════════════════════════
+
+✅ Wave 0
+    ✅ #1386   [DONE     ]  Odin's Spear TUI: foundation — Ink setup…
+
+   Wave 1
+    🟢 #1496   [READY    ]  Odin's Spear: extract into standalone package…
+
+   Wave 2
+    🔴 #1495   [BLOCKED  ]  Odin's Spear: command & help subsystem…  ← blocked by #1496
+    ⚠️  #1390   [DUPLICATE]  Odin's Spear TUI: command palette…        ← duplicate of #1495
+
+   Wave 3  (parallel)
+    🔴 #1387   [BLOCKED  ]  Odin's Spear TUI: Users tab…               ← blocked by #1496, #1495
+    🔴 #1388   [BLOCKED  ]  Odin's Spear TUI: Households tab…          ← blocked by #1496, #1495
+
+   Wave 4  (parallel)
+    🔴 #1389   [BLOCKED  ]  Odin's Spear TUI: Card drill-down view…    ← blocked by #1387
+    🔴 #1472   [BLOCKED  ]  Odin's Spear — trial manipulation…         ← blocked by #1495
+
+──────────────────────────────────────────────────────────────────────────
+  1 done  |  0 running  |  1 ready  |  5 blocked  |  1 duplicate
+──────────────────────────────────────────────────────────────────────────
+
+  ▶  Next to dispatch (1 issue):
+
+    /dispatch #1496   — Odin's Spear: extract into standalone package…
+
+  ⚠️  Duplicate stories detected — close before dispatching:
+    #1390 — Odin's Spear TUI: command palette + confirmation dialogs
+    gh issue close 1390 --comment "Superseded by #1495"
+```
+
+## After the Dashboard
+
+Read the output and:
+
+1. **If duplicates are flagged** — close them with the suggested `gh issue close` command, then re-run.
+2. **If stories are ready** — ask Odin: *"Wave N is unblocked. Dispatch #X [and #Y in parallel]?"*
+   Then invoke `/dispatch #X` (or `/fire-next-up #X #Y` for parallel dispatch).
+3. **If nothing is ready and nothing is running** — flag to Odin that the epic may be stalled.
+4. **If epic is complete** — congratulate, update the epic file `state` fields, and HKR.
+
+## Epic File Format
+
+The epic file `tmp/epics/<N>.json` must match this schema:
+
+```json
+{
+  "epic": {
+    "number": 1386,
+    "title": "Odin's Spear TUI",
+    "description": "..."
+  },
+  "stories": [
+    {
+      "number": 1386,
+      "title": "Odin's Spear TUI: foundation — Ink setup, auto-startup, tab shell",
+      "state": "closed",
+      "wave": 0,
+      "blocks": [1496],
+      "blocked_by": [],
+      "parallel_with": [],
+      "note": "DONE — produces development/frontend/scripts/odins-spear.mjs"
+    },
+    {
+      "number": 1496,
+      "title": "Odin's Spear: extract into standalone package",
+      "state": "open",
+      "wave": 1,
+      "blocks": [1495, 1387, 1388],
+      "blocked_by": [1386],
+      "parallel_with": [],
+      "note": ""
+    }
+  ]
+}
+```
+
+> **Note:** `state` in the JSON is the initial/authored state. The script ignores it and
+> always uses live GitHub state. It is kept for human reference only.
+
+## Rules
+
+1. **Always run the script** — never manually reconstruct the dashboard from memory.
+2. **K8s query is best-effort** — if `kubectl` is unavailable (e.g., no cluster access),
+   the script continues without K8s data and marks K8s status as unknown.
+3. **Never dispatch without showing the dashboard first** — Odin must see the state before
+   agents are spawned.
+4. **Duplicate check is mandatory** — if `--dispatch` is passed, warn about duplicates
+   before printing dispatch commands.
+5. **Epic file is the graph source of truth** — GitHub/K8s are for live state only.
+   Dependencies (`blocked_by`, `blocks`, `wave`) come from the JSON file.

--- a/.claude/commands/plan-w-team.md
+++ b/.claude/commands/plan-w-team.md
@@ -165,27 +165,91 @@ and auto-dispatch prompt for bugs.
 gh issue comment <N> --body "Blocks #M — <one-line summary of dependent issue>"
 ```
 
+### Step 5b — Write Epic Graph File
+
+After all issues are created and their numbers are known, write the epic dependency
+graph to `tmp/epics/<root-issue-number>.json`.
+
+The **root issue** is the foundational story — wave 0, the first issue that everything
+else depends on (directly or transitively). If there is no single root, use the lowest
+issue number.
+
+**Schema:**
+
+```json
+{
+  "epic": {
+    "number": <root-issue-number>,
+    "title": "<epic title>",
+    "description": "<one-sentence description>"
+  },
+  "stories": [
+    {
+      "number": <N>,
+      "title": "<GitHub issue title>",
+      "state": "open",
+      "wave": <0-based wave index>,
+      "blocks": [<issue numbers this story unblocks>],
+      "blocked_by": [<issue numbers that must close before this starts>],
+      "parallel_with": [<issue numbers in the same wave that run in parallel>],
+      "duplicate_of": null,
+      "note": "<optional human note>"
+    }
+  ]
+}
+```
+
+**Wave assignment rules:**
+- Wave 0 — root / foundation story (no `blocked_by`)
+- Wave N+1 — stories whose last blocker is in wave N
+- Stories in the same wave with no dependency between them get the same wave number
+  and list each other in `parallel_with`
+
+**Write the file:**
+
+```bash
+mkdir -p tmp/epics
+# write JSON via Write tool — do NOT use bash heredoc or echo
+```
+
+Use the Write tool directly with the JSON content. Do not shell-escape or base64 encode.
+
+After writing, verify:
+```bash
+node -e "JSON.parse(require('fs').readFileSync('tmp/epics/<N>.json','utf8')); console.log('valid JSON')"
+```
+
+Commit the file on `main` so agents can find it:
+```bash
+git add tmp/epics/<N>.json
+git commit -m "chore: add epic graph for #<N> — <title>
+
+Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
+git push
+```
+
 ### Step 6 — Report
 
-After all issues are created, report:
+After all issues are created and the epic file is written, report:
 
 ```
 ## Plan Filed
 
 **Topic:** <brief description>
 **Issues created:** N
+**Epic graph:** tmp/epics/<root-N>.json
 
-| # | Title | Type | Priority | Chain | Depends On |
-|---|-------|------|----------|-------|------------|
-| #N | ... | enhancement | normal | Decko -> Loki | — |
-| #M | ... | ux | high | Luna -> Decko -> Loki | #N |
+| # | Title | Type | Priority | Chain | Wave | Depends On |
+|---|-------|------|----------|-------|------|------------|
+| #N | ... | enhancement | normal | Decko -> Loki | 0 | — |
+| #M | ... | ux | high | Luna -> Decko -> Loki | 1 | #N |
 
 **Wireframes:** <path or "none">
 
 To start execution:
-- `/fire-next-up` — pick the top unblocked issue
-- `/fire-next-up --batch 3` — pick top 3 unblocked issues in parallel
-- `/fire-next-up --peek` — preview the queue
+- `/epic-manager <root-N>` — dashboard + next dispatch recommendation
+- `/epic-manager <root-N> --dispatch` — dashboard + ready dispatch commands
+- `/fire-next-up` — pick the top unblocked issue from the board
 ```
 
 ## Rules
@@ -200,3 +264,4 @@ To start execution:
 8. **Freya always interviews** — never skip the product owner interview
 9. **Luna only for UI** — skip wireframes for pure backend/infra/test work
 10. **Use the issue template** — all required sections must be present for agents to work from
+11. **Always write the epic graph** — `tmp/epics/<N>.json` is mandatory output for every plan. `/epic-manager` depends on it.

--- a/.claude/scripts/epic-manager.mjs
+++ b/.claude/scripts/epic-manager.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * epic-manager.mjs — Epic dependency graph tracker + dispatch advisor
+ *
+ * Reads tmp/epics/<N>.json, cross-references live GitHub issue states and
+ * active GKE K8s jobs, then prints a dashboard showing what is done,
+ * running, blocked, or ready to dispatch.
+ *
+ * Usage:
+ *   node .claude/scripts/epic-manager.mjs <root-issue-number> [--dispatch]
+ *
+ * Flags:
+ *   --dispatch   Print ready dispatch commands (does not execute them)
+ *   --json       Emit machine-readable JSON instead of human dashboard
+ */
+
+import { readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { resolve } from "node:path";
+
+// ── CLI args ────────────────────────────────────────────────────────────────
+const args = process.argv.slice(2);
+const rootIssue = args.find((a) => /^\d+$/.test(a));
+const flagDispatch = args.includes("--dispatch");
+const flagJson = args.includes("--json");
+
+if (!rootIssue) {
+  console.error("Usage: epic-manager.mjs <root-issue-number> [--dispatch] [--json]");
+  process.exit(1);
+}
+
+// ── Load epic graph ─────────────────────────────────────────────────────────
+const epicFile = resolve(`tmp/epics/${rootIssue}.json`);
+if (!existsSync(epicFile)) {
+  console.error(`Epic file not found: ${epicFile}`);
+  console.error(`Run /plan-w-team or create it manually.`);
+  process.exit(1);
+}
+
+const epic = JSON.parse(readFileSync(epicFile, "utf8"));
+const stories = epic.stories ?? [];
+
+// ── Helper: run a command and return stdout, or null on error ───────────────
+function run(cmd) {
+  try {
+    return execSync(cmd, { encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+// ── 1. Batch-fetch GitHub issue states ─────────────────────────────────────
+// Fetch all issues in parallel using Promise-like pattern via synchronous
+// child_process — one gh call per issue (gh doesn't support batch JSON).
+const issueNumbers = [...new Set(stories.flatMap((s) => [s.number, ...(s.blocked_by ?? [])]))];
+
+const ghStates = {};
+for (const n of issueNumbers) {
+  const raw = run(`gh issue view ${n} --json number,state,title 2>/dev/null`);
+  if (raw) {
+    try {
+      const data = JSON.parse(raw);
+      ghStates[data.number] = { state: data.state?.toUpperCase(), title: data.title };
+    } catch {
+      ghStates[n] = { state: "UNKNOWN", title: `issue #${n}` };
+    }
+  } else {
+    ghStates[n] = { state: "UNKNOWN", title: `issue #${n}` };
+  }
+}
+
+// ── 2. Query active GKE K8s jobs ────────────────────────────────────────────
+// Job names: agent-issue-<N>-step<S>-<agent>-<uuid>
+// Labels:    fenrir.dev/session-id: "issue-<N>-step<S>-<agent>-<uuid>"
+//
+// A job is "running" only if status.active > 0 (not completed/failed).
+const runningIssues = new Set();
+const jobDetails = {}; // issueN -> { jobName, agent, sessionId }
+
+const k8sRaw = run("kubectl get jobs -n fenrir-agents -o json 2>/dev/null");
+if (k8sRaw) {
+  let k8sJobs;
+  try { k8sJobs = JSON.parse(k8sRaw).items ?? []; } catch { k8sJobs = []; }
+
+  for (const job of k8sJobs) {
+    const active = (job.status?.active ?? 0) > 0;
+    if (!active) continue; // skip completed / failed
+
+    const name = job.metadata?.name ?? "";
+    const labels = job.metadata?.labels ?? {};
+    const sessionId = labels["fenrir.dev/session-id"] ?? labels["fenrir/session-id"] ?? "";
+
+    // Extract issue number from session-id label first (most reliable),
+    // then fall back to job name pattern.
+    const sources = [sessionId, name];
+    for (const src of sources) {
+      const m = src.match(/issue[_-](\d+)/i);
+      if (m) {
+        const issueN = parseInt(m[1], 10);
+        runningIssues.add(issueN);
+        // Extract agent name from session id (issue-N-stepS-AGENT-uuid)
+        const agentM = sessionId.match(/issue-\d+-step\d+-([a-z-]+)-[a-f0-9]+/i);
+        jobDetails[issueN] = {
+          jobName: name,
+          agent: agentM ? agentM[1] : "unknown",
+          sessionId,
+        };
+        break;
+      }
+    }
+  }
+}
+
+// ── 3. Compute per-story status ─────────────────────────────────────────────
+// Priority: closed > running > blocked > ready > open(unknown)
+function computeStatus(story) {
+  const ghState = ghStates[story.number]?.state ?? "UNKNOWN";
+  if (ghState === "CLOSED") return "done";
+
+  if (runningIssues.has(story.number)) return "running";
+
+  const blockers = story.blocked_by ?? [];
+  const openBlockers = blockers.filter((b) => ghStates[b]?.state !== "CLOSED");
+  if (openBlockers.length > 0) return "blocked";
+
+  // Marked as duplicate — skip unless it's the canonical one
+  if (story.duplicate_of) return "duplicate";
+
+  return "ready";
+}
+
+const computed = stories.map((s) => ({
+  ...s,
+  _status: computeStatus(s),
+  _ghTitle: ghStates[s.number]?.title ?? s.title,
+  _ghState: ghStates[s.number]?.state ?? "UNKNOWN",
+  _openBlockers: (s.blocked_by ?? []).filter((b) => ghStates[b]?.state !== "CLOSED"),
+  _jobDetail: jobDetails[s.number] ?? null,
+}));
+
+// ── 4. JSON output mode ─────────────────────────────────────────────────────
+if (flagJson) {
+  console.log(JSON.stringify({ epic: epic.epic, stories: computed, runningIssues: [...runningIssues] }, null, 2));
+  process.exit(0);
+}
+
+// ── 5. Dashboard output ─────────────────────────────────────────────────────
+const STATUS_ICON = {
+  done:      "✅",
+  running:   "🔄",
+  ready:     "🟢",
+  blocked:   "🔴",
+  duplicate: "⚠️ ",
+};
+const STATUS_LABEL = {
+  done:      "DONE",
+  running:   "RUNNING",
+  ready:     "READY",
+  blocked:   "BLOCKED",
+  duplicate: "DUPLICATE",
+};
+
+console.log(`\n${"═".repeat(72)}`);
+console.log(`  EPIC #${epic.epic?.number ?? rootIssue} — ${epic.epic?.title ?? "Odin's Spear"}`);
+console.log(`${"═".repeat(72)}\n`);
+
+// Group by wave
+const waves = [...new Set(computed.map((s) => s.wave ?? 0))].sort((a, b) => a - b);
+
+for (const wave of waves) {
+  const waveStories = computed.filter((s) => (s.wave ?? 0) === wave);
+  const allDone = waveStories.every((s) => s._status === "done");
+  const waveIcon = allDone ? "✅" : "  ";
+  console.log(`${waveIcon} Wave ${wave}${waveStories.length > 1 && !allDone ? "  (parallel)" : ""}`);
+
+  for (const s of waveStories) {
+    const icon = STATUS_ICON[s._status] ?? "  ";
+    const label = STATUS_LABEL[s._status] ?? s._status.toUpperCase();
+    const titleTrunc = s._ghTitle.length > 52 ? s._ghTitle.slice(0, 49) + "…" : s._ghTitle;
+    const jobInfo = s._jobDetail ? `  [${s._jobDetail.agent} @ ${s._jobDetail.sessionId}]` : "";
+    const blockerInfo =
+      s._openBlockers.length > 0
+        ? `  ← blocked by #${s._openBlockers.join(", #")}`
+        : "";
+    const dupInfo = s.duplicate_of ? `  ← duplicate of #${s.duplicate_of}` : "";
+
+    console.log(`    ${icon} #${String(s.number).padEnd(6)} [${label.padEnd(9)}]  ${titleTrunc}${jobInfo}${blockerInfo}${dupInfo}`);
+  }
+  console.log();
+}
+
+// ── Summary counts ──────────────────────────────────────────────────────────
+const counts = { done: 0, running: 0, ready: 0, blocked: 0, duplicate: 0 };
+for (const s of computed) counts[s._status] = (counts[s._status] ?? 0) + 1;
+
+console.log(`${"─".repeat(72)}`);
+console.log(
+  `  ${counts.done} done  |  ${counts.running} running  |  ${counts.ready} ready  |  ${counts.blocked} blocked  |  ${counts.duplicate} duplicate`
+);
+console.log(`${"─".repeat(72)}\n`);
+
+// ── 6. Ready stories — dispatch suggestions ─────────────────────────────────
+const readyStories = computed.filter((s) => s._status === "ready");
+if (readyStories.length === 0) {
+  if (counts.running > 0) {
+    console.log("  No new stories ready — waiting for running jobs to complete.\n");
+  } else if (counts.done === computed.length) {
+    console.log("  🎉 Epic complete — all stories done.\n");
+  } else {
+    console.log("  No stories ready. Check blocked dependencies above.\n");
+  }
+} else {
+  const parallel = readyStories.length > 1;
+  console.log(
+    `  ${parallel ? "⚡ Parallel dispatch available" : "▶  Next to dispatch"} (${readyStories.length} issue${readyStories.length > 1 ? "s" : ""}):\n`
+  );
+
+  for (const s of readyStories) {
+    console.log(`    /dispatch #${s.number}   — ${s._ghTitle}`);
+  }
+
+  if (parallel) {
+    const nums = readyStories.map((s) => `#${s.number}`).join(" ");
+    console.log(`\n    Or dispatch all in parallel:\n    /fire-next-up ${nums}`);
+  }
+
+  if (flagDispatch) {
+    console.log("\n  ── Dispatch commands (copy-paste) ──────────────────────────────");
+    for (const s of readyStories) {
+      console.log(`  /dispatch #${s.number}`);
+    }
+  }
+}
+
+console.log();
+
+// ── 7. Warnings ─────────────────────────────────────────────────────────────
+const duplicates = computed.filter((s) => s._status === "duplicate");
+if (duplicates.length > 0) {
+  console.log("  ⚠️  Duplicate stories detected — close before dispatching:");
+  for (const s of duplicates) {
+    console.log(`    #${s.number} — ${s._ghTitle}  (duplicate of #${s.duplicate_of})`);
+    console.log(`    gh issue close ${s.number} --comment "Superseded by #${s.duplicate_of}"`);
+  }
+  console.log();
+}

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ logs/
 
 # Temp files (for parallel agent development)
 tmp/
+!tmp/epics/
 development/frontend/.claude/
 .vercel/
 

--- a/tmp/epics/1386.json
+++ b/tmp/epics/1386.json
@@ -1,0 +1,97 @@
+{
+  "epic": {
+    "number": 1386,
+    "title": "Odin's Spear TUI",
+    "description": "Full Ink-based admin TUI extracted into a standalone package with modular architecture, shared Fenrir logger, command palette, and complete tab content."
+  },
+  "stories": [
+    {
+      "number": 1386,
+      "title": "Odin's Spear TUI: foundation — Ink setup, auto-startup, tab shell",
+      "state": "closed",
+      "wave": 0,
+      "blocks": [1496],
+      "blocked_by": [],
+      "parallel_with": [],
+      "duplicate_of": null,
+      "note": "DONE — produces development/frontend/scripts/odins-spear.mjs"
+    },
+    {
+      "number": 1496,
+      "title": "Odin's Spear: extract into standalone package development/odins-spear with modular architecture",
+      "state": "open",
+      "wave": 1,
+      "blocks": [1495, 1387, 1388],
+      "blocked_by": [1386],
+      "parallel_with": [],
+      "duplicate_of": null,
+      "note": "Moves odins-spear.* out of frontend/scripts into development/odins-spear/. Wires @fenrir/logger alias. Must enumerate all odins-spear.* files before starting."
+    },
+    {
+      "number": 1495,
+      "title": "Odin's Spear: command & help subsystem — unified palette for Redis, Firestore, Stripe",
+      "state": "open",
+      "wave": 2,
+      "blocks": [1387, 1388, 1389, 1472],
+      "blocked_by": [1496],
+      "parallel_with": [],
+      "duplicate_of": null,
+      "note": "PALETTE_COMMANDS registry, CommandPalette (/ key), HelpOverlay (? key), ResultsOverlay, ConfirmDialog."
+    },
+    {
+      "number": 1390,
+      "title": "Odin's Spear TUI: command palette + confirmation dialogs",
+      "state": "open",
+      "wave": 2,
+      "blocks": [],
+      "blocked_by": [1496],
+      "parallel_with": [],
+      "duplicate_of": 1495,
+      "note": "WARNING: substantially overlaps #1495. Close as duplicate before wave 2 begins."
+    },
+    {
+      "number": 1387,
+      "title": "Odin's Spear TUI: Users tab — list + detail panel",
+      "state": "open",
+      "wave": 3,
+      "blocks": [1389],
+      "blocked_by": [1496, 1495],
+      "parallel_with": [1388],
+      "duplicate_of": null,
+      "note": ""
+    },
+    {
+      "number": 1388,
+      "title": "Odin's Spear TUI: Households tab — list + detail panel",
+      "state": "open",
+      "wave": 3,
+      "blocks": [],
+      "blocked_by": [1496, 1495],
+      "parallel_with": [1387],
+      "duplicate_of": null,
+      "note": ""
+    },
+    {
+      "number": 1389,
+      "title": "Odin's Spear TUI: Card drill-down view",
+      "state": "open",
+      "wave": 4,
+      "blocks": [],
+      "blocked_by": [1387],
+      "parallel_with": [1472],
+      "duplicate_of": null,
+      "note": ""
+    },
+    {
+      "number": 1472,
+      "title": "Odin's Spear — trial manipulation controls for user admin",
+      "state": "open",
+      "wave": 4,
+      "blocks": [],
+      "blocked_by": [1495],
+      "parallel_with": [1389],
+      "duplicate_of": null,
+      "note": ""
+    }
+  ]
+}

--- a/tmp/epics/1386.yml
+++ b/tmp/epics/1386.yml
@@ -1,0 +1,106 @@
+epic:
+  number: 1386
+  title: "Odin's Spear TUI"
+  description: >
+    Full rewrite of the Odin's Spear admin TUI as a proper Ink-based Node.js
+    application, extracted into a standalone package with modular architecture,
+    shared Fenrir logger, and a complete command palette + tab content layer.
+
+stories:
+  - number: 1386
+    title: "Odin's Spear TUI: foundation — Ink setup, auto-startup, tab shell"
+    state: closed
+    wave: 0
+    blocks: [1496]
+    blocked_by: []
+    note: "DONE — produces development/frontend/scripts/odins-spear.mjs"
+
+  - number: 1496
+    title: "Odin's Spear: extract into standalone package development/odins-spear with modular architecture"
+    state: open
+    wave: 1
+    blocks: [1495, 1387, 1388]
+    blocked_by: [1386]
+    note: >
+      Moves odins-spear.mjs (and any other odins-spear.* files) out of
+      development/frontend/scripts/ into a standalone development/odins-spear/
+      package. Wires @fenrir/logger path alias to frontend/src/lib/logger.ts.
+      Splits monolith into modules. Removes Ink deps from frontend package.json.
+      Must enumerate all odins-spear.* files before starting.
+
+  - number: 1495
+    title: "Odin's Spear: command & help subsystem — unified palette for Redis, Firestore, Stripe"
+    state: open
+    wave: 2
+    blocks: [1387, 1388, 1389, 1472]
+    blocked_by: [1496]
+    note: >
+      PALETTE_COMMANDS registry, CommandPalette (/ key), HelpOverlay (? key),
+      ResultsOverlay, ConfirmDialog. Context-gated commands. Structured logging
+      via @fenrir/logger throughout.
+
+  - number: 1390
+    title: "Odin's Spear TUI: command palette + confirmation dialogs"
+    state: open
+    wave: 2
+    blocks: []
+    blocked_by: [1496]
+    duplicate_of: 1495
+    note: >
+      WARNING: substantially overlaps #1495 which is the authoritative
+      implementation spec. Should be closed as duplicate before wave 2 begins.
+
+  - number: 1387
+    title: "Odin's Spear TUI: Users tab — list + detail panel"
+    state: open
+    wave: 3
+    blocks: [1389]
+    blocked_by: [1496, 1495]
+    parallel_with: [1388]
+
+  - number: 1388
+    title: "Odin's Spear TUI: Households tab — list + detail panel"
+    state: open
+    wave: 3
+    blocks: []
+    blocked_by: [1496, 1495]
+    parallel_with: [1387]
+
+  - number: 1389
+    title: "Odin's Spear TUI: Card drill-down view"
+    state: open
+    wave: 4
+    blocks: []
+    blocked_by: [1387]
+    parallel_with: [1472]
+
+  - number: 1472
+    title: "Odin's Spear — trial manipulation controls for user admin"
+    state: open
+    wave: 4
+    blocks: []
+    blocked_by: [1495]
+    parallel_with: [1389]
+
+execution_order:
+  - wave: 0
+    status: done
+    stories: [1386]
+  - wave: 1
+    status: ready
+    stories: [1496]
+  - wave: 2
+    status: blocked
+    stories: [1495]
+    notes: "Close #1390 as duplicate of #1495 before starting this wave"
+  - wave: 3
+    status: blocked
+    stories: [1387, 1388]
+    parallel: true
+  - wave: 4
+    status: blocked
+    stories: [1389, 1472]
+    parallel: true
+
+actions:
+  - Close #1390 as duplicate of #1495 before wave 2 begins


### PR DESCRIPTION
## Summary

- Adds `/epic-manager <N>` command — monitors epic progress against live GitHub + GKE state and identifies next dispatch candidates
- Updates `/plan-w-team` to write `tmp/epics/<N>.json` as mandatory output after every plan
- Unblocks `tmp/epics/` from `.gitignore` so graphs are committed and available to agents
- Seeds `tmp/epics/1386.json` for the Odin's Spear TUI epic

## How it works

`/epic-manager <N>` runs a single MJS script (`.claude/scripts/epic-manager.mjs`) that:
1. Reads `tmp/epics/<N>.json` for the dependency graph
2. Batch-fetches live GitHub issue states via `gh issue view`
3. Queries `kubectl get jobs -n fenrir-agents -o json` for active K8s jobs — extracts issue numbers from `fenrir.dev/session-id` labels and job name patterns (`agent-issue-<N>-...`)
4. Computes status per story: `done → running → blocked → duplicate → ready`
5. Prints a wave-by-wave dashboard with dispatch recommendations and duplicate warnings

## Test plan

- [ ] `node .claude/scripts/epic-manager.mjs 1386` — runs without error, shows dashboard
- [ ] Wave 0 shows ✅ (issue #1386 is closed)
- [ ] Wave 1 shows 🟢 READY for #1496
- [ ] Waves 2–4 show 🔴 BLOCKED with correct blocker references
- [ ] #1390 shows ⚠️ DUPLICATE with close suggestion
- [ ] `--dispatch` flag appends copy-paste dispatch commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)