### PR TITLE
Issue #1516 - feat: migrate trial store from Redis to Firestore

### DIFF
--- a/development/frontend/src/__tests__/lib/trial-store.test.ts
+++ b/development/frontend/src/__tests__/lib/trial-store.test.ts
@@ -1,21 +1,33 @@
 /**
- * Unit tests for kv/trial-store.ts — Redis trial CRUD operations.
+ * Unit tests for kv/trial-store.ts — Firestore trial CRUD operations.
  *
- * Mocks ioredis via redis-client to test get/set paths and error handling.
+ * Mocks the Firestore client to test get/set paths and error handling.
  * Includes boundary condition tests merged from trial/trial-store.test.ts (issue #944).
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
-// ── Mock Redis client ─────────────────────────────────────────────────────
+// ── Mock Firestore client ──────────────────────────────────────────────────
 
-const mockRedis = vi.hoisted(() => ({
+const mockDocRef = vi.hoisted(() => ({
   get: vi.fn(),
   set: vi.fn(),
+  update: vi.fn(),
 }));
 
-vi.mock("@/lib/kv/redis-client", () => ({
-  getRedisClient: () => mockRedis,
+const mockCollectionRef = vi.hoisted(() => ({
+  where: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  get: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+  doc: vi.fn(() => mockDocRef),
+  collection: vi.fn(() => mockCollectionRef),
+}));
+
+vi.mock("@/lib/firebase/firestore", () => ({
+  getFirestore: () => mockDb,
 }));
 
 vi.mock("@/lib/logger", () => ({
@@ -24,82 +36,172 @@ vi.mock("@/lib/logger", () => ({
 
 // ── Import after mock ────────────────────────────────────────────────────
 
-import { getTrial, initTrial, markTrialConverted, computeTrialStatus } from "@/lib/kv/trial-store";
+import { getTrial, initTrial, markTrialConverted, computeTrialStatus, linkTrialToUser, getFingerprintByUserId } from "@/lib/kv/trial-store";
 import type { StoredTrial } from "@/lib/kv/trial-store";
 import { TRIAL_DURATION_DAYS } from "@/lib/trial-utils";
 
 // ── Test data ────────────────────────────────────────────────────────────
 
 const FINGERPRINT = "a".repeat(64);
-const TRIAL_TTL = 60 * 24 * 60 * 60;
+
+/** Helper: snapshot that returns an existing trial. */
+function existingSnap(trial: StoredTrial) {
+  return { exists: true, data: () => ({ ...trial, expiresAt: {} }) };
+}
+
+/** Helper: snapshot for a missing document. */
+const missingSnap = { exists: false, data: () => null };
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 describe("trial-store", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: doc not found
+    mockDocRef.get.mockResolvedValue(missingSnap);
+    mockDocRef.set.mockResolvedValue(undefined);
+    mockDocRef.update.mockResolvedValue(undefined);
+    mockCollectionRef.get.mockResolvedValue({ empty: true, docs: [] });
   });
 
   describe("getTrial", () => {
-    it("returns trial when found in Redis", async () => {
+    it("returns trial when found in Firestore", async () => {
       const trial: StoredTrial = { startDate: "2025-01-01T00:00:00.000Z" };
-      mockRedis.get.mockResolvedValueOnce(JSON.stringify(trial));
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
 
       const result = await getTrial(FINGERPRINT);
       expect(result).toEqual(trial);
-      expect(mockRedis.get).toHaveBeenCalledWith(`trial:${FINGERPRINT}`);
+      expect(mockDb.doc).toHaveBeenCalledWith(`trials/${FINGERPRINT}`);
     });
 
     it("returns null when not found", async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
 
       const result = await getTrial(FINGERPRINT);
       expect(result).toBeNull();
     });
 
-    it("returns null on Redis failure (does not throw)", async () => {
-      mockRedis.get.mockRejectedValueOnce(new Error("Redis connection failed"));
+    it("returns null on Firestore failure (does not throw)", async () => {
+      mockDocRef.get.mockRejectedValueOnce(new Error("Firestore connection failed"));
 
       const result = await getTrial(FINGERPRINT);
       expect(result).toBeNull();
+    });
+
+    it("strips expiresAt from returned trial", async () => {
+      const trial: StoredTrial = { startDate: "2025-01-01T00:00:00.000Z" };
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
+
+      const result = await getTrial(FINGERPRINT);
+      expect(result).not.toHaveProperty("expiresAt");
     });
   });
 
   describe("initTrial", () => {
     it("returns existing trial if already exists (idempotent)", async () => {
       const trial: StoredTrial = { startDate: "2025-01-01T00:00:00.000Z" };
-      mockRedis.get.mockResolvedValueOnce(JSON.stringify(trial));
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
 
       const result = await initTrial(FINGERPRINT);
       expect(result).toEqual(trial);
-      expect(mockRedis.set).not.toHaveBeenCalled();
+      expect(mockDocRef.set).not.toHaveBeenCalled();
     });
 
     it("creates new trial when none exists", async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
-      mockRedis.set.mockResolvedValueOnce("OK");
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
 
       const result = await initTrial(FINGERPRINT);
       expect(result.startDate).toBeDefined();
-      expect(mockRedis.set).toHaveBeenCalledWith(
-        `trial:${FINGERPRINT}`,
-        expect.any(String),
-        "EX",
-        TRIAL_TTL
-      );
+      expect(mockDocRef.set).toHaveBeenCalledOnce();
+      const written = mockDocRef.set.mock.calls[0]![0] as Record<string, unknown>;
+      expect(written).toMatchObject({ startDate: expect.any(String) });
+      expect(written).toHaveProperty("expiresAt");
     });
 
-    it("throws on Redis failure during write", async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
-      mockRedis.set.mockRejectedValueOnce(new Error("Redis write failed"));
+    it("stores document at trials/{fingerprint}", async () => {
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
 
-      await expect(initTrial(FINGERPRINT)).rejects.toThrow("Redis write failed");
+      await initTrial(FINGERPRINT);
+
+      expect(mockDb.doc).toHaveBeenCalledWith(`trials/${FINGERPRINT}`);
+    });
+
+    it("includes userId when provided", async () => {
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
+
+      const result = await initTrial(FINGERPRINT, "user-123");
+      expect(result.userId).toBe("user-123");
+      const written = mockDocRef.set.mock.calls[0]![0] as Record<string, unknown>;
+      expect(written).toMatchObject({ userId: "user-123" });
+    });
+
+    it("throws on Firestore failure during write", async () => {
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
+      mockDocRef.set.mockRejectedValueOnce(new Error("Firestore write failed"));
+
+      await expect(initTrial(FINGERPRINT)).rejects.toThrow("Firestore write failed");
+    });
+  });
+
+  describe("linkTrialToUser", () => {
+    it("updates userId on existing trial", async () => {
+      const trial: StoredTrial = { startDate: "2025-01-01T00:00:00.000Z" };
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
+
+      await linkTrialToUser(FINGERPRINT, "user-456");
+
+      expect(mockDocRef.update).toHaveBeenCalledWith({ userId: "user-456" });
+    });
+
+    it("no-ops when trial not found", async () => {
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
+
+      await linkTrialToUser(FINGERPRINT, "user-456");
+
+      expect(mockDocRef.update).not.toHaveBeenCalled();
+    });
+
+    it("no-ops when trial already linked to same userId", async () => {
+      const trial: StoredTrial = { startDate: "2025-01-01T00:00:00.000Z", userId: "user-456" };
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
+
+      await linkTrialToUser(FINGERPRINT, "user-456");
+
+      expect(mockDocRef.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getFingerprintByUserId", () => {
+    it("returns fingerprint when userId found", async () => {
+      const fp = FINGERPRINT;
+      mockCollectionRef.get.mockResolvedValueOnce({
+        empty: false,
+        docs: [{ id: fp }],
+      });
+
+      const result = await getFingerprintByUserId("user-123");
+      expect(result).toBe(fp);
+      expect(mockDb.collection).toHaveBeenCalledWith("trials");
+    });
+
+    it("returns null when userId not found", async () => {
+      mockCollectionRef.get.mockResolvedValueOnce({ empty: true, docs: [] });
+
+      const result = await getFingerprintByUserId("user-unknown");
+      expect(result).toBeNull();
+    });
+
+    it("returns null on Firestore failure", async () => {
+      mockCollectionRef.get.mockRejectedValueOnce(new Error("Firestore error"));
+
+      const result = await getFingerprintByUserId("user-123");
+      expect(result).toBeNull();
     });
   });
 
   describe("markTrialConverted", () => {
     it("returns false if no trial exists", async () => {
-      mockRedis.get.mockResolvedValueOnce(null);
+      mockDocRef.get.mockResolvedValueOnce(missingSnap);
 
       const result = await markTrialConverted(FINGERPRINT);
       expect(result).toBe(false);
@@ -110,25 +212,21 @@ describe("trial-store", () => {
         startDate: "2025-01-01T00:00:00.000Z",
         convertedDate: "2025-01-15T00:00:00.000Z",
       };
-      mockRedis.get.mockResolvedValueOnce(JSON.stringify(trial));
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
 
       const result = await markTrialConverted(FINGERPRINT);
       expect(result).toBe(true);
-      expect(mockRedis.set).not.toHaveBeenCalled();
+      expect(mockDocRef.update).not.toHaveBeenCalled();
     });
 
-    it("sets convertedDate on unconverted trial", async () => {
+    it("sets convertedDate on unconverted trial via update", async () => {
       const trial: StoredTrial = { startDate: "2025-01-01T00:00:00.000Z" };
-      mockRedis.get.mockResolvedValueOnce(JSON.stringify(trial));
-      mockRedis.set.mockResolvedValueOnce("OK");
+      mockDocRef.get.mockResolvedValueOnce(existingSnap(trial));
 
       const result = await markTrialConverted(FINGERPRINT);
       expect(result).toBe(true);
-      expect(mockRedis.set).toHaveBeenCalledWith(
-        `trial:${FINGERPRINT}`,
-        expect.stringContaining("convertedDate"),
-        "EX",
-        TRIAL_TTL
+      expect(mockDocRef.update).toHaveBeenCalledWith(
+        expect.objectContaining({ convertedDate: expect.any(String) })
       );
     });
   });
@@ -168,7 +266,7 @@ describe("trial-store", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Loki boundary condition tests (merged from trial/trial-store.test.ts — issue #944)
+// Boundary condition tests (merged from trial/trial-store.test.ts — issue #944)
 // ---------------------------------------------------------------------------
 
 function daysAgo(n: number): string {
@@ -179,7 +277,7 @@ function daysAgo(n: number): string {
 const VALID_FINGERPRINT_B = "b".repeat(64);
 
 describe("computeTrialStatus — boundary conditions (#944 AC2)", () => {
-  it("returns status:none when trial is null (no record in Redis)", () => {
+  it("returns status:none when trial is null (no record in Firestore)", () => {
     const result = computeTrialStatus(null);
     expect(result.status).toBe("none");
     expect(result.remainingDays).toBe(0);
@@ -209,33 +307,35 @@ describe("computeTrialStatus — boundary conditions (#944 AC2)", () => {
   });
 });
 
-describe("initTrial — Redis key format and TTL (#944 AC1)", () => {
+describe("initTrial — Firestore document path and expiresAt field (#944 AC1)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockDocRef.get.mockResolvedValue(missingSnap);
+    mockDocRef.set.mockResolvedValue(undefined);
   });
 
-  it("writes trial under key `trial:{fingerprint}` with TTL 5184000 s (60 days)", async () => {
-    mockRedis.get.mockResolvedValueOnce(null); // no existing trial
-    mockRedis.set.mockResolvedValueOnce("OK");
-
+  it("writes trial under trials/{fingerprint} with expiresAt set to ~60 days from now", async () => {
     await initTrial(VALID_FINGERPRINT_B);
 
-    expect(mockRedis.set).toHaveBeenCalledOnce();
-    const [key, , exFlag, ttl] = mockRedis.set.mock.calls[0] as [string, string, string, number];
-    expect(key).toBe(`trial:${VALID_FINGERPRINT_B}`);
-    expect(exFlag).toBe("EX");
-    // 60 days × 24 h × 60 min × 60 s = 5 184 000 s
-    expect(ttl).toBe(60 * 24 * 60 * 60);
+    expect(mockDb.doc).toHaveBeenCalledWith(`trials/${VALID_FINGERPRINT_B}`);
+    expect(mockDocRef.set).toHaveBeenCalledOnce();
+
+    const written = mockDocRef.set.mock.calls[0]![0] as Record<string, unknown>;
+    expect(written).toHaveProperty("expiresAt");
+    expect(written).toHaveProperty("startDate");
+    // expiresAt should be a Firestore Timestamp object (not a string)
+    const expiresAt = written["expiresAt"] as { seconds?: number };
+    expect(typeof expiresAt).toBe("object");
   });
 });
 
-describe("getTrial — malformed JSON error handling", () => {
+describe("getTrial — malformed/missing data error handling", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("returns null (not throws) when Redis contains malformed JSON", async () => {
-    mockRedis.get.mockResolvedValueOnce("not-valid-json{{{");
+  it("returns null (not throws) when Firestore throws an error", async () => {
+    mockDocRef.get.mockRejectedValueOnce(new Error("network error"));
 
     const result = await getTrial(VALID_FINGERPRINT_B);
     expect(result).toBeNull();

--- a/development/frontend/src/__tests__/trial/trial-init-route.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-init-route.test.ts
@@ -2,15 +2,15 @@
  * Integration tests for POST /api/trial/init
  *
  * Covers:
- *  - Trial auto-starts on first sign-in (new fingerprint → Redis write)
+ *  - Trial auto-starts on first sign-in (new fingerprint → Firestore write)
  *  - Idempotent: second call preserves original start date, no re-write
  *  - Invalid fingerprint returns 400
  *  - Missing fingerprint returns 400
  *  - Unauthenticated request returns 401
- *  - Redis failure returns 500
+ *  - Firestore failure returns 500
  *
  * @see src/app/api/trial/init/route.ts
- * @ref Issue #922
+ * @ref Issue #922, #1516
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -18,13 +18,25 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-const mockRedis = vi.hoisted(() => ({
+const mockDocRef = vi.hoisted(() => ({
   get: vi.fn(),
   set: vi.fn(),
+  update: vi.fn(),
 }));
 
-vi.mock("@/lib/kv/redis-client", () => ({
-  getRedisClient: () => mockRedis,
+const mockCollectionRef = vi.hoisted(() => ({
+  where: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  get: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+  doc: vi.fn(() => mockDocRef),
+  collection: vi.fn(() => mockCollectionRef),
+}));
+
+vi.mock("@/lib/firebase/firestore", () => ({
+  getFirestore: () => mockDb,
 }));
 
 const mockRateLimit = vi.hoisted(() => vi.fn(() => ({ success: true, remaining: 9 })));
@@ -51,6 +63,14 @@ import { POST } from "@/app/api/trial/init/route";
 
 const VALID_FINGERPRINT = "a".repeat(64);
 
+/** Snapshot for a missing document. */
+const missingSnap = { exists: false, data: () => null };
+
+/** Snapshot for an existing trial. */
+function existingSnap(trial: Record<string, unknown>) {
+  return { exists: true, data: () => ({ ...trial, expiresAt: {} }) };
+}
+
 function makeRequest(body: Record<string, unknown> = {}, token = "valid-token"): NextRequest {
   return new NextRequest("http://localhost:9653/api/trial/init", {
     method: "POST",
@@ -69,19 +89,17 @@ function authOk() {
   mockRequireAuthz.mockResolvedValue({ ok: true, user: { sub: "google-sub-123" }, firestoreUser: MOCK_FIRESTORE_USER });
 }
 
-function authFail() {
-  mockRequireAuthz.mockResolvedValue({
-    ok: false,
-    response: new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }),
-  });
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 describe("POST /api/trial/init", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authOk();
+    // Default: doc not found
+    mockDocRef.get.mockResolvedValue(missingSnap);
+    mockDocRef.set.mockResolvedValue(undefined);
+    mockDocRef.update.mockResolvedValue(undefined);
+    mockCollectionRef.get.mockResolvedValue({ empty: true, docs: [] });
   });
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -89,8 +107,10 @@ describe("POST /api/trial/init", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   it("creates a new trial on first sign-in and returns isNew:true", async () => {
-    mockRedis.get.mockResolvedValueOnce(null); // no existing trial
-    mockRedis.set.mockResolvedValueOnce("OK");
+    // Route calls getTrial → doc not found; then initTrial → getTrial again → not found → set
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap) // route's getTrial
+      .mockResolvedValueOnce(missingSnap); // initTrial's internal getTrial
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -98,18 +118,14 @@ describe("POST /api/trial/init", () => {
     expect(res.status).toBe(200);
     expect(body.isNew).toBe(true);
     expect(typeof body.startDate).toBe("string");
-    expect(mockRedis.set).toHaveBeenCalledOnce();
-    expect(mockRedis.set).toHaveBeenCalledWith(
-      `trial:${VALID_FINGERPRINT}`,
-      expect.any(String),
-      "EX",
-      expect.any(Number),
-    );
+    expect(mockDocRef.set).toHaveBeenCalledOnce();
+    expect(mockDb.doc).toHaveBeenCalledWith(`trials/${VALID_FINGERPRINT}`);
   });
 
-  it("writes a valid ISO start date to Redis on first sign-in", async () => {
-    mockRedis.get.mockResolvedValueOnce(null);
-    mockRedis.set.mockResolvedValueOnce("OK");
+  it("writes a valid ISO start date to Firestore on first sign-in", async () => {
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap)
+      .mockResolvedValueOnce(missingSnap);
 
     const before = Date.now();
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
@@ -127,9 +143,7 @@ describe("POST /api/trial/init", () => {
 
   it("returns isNew:false and preserves original startDate on second call", async () => {
     const originalStartDate = "2026-03-01T00:00:00.000Z";
-    mockRedis.get.mockResolvedValueOnce(
-      JSON.stringify({ startDate: originalStartDate }),
-    );
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate: originalStartDate }));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -137,8 +151,8 @@ describe("POST /api/trial/init", () => {
     expect(res.status).toBe(200);
     expect(body.isNew).toBe(false);
     expect(body.startDate).toBe(originalStartDate);
-    // Redis set should NOT be called — existing trial preserved
-    expect(mockRedis.set).not.toHaveBeenCalled();
+    // Firestore set should NOT be called — existing trial preserved
+    expect(mockDocRef.set).not.toHaveBeenCalled();
   });
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -146,8 +160,9 @@ describe("POST /api/trial/init", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   it("allows anonymous request (no Bearer token) with valid fingerprint", async () => {
-    mockRedis.get.mockResolvedValueOnce(null);
-    mockRedis.set.mockResolvedValueOnce("OK");
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap)
+      .mockResolvedValueOnce(missingSnap);
 
     // Request with no Authorization header
     const req = new NextRequest("http://localhost:9653/api/trial/init", {
@@ -210,12 +225,14 @@ describe("POST /api/trial/init", () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════
-  // Redis failure
+  // Firestore failure
   // ═══════════════════════════════════════════════════════════════════════
 
-  it("returns 500 when Redis write fails", async () => {
-    mockRedis.get.mockResolvedValueOnce(null); // no existing trial
-    mockRedis.set.mockRejectedValueOnce(new Error("Redis unavailable"));
+  it("returns 500 when Firestore write fails", async () => {
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap) // route's getTrial
+      .mockResolvedValueOnce(missingSnap); // initTrial's internal getTrial
+    mockDocRef.set.mockRejectedValueOnce(new Error("Firestore unavailable"));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -229,8 +246,9 @@ describe("POST /api/trial/init", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   it("response includes Cache-Control: no-store", async () => {
-    mockRedis.get.mockResolvedValueOnce(null);
-    mockRedis.set.mockResolvedValueOnce("OK");
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap)
+      .mockResolvedValueOnce(missingSnap);
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
 

--- a/development/frontend/src/__tests__/trial/trial-status-route.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-status-route.test.ts
@@ -9,12 +9,11 @@
  *  - Returns correct status for converted trial
  *  - Invalid fingerprint returns 400
  *  - Missing fingerprint returns 400
- *  - Unauthenticated request returns 401
  *  - Rate limit returns 429
- *  - Redis failure falls through gracefully
+ *  - Firestore failure falls through gracefully
  *
  * @see src/app/api/trial/status/route.ts
- * @ref Issue #944 (regression of #922)
+ * @ref Issue #944 (regression of #922), #1516
  */
 
 import { describe, it, expect, beforeEach, vi } from "vitest";
@@ -22,13 +21,25 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
-const mockRedis = vi.hoisted(() => ({
+const mockDocRef = vi.hoisted(() => ({
   get: vi.fn(),
   set: vi.fn(),
+  update: vi.fn(),
 }));
 
-vi.mock("@/lib/kv/redis-client", () => ({
-  getRedisClient: () => mockRedis,
+const mockCollectionRef = vi.hoisted(() => ({
+  where: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  get: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+  doc: vi.fn(() => mockDocRef),
+  collection: vi.fn(() => mockCollectionRef),
+}));
+
+vi.mock("@/lib/firebase/firestore", () => ({
+  getFirestore: () => mockDb,
 }));
 
 const mockRateLimit = vi.hoisted(() => vi.fn(() => ({ success: true, remaining: 29 })));
@@ -54,6 +65,14 @@ import { POST } from "@/app/api/trial/status/route";
 
 const VALID_FINGERPRINT = "a".repeat(64);
 
+/** Snapshot for a missing document. */
+const missingSnap = { exists: false, data: () => null };
+
+/** Snapshot for an existing trial. */
+function existingSnap(trial: Record<string, unknown>) {
+  return { exists: true, data: () => ({ ...trial, expiresAt: {} }) };
+}
+
 function makeRequest(body: Record<string, unknown> = {}, token = "valid-token"): NextRequest {
   return new NextRequest("http://localhost:9653/api/trial/status", {
     method: "POST",
@@ -72,13 +91,6 @@ function authOk() {
   mockRequireAuthz.mockResolvedValue({ ok: true, user: { sub: "google-sub-123" }, firestoreUser: MOCK_FIRESTORE_USER });
 }
 
-function authFail() {
-  mockRequireAuthz.mockResolvedValue({
-    ok: false,
-    response: new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 }),
-  });
-}
-
 /** Returns an ISO date N days ago. */
 function daysAgo(n: number): string {
   const d = new Date();
@@ -92,15 +104,20 @@ describe("POST /api/trial/status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     authOk();
+    // Default: doc not found
+    mockDocRef.get.mockResolvedValue(missingSnap);
+    mockDocRef.set.mockResolvedValue(undefined);
+    mockDocRef.update.mockResolvedValue(undefined);
+    mockCollectionRef.get.mockResolvedValue({ empty: true, docs: [] });
   });
 
   // ═══════════════════════════════════════════════════════════════════════
-  // Active trial — existing Redis record
+  // Active trial — existing Firestore record
   // ═══════════════════════════════════════════════════════════════════════
 
   it("returns active status with remaining days for a new trial", async () => {
     const startDate = daysAgo(0); // started today
-    mockRedis.get.mockResolvedValueOnce(JSON.stringify({ startDate }));
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate }));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -108,13 +125,13 @@ describe("POST /api/trial/status", () => {
     expect(res.status).toBe(200);
     expect(body.status).toBe("active");
     expect(body.remainingDays).toBe(30);
-    // Redis set should NOT be called — trial already exists
-    expect(mockRedis.set).not.toHaveBeenCalled();
+    // Firestore set should NOT be called — trial already exists
+    expect(mockDocRef.set).not.toHaveBeenCalled();
   });
 
   it("returns correct remaining days based on start date", async () => {
     const startDate = daysAgo(5); // 5 days into 30-day trial
-    mockRedis.get.mockResolvedValueOnce(JSON.stringify({ startDate }));
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate }));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -129,12 +146,12 @@ describe("POST /api/trial/status", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   it("auto-initializes trial when none exists and returns active status", async () => {
-    // First GET (getTrial check) returns null — trial not found
-    mockRedis.get.mockResolvedValueOnce(null);
-    // Second GET (inside initTrial's getTrial check) also returns null
-    mockRedis.get.mockResolvedValueOnce(null);
-    // Redis SET succeeds for the new trial
-    mockRedis.set.mockResolvedValueOnce("OK");
+    // First GET (status route's getTrial) returns null
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap) // getTrial in status route: not found
+      .mockResolvedValueOnce(missingSnap); // getTrial inside initTrial: also not found
+    // Firestore SET succeeds for the new trial
+    mockDocRef.set.mockResolvedValueOnce(undefined);
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -142,31 +159,25 @@ describe("POST /api/trial/status", () => {
     expect(res.status).toBe(200);
     expect(body.status).toBe("active");
     expect(body.remainingDays).toBe(30);
-    // Trial was written to Redis
-    expect(mockRedis.set).toHaveBeenCalledOnce();
-    expect(mockRedis.set).toHaveBeenCalledWith(
-      `trial:${VALID_FINGERPRINT}`,
-      expect.any(String),
-      "EX",
-      expect.any(Number),
-    );
+    // Trial was written to Firestore
+    expect(mockDocRef.set).toHaveBeenCalledOnce();
+    expect(mockDb.doc).toHaveBeenCalledWith(`trials/${VALID_FINGERPRINT}`);
   });
 
   it("auto-init is idempotent: if trial exists between getTrial and initTrial, preserves original", async () => {
     const originalStartDate = "2026-03-01T00:00:00.000Z";
     // getTrial returns null (missed by callback), but initTrial finds it (race condition resolved)
-    mockRedis.get.mockResolvedValueOnce(null); // getTrial in status route: not found
-    mockRedis.get.mockResolvedValueOnce( // getTrial inside initTrial: found (another init already ran)
-      JSON.stringify({ startDate: originalStartDate }),
-    );
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap) // getTrial in status route: not found
+      .mockResolvedValueOnce(existingSnap({ startDate: originalStartDate })); // getTrial inside initTrial: found
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
 
     expect(res.status).toBe(200);
     expect(body.status).toBe("active");
-    // No new Redis write — initTrial returned the existing record
-    expect(mockRedis.set).not.toHaveBeenCalled();
+    // No new Firestore write — initTrial returned the existing record
+    expect(mockDocRef.set).not.toHaveBeenCalled();
   });
 
   // ═══════════════════════════════════════════════════════════════════════
@@ -174,13 +185,11 @@ describe("POST /api/trial/status", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   it("returns active trial for a user with a canceled Stripe subscription", async () => {
-    // The status route does NOT check Stripe status — no entitlement lookup occurs here.
-    // A user with stripeStatus:canceled has no trial in Redis; the route auto-inits it.
-    mockRedis.get.mockResolvedValueOnce(null); // getTrial: not found
-    mockRedis.get.mockResolvedValueOnce(null); // getTrial inside initTrial: also not found
-    mockRedis.set.mockResolvedValueOnce("OK"); // initTrial writes new trial
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap)
+      .mockResolvedValueOnce(missingSnap);
+    mockDocRef.set.mockResolvedValueOnce(undefined);
 
-    // Auth user simulates a canceled Stripe customer — no difference at this route level
     mockRequireAuthz.mockResolvedValue({
       ok: true,
       user: { sub: "google-sub-canceled-stripe", email: "user@example.com" },
@@ -201,7 +210,7 @@ describe("POST /api/trial/status", () => {
 
   it("returns expired status for trial started 31 days ago", async () => {
     const startDate = daysAgo(31); // 31 days ago — beyond the 30-day trial
-    mockRedis.get.mockResolvedValueOnce(JSON.stringify({ startDate }));
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate }));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -218,7 +227,7 @@ describe("POST /api/trial/status", () => {
   it("returns converted status for a trial with a convertedDate", async () => {
     const startDate = daysAgo(10);
     const convertedDate = daysAgo(2);
-    mockRedis.get.mockResolvedValueOnce(JSON.stringify({ startDate, convertedDate }));
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate, convertedDate }));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
@@ -235,7 +244,7 @@ describe("POST /api/trial/status", () => {
 
   it("allows anonymous request (no Bearer token) with valid fingerprint", async () => {
     const startDate = daysAgo(0);
-    mockRedis.get.mockResolvedValueOnce(JSON.stringify({ startDate }));
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate }));
 
     // Request with no Authorization header
     const req = new NextRequest("http://localhost:9653/api/trial/status", {
@@ -310,7 +319,7 @@ describe("POST /api/trial/status", () => {
 
   it("response includes Cache-Control: no-store", async () => {
     const startDate = daysAgo(0);
-    mockRedis.get.mockResolvedValueOnce(JSON.stringify({ startDate }));
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate }));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
 
@@ -318,12 +327,12 @@ describe("POST /api/trial/status", () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════
-  // Auto-init failure: Redis unavailable
+  // Auto-init failure: Firestore unavailable
   // ═══════════════════════════════════════════════════════════════════════
 
-  it("returns none status when both getTrial and auto-init fail due to Redis error", async () => {
-    // getTrial fails — Redis error
-    mockRedis.get.mockRejectedValueOnce(new Error("Redis unavailable"));
+  it("returns none status when both getTrial and auto-init fail due to Firestore error", async () => {
+    // getTrial fails — Firestore error (caught, returns null)
+    mockDocRef.get.mockRejectedValueOnce(new Error("Firestore unavailable"));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();

--- a/development/frontend/src/lib/kv/trial-store.ts
+++ b/development/frontend/src/lib/kv/trial-store.ts
@@ -1,17 +1,20 @@
 /**
- * Redis trial store — server-side persistence for trial state.
+ * Firestore trial store — server-side persistence for trial state.
  *
- * Stores and retrieves trial records keyed by browser fingerprint.
+ * Stores and retrieves trial records in the Firestore `trials/` collection,
+ * keyed by browser fingerprint (document ID).
  *
- * Key format:  `trial:{fingerprint}`     → StoredTrial
- * Reverse idx: `trial:user:{userId}`     → fingerprint string
+ * Collection:  `trials/{fingerprint}`  → StoredTrial
+ * Reverse idx: query `trials` where `userId == userId` limit 1
  *
- * TTL: 60 days (covers the 30-day trial + 30 days of post-trial data retention).
+ * TTL: 60 days via `expiresAt` Firestore Timestamp field.
+ * TTL policy is configured on the `trials` collection in firestore.tf.
  *
  * @module kv/trial-store
  */
 
-import { getRedisClient } from "@/lib/kv/redis-client";
+import { Timestamp } from "@google-cloud/firestore";
+import { getFirestore } from "@/lib/firebase/firestore";
 import { log } from "@/lib/logger";
 import { TRIAL_DURATION_DAYS } from "@/lib/trial-utils";
 
@@ -19,7 +22,7 @@ import { TRIAL_DURATION_DAYS } from "@/lib/trial-utils";
 // Types
 // ---------------------------------------------------------------------------
 
-/** Shape of a trial record stored in Redis. */
+/** Shape of a trial record stored in Firestore (public interface). */
 export interface StoredTrial {
   /** ISO timestamp of when the trial started (first card creation). */
   startDate: string;
@@ -29,29 +32,31 @@ export interface StoredTrial {
   userId?: string;
 }
 
+/** Internal Firestore document shape — includes TTL field. */
+interface FirestoreTrialDoc extends StoredTrial {
+  /** Firestore Timestamp — TTL policy purges docs automatically after 60 days. */
+  expiresAt: Timestamp;
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
 
-/** 60 days in seconds — covers trial + post-trial data retention. */
-const TRIAL_TTL_SECONDS = 60 * 24 * 60 * 60;
+const TRIALS_COLLECTION = "trials";
+
+/** 60 days in milliseconds — covers trial + post-trial data retention. */
+const TRIAL_TTL_MS = 60 * 24 * 60 * 60 * 1000;
 
 // ---------------------------------------------------------------------------
-// Key builders
+// Helpers
 // ---------------------------------------------------------------------------
 
-/**
- * Builds the KV key for a trial record.
- *
- * @param fingerprint - 64-char SHA-256 hex fingerprint
- * @returns KV key string
- */
-function trialKey(fingerprint: string): string {
-  return `trial:${fingerprint}`;
+function trialDocRef(fingerprint: string) {
+  return getFirestore().doc(`${TRIALS_COLLECTION}/${fingerprint}`);
 }
 
-function userTrialKey(userId: string): string {
-  return `trial:user:${userId}`;
+function makeExpiresAt(): Timestamp {
+  return Timestamp.fromDate(new Date(Date.now() + TRIAL_TTL_MS));
 }
 
 // ---------------------------------------------------------------------------
@@ -67,14 +72,18 @@ function userTrialKey(userId: string): string {
 export async function getTrial(fingerprint: string): Promise<StoredTrial | null> {
   log.debug("getTrial called", { fingerprint });
   try {
-    const redis = getRedisClient();
-    const raw = await redis.get(trialKey(fingerprint));
-    const result: StoredTrial | null = raw ? JSON.parse(raw) : null;
-    log.debug("getTrial returning", {
-      fingerprint,
-      found: result !== null,
-      startDate: result?.startDate,
-    });
+    const snap = await trialDocRef(fingerprint).get();
+    if (!snap.exists) {
+      log.debug("getTrial returning", { fingerprint, found: false });
+      return null;
+    }
+    const doc = snap.data() as FirestoreTrialDoc;
+    const result: StoredTrial = {
+      startDate: doc.startDate,
+      ...(doc.convertedDate ? { convertedDate: doc.convertedDate } : {}),
+      ...(doc.userId ? { userId: doc.userId } : {}),
+    };
+    log.debug("getTrial returning", { fingerprint, found: true, startDate: result.startDate });
     return result;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -84,10 +93,10 @@ export async function getTrial(fingerprint: string): Promise<StoredTrial | null>
 }
 
 /**
- * Creates a new trial record in KV. If a record already exists for this
+ * Creates a new trial record in Firestore. If a record already exists for this
  * fingerprint, this is a no-op — the original start date is preserved.
- * If `userId` is provided, it is stored on the trial and a reverse-lookup
- * key `trial:user:{userId}` → fingerprint is written.
+ * If `userId` is provided, it is stored on the trial and allows reverse-lookup
+ * via a Firestore query on the `userId` field.
  *
  * @param fingerprint - 64-char SHA-256 hex fingerprint
  * @param userId - Google OAuth `sub` (optional; present when user is signed in)
@@ -95,8 +104,6 @@ export async function getTrial(fingerprint: string): Promise<StoredTrial | null>
  */
 export async function initTrial(fingerprint: string, userId?: string): Promise<StoredTrial> {
   log.debug("initTrial called", { fingerprint, hasUserId: !!userId });
-
-  const redis = getRedisClient();
 
   // Check for existing trial first (idempotent)
   const existing = await getTrial(fingerprint);
@@ -114,11 +121,13 @@ export async function initTrial(fingerprint: string, userId?: string): Promise<S
     ...(userId ? { userId } : {}),
   };
 
+  const doc: FirestoreTrialDoc = {
+    ...trial,
+    expiresAt: makeExpiresAt(),
+  };
+
   try {
-    await redis.set(trialKey(fingerprint), JSON.stringify(trial), "EX", TRIAL_TTL_SECONDS);
-    if (userId) {
-      await redis.set(userTrialKey(userId), fingerprint, "EX", TRIAL_TTL_SECONDS);
-    }
+    await trialDocRef(fingerprint).set(doc);
     log.debug("initTrial returning", { fingerprint, startDate: trial.startDate });
     return trial;
   } catch (err) {
@@ -130,8 +139,7 @@ export async function initTrial(fingerprint: string, userId?: string): Promise<S
 
 /**
  * Links an existing anonymous trial to a Google user ID.
- * Patches the trial record with `userId` and writes the reverse-lookup key.
- * No-op if the trial is already linked to this user.
+ * Patches the trial record with `userId`. No-op if already linked to this user.
  *
  * @param fingerprint - 64-char SHA-256 hex fingerprint
  * @param userId - Google OAuth `sub`
@@ -139,14 +147,11 @@ export async function initTrial(fingerprint: string, userId?: string): Promise<S
 export async function linkTrialToUser(fingerprint: string, userId: string): Promise<void> {
   log.debug("linkTrialToUser called", { fingerprint, userId });
   try {
-    const redis = getRedisClient();
     const existing = await getTrial(fingerprint);
     if (!existing) return;
     if (existing.userId === userId) return;
 
-    const updated: StoredTrial = { ...existing, userId };
-    await redis.set(trialKey(fingerprint), JSON.stringify(updated), "EX", TRIAL_TTL_SECONDS);
-    await redis.set(userTrialKey(userId), fingerprint, "EX", TRIAL_TTL_SECONDS);
+    await trialDocRef(fingerprint).update({ userId });
     log.debug("linkTrialToUser success", { fingerprint, userId });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -155,7 +160,7 @@ export async function linkTrialToUser(fingerprint: string, userId: string): Prom
 }
 
 /**
- * Looks up the trial fingerprint for a given Google user ID via the reverse index.
+ * Looks up the trial fingerprint for a given Google user ID via a Firestore query.
  *
  * @param userId - Google OAuth `sub`
  * @returns fingerprint string or null if not found
@@ -163,10 +168,19 @@ export async function linkTrialToUser(fingerprint: string, userId: string): Prom
 export async function getFingerprintByUserId(userId: string): Promise<string | null> {
   log.debug("getFingerprintByUserId called", { userId });
   try {
-    const redis = getRedisClient();
-    const fp = await redis.get(userTrialKey(userId));
-    log.debug("getFingerprintByUserId returning", { userId, found: !!fp });
-    return fp;
+    const db = getFirestore();
+    const snap = await db
+      .collection(TRIALS_COLLECTION)
+      .where("userId", "==", userId)
+      .limit(1)
+      .get();
+    if (snap.empty || !snap.docs[0]) {
+      log.debug("getFingerprintByUserId returning", { userId, found: false });
+      return null;
+    }
+    const fingerprint = snap.docs[0].id;
+    log.debug("getFingerprintByUserId returning", { userId, found: true });
+    return fingerprint;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error("getFingerprintByUserId failed", { userId, error: message });
@@ -195,18 +209,10 @@ export async function markTrialConverted(fingerprint: string): Promise<boolean> 
     return true;
   }
 
-  const updated: StoredTrial = {
-    ...existing,
-    convertedDate: new Date().toISOString(),
-  };
-
   try {
-    const redis = getRedisClient();
-    await redis.set(trialKey(fingerprint), JSON.stringify(updated), "EX", TRIAL_TTL_SECONDS);
-    log.debug("markTrialConverted success", {
-      fingerprint,
-      convertedDate: updated.convertedDate,
-    });
+    const convertedDate = new Date().toISOString();
+    await trialDocRef(fingerprint).update({ convertedDate });
+    log.debug("markTrialConverted success", { fingerprint, convertedDate });
     return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/infrastructure/firestore/firestore.rules
+++ b/infrastructure/firestore/firestore.rules
@@ -153,6 +153,20 @@ service cloud.firestore {
       }
     }
 
+    // ─── /trials/{fingerprint} ────────────────────────────────────────────────
+    //
+    // Trial records are written exclusively from the server (Admin SDK).
+    // Client SDKs have no access. These rules document intent and enforce
+    // it in the emulator / future client-SDK usage.
+    //
+    // TTL policy is configured on the `trials` collection via firestore.tf:
+    //   the `expiresAt` Timestamp field is used for auto-deletion after 60 days.
+
+    match /trials/{fingerprint} {
+      // No client-side read or write access. All access is via Admin SDK.
+      allow read, write: if false;
+    }
+
     // ─── Deny all other paths ──────────────────────────────────────────────────
 
     match /{document=**} {


### PR DESCRIPTION
PR for issue: #1516

## Summary
- Migrated `trial-store.ts` from Redis to Firestore `trials/{fingerprint}` collection
- Firestore TTL via `expiresAt` Timestamp field (60 days); TTL policy configured in firestore.tf
- Reverse lookup (userId → fingerprint) via Firestore query on `userId` field, replacing Redis key `trial:user:{userId}`
- `firestore.rules` updated: `trials/` write blocked from client SDK (server Admin SDK only)
- No Redis imports remain in `trial-store.ts`
- Updated `trial-store.test.ts`, `trial-init-route.test.ts`, `trial-status-route.test.ts` to mock Firestore

## Test Results
- 165/165 trial-related Vitest tests passing
- 2159/2159 total Vitest tests passing (1 pre-existing failure in `chronicles/mdx-escaping.test.ts` — missing `@mdx-js/mdx` dep, exists on main)
- tsc: PASS
- build: PASS (45 routes)

## Fixes
Fixes #1516