### PR TITLE
fix(docker): copy per-package node_modules for pnpm strict hoisting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,8 +48,11 @@ ENV NEXT_PUBLIC_UMAMI_WEBSITE_ID=${NEXT_PUBLIC_UMAMI_WEBSITE_ID}
 # Next.js telemetry opt-out
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# Copy deps from previous stage (workspace node_modules at root)
+# Copy deps from previous stage — pnpm hoists to root node_modules/.pnpm/
+# but also creates per-package node_modules with symlinks back to the store.
+# Both must be present for the build to resolve imports correctly.
 COPY --from=deps /app/node_modules ./node_modules
+COPY --from=deps /app/development/frontend/node_modules ./development/frontend/node_modules
 
 # Copy workspace manifests
 COPY package.json pnpm-workspace.yaml pnpm-lock.yaml ./


### PR DESCRIPTION
## Summary
- Copies `development/frontend/node_modules` in the builder stage alongside root `node_modules`
- Fixes `ENOENT: next-themes/dist/index.js` build failure introduced by pnpm migration (#1520)
- pnpm's strict hoisting creates per-package symlinks that must be present at build time

Fixes the deploy failure: https://github.com/declanshanaghy/fenrir-ledger/actions/runs/23328593666

🤖 Generated with [Claude Code](https://claude.com/claude-code)