### PR TITLE
fix(odins-spear): route debug logging to file

### DIFF
--- a/development/frontend/src/lib/logger.ts
+++ b/development/frontend/src/lib/logger.ts
@@ -21,6 +21,8 @@
  */
 
 import { Logger } from "tslog";
+import { appendFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
 
 /**
  * Keys whose values are automatically masked in log output.
@@ -94,3 +96,28 @@ export const log = new Logger({
   maskPlaceholder: "[***]",
   hideLogPositionForProduction: isProd,
 });
+
+/**
+ * Create a named logger that writes JSON lines to a file instead of stdout.
+ * Console output is suppressed — all output goes to the file.
+ *
+ * Usage:
+ *   import { createFileLogger } from "@fenrir/logger";
+ *   const log = createFileLogger("odins-spear", "tmp/logs/odins-spear.log");
+ */
+export function createFileLogger(name: string, filePath: string) {
+  mkdirSync(dirname(filePath), { recursive: true });
+  const fileLogger = new Logger({
+    name,
+    type: "hidden",           // suppress console output
+    minLevel: 0,              // silly+ (everything)
+    maskValuesOfKeys: MASKED_KEYS,
+    maskValuesOfKeysCaseInsensitive: true,
+    maskValuesRegEx: MASKED_PATTERNS,
+    maskPlaceholder: "[***]",
+  });
+  fileLogger.attachTransport((logObj) => {
+    appendFileSync(filePath, JSON.stringify(logObj) + "\n");
+  });
+  return fileLogger;
+}

--- a/development/odins-spear/loader.mjs
+++ b/development/odins-spear/loader.mjs
@@ -1,6 +1,6 @@
 /**
  * Node.js ESM resolve hook — maps @fenrir/* tsconfig path aliases
- * to the frontend source tree at runtime.
+ * to the correct source files at runtime.
  *
  * Registered via register.mjs (--import ./register.mjs).
  */
@@ -8,8 +8,10 @@
 const baseDir = new URL(".", import.meta.url);
 
 const aliases = [
-  { prefix: "@fenrir/logger", target: "../frontend/src/lib/logger.ts", exact: true },
-  { prefix: "@fenrir/", target: "../frontend/src/" },
+  // Order matters: exact matches before prefix matches
+  { prefix: "@fenrir/logger-base", target: "../frontend/src/lib/logger.ts", exact: true },
+  { prefix: "@fenrir/logger",      target: "./src/log.ts",                  exact: true },
+  { prefix: "@fenrir/",            target: "../frontend/src/" },
 ];
 
 export function resolve(specifier, context, nextResolve) {

--- a/development/odins-spear/src/log.ts
+++ b/development/odins-spear/src/log.ts
@@ -1,0 +1,12 @@
+/**
+ * Odin's Spear logger — writes to tmp/logs/odins-spear.log instead of stdout.
+ * All files import { log } from "@fenrir/logger" which resolves here via tsconfig paths + loader.
+ */
+import { createFileLogger } from "@fenrir/logger-base";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(import.meta.url), "../../../..");
+const logPath = resolve(repoRoot, "tmp/logs/odins-spear.log");
+
+export const log = createFileLogger("odins-spear", logPath);

--- a/development/odins-spear/tsconfig.json
+++ b/development/odins-spear/tsconfig.json
@@ -20,8 +20,9 @@
     "allowUnreachableCode": false,
     "allowUnusedLabels": false,
     "paths": {
-      "@fenrir/logger": ["../frontend/src/lib/logger.ts"],
-      "@fenrir/*":      ["../frontend/src/*"]
+      "@fenrir/logger":      ["./src/log.ts"],
+      "@fenrir/logger-base": ["../frontend/src/lib/logger.ts"],
+      "@fenrir/*":           ["../frontend/src/*"]
     },
     "outDir": "dist"
   },


### PR DESCRIPTION
## Summary
- Adds `createFileLogger(name, filePath)` to shared logger — tslog `hidden` type + JSON-line file transport
- Odin's Spear debug logs now go to `tmp/logs/odins-spear.log` instead of polluting the TUI console
- ESM loader updated with `@fenrir/logger-base` alias for the shared logger factory

## Test plan
- [x] `just spear run` — console clean, no debug output
- [x] `tail tmp/logs/odins-spear.log` — JSON lines written
- [x] `just spear test` — 504/504 pass
- [x] Frontend `tsc --noEmit` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)