### PR TITLE
epic-manager: detect story numbers and redirect to tracker

### DIFF
--- a/.claude/skills/epic-manager/epic-manager.mjs
+++ b/.claude/skills/epic-manager/epic-manager.mjs
@@ -9,7 +9,7 @@
  * Help/usage: see SKILL.md (help is displayed by the orchestrator, not this script).
  */
 
-import { readFileSync, writeFileSync, existsSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, unlinkSync, readdirSync } from "node:fs";
 import { execSync } from "node:child_process";
 import { resolve } from "node:path";
 import yaml from "js-yaml";
@@ -65,6 +65,22 @@ if (!existsSync(epicFileYml)) {
     unlinkSync(epicFileJson);
     console.log(`  Migrated ${epicFileJson} → ${epicFileYml}`);
   } else {
+    // Check if this issue number is a story inside another epic
+    const epicsDir = resolve("tmp/epics");
+    try {
+      const epicFiles = readdirSync(epicsDir).filter((f) => f.endsWith(".yml"));
+      for (const ef of epicFiles) {
+        const content = yaml.load(readFileSync(resolve(epicsDir, ef), "utf8"));
+        const stories = content?.stories ?? [];
+        const match = stories.find((s) => String(s.number) === rootIssue);
+        if (match) {
+          const epicNum = ef.replace(".yml", "");
+          console.error(`#${rootIssue} is a story inside epic #${epicNum} ("${content?.epic?.title ?? "unknown"}").`);
+          console.error(`Run: /epic-manager ${epicNum}`);
+          process.exit(1);
+        }
+      }
+    } catch { /* epics dir doesn't exist or unreadable */ }
     console.error(`Epic file not found: ${epicFileYml}`);
     console.error(`Run /plan-w-team or create it manually.`);
     process.exit(1);


### PR DESCRIPTION
## Summary
- Added `readdirSync` import
- When a non-tracker issue number is passed, scans all epic YAMLs to find the containing epic
- Shows helpful error: `#1505 is a story inside epic #1526 ("Odin's Spear TUI"). Run: /epic-manager 1526`

## Test plan
- [ ] `/epic-manager 1505` → redirects to #1526
- [ ] `/epic-manager 1386` → redirects to #1526
- [ ] `/epic-manager 9999` → "file not found"
- [ ] `/epic-manager 1526` → renders dashboard normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)