### PR TITLE
Issue #1541 - fix: status badge icons with consistent hover behavior

### DIFF
--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
-import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_ICONS, STATUS_LABELS } from "../lib/constants";
+import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_LABELS } from "../lib/constants";
+import { StatusIconSvg } from "./StatusIcon";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 import type { DisplayMode } from "./Sidebar";
 
@@ -37,7 +38,6 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
   const agentColor = AGENT_COLORS[job.agentKey ?? ""] || "#c9920a";
   const avatar = AGENT_AVATARS[job.agentKey ?? ""];
   const sColor = STATUS_COLORS[job.status] || "#606070";
-  const sIcon = STATUS_ICONS[job.status] || "\u2014";
   const sLabel = STATUS_LABELS[job.status] || job.status;
   const pulse = job.status === "running" ? " pulse" : "";
   const displayTitle = resolveSessionTitle(job);
@@ -55,7 +55,7 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
         title={cardTitle}
       >
         <span className={`card-status${pulse}`} style={{ color: sColor }} aria-hidden="true">
-          {sIcon}
+          <StatusIconSvg status={job.status} />
         </span>
         <span className="card-minimal-issue" aria-label={`Issue ${job.issue}`}>
           #{job.issue}
@@ -108,9 +108,16 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
         <span className="card-issue-title" title={cardTitle}>
           {cardTitle}
         </span>
+      </div>
+      <div className="card-meta-new">
+        <span className="card-agent-badge" style={{ color: agentColor }}>
+          {job.agentName}
+        </span>
+        <span>Step {job.step}</span>
+        {job.fixture && <span className="card-fixture-badge" title="Fixture (replayed log)">ᚠ</span>}
         {job.status === "running" && onCancelJob ? (
           <button
-            className={`card-status card-status--clickable${pulse}`}
+            className={`card-status-icon-btn card-status-icon-btn--cancel${pulse}`}
             style={{ color: sColor }}
             title="Invoke Ragnarök — click to cancel this job"
             aria-label="Cancel running job"
@@ -119,26 +126,18 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
               onCancelJob(job.sessionId);
             }}
           >
-            {sIcon} <span className="cancel-label">{sLabel}</span>
+            <StatusIconSvg status={job.status} />
           </button>
         ) : (
           <span
-            className={`card-status${pulse}`}
+            className={`card-status-icon-btn${pulse}`}
             style={{ color: sColor }}
             title={sLabel}
             aria-label={`Status: ${sLabel}`}
           >
-            {sIcon}
+            <StatusIconSvg status={job.status} />
           </span>
         )}
-      </div>
-      <div className="card-meta-new">
-        <span className="card-agent-badge" style={{ color: agentColor }}>
-          {job.agentName}
-        </span>
-        <span>Step {job.step}</span>
-        <span style={{ color: sColor }}>{sLabel}</span>
-        {job.fixture && <span className="card-fixture-badge" title="Fixture (replayed log)">ᚠ</span>}
         {onTogglePin && (
           <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
         )}

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -82,7 +82,8 @@ import { ToolBlock } from "./ToolBlock";
 import { NorseErrorTablet } from "./NorseErrorTablet";
 import { NorseVerdictInscription, isVerdictMessage } from "./NorseVerdictInscription";
 import { DecreeBlock, isDecreeBlock } from "./DecreeBlock";
-import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_ICONS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
+import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
+import { StatusIconSvg } from "./StatusIcon";
 
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 
@@ -137,22 +138,22 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
       <span className="header-badges">
         {job.status === "running" && onCancelJob ? (
           <button
-            className="job-status-badge job-status-badge--cancel pulse"
+            className={`job-status-icon-btn job-status-icon-btn--cancel${job.status === "running" ? " pulse" : ""}`}
             style={{ color: STATUS_COLORS[job.status] }}
             title="Click to cancel this job"
             aria-label="Cancel running job"
             onClick={() => onCancelJob(job.sessionId)}
           >
-            {STATUS_ICONS[job.status]} {STATUS_LABELS[job.status]}
+            <StatusIconSvg status={job.status} />
           </button>
         ) : (
           <span
-            className={`job-status-badge${job.status === "running" ? " pulse" : ""}`}
+            className={`job-status-icon-btn${job.status === "running" ? " pulse" : ""}`}
             style={{ color: STATUS_COLORS[job.status] }}
-            title={`Job status: ${job.status}`}
+            title={`Job status: ${STATUS_LABELS[job.status]}`}
             aria-label={`Job status: ${STATUS_LABELS[job.status]}`}
           >
-            {STATUS_ICONS[job.status]} {STATUS_LABELS[job.status]}
+            <StatusIconSvg status={job.status} />
           </span>
         )}
         {replayedFromCache && (

--- a/development/monitor-ui/src/components/StatusIcon.tsx
+++ b/development/monitor-ui/src/components/StatusIcon.tsx
@@ -1,0 +1,145 @@
+import type { Job } from "../lib/types";
+
+/** SVG icon for a job status — 12×12 rendered at 16×16 viewBox */
+export function StatusIconSvg({ status }: { status: Job["status"] }) {
+  switch (status) {
+    case "running":
+      return (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+          className="status-svg-spin"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            r="5.5"
+            stroke="currentColor"
+            strokeWidth="2.2"
+            fill="none"
+            strokeDasharray="22 12"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "succeeded":
+      return (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <polyline
+            points="3,9 6.5,13 13,4"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case "failed":
+      return (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <line
+            x1="4"
+            y1="4"
+            x2="12"
+            y2="12"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+          <line
+            x1="12"
+            y1="4"
+            x2="4"
+            y2="12"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+    case "pending":
+      return (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M4 2h8M4 14h8"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+          <path
+            d="M5 2v4l6 4v4M11 2v4L5 10v4"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      );
+    case "purged":
+      return (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <circle
+            cx="8"
+            cy="8"
+            r="4.5"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+          />
+        </svg>
+      );
+    case "cached":
+      return (
+        <svg
+          width="12"
+          height="12"
+          viewBox="0 0 16 16"
+          fill="none"
+          aria-hidden="true"
+        >
+          <path
+            d="M10 2L14 6L10.5 9.5L8.5 14L7 12.5L9 8.5L5.5 5L2 3.5L6.5 1.5L10 2Z"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinejoin="round"
+          />
+          <line
+            x1="5"
+            y1="11"
+            x2="2"
+            y2="14"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      );
+  }
+}

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -498,6 +498,65 @@ body {
   border: 1px solid currentColor; white-space: nowrap; flex-shrink: 0;
 }
 .job-status-badge.pulse { animation: pulse 1.5s ease-in-out infinite; }
+
+/* ── Status icon spin animation ─────────────────── */
+@keyframes status-spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+.status-svg-spin {
+  animation: status-spin 1.4s linear infinite;
+  transform-origin: center;
+  display: block;
+}
+
+/* ── Header status icon button ──────────────────────
+   Matches copy-session-btn / pin-btn sizing.
+   Hover = color change only (no zoom). */
+.job-status-icon-btn {
+  display: flex; align-items: center; justify-content: center;
+  width: 1.6rem; height: 1.6rem; padding: 0;
+  background: transparent; border: 1px solid currentColor;
+  border-radius: 3px; cursor: default; flex-shrink: 0;
+  transition: color 0.2s, border-color 0.2s, opacity 0.2s;
+  opacity: 0.8;
+}
+.job-status-icon-btn:hover { opacity: 1; }
+.job-status-icon-btn--cancel { cursor: pointer; }
+.job-status-icon-btn--cancel:hover {
+  color: var(--error-strong);
+  border-color: var(--error-strong);
+  opacity: 1;
+}
+.job-status-icon-btn:focus-visible {
+  outline: 2px solid var(--gold); outline-offset: 2px;
+}
+.job-status-icon-btn.pulse { animation: pulse 1.5s ease-in-out infinite; }
+@media (min-width: 640px) {
+  .job-status-icon-btn { min-width: 1.6rem; min-height: 1.6rem; }
+}
+
+/* ── Card status icon button (sidebar second line) ──
+   Matches card-pin-btn — inline, border, color-only hover. */
+.card-status-icon-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 2px 3px;
+  background: transparent; border: 1px solid var(--rune-border);
+  border-radius: 2px; cursor: default;
+  line-height: 1; transition: color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+.card-status-icon-btn:hover { border-color: currentColor; }
+.card-status-icon-btn--cancel { cursor: pointer; }
+.card-status-icon-btn--cancel:hover {
+  color: var(--error-strong);
+  border-color: var(--error-strong);
+}
+.card-status-icon-btn:focus-visible {
+  outline: 2px solid var(--gold); outline-offset: 2px;
+}
+.card-status-icon-btn.pulse { animation: pulse 1.5s ease-in-out infinite; }
+
 /* ── Pin button (replaces download) ────────────────
    44x44 touch target via min-width/height on mobile,
    compact 1.6rem on desktop. */


### PR DESCRIPTION
PR for issue: #1541

Replaces text status badges in Odin's Throne with compact SVG icons matching the existing pin/settings icon visual style. Adds consistent color-change hover animation to both sidebar and header locations.

## Summary
- New StatusIcon.tsx: SVG icons for all 6 statuses (spinning arc for running, checkmark for succeeded, X for failed, hourglass for pending, dashed circle for purged, pin for cached)
- JobCard.tsx: status moved to second line as card-status-icon-btn alongside pin icon; running jobs show cancel button
- LogViewer.tsx SessionHeader: text badge replaced with compact job-status-icon-btn (1.6rem x 1.6rem, matching copy-session-btn)
- CSS: status-svg-spin keyframe for running spinner; both button classes use color-only hover (no transform: scale)

## QA Results (Loki)
- tsc: PASS
- build: PASS (45 routes)
- Vitest: N/A (monitor-ui change — no test infrastructure)

Fixes #1541