### PR TITLE
Issue #1511 - fix: just odins-spear recipe installs node_modules before running

### DIFF
--- a/development/frontend/Justfile
+++ b/development/frontend/Justfile
@@ -46,8 +46,15 @@ verify-fast:
 
 # ── Trial / Subscription ───────────────────────────────────────────────────
 
+# Install node_modules for odins-spear if absent
+_install-odins-spear:
+    #!/usr/bin/env bash
+    if [ ! -d "{{repo_root}}/development/odins-spear/node_modules" ]; then
+        npm install --prefix "{{repo_root}}/development/odins-spear"
+    fi
+
 # Odin's Spear — Interactive REPL for managing trials, entitlements, and Stripe (auto port-forwards)
-odins-spear *args:
+odins-spear *args: _install-odins-spear
     cd "{{repo_root}}/development/odins-spear" && npx tsx src/index.ts {{args}}
 
 # ── Utilities ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes #1511

## Summary
- Added `_install-odins-spear` dependency recipe in `development/frontend/Justfile`
- Recipe checks if `development/odins-spear/node_modules` exists; runs `npm install --prefix development/odins-spear` if absent
- `odins-spear` recipe now depends on `_install-odins-spear`, ensuring deps are always installed before `npx tsx src/index.ts` runs

## Test plan
- tsc PASS
- build PASS (45 routes)
- Full Vitest suite: 2611/2611 PASS