### PR TITLE
chore: add Justfile for odins-spear

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -13,6 +13,7 @@ pack      := repo_root / ".claude" / "skills" / "fire-next-up" / "scripts" / "pa
 # ── Submodules ─────────────────────────────────────────────────────────────
 
 mod frontend 'development/frontend'
+mod spear 'development/odins-spear'
 mod quality 'quality'
 mod infra 'infrastructure'
 

--- a/development/odins-spear/Justfile
+++ b/development/odins-spear/Justfile
@@ -1,0 +1,52 @@
+# Odin's Spear — Admin TUI for trials, entitlements, and Stripe
+# Invoked via: just spear <recipe>
+
+set dotenv-load := false
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
+this_dir  := source_directory()
+repo_root := this_dir / "../.."
+
+# ── Build & Verify ──────────────────────────────────────────────────────────
+
+# Run TypeScript type checking
+tsc:
+    cd "{{this_dir}}" && npx tsc --noEmit
+
+# Run build (type check only — no bundler)
+build: tsc
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+# Run unit tests (Vitest)
+test:
+    cd "{{this_dir}}" && npx vitest run
+
+# Run unit tests in watch mode
+test-watch:
+    cd "{{this_dir}}" && npx vitest
+
+# ── Run ─────────────────────────────────────────────────────────────────────
+
+# Start Odin's Spear in dev mode (tsx --watch)
+dev:
+    cd "{{this_dir}}" && npx tsx watch src/index.ts
+
+# Run Odin's Spear
+run *args:
+    cd "{{this_dir}}" && npx tsx src/index.ts {{args}}
+
+# ── Utilities ───────────────────────────────────────────────────────────────
+
+# Install dependencies if node_modules is absent
+install:
+    #!/usr/bin/env bash
+    if [ ! -d "{{this_dir}}/node_modules" ]; then
+        cd "{{repo_root}}" && pnpm install --filter odins-spear
+    else
+        echo "node_modules already present"
+    fi
+
+# Clean build artifacts
+clean:
+    rm -rf "{{this_dir}}/dist"


### PR DESCRIPTION
## Summary
- Adds `development/odins-spear/Justfile` with build, test, dev, run, install, and clean recipes
- Registers as `mod spear` in top-level Justfile (`just spear <recipe>`)

## Test plan
- [x] `just --list spear` shows all recipes

🤖 Generated with [Claude Code](https://claude.com/claude-code)