### PR TITLE
fix(epic-manager): run script --help when invoked without root issue

### DIFF
--- a/.claude/skills/epic-manager/SKILL.md
+++ b/.claude/skills/epic-manager/SKILL.md
@@ -42,6 +42,12 @@ the next wave of stories for dispatch.
 node .claude/skills/epic-manager/epic-manager.mjs <N> [--dispatch]
 ```
 
+If `--help` is the only argument, run the script directly to show its built-in help:
+
+```bash
+node .claude/skills/epic-manager/epic-manager.mjs --help
+```
+
 That is the entire execution. No other tool calls needed unless the output requires
 follow-up action (e.g., closing a duplicate, dispatching a ready story).
 


### PR DESCRIPTION
When `/epic-manager --help` is called, the SKILL.md now instructs Claude to run the script directly so Odin sees the script's built-in help output rather than the raw SKILL.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)