### PR TITLE
chore: move epic-manager + plan-w-team to self-packaged skills

### DIFF
--- a/.claude/skills/epic-manager/SKILL.md
+++ b/.claude/skills/epic-manager/SKILL.md
@@ -1,11 +1,11 @@
 ---
+name: epic-manager
 description: >
   Monitor epic progress and dispatch next ready stories. Reads tmp/epics/<N>.json,
   cross-references live GitHub issue states and active GKE K8s jobs, prints a
   wave-by-wave dashboard, and identifies what's ready to dispatch next.
   Use when the user says 'epic status', 'epic manager', 'what's next in epic',
   '/epic-manager <N>', or provides a root issue number to track.
-argument-hint: "<root-issue-number> [--dispatch]"
 ---
 
 # Epic Manager
@@ -33,7 +33,7 @@ the next wave of stories for dispatch.
 ## Execution
 
 ```bash
-node .claude/scripts/epic-manager.mjs <N> [--dispatch]
+node .claude/skills/epic-manager/epic-manager.mjs <N> [--dispatch]
 ```
 
 That is the entire execution. No other tool calls needed unless the output requires
@@ -142,6 +142,7 @@ The epic file `tmp/epics/<N>.json` must match this schema:
       "blocks": [1496],
       "blocked_by": [],
       "parallel_with": [],
+      "duplicate_of": null,
       "note": "DONE — produces development/frontend/scripts/odins-spear.mjs"
     },
     {
@@ -152,6 +153,7 @@ The epic file `tmp/epics/<N>.json` must match this schema:
       "blocks": [1495, 1387, 1388],
       "blocked_by": [1386],
       "parallel_with": [],
+      "duplicate_of": null,
       "note": ""
     }
   ]

--- a/.claude/skills/epic-manager/epic-manager.mjs
+++ b/.claude/skills/epic-manager/epic-manager.mjs
@@ -7,7 +7,7 @@
  * running, blocked, or ready to dispatch.
  *
  * Usage:
- *   node .claude/scripts/epic-manager.mjs <root-issue-number> [--dispatch]
+ *   node .claude/skills/epic-manager/epic-manager.mjs <root-issue-number> [--dispatch]
  *
  * Flags:
  *   --dispatch   Print ready dispatch commands (does not execute them)

--- a/.claude/skills/plan-w-team/SKILL.md
+++ b/.claude/skills/plan-w-team/SKILL.md
@@ -1,13 +1,27 @@
 ---
-description: Break work into GitHub Issues with labels, dependencies, and acceptance criteria. Interviews Odin via Freya, wireframes via Luna (if UI), then files issues to the Project board.
-argument-hint: [user prompt]
-model: opus
-disallowed-tools: Task, EnterPlanMode
+name: plan-w-team
+description: >
+  Break work into GitHub Issues with labels, dependencies, and acceptance criteria.
+  Interviews Odin via Freya, wireframes via Luna (if UI), then files issues to the
+  Project board and writes an epic dependency graph to tmp/epics/<N>.json for
+  /epic-manager to track. Use when the user says 'plan', 'plan with team',
+  'break this into issues', or describes a feature/bug needing structured planning.
 ---
 
 # Plan With Team
 
-Break the user's request into GitHub Issues on Project #1. Each issue becomes a unit of work that `/fire-next-up` picks up and runs through the agent chain.
+Break the user's request into GitHub Issues on Project #1. Each issue becomes a unit
+of work that `/fire-next-up` picks up and runs through the agent chain. After filing,
+write `tmp/epics/<root-N>.json` so `/epic-manager` can track and dispatch the epic.
+
+## Model
+
+Use **Opus** for this skill — deep reasoning required for dependency analysis and
+issue decomposition.
+
+## Disallowed Tools
+
+Do NOT use: `Task`, `EnterPlanMode`
 
 ## Variables
 
@@ -21,7 +35,7 @@ TEAM_MEMBERS:
 
 ## Instructions
 
-- **PLANNING ONLY**: Do NOT build, write code, or deploy agents. Your only output is GitHub Issues.
+- **PLANNING ONLY**: Do NOT build, write code, or deploy agents. Your only output is GitHub Issues + the epic graph file.
 - If no `USER_PROMPT` is provided, stop and ask the user to provide it.
 - Think deeply about the best approach before breaking work into issues.
 - Understand the codebase directly (no subagents) to understand existing patterns.
@@ -221,12 +235,15 @@ node -e "JSON.parse(require('fs').readFileSync('tmp/epics/<N>.json','utf8')); co
 
 Commit the file on `main` so agents can find it:
 ```bash
-git add tmp/epics/<N>.json
+git add -f tmp/epics/<N>.json
 git commit -m "chore: add epic graph for #<N> — <title>
 
 Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"
 git push
 ```
+
+> **Note:** `tmp/` is gitignored but `tmp/epics/` is explicitly unblocked via
+> `!tmp/epics/` in `.gitignore`. Use `git add -f` if needed.
 
 ### Step 6 — Report
 


### PR DESCRIPTION
## Summary

- Moves `epic-manager` and `plan-w-team` from `.claude/commands/` to `.claude/skills/` so each is fully self-contained in its own directory
- Moves `epic-manager.mjs` from `.claude/scripts/` into `.claude/skills/epic-manager/` alongside its SKILL.md
- Updates script path reference accordingly
- Converts `plan-w-team` frontmatter from command format (`model`, `disallowed-tools`) to skill format (`name`, `description`); model/tool constraints documented in skill body

## Layout after

```
.claude/skills/
  epic-manager/
    SKILL.md
    epic-manager.mjs
  plan-w-team/
    SKILL.md
```

## Test plan

- [ ] `/epic-manager 1386` triggers the skill and runs `node .claude/skills/epic-manager/epic-manager.mjs 1386`
- [ ] `/plan-w-team` triggers the skill correctly
- [ ] No stale references to `.claude/commands/epic-manager.md`, `.claude/commands/plan-w-team.md`, or `.claude/scripts/epic-manager.mjs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)