### PR TITLE
Fix about dialog: label build info and use local timezone

### DIFF
--- a/development/frontend/src/__tests__/layout/AboutModal.test.tsx
+++ b/development/frontend/src/__tests__/layout/AboutModal.test.tsx
@@ -2,13 +2,13 @@
  * AboutModal.test.tsx
  *
  * Vitest suite for AboutModal build info section — Issue #1349.
- * Tests that build info (version, commit, build date, environment)
- * renders correctly in the left column.
+ * Tests that build info (commit, build date, environment)
+ * renders correctly in the left column with labels.
  *
  * Written by FiremanDecko, Principal Engineer.
  */
 
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { AboutModal } from "@/components/layout/AboutModal";
 
@@ -63,6 +63,13 @@ describe("AboutModal — build info section", () => {
     expect(commitEl).toHaveTextContent("unknown");
   });
 
+  it("shows 'commit' label before SHA", () => {
+    process.env.NEXT_PUBLIC_APP_VERSION = "abcdef1234567890";
+    renderModal();
+    const commitEl = document.querySelector("[data-testid='build-info-commit']");
+    expect(commitEl?.closest("span")).toHaveTextContent("commit");
+  });
+
   it("truncates NEXT_PUBLIC_APP_VERSION to 7 chars for commit SHA", () => {
     process.env.NEXT_PUBLIC_APP_VERSION = "abcdef1234567890";
     renderModal();
@@ -85,17 +92,28 @@ describe("AboutModal — build info section", () => {
     expect(dateEl).toHaveTextContent("unknown");
   });
 
-  it("formats NEXT_PUBLIC_BUILD_DATE as UTC string", () => {
+  it("shows 'built' label before date", () => {
     process.env.NEXT_PUBLIC_BUILD_DATE = "2026-03-18T12:00:00.000Z";
     renderModal();
     const dateEl = document.querySelector("[data-testid='build-info-date']");
-    expect(dateEl).toHaveTextContent("UTC");
+    expect(dateEl).toHaveTextContent("built");
   });
 
-  it("shows environment from NEXT_PUBLIC_ENV", () => {
+  it("formats date in locale format (not UTC)", () => {
+    process.env.NEXT_PUBLIC_BUILD_DATE = "2026-03-18T12:00:00.000Z";
+    renderModal();
+    const dateEl = document.querySelector("[data-testid='build-info-date']");
+    // Should NOT contain "UTC" — uses toLocaleString for local timezone
+    expect(dateEl?.textContent).not.toContain("UTC");
+    // Should contain the year
+    expect(dateEl).toHaveTextContent("2026");
+  });
+
+  it("shows 'env' label before environment", () => {
     process.env.NEXT_PUBLIC_ENV = "staging";
     renderModal();
     const envEl = document.querySelector("[data-testid='build-info-env']");
+    expect(envEl).toHaveTextContent("env");
     expect(envEl).toHaveTextContent("staging");
   });
 
@@ -105,20 +123,6 @@ describe("AboutModal — build info section", () => {
     renderModal();
     const envEl = document.querySelector("[data-testid='build-info-env']");
     expect(envEl).toHaveTextContent("test");
-  });
-
-  it("renders version prefixed with 'v'", () => {
-    process.env.NEXT_PUBLIC_APP_VERSION = "1.2.3";
-    renderModal();
-    const buildInfo = document.querySelector("[data-testid='build-info']");
-    expect(buildInfo).toHaveTextContent("v1.2.3");
-  });
-
-  it("falls back to v0.1.0 when NEXT_PUBLIC_APP_VERSION is not set", () => {
-    delete process.env.NEXT_PUBLIC_APP_VERSION;
-    renderModal();
-    const buildInfo = document.querySelector("[data-testid='build-info']");
-    expect(buildInfo).toHaveTextContent("v0.1.0");
   });
 
   // ── Loki QA additions — gap coverage ─────────────────────────────────────

--- a/development/frontend/src/components/layout/AboutModal.tsx
+++ b/development/frontend/src/components/layout/AboutModal.tsx
@@ -64,14 +64,11 @@ function BuildInfo() {
   const buildDate = process.env.NEXT_PUBLIC_BUILD_DATE ?? "";
   const env = process.env.NEXT_PUBLIC_ENV ?? process.env.NODE_ENV ?? "unknown";
 
-  // Version: prefer semver-like string; fall back to first 7 chars of SHA
-  const rawVersion = process.env.NEXT_PUBLIC_APP_VERSION ?? "";
-  const version = rawVersion.match(/^\d+\.\d+/)
-    ? rawVersion
-    : rawVersion.slice(0, 7) || "0.1.0";
-
   const formattedDate = buildDate
-    ? new Date(buildDate).toUTCString().replace(" GMT", " UTC")
+    ? new Date(buildDate).toLocaleString(undefined, {
+        dateStyle: "medium",
+        timeStyle: "short",
+      })
     : "unknown";
 
   return (
@@ -79,27 +76,33 @@ function BuildInfo() {
       className="mt-2 flex flex-col gap-0.5 text-[11px] font-mono text-muted-foreground/60 w-full"
       data-testid="build-info"
     >
-      <span>v{version}</span>
       {sha !== "unknown" ? (
-        <a
-          href={`${GITHUB_REPO}/commit/${rawCommit}`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="hover:text-gold transition-colors truncate"
-          title={rawCommit}
-          data-testid="build-info-commit"
-        >
-          {sha}
-        </a>
+        <span>
+          <span className="text-muted-foreground/40">commit </span>
+          <a
+            href={`${GITHUB_REPO}/commit/${rawCommit}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="hover:text-gold transition-colors"
+            title={rawCommit}
+            data-testid="build-info-commit"
+          >
+            {sha}
+          </a>
+        </span>
       ) : (
-        <span data-testid="build-info-commit">{sha}</span>
+        <span data-testid="build-info-commit">
+          <span className="text-muted-foreground/40">commit </span>{sha}
+        </span>
       )}
-      <span data-testid="build-info-date">{formattedDate}</span>
+      <span data-testid="build-info-date">
+        <span className="text-muted-foreground/40">built </span>{formattedDate}
+      </span>
       <span
         className="capitalize"
         data-testid="build-info-env"
       >
-        {env}
+        <span className="text-muted-foreground/40 normal-case">env </span>{env}
       </span>
     </div>
   );


### PR DESCRIPTION
## Summary
- Removed confusing unlabeled version line (`va5f5b08` = SHA with v prefix)
- Added labels: `commit`, `built`, `env` before each value
- Changed date from UTC (`toUTCString`) to local timezone (`toLocaleString`)
- Updated tests to match new format

## Test plan
- [ ] Open about dialog — verify `commit <sha>`, `built <local date>`, `env <env>` format
- [ ] Verify date shows in local timezone, not UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)