### PR TITLE
Issue #1387 - feat(odins-spear): Users tab — list + detail panel

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -56,6 +56,7 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
   const [cmdStatus, setCmdStatusMsg] = useState<string | null>(null);
   const [connState, setConnState] = useState<ConnStatus>(initialConnStatus);
   const [countState, setCountState] = useState<Counts>(initialCounts);
+  const [inputCaptured, setInputCaptured] = useState(false);
 
   // Suppress unused-variable warnings for setters wired in later stories
   void setConnState;
@@ -159,6 +160,9 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     // Overlays own their own input via useInput — we suppress global keys here
     if (overlay.kind !== "none") return;
 
+    // A tab has captured input (e.g. tier prompt) — global keys must not fire
+    if (inputCaptured) return;
+
     if (input === "q") {
       log.debug("SpearInner: quitting");
       if (pfProc) {
@@ -246,7 +250,13 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
       />
     );
   } else if (activeTab === 0) {
-    mainContent = <UsersTab cmdStatus={cmdStatus} />;
+    mainContent = (
+      <UsersTab
+        cmdStatus={cmdStatus}
+        onInputCapture={setInputCaptured}
+        onJumpToHousehold={() => { setActiveTab(1); }}
+      />
+    );
   } else {
     mainContent = <HouseholdsTab cmdStatus={cmdStatus} />;
   }

--- a/development/odins-spear/src/tabs/UsersTab.tsx
+++ b/development/odins-spear/src/tabs/UsersTab.tsx
@@ -1,26 +1,629 @@
-import React from "react";
-import { Box, Text } from "ink";
+import React, { useState, useEffect, useCallback } from "react";
+import { Box, Text, useInput } from "ink";
 import { log } from "@fenrir/logger";
+import { firestoreClient } from "../lib/firestore.js";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface EnrichedUser {
+  id: string;
+  email: string;
+  displayName: string;
+  role: string;
+  tier: string;
+  householdId: string | null;
+  householdName: string | null;
+  createdAt: string | null;
+  stripeCustomerId: string | null;
+  lastSyncAt: string | null;
+  syncCount: number | null;
+  syncHealth: string | null;
+}
+
+interface UserDetail {
+  household: { id: string; name: string; tier: string } | null;
+  cloudSync: { lastSync: string | null; totalSyncs: number; health: string } | null;
+  cardCount: { active: number; total: number } | null;
+}
+
+type ActionMode = "none" | "delete_confirm" | "tier_input" | "sub_cancel_confirm";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
 
 const GRAY = "#6b6b80";
+const LIST_HEIGHT = 18;
+const EMAIL_MAX = 22;
+
+// ─── Tier helpers ─────────────────────────────────────────────────────────────
+
+const TIER_STYLES: Record<string, { label: string; bg: string | undefined; color: string }> = {
+  karl:   { label: "KARL",   bg: "yellow",       color: "black" },
+  trial:  { label: "TRIAL",  bg: "yellowBright", color: "black" },
+  thrall: { label: "THRALL", bg: undefined,       color: "gray"  },
+};
+
+function getTierStyle(tier: string): { label: string; bg: string | undefined; color: string } {
+  return TIER_STYLES[tier] ?? TIER_STYLES["thrall"]!;
+}
+
+function validateTierInput(raw: string): "karl" | "trial" | "thrall" | null {
+  const t = raw.trim().toLowerCase();
+  if (t === "karl" || t === "trial" || t === "thrall") return t;
+  return null;
+}
+
+// ─── TierBadge ────────────────────────────────────────────────────────────────
+
+function TierBadge({ tier }: { tier: string }): React.JSX.Element {
+  const s = getTierStyle(tier);
+  if (s.bg) {
+    return <Text backgroundColor={s.bg} color={s.color}> {s.label} </Text>;
+  }
+  return <Text color={s.color}>[{s.label}]</Text>;
+}
+
+// ─── UserListRow ──────────────────────────────────────────────────────────────
+
+function UserListRow({
+  user,
+  selected,
+}: {
+  user: EnrichedUser;
+  selected: boolean;
+}): React.JSX.Element {
+  const email =
+    user.email.length > EMAIL_MAX
+      ? user.email.slice(0, EMAIL_MAX - 1) + "\u2026"
+      : user.email.padEnd(EMAIL_MAX);
+  return (
+    <Box>
+      <Text color={selected ? "cyan" : GRAY}>{selected ? "\u25B6 " : "  "}</Text>
+      <Text color={selected ? "cyan" : undefined} bold={selected}>
+        {email}{" "}
+      </Text>
+      <TierBadge tier={user.tier} />
+    </Box>
+  );
+}
+
+// ─── UserDetailPanel ──────────────────────────────────────────────────────────
+
+interface UserDetailPanelProps {
+  user: EnrichedUser;
+  detail: UserDetail | null;
+  actionMode: ActionMode;
+  tierInput: string;
+  tierError: string | null;
+  statusMsg: string | null;
+}
+
+function UserDetailPanel({
+  user,
+  detail,
+  actionMode,
+  tierInput,
+  tierError,
+  statusMsg,
+}: UserDetailPanelProps): React.JSX.Element {
+  const joinedDate = user.createdAt
+    ? new Date(user.createdAt).toLocaleDateString()
+    : "Unknown";
+
+  return (
+    <Box flexDirection="column" paddingX={2} paddingY={1} flexGrow={1}>
+      {/* Status message */}
+      {statusMsg ? (
+        <Box marginBottom={1}>
+          <Text color="#9b9baa">{statusMsg}</Text>
+        </Box>
+      ) : null}
+
+      {/* User ID — never truncated */}
+      <Box>
+        <Text color={GRAY}>{"ID:     "}</Text>
+        <Text color="cyan">{user.id}</Text>
+      </Box>
+
+      {/* Email */}
+      <Box>
+        <Text color={GRAY}>{"Email:  "}</Text>
+        <Text>{user.email}</Text>
+      </Box>
+
+      {/* Tier */}
+      <Box>
+        <Text color={GRAY}>{"Tier:   "}</Text>
+        <TierBadge tier={user.tier} />
+      </Box>
+
+      {/* Role */}
+      {user.role ? (
+        <Box>
+          <Text color={GRAY}>{"Role:   "}</Text>
+          <Text>{user.role}</Text>
+        </Box>
+      ) : null}
+
+      {/* Joined */}
+      <Box>
+        <Text color={GRAY}>{"Joined: "}</Text>
+        <Text>{joinedDate}</Text>
+      </Box>
+
+      {/* Household */}
+      <Box marginTop={1}>
+        {detail?.household ? (
+          <Box>
+            <Text color={GRAY}>{"Household: "}</Text>
+            <Text>{detail.household.name}</Text>
+            <Text color={GRAY}> [h]</Text>
+          </Box>
+        ) : (
+          <Box>
+            <Text color={GRAY}>{"Household: "}</Text>
+            <Text color={GRAY} dimColor>
+              No household (solo user)
+            </Text>
+          </Box>
+        )}
+      </Box>
+
+      {/* Cloud Sync */}
+      <Box marginTop={1} flexDirection="column">
+        <Text color={GRAY} bold>
+          Cloud Sync
+        </Text>
+        {detail?.cloudSync ? (
+          <Box flexDirection="column">
+            <Box>
+              <Text color={GRAY}>{"  Last:   "}</Text>
+              <Text>{detail.cloudSync.lastSync ?? "N/A"}</Text>
+            </Box>
+            <Box>
+              <Text color={GRAY}>{"  Total:  "}</Text>
+              <Text>{String(detail.cloudSync.totalSyncs)}</Text>
+            </Box>
+            <Box>
+              <Text color={GRAY}>{"  Health: "}</Text>
+              <Text>{detail.cloudSync.health}</Text>
+            </Box>
+          </Box>
+        ) : (
+          <Text color={GRAY} dimColor>
+            {"  N/A"}
+          </Text>
+        )}
+      </Box>
+
+      {/* Card count */}
+      {detail?.cardCount ? (
+        <Box marginTop={1}>
+          <Text color={GRAY}>{"Cards: "}</Text>
+          <Text>
+            {String(detail.cardCount.active)} active /{" "}
+            {String(detail.cardCount.total)} total
+          </Text>
+        </Box>
+      ) : null}
+
+      {/* Stripe */}
+      {user.stripeCustomerId ? (
+        <Box marginTop={1} flexDirection="column">
+          <Text color={GRAY} bold>
+            Stripe
+          </Text>
+          <Box>
+            <Text color={GRAY}>{"  Customer: "}</Text>
+            <Text>{user.stripeCustomerId}</Text>
+          </Box>
+        </Box>
+      ) : null}
+
+      {/* Divider */}
+      <Box marginTop={1}>
+        <Text color="#3b3b4f">{"\u2500".repeat(40)}</Text>
+      </Box>
+
+      {/* Action bar */}
+      {actionMode === "none" ? (
+        <Box>
+          <Text color={GRAY}>
+            {"[d] Delete  [t] Tier"}
+            {user.stripeCustomerId ? "  [s] Cancel sub" : ""}
+            {detail?.household ? "  [h] Household" : ""}
+          </Text>
+        </Box>
+      ) : actionMode === "delete_confirm" ? (
+        <Box>
+          <Text color="red">
+            {"Delete "}{user.email}{"? [y] confirm  [Esc] cancel"}
+          </Text>
+        </Box>
+      ) : actionMode === "tier_input" ? (
+        <Box flexDirection="column">
+          <Box>
+            <Text color={GRAY}>{"New tier (karl/trial/thrall): "}</Text>
+            <Text color="cyan">{tierInput}</Text>
+            <Text color="cyan">{"\u258C"}</Text>
+          </Box>
+          {tierError ? <Text color="red">{tierError}</Text> : null}
+          <Text color={GRAY}>{"[Enter] confirm  [Esc] cancel"}</Text>
+        </Box>
+      ) : actionMode === "sub_cancel_confirm" ? (
+        <Box>
+          <Text color="red">
+            {"Cancel sub for "}{user.email}{"? [y] confirm  [Esc] cancel"}
+          </Text>
+        </Box>
+      ) : null}
+    </Box>
+  );
+}
+
+// ─── UsersTab ─────────────────────────────────────────────────────────────────
 
 interface UsersTabProps {
   cmdStatus: string | null;
+  onInputCapture?: (captured: boolean) => void;
+  onJumpToHousehold?: () => void;
 }
 
-/**
- * UsersTab — Users master-detail panel
- * Left panel ~34 cols, right panel flex-grow
- * Real user list comes in #1387
- */
-export function UsersTab({ cmdStatus }: UsersTabProps): React.JSX.Element {
+export function UsersTab({
+  cmdStatus,
+  onInputCapture,
+  onJumpToHousehold,
+}: UsersTabProps): React.JSX.Element {
   log.debug("UsersTab render");
+
+  const [users, setUsers] = useState<EnrichedUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedIdx, setSelectedIdx] = useState(-1);
+  const [scrollOffset, setScrollOffset] = useState(0);
+  const [detail, setDetail] = useState<UserDetail | null>(null);
+  const [actionMode, setActionMode] = useState<ActionMode>("none");
+  const [tierInput, setTierInput] = useState("");
+  const [tierError, setTierError] = useState<string | null>(null);
+  const [statusMsg, setStatusMsg] = useState<string | null>(null);
+
+  const inputCaptured = actionMode === "tier_input";
+
+  // Notify parent when input is captured / released
+  useEffect(() => {
+    onInputCapture?.(inputCaptured);
+  }, [inputCaptured, onInputCapture]);
+
+  // Load users on mount
+  useEffect(() => {
+    void (async () => {
+      log.debug("UsersTab: loading users");
+      setLoading(true);
+      setError(null);
+      try {
+        if (!firestoreClient) {
+          setError("Firestore not connected");
+          setLoading(false);
+          return;
+        }
+        const [usersSnap, householdsSnap] = await Promise.all([
+          firestoreClient.collection("users").get(),
+          firestoreClient.collection("households").get(),
+        ]);
+
+        // Build household tier map
+        const hhMap = new Map<string, { tier: string; name: string }>();
+        householdsSnap.docs.forEach((d) => {
+          const h = d.data() as { tier?: string; name?: string };
+          hhMap.set(d.id, { tier: h["tier"] || "thrall", name: h["name"] || "" });
+        });
+
+        // Enrich users with tier from household map
+        const enriched: EnrichedUser[] = usersSnap.docs.map((d) => {
+          const u = d.data() as {
+            email?: string;
+            displayName?: string;
+            role?: string;
+            householdId?: string;
+            createdAt?: string;
+            tier?: string;
+            stripeCustomerId?: string;
+            lastSyncAt?: string;
+            syncCount?: number;
+            syncHealth?: string;
+          };
+          const hh = u["householdId"] ? (hhMap.get(u["householdId"]) ?? null) : null;
+          return {
+            id: d.id,
+            email: u["email"] || "",
+            displayName: u["displayName"] || "",
+            role: u["role"] || "",
+            tier: hh ? hh.tier : (u["tier"] || "thrall"),
+            householdId: u["householdId"] || null,
+            householdName: hh ? hh.name : null,
+            createdAt: u["createdAt"] || null,
+            stripeCustomerId: u["stripeCustomerId"] || null,
+            lastSyncAt: u["lastSyncAt"] || null,
+            syncCount: u["syncCount"] ?? null,
+            syncHealth: u["syncHealth"] || null,
+          };
+        });
+
+        log.debug("UsersTab: users loaded", { count: enriched.length });
+        setUsers(enriched);
+      } catch (err) {
+        log.error("UsersTab: load error", err as Error);
+        setError((err as Error).message);
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  // Load detail when selection changes
+  useEffect(() => {
+    if (selectedIdx < 0 || selectedIdx >= users.length) {
+      setDetail(null);
+      return;
+    }
+    const user = users[selectedIdx];
+    if (!user) return;
+
+    void (async () => {
+      log.debug("UsersTab: loading detail", { userId: user.id });
+      try {
+        if (!firestoreClient) return;
+
+        let household: { id: string; name: string; tier: string } | null = null;
+        let cloudSync: { lastSync: string | null; totalSyncs: number; health: string } | null = null;
+        let cardCount: { active: number; total: number } | null = null;
+
+        if (user.householdId) {
+          const [hhSnap, cardsSnap] = await Promise.all([
+            firestoreClient.collection("households").doc(user.householdId).get(),
+            firestoreClient
+              .collection("households")
+              .doc(user.householdId)
+              .collection("cards")
+              .get(),
+          ]);
+
+          if (hhSnap.exists) {
+            const hh = hhSnap.data() as {
+              name?: string;
+              tier?: string;
+              lastSyncAt?: string;
+              syncCount?: number;
+              syncHealth?: string;
+            };
+            household = {
+              id: user.householdId,
+              name: hh["name"] || "",
+              tier: hh["tier"] || "thrall",
+            };
+
+            // Cloud sync: user doc primary, household fallback
+            if (user.lastSyncAt != null) {
+              cloudSync = {
+                lastSync: user.lastSyncAt,
+                totalSyncs: user.syncCount || 0,
+                health: user.syncHealth || "unknown",
+              };
+            } else if (hh["lastSyncAt"] || hh["syncCount"] != null) {
+              cloudSync = {
+                lastSync: hh["lastSyncAt"] || null,
+                totalSyncs: hh["syncCount"] || 0,
+                health: hh["syncHealth"] || "unknown",
+              };
+            }
+
+            const cards = cardsSnap.docs.map((d) => d.data() as { deletedAt?: string });
+            const active = cards.filter((c) => !c["deletedAt"]).length;
+            cardCount = { active, total: cards.length };
+          }
+        } else if (user.lastSyncAt != null) {
+          cloudSync = {
+            lastSync: user.lastSyncAt,
+            totalSyncs: user.syncCount || 0,
+            health: user.syncHealth || "unknown",
+          };
+        }
+
+        setDetail({ household, cloudSync, cardCount });
+        log.debug("UsersTab: detail loaded", { userId: user.id });
+      } catch (err) {
+        log.error("UsersTab: detail load error", err as Error);
+      }
+    })();
+  }, [selectedIdx, users]);
+
+  // Delete user
+  const doDeleteUser = useCallback(
+    async (user: EnrichedUser): Promise<void> => {
+      if (!firestoreClient) return;
+      try {
+        if (user.householdId) {
+          const hhSnap = await firestoreClient
+            .collection("households")
+            .doc(user.householdId)
+            .get();
+          if (hhSnap.exists) {
+            const hh = hhSnap.data() as { memberIds?: string[] };
+            const newMembers = (hh["memberIds"] || []).filter((id) => id !== user.id);
+            await firestoreClient
+              .collection("households")
+              .doc(user.householdId)
+              .update({ memberIds: newMembers });
+          }
+        }
+        await firestoreClient.collection("users").doc(user.id).delete();
+        setUsers((prev) => prev.filter((u) => u.id !== user.id));
+        setSelectedIdx(-1);
+        setStatusMsg(`Deleted ${user.id}`);
+      } catch (err) {
+        setStatusMsg(`Error: ${(err as Error).message}`);
+      }
+    },
+    []
+  );
+
+  // Update tier
+  const doUpdateTier = useCallback(
+    async (user: EnrichedUser, tier: "karl" | "trial" | "thrall"): Promise<void> => {
+      if (!firestoreClient) return;
+      try {
+        if (user.householdId) {
+          await firestoreClient
+            .collection("households")
+            .doc(user.householdId)
+            .update({ tier });
+          setUsers((prev) =>
+            prev.map((u) =>
+              u.householdId === user.householdId ? { ...u, tier } : u
+            )
+          );
+        } else {
+          await firestoreClient.collection("users").doc(user.id).update({ tier });
+          setUsers((prev) =>
+            prev.map((u) => (u.id === user.id ? { ...u, tier } : u))
+          );
+        }
+        setStatusMsg(`Updated tier to ${tier}`);
+      } catch (err) {
+        setStatusMsg(`Error: ${(err as Error).message}`);
+      }
+    },
+    []
+  );
+
+  useInput((input, key) => {
+    // Tier prompt captures all input — global handlers must not fire
+    if (actionMode === "tier_input") {
+      if (key.escape) {
+        setActionMode("none");
+        setTierInput("");
+        setTierError(null);
+        return;
+      }
+      if (key.return) {
+        const valid = validateTierInput(tierInput);
+        if (!valid) {
+          setTierError("Invalid tier. Enter: karl, trial, or thrall");
+          return;
+        }
+        setActionMode("none");
+        setTierInput("");
+        setTierError(null);
+        const user = users[selectedIdx];
+        if (user) void doUpdateTier(user, valid);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setTierInput((prev) => prev.slice(0, -1));
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setTierInput((prev) => prev + input);
+      }
+      return;
+    }
+
+    // Delete confirmation
+    if (actionMode === "delete_confirm") {
+      if (key.escape || input === "n") {
+        setActionMode("none");
+        return;
+      }
+      if (input === "y") {
+        const user = users[selectedIdx];
+        if (user) void doDeleteUser(user);
+        setActionMode("none");
+      }
+      return;
+    }
+
+    // Sub cancel confirmation
+    if (actionMode === "sub_cancel_confirm") {
+      if (key.escape || input === "n") {
+        setActionMode("none");
+        return;
+      }
+      if (input === "y") {
+        setStatusMsg("Subscription cancellation not yet implemented");
+        setActionMode("none");
+      }
+      return;
+    }
+
+    // Navigation
+    if (key.upArrow) {
+      const newIdx = Math.max(0, selectedIdx <= 0 ? 0 : selectedIdx - 1);
+      const newScroll = newIdx < scrollOffset ? newIdx : scrollOffset;
+      setSelectedIdx(newIdx);
+      setScrollOffset(newScroll);
+      return;
+    }
+
+    if (key.downArrow) {
+      const maxIdx = users.length - 1;
+      const newIdx = selectedIdx < 0 ? 0 : Math.min(maxIdx, selectedIdx + 1);
+      const newScroll =
+        newIdx >= scrollOffset + LIST_HEIGHT
+          ? newIdx - LIST_HEIGHT + 1
+          : scrollOffset;
+      setSelectedIdx(newIdx);
+      setScrollOffset(newScroll);
+      return;
+    }
+
+    if (key.return) {
+      if (selectedIdx < 0 && users.length > 0) setSelectedIdx(0);
+      return;
+    }
+
+    if (key.escape) {
+      setSelectedIdx(-1);
+      setActionMode("none");
+      return;
+    }
+
+    // Action shortcuts (only when a user is selected)
+    if (selectedIdx >= 0) {
+      const user = users[selectedIdx];
+      if (!user) return;
+
+      if (input === "d") {
+        setActionMode("delete_confirm");
+        return;
+      }
+      if (input === "t") {
+        setTierInput("");
+        setTierError(null);
+        setActionMode("tier_input");
+        return;
+      }
+      if (input === "s" && user.stripeCustomerId) {
+        setActionMode("sub_cancel_confirm");
+        return;
+      }
+      if (input === "h" && detail?.household) {
+        onJumpToHousehold?.();
+        return;
+      }
+    }
+  });
+
+  const selectedUser =
+    selectedIdx >= 0 && selectedIdx < users.length
+      ? (users[selectedIdx] ?? null)
+      : null;
+
+  const visibleUsers = users.slice(scrollOffset, scrollOffset + LIST_HEIGHT);
+
   return (
     <Box flexDirection="row" flexGrow={1}>
-      {/* Left panel */}
+      {/* Left panel — user list */}
       <Box
         flexDirection="column"
-        width={34}
+        width={36}
         borderStyle="single"
         borderRight={true}
         borderLeft={false}
@@ -28,10 +631,9 @@ export function UsersTab({ cmdStatus }: UsersTabProps): React.JSX.Element {
         borderBottom={false}
         borderColor="#1e1e2e"
       >
-        {/* Search placeholder */}
+        {/* Header */}
         <Box
           paddingX={1}
-          paddingY={0}
           borderStyle="single"
           borderBottom={true}
           borderTop={false}
@@ -39,31 +641,69 @@ export function UsersTab({ cmdStatus }: UsersTabProps): React.JSX.Element {
           borderRight={false}
           borderColor="#1e1e2e"
         >
-          <Text color={GRAY}>{"Search\u2026 (/ for commands)"}</Text>
+          <Text color={GRAY}>
+            {"Users ("}
+            {String(users.length)}
+            {")"}
+          </Text>
         </Box>
-        {/* List placeholder */}
-        <Box flexDirection="column" flexGrow={1} paddingX={1} paddingY={1}>
-          <Text color={GRAY} dimColor>{"\u2014 Users list coming in"}</Text>
-          <Text color={GRAY} dimColor>{"  #1387 \u2014"}</Text>
+
+        {/* User list */}
+        <Box flexDirection="column" flexGrow={1} paddingX={1} paddingY={0}>
+          {loading ? (
+            <Text color={GRAY}>{"Loading\u2026"}</Text>
+          ) : error ? (
+            <Text color="red">{error}</Text>
+          ) : users.length === 0 ? (
+            <Text color={GRAY} dimColor>
+              No users found
+            </Text>
+          ) : (
+            visibleUsers.map((user, i) => (
+              <UserListRow
+                key={user.id}
+                user={user}
+                selected={scrollOffset + i === selectedIdx}
+              />
+            ))
+          )}
         </Box>
       </Box>
-      {/* Right panel */}
-      <Box
-        flexDirection="column"
-        flexGrow={1}
-        alignItems="center"
-        justifyContent="center"
-        paddingX={2}
-      >
-        <Text color="#8a6408" bold>{"\u16C5"}</Text>
-        <Box height={1} />
-        <Text color={GRAY}>Select a user from the list</Text>
-        <Text color="#3b3b4f" dimColor>Use arrow keys to navigate</Text>
-        {cmdStatus ? (
-          <Box marginTop={1}>
-            <Text color="#9b9baa">{cmdStatus}</Text>
+
+      {/* Right panel — detail or empty state */}
+      <Box flexDirection="column" flexGrow={1}>
+        {selectedUser ? (
+          <UserDetailPanel
+            user={selectedUser}
+            detail={detail}
+            actionMode={actionMode}
+            tierInput={tierInput}
+            tierError={tierError}
+            statusMsg={statusMsg ?? cmdStatus}
+          />
+        ) : (
+          <Box
+            flexDirection="column"
+            flexGrow={1}
+            alignItems="center"
+            justifyContent="center"
+            paddingX={2}
+          >
+            <Text color="#8a6408" bold>
+              {"\u16C5"}
+            </Text>
+            <Box height={1} />
+            <Text color={GRAY}>Select a user from the list</Text>
+            <Text color="#3b3b4f" dimColor>
+              Use arrow keys to navigate
+            </Text>
+            {(statusMsg ?? cmdStatus) ? (
+              <Box marginTop={1}>
+                <Text color="#9b9baa">{statusMsg ?? cmdStatus}</Text>
+              </Box>
+            ) : null}
           </Box>
-        ) : null}
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
Fixes #1387

## Summary
- Implements the Users tab in Odin's Spear TUI with full master-detail layout
- Left panel: scrollable user list with tier badges (Karl/Trial/Thrall), keyboard navigation
- Right panel: full user detail (userId never truncated, email, tier, household, Cloud Sync, Stripe, action bar)
- \`inputCaptured\` guard prevents global shortcuts firing during tier prompt

## Test plan
- [x] 570/570 odins-spear Vitest tests pass (13 files, includes 59 users-tab tests)
- [x] 2186/2186 frontend Vitest tests pass (148 files)
- [x] tsc: 0 errors in new source files (pre-existing test-file/dep errors unchanged from main)
- [x] next build: PASS (all routes)
- [x] Rebased on latest main

🤖 Generated with [Claude Code](https://claude.com/claude-code)