### PR TITLE
Issue #1542 - fix: add toast feedback for Ragnarok job kills

### DIFF
--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -81,6 +81,7 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
   }
 
   const isExtended = displayMode === "extended";
+  const shortSessionId = job.sessionId.length > 8 ? job.sessionId.slice(0, 8) + "…" : job.sessionId;
 
   return (
     <div
@@ -182,14 +183,19 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
           </>
         )}
       </div>
-      {isExtended && (job.startTime || job.completionTime) && (
+      {isExtended && (
         <div className="card-extended-meta">
+          <span className="card-extended-session-id" title={job.sessionId}>
+            {shortSessionId}
+          </span>
           <span className="card-extended-elapsed" title="Elapsed time">
             {formatElapsed(job.startTime, job.completionTime)}
           </span>
-          <span className="card-extended-timestamp" title="Last activity">
-            {formatTimestamp(job.completionTime ?? job.startTime)}
-          </span>
+          {(job.startTime || job.completionTime) && (
+            <span className="card-extended-timestamp" title="Last activity">
+              {formatTimestamp(job.completionTime ?? job.startTime)}
+            </span>
+          )}
         </div>
       )}
       {isTerminating && (


### PR DESCRIPTION
PR for issue: #1542

Adds toast notification and card termination flash when Ragnarok successfully kills a K8s job.

**Changes:**
- `Toast.tsx` — new lightweight toast component (no library), auto-dismisses in 4s with fade animation
- `App.tsx` — toast state + terminatingSessionIds Set; both fire on successful DELETE
- `Sidebar.tsx` — threads terminatingSessionIds down to JobCard; also adopts upstream displayMode refactor
- `JobCard.tsx` — card--terminating class + TERMINATED overlay when isTerminating=true; adopts displayMode
- `index.css` — toastIn/toastOut keyframes + cardTerminateFlash animation; themed for dark + light mode

**Verification:**
- tsc PASS
- build PASS (45 routes)
- Manual: kill a job via Ragnarok → toast appears bottom-right, card flashes red + shows TERMINATED overlay