### PR TITLE
Move epic-manager help from MJS to SKILL.md

### DIFF
--- a/.claude/skills/epic-manager/SKILL.md
+++ b/.claude/skills/epic-manager/SKILL.md
@@ -30,22 +30,59 @@ the next wave of stories for dispatch.
 | `--parallel-with <N>[,N...]` | No | Peers in the same wave (bidirectional update) |
 | `--note "..."` | No | Optional note text for the new story |
 
+## Help
+
+If no issue number is provided, or `--help` / `-h` is passed, **display this help
+text directly** (do NOT run the script):
+
+```
+/epic-manager — Epic dependency graph tracker + dispatch advisor
+
+USAGE
+  /epic-manager <N>                          Show dashboard for epic #N
+  /epic-manager <N> --dispatch               Dashboard + copy-paste dispatch commands
+  /epic-manager <N> --json                   Machine-readable JSON output
+  /epic-manager <N> --add <M> --blocked-by <X>[,Y]   Add story #M to epic graph
+
+DASHBOARD EXAMPLES
+  /epic-manager 1386                         Live status of epic #1386
+  /epic-manager 1386 --dispatch              Dashboard + ready dispatch commands
+
+ADD STORY EXAMPLES
+  /epic-manager 1386 --add 1507 --blocked-by 1495
+  /epic-manager 1386 --add 1508 --blocked-by 1495 --parallel-with 1507
+  /epic-manager 1386 --add 1509 --blocked-by 1495 --wave 3 --note "Extra context"
+
+ADD FLAGS
+  --add <N>              Issue number to insert into the graph
+  --blocked-by <N>[,N]   Comma-separated blockers (must close before this starts)
+  --parallel-with <N>[,N] Peers in the same wave (bidirectional link)
+  --wave <N>             Override wave (default: max blocker wave + 1)
+  --note "..."           Optional note stored in the YAML
+
+DASHBOARD ICONS
+  ✅  done      — GitHub issue is CLOSED
+  🔄  running   — Active K8s job found for this issue
+  🟢  ready     — All blockers closed, not yet running
+  🔴  blocked   — One or more blockers still OPEN
+  ⚠️   duplicate — duplicate_of is set; close manually before dispatching
+
+EPIC FILE
+  Reads/writes tmp/epics/<root-issue>.yml
+  Auto-migrates legacy .json files to .yml on first run.
+```
+
 ## Speed Rules (UNBREAKABLE)
 
 1. **One tool call.** Run the MJS script directly — no pre-fetching, no narration between calls.
 2. **Never re-fetch what the script already fetches.** The script queries GitHub and K8s itself.
 3. **If the epic file is missing**, tell Odin to run `/plan-w-team` or check the issue number.
+4. **If no issue number or `--help`**, display the Help section above — do NOT run the script.
 
 ## Execution
 
 ```bash
 node .claude/skills/epic-manager/epic-manager.mjs <N> [--dispatch]
-```
-
-If `--help` is the only argument, run the script directly to show its built-in help:
-
-```bash
-node .claude/skills/epic-manager/epic-manager.mjs --help
 ```
 
 That is the entire execution. No other tool calls needed unless the output requires

--- a/.claude/skills/epic-manager/epic-manager.mjs
+++ b/.claude/skills/epic-manager/epic-manager.mjs
@@ -6,18 +6,7 @@
  * active GKE K8s jobs, then prints a dashboard showing what is done,
  * running, blocked, or ready to dispatch.
  *
- * Usage:
- *   node .claude/skills/epic-manager/epic-manager.mjs <root-issue-number> [--dispatch]
- *   node .claude/skills/epic-manager/epic-manager.mjs <root-issue-number> --add <N> --blocked-by <N>[,N...] [--wave <N>] [--parallel-with <N>[,N...]] [--note "..."]
- *
- * Flags:
- *   --dispatch        Print ready dispatch commands (does not execute them)
- *   --json            Emit machine-readable JSON instead of human dashboard
- *   --add <N>         Add issue #N to the graph (fetches title from GitHub)
- *   --blocked-by <N>  Comma-separated list of issues that must close before --add issue starts
- *   --wave <N>        Override wave assignment (default: auto-computed from blockers)
- *   --parallel-with   Comma-separated issues in the same wave that run alongside --add issue
- *   --note "..."      Optional note for the new story
+ * Help/usage: see SKILL.md (help is displayed by the orchestrator, not this script).
  */
 
 import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
@@ -28,54 +17,8 @@ import yaml from "js-yaml";
 // ── CLI args ────────────────────────────────────────────────────────────────
 const args = process.argv.slice(2);
 
-// ── --help ───────────────────────────────────────────────────────────────────
-if (args.includes("--help") || args.includes("-h")) {
-  console.log(`
-epic-manager — Epic dependency graph tracker + dispatch advisor
-
-USAGE
-  node epic-manager.mjs <root-issue>              Show dashboard
-  node epic-manager.mjs <root-issue> --dispatch   Dashboard + copy-paste dispatch commands
-  node epic-manager.mjs <root-issue> --add <N>    Add a new story to the graph
-  node epic-manager.mjs <root-issue> --json       Machine-readable JSON output
-
-DASHBOARD EXAMPLES
-  # Show the live status of epic #1386
-  node epic-manager.mjs 1386
-
-  # Show dashboard and print ready dispatch commands
-  node epic-manager.mjs 1386 --dispatch
-
-ADD STORY EXAMPLES
-  # Add issue #1507 blocked by #1495 (wave auto-computed)
-  node epic-manager.mjs 1386 --add 1507 --blocked-by 1495
-
-  # Add issue #1508 running in parallel with #1507 at wave 3
-  node epic-manager.mjs 1386 --add 1508 --blocked-by 1495 --parallel-with 1507
-
-  # Add with explicit wave override and a note
-  node epic-manager.mjs 1386 --add 1509 --blocked-by 1495 --wave 3 --note "Extra context here"
-
-ADD FLAGS
-  --add <N>              Issue number to insert into the graph
-  --blocked-by <N>[,N]   Comma-separated blockers (must close before this starts)
-  --parallel-with <N>[,N] Peers in the same wave (bidirectional link)
-  --wave <N>             Override wave (default: max blocker wave + 1)
-  --note "..."           Optional note stored in the YAML
-
-DASHBOARD ICONS
-  ✅  done      — GitHub issue is CLOSED
-  🔄  running   — Active K8s job found for this issue
-  🟢  ready     — All blockers closed, not yet running
-  🔴  blocked   — One or more blockers still OPEN
-  ⚠️   duplicate — duplicate_of is set; close manually before dispatching
-
-EPIC FILE
-  Reads/writes tmp/epics/<root-issue>.yml
-  Auto-migrates legacy .json files to .yml on first run.
-`);
-  process.exit(0);
-}
+// Help is handled by SKILL.md — the orchestrator displays it directly.
+// No --help flag in this script.
 
 const rootIssue = args.find((a) => /^\d+$/.test(a));
 const flagDispatch = args.includes("--dispatch");
@@ -104,8 +47,8 @@ const noteIdx = args.indexOf("--note");
 const flagNote = noteIdx !== -1 ? (args[noteIdx + 1] ?? "") : "";
 
 if (!rootIssue) {
-  console.error("Usage: epic-manager.mjs <root-issue-number> [--dispatch|--add|--json]");
-  console.error("       epic-manager.mjs --help   for full usage and examples");
+  console.error("Usage: /epic-manager <root-issue-number> [--dispatch|--add|--json]");
+  console.error("       /epic-manager --help   for full usage and examples");
   process.exit(1);
 }
 


### PR DESCRIPTION
## Summary
- Removed `--help` / `-h` handler from `epic-manager.mjs` — it printed to script stdout which Odin never sees
- Added `## Help` section to `SKILL.md` with full usage, examples, and icon legend
- Orchestrator now displays help directly when no args or `--help` is passed (no script execution)
- Updated script error messages to reference `/epic-manager` instead of `epic-manager.mjs`

## Test plan
- [ ] `/epic-manager --help` displays help text in the conversation
- [ ] `/epic-manager` with no args displays help text
- [ ] `/epic-manager 1516` still runs the script and shows the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)