### PR TITLE
Issue #1537 - fix: resizable sidebar with 3 display modes

### DIFF
--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
 import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_ICONS, STATUS_LABELS } from "../lib/constants";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
+import type { DisplayMode } from "./Sidebar";
 
 interface Props {
   job: DisplayJob;
@@ -11,10 +12,27 @@ interface Props {
   isPinned?: boolean;
   onTogglePin?: () => void;
   onCancelJob?: (sessionId: string) => void;
-  collapsed?: boolean;
+  displayMode?: DisplayMode;
 }
 
-export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = false, onTogglePin, onCancelJob, collapsed = false }: Props) {
+function formatElapsed(startTime: number | null, completionTime: number | null): string {
+  if (!startTime) return "—";
+  const end = completionTime ?? Date.now();
+  const ms = end - startTime;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  const hours = Math.floor(minutes / 60);
+  return `${hours}h ${minutes % 60}m`;
+}
+
+function formatTimestamp(ts: number | null): string {
+  if (!ts) return "—";
+  return new Date(ts).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = false, onTogglePin, onCancelJob, displayMode = "normal" }: Props) {
   const agentColor = AGENT_COLORS[job.agentKey ?? ""] || "#c9920a";
   const avatar = AGENT_AVATARS[job.agentKey ?? ""];
   const sColor = STATUS_COLORS[job.status] || "#606070";
@@ -22,12 +40,11 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
   const sLabel = STATUS_LABELS[job.status] || job.status;
   const pulse = job.status === "running" ? " pulse" : "";
   const displayTitle = resolveSessionTitle(job);
-  // Shorten to issue + short title for card (trim trailing "– Step N" from full title)
   const cardTitle = job.issueTitle
     ? `#${job.issue} \u2013 ${job.issueTitle}`
     : displayTitle;
 
-  if (collapsed) {
+  if (displayMode === "compact") {
     return (
       <div
         className={`card card--minimal${isActive ? " active" : ""}`}
@@ -62,6 +79,8 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
       </div>
     );
   }
+
+  const shortSessionId = job.sessionId.length > 8 ? job.sessionId.slice(0, 8) + "…" : job.sessionId;
 
   return (
     <div
@@ -122,6 +141,21 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
           <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
         )}
       </div>
+      {displayMode === "extended" && (
+        <div className="card-extended-meta">
+          <span className="card-extended-session-id" title={job.sessionId}>
+            {shortSessionId}
+          </span>
+          <span className="card-extended-elapsed" title="Elapsed time">
+            {formatElapsed(job.startTime, job.completionTime)}
+          </span>
+          {(job.startTime || job.completionTime) && (
+            <span className="card-extended-timestamp" title="Last activity">
+              {formatTimestamp(job.completionTime ?? job.startTime)}
+            </span>
+          )}
+        </div>
+      )}
     </div>
   );
 }
@@ -129,7 +163,6 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
 function CardPinButton({ isPinned, onTogglePin }: { isPinned: boolean; onTogglePin: () => void }) {
   const [confirming, setConfirming] = useState(false);
 
-  // Reset confirmation state whenever pin state changes externally
   useEffect(() => {
     setConfirming(false);
   }, [isPinned]);

--- a/development/monitor-ui/src/components/Sidebar.tsx
+++ b/development/monitor-ui/src/components/Sidebar.tsx
@@ -1,26 +1,42 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
 import { useTheme } from "../hooks/useTheme";
 import { JobCard } from "./JobCard";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 import { StatusBadge } from "./StatusBadge";
 
-const COLLAPSE_KEY = "hlidskjalf:sidebar-collapsed";
+const WIDTH_KEY = "hlidskjalf:sidebar-width";
+const DEFAULT_WIDTH = 300;
+const MIN_WIDTH = 150;
+const MAX_WIDTH = 600;
 
-function loadCollapsed(): boolean {
+function loadWidth(): number {
   try {
-    return localStorage.getItem(COLLAPSE_KEY) === "true";
-  } catch {
-    return false;
-  }
-}
-
-function saveCollapsed(value: boolean): void {
-  try {
-    localStorage.setItem(COLLAPSE_KEY, String(value));
+    const v = localStorage.getItem(WIDTH_KEY);
+    if (v !== null) {
+      const n = parseInt(v, 10);
+      if (!isNaN(n)) return Math.min(Math.max(n, MIN_WIDTH), MAX_WIDTH);
+    }
   } catch {
     // private browsing — ignore
   }
+  return DEFAULT_WIDTH;
+}
+
+function saveWidth(value: number): void {
+  try {
+    localStorage.setItem(WIDTH_KEY, String(value));
+  } catch {
+    // private browsing — ignore
+  }
+}
+
+export type DisplayMode = "compact" | "normal" | "extended";
+
+function getDisplayMode(width: number): DisplayMode {
+  if (width < 240) return "compact";
+  if (width <= 400) return "normal";
+  return "extended";
 }
 
 interface Props {
@@ -38,18 +54,56 @@ interface Props {
 
 export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession, onAvatarClick, onOdinClick, onTogglePinSession, pinnedSessionIds, onCancelJob }: Props) {
   const { theme, setTheme } = useTheme();
-  const [collapsed, setCollapsed] = useState<boolean>(loadCollapsed);
+  const [width, setWidth] = useState<number>(loadWidth);
+  const isDraggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(0);
 
-  const handleToggleCollapse = useCallback(() => {
-    setCollapsed((prev) => {
-      const next = !prev;
-      saveCollapsed(next);
-      return next;
-    });
+  const displayMode = getDisplayMode(width);
+  const isCompact = displayMode === "compact";
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = width;
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+  }, [width]);
+
+  useEffect(() => {
+    function onMouseMove(e: MouseEvent) {
+      if (!isDraggingRef.current) return;
+      const delta = e.clientX - startXRef.current;
+      const newWidth = Math.min(Math.max(startWidthRef.current + delta, MIN_WIDTH), MAX_WIDTH);
+      setWidth(newWidth);
+    }
+
+    function onMouseUp() {
+      if (!isDraggingRef.current) return;
+      isDraggingRef.current = false;
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      setWidth((w) => {
+        saveWidth(w);
+        return w;
+      });
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+    return () => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
   }, []);
 
   return (
-    <nav className={`sidebar${collapsed ? " sidebar--collapsed" : ""}`} aria-label="Agent sessions">
+    <nav
+      className="sidebar"
+      aria-label="Agent sessions"
+      style={{ width, minWidth: width, maxWidth: width }}
+    >
       <div className="sidebar-header">
         <div className="brand">
           <button
@@ -63,23 +117,14 @@ export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession
               alt="Odin"
             />
           </button>
-          {!collapsed && <h1>Hlidskjalf</h1>}
-          {!collapsed && (
+          {!isCompact && <h1>Hlidskjalf</h1>}
+          {!isCompact && (
             <span className="brand-wss-badge">
               <StatusBadge state={wsState} />
             </span>
           )}
-          <button
-            className="sidebar-collapse-btn"
-            onClick={handleToggleCollapse}
-            aria-label={collapsed ? "Expand session list" : "Collapse session list"}
-            title={collapsed ? "Expand session list" : "Collapse session list"}
-            aria-expanded={!collapsed}
-          >
-            <CollapseChevron collapsed={collapsed} />
-          </button>
         </div>
-        {!collapsed && (
+        {!isCompact && (
           <>
             <div className="quote" role="note">
               &ldquo;{quote}&rdquo;
@@ -95,7 +140,7 @@ export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession
       </div>
       <div className="card-list" role="list" aria-label="Job sessions">
         {jobs.length === 0 ? (
-          !collapsed && (
+          !isCompact && (
             <div
               style={{
                 padding: "1rem",
@@ -118,33 +163,17 @@ export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession
               isPinned={pinnedSessionIds?.has(job.sessionId) ?? false}
               onTogglePin={onTogglePinSession ? () => onTogglePinSession(job.sessionId) : undefined}
               onCancelJob={onCancelJob}
-              collapsed={collapsed}
+              displayMode={displayMode}
             />
           ))
         )}
       </div>
-    </nav>
-  );
-}
-
-function CollapseChevron({ collapsed }: { collapsed: boolean }) {
-  return (
-    <svg
-      width="12"
-      height="12"
-      viewBox="0 0 12 12"
-      fill="none"
-      aria-hidden="true"
-      className={`collapse-chevron${collapsed ? " collapse-chevron--collapsed" : ""}`}
-    >
-      <polyline
-        points={collapsed ? "4,2 8,6 4,10" : "8,2 4,6 8,10"}
-        stroke="currentColor"
-        strokeWidth="1.8"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        fill="none"
+      <div
+        className="sidebar-resize-handle"
+        onMouseDown={handleMouseDown}
+        aria-hidden="true"
+        title="Drag to resize sidebar"
       />
-    </svg>
+    </nav>
   );
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -181,11 +181,13 @@ body {
 
 /* ── Sidebar ───────────────────────────────────── */
 .sidebar {
-  width: 300px; min-width: 300px; height: 100%;
+  height: 100%;
   overflow-y: auto;
   border-right: 1px solid var(--rune-border);
   background: var(--forge);
   display: flex; flex-direction: column;
+  position: relative;
+  flex-shrink: 0;
 }
 .sidebar-header {
   padding: 1rem;
@@ -309,42 +311,20 @@ body {
 }
 .card-list { flex: 1; overflow-y: auto; padding: 0.5rem; }
 
-/* ── Sidebar collapse ──────────────────────────── */
-.sidebar {
-  transition: width 0.2s ease, min-width 0.2s ease;
+/* ── Sidebar resize handle ─────────────────────── */
+.sidebar-resize-handle {
+  position: absolute;
+  top: 0; right: 0;
+  width: 6px; height: 100%;
+  cursor: col-resize;
+  z-index: 10;
+  background: transparent;
+  transition: background 0.15s;
 }
-.sidebar--collapsed {
-  width: 72px; min-width: 72px;
-  overflow-x: hidden;
-}
-.sidebar--collapsed .sidebar-header {
-  padding: 0.6rem 0.5rem;
-}
-.sidebar--collapsed .card-list {
-  padding: 0.25rem 0.3rem;
-}
-.sidebar--collapsed .brand {
-  flex-direction: column; gap: 0.4rem; margin-bottom: 0;
-  align-items: center;
-}
-.sidebar--collapsed .odin-avatar-btn img {
-  width: 32px; height: 32px;
-}
-.sidebar-collapse-btn {
-  display: flex; align-items: center; justify-content: center;
-  background: transparent; border: 1px solid var(--rune-border);
-  border-radius: 3px; padding: 3px; cursor: pointer;
-  color: var(--text-void); flex-shrink: 0;
-  transition: background 0.15s, color 0.15s;
-}
-.sidebar-collapse-btn:hover {
-  background: var(--chain); color: var(--text-saga);
-}
-.sidebar--collapsed .sidebar-collapse-btn {
-  margin-top: 0.25rem;
-}
-.collapse-chevron {
-  display: block; transition: none;
+.sidebar-resize-handle:hover,
+.sidebar-resize-handle:active {
+  background: var(--gold);
+  opacity: 0.35;
 }
 
 /* ── Minimal (collapsed) card ──────────────────── */
@@ -429,6 +409,27 @@ body {
   border-radius: 2px;
   padding: 0 3px;
   opacity: 0.7;
+  margin-left: auto;
+}
+
+/* ── Extended card row (sidebar > 400px) ──────── */
+.card-extended-meta {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 0.15rem;
+  font-family: 'JetBrains Mono', monospace; font-size: 0.6rem; color: var(--text-void);
+  overflow: hidden;
+}
+.card-extended-session-id {
+  font-style: italic; flex-shrink: 0;
+  color: var(--text-void);
+}
+.card-extended-elapsed {
+  flex-shrink: 0;
+  color: var(--text-rune);
+}
+.card-extended-timestamp {
+  flex-shrink: 0;
+  color: var(--text-void);
   margin-left: auto;
 }
 


### PR DESCRIPTION
PR for issue: #1537

Replaces the binary collapse toggle with a horizontally resizable sidebar. Session list adapts across compact/normal/extended display modes based on width.

**Changes:**
- Removed collapse `<` icon from Sidebar header entirely
- Added drag-resizable sidebar via mouse event listeners on a right-edge handle
- 3 responsive display modes for session list items:
  - **Compact** (<240px): icon + issue number + agent avatar/initial
  - **Normal** (240–400px): full issue title, agent badge, step, status
  - **Extended** (>400px): normal + session ID, elapsed time, last activity timestamp
- Width persisted in localStorage (`hlidskjalf:sidebar-width`) across reloads
- Min 150px / max 600px constraints enforced during drag
- CSS: removed `.sidebar--collapsed` blocks, added `.sidebar-resize-handle` and `.card-extended-meta` styles

**Verification:**
- Drag sidebar right edge — session items adapt format at 240px and 400px thresholds
- Reload page — width persists
- Drag to min (~150px) and max (~600px) — constraints hold
- Extended mode shows session ID, elapsed time, and last activity

**Build:** tsc PASS | next build PASS (45 routes)