### PR TITLE
fix: declare @mdx-js/mdx as explicit dep — pnpm phantom dep fix (#1520)

### DIFF
--- a/development/frontend/package.json
+++ b/development/frontend/package.json
@@ -48,6 +48,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@mdx-js/mdx": "^3.1.1",
     "@playwright/test": "^1.58.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
         specifier: ^3.24.1
         version: 3.25.76
     devDependencies:
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
       '@playwright/test':
         specifier: ^1.58.2
         version: 1.58.2


### PR DESCRIPTION
## Summary

- Adds `@mdx-js/mdx@^3.1.1` as an explicit `devDependency` in `development/frontend/package.json`
- Fixes phantom dependency failure: `@mdx-js/mdx` was accessible via transitive hoisting under npm (via `next-mdx-remote`) but pnpm strict hoisting requires it to be explicitly declared
- The `mdx-escaping.test.ts` suite (7 tests covering Issue #1452) was failing to resolve this import

PR for issue: #1520

## Test plan

- [x] Full Vitest suite: 2157 tests all passing (146 test files)
- [x] tsc: PASS
- [x] build: PASS (45 routes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)