### PR TITLE
fix(odins-spear): logging cleanup, rollover, and Stripe secret fix

### DIFF
--- a/development/frontend/src/lib/logger.ts
+++ b/development/frontend/src/lib/logger.ts
@@ -21,7 +21,7 @@
  */
 
 import { Logger } from "tslog";
-import { appendFileSync, mkdirSync } from "node:fs";
+import { appendFileSync, mkdirSync, existsSync, renameSync, unlinkSync } from "node:fs";
 import { dirname } from "node:path";
 
 /**
@@ -97,16 +97,49 @@ export const log = new Logger({
   hideLogPositionForProduction: isProd,
 });
 
+const MAX_LOG_SIZE = 10 * 1024 * 1024; // 10 MB
+const MAX_LOG_FILES = 5;
+
 /**
- * Create a named logger that writes JSON lines to a file instead of stdout.
+ * Rotate log files: foo.jsonl → foo.1.jsonl → foo.2.jsonl … foo.5.jsonl (deleted).
+ * Called at startup and when the active file exceeds MAX_LOG_SIZE.
+ */
+function rotateLogFile(logPath: string): void {
+  if (!existsSync(logPath)) return;
+  const base = logPath.replace(/\.jsonl$/, "");
+  // Delete oldest if at capacity
+  const oldest = `${base}.${MAX_LOG_FILES}.jsonl`;
+  if (existsSync(oldest)) unlinkSync(oldest);
+  // Shift .4→.5, .3→.4, .2→.3, .1→.2
+  for (let i = MAX_LOG_FILES - 1; i >= 1; i--) {
+    const src = `${base}.${i}.jsonl`;
+    if (existsSync(src)) renameSync(src, `${base}.${i + 1}.jsonl`);
+  }
+  // Active → .1
+  renameSync(logPath, `${base}.1.jsonl`);
+}
+
+/**
+ * Create a named logger that writes JSONL to a file instead of stdout.
  * Console output is suppressed — all output goes to the file.
+ *
+ * The file extension is forced to `.jsonl` regardless of what is passed.
+ * Rotates the existing log at startup and when the file exceeds 10 MB.
+ * Keeps up to 5 previous log files (foo.1.jsonl … foo.5.jsonl).
  *
  * Usage:
  *   import { createFileLogger } from "@fenrir/logger";
- *   const log = createFileLogger("odins-spear", "tmp/logs/odins-spear.log");
+ *   const log = createFileLogger("odins-spear", "tmp/logs/odins-spear");
  */
 export function createFileLogger(name: string, filePath: string) {
-  mkdirSync(dirname(filePath), { recursive: true });
+  const normalised = filePath.replace(/\.(log|jsonl?)$/i, "") + ".jsonl";
+  mkdirSync(dirname(normalised), { recursive: true });
+
+  // Rotate on startup so each run gets a fresh file
+  rotateLogFile(normalised);
+
+  let bytesWritten = 0;
+
   const fileLogger = new Logger({
     name,
     type: "hidden",           // suppress console output
@@ -117,7 +150,40 @@ export function createFileLogger(name: string, filePath: string) {
     maskPlaceholder: "[***]",
   });
   fileLogger.attachTransport((logObj) => {
-    appendFileSync(filePath, JSON.stringify(logObj) + "\n");
+    const meta = (logObj as Record<string, unknown>)["_meta"] as Record<string, unknown> | undefined;
+    const metaPath = meta?.["path"] as Record<string, unknown> | undefined;
+
+    const args: unknown[] = [];
+    for (let i = 0; i in (logObj as Record<string, unknown>); i++) {
+      args.push((logObj as Record<string, unknown>)[String(i)]);
+    }
+    const message = args.length === 1 && typeof args[0] === "string"
+      ? args[0]
+      : args.map(a => typeof a === "string" ? a : JSON.stringify(a)).join(" ");
+
+    const entry: Record<string, unknown> = {
+      datetime: meta?.["date"],
+      runtimeVersion: meta?.["runtimeVersion"],
+      hostname: meta?.["hostname"],
+      name: meta?.["name"],
+      logLevelId: meta?.["logLevelId"],
+      level: meta?.["logLevelName"],
+      message,
+      codeLocation: metaPath?.["fullFilePath"] ?? undefined,
+    };
+    if (args.length > 1 && typeof args[args.length - 1] === "object" && args[args.length - 1] !== null) {
+      entry["data"] = args[args.length - 1];
+    }
+
+    // Size-based rotation
+    if (bytesWritten >= MAX_LOG_SIZE) {
+      rotateLogFile(normalised);
+      bytesWritten = 0;
+    }
+
+    const line = JSON.stringify(entry) + "\n";
+    appendFileSync(normalised, line);
+    bytesWritten += Buffer.byteLength(line);
   });
   return fileLogger;
 }

--- a/development/odins-spear/src/index.ts
+++ b/development/odins-spear/src/index.ts
@@ -37,43 +37,37 @@ async function startup(): Promise<void> {
   log.debug("startup called");
 
   // 1. Redis port-forward + connect
-  console.log("Connecting to Redis\u2026");
+  log.info("Connecting to Redis…");
   try {
     await ensureRedisPortForward(tuiLog);
     await connectRedis(tuiLog);
     initialConnStatus.redis = true;
-    log.debug("startup: Redis connected");
-    console.log("Redis connected.");
+    log.info("Redis connected");
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
-    log.debug("startup: Redis failed", { messageLength: msg.length });
-    console.error(`Redis: ${msg} (continuing)`);
+    log.warn("Redis failed, continuing", { error: msg });
   }
 
   // 2. Google ADC
-  console.log("Authenticating Google ADC\u2026");
+  log.info("Authenticating Google ADC…");
   try {
     await ensureAuthenticated();
-    log.debug("startup: Google ADC authenticated");
-    console.log("Google ADC authenticated.");
+    log.info("Google ADC authenticated");
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
-    log.debug("startup: ADC auth failed", { messageLength: msg.length });
-    console.error(`ADC auth error: ${msg}`);
+    log.fatal("ADC auth failed", { error: msg });
     process.exit(1);
   }
 
   // 3. Firestore
-  console.log("Connecting to Firestore\u2026");
+  log.info("Connecting to Firestore…");
   try {
     await connectFirestore();
     initialConnStatus.firestore = true;
-    log.debug("startup: Firestore connected");
-    console.log("Firestore connected.");
+    log.info("Firestore connected");
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
-    log.debug("startup: Firestore failed", { messageLength: msg.length });
-    console.error(`Firestore: ${msg} (continuing)`);
+    log.warn("Firestore failed, continuing", { error: msg });
   }
 
   // 4. Stripe key

--- a/development/odins-spear/src/lib/firestore.ts
+++ b/development/odins-spear/src/lib/firestore.ts
@@ -80,20 +80,19 @@ export async function ensureAuthenticated(): Promise<void> {
     }
   }
 
-  log.debug("ensureAuthenticated: opening browser for Google auth");
-  console.log("Opening browser for Google authentication...");
+  log.info("Opening browser for Google authentication…");
   const { execSync } = require("child_process") as typeof import("child_process");
   try {
     execSync("gcloud auth application-default login", { stdio: "inherit" });
-    log.debug("ensureAuthenticated: gcloud login complete");
+    log.info("gcloud login complete");
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
     if (/gcloud/.test(msg) || /ENOENT/.test(msg) || /not found/.test(msg)) {
-      console.error("gcloud CLI not found. Install it from https://cloud.google.com/sdk/docs/install");
+      log.fatal("gcloud CLI not found — install from https://cloud.google.com/sdk/docs/install");
     } else if (/cancelled|cancel|abort/i.test(msg)) {
-      console.error("Authentication cancelled. Odin's Spear requires Google credentials to access Firestore.");
+      log.fatal("Authentication cancelled — Odin's Spear requires Google credentials for Firestore");
     } else {
-      console.error(`Authentication failed: ${msg}`);
+      log.fatal("Authentication failed", { error: msg });
     }
     process.exit(1);
   }

--- a/development/odins-spear/src/lib/stripe.ts
+++ b/development/odins-spear/src/lib/stripe.ts
@@ -21,7 +21,7 @@ export async function getStripeKey(): Promise<string | null> {
 
   try {
     const { stdout } = await execAsync(
-      `kubectl get secret fenrir-secrets -n fenrir-app -o jsonpath='{.data.STRIPE_SECRET_KEY}' | base64 -d`
+      `kubectl get secret fenrir-app-secrets -n fenrir-app -o jsonpath='{.data.STRIPE_SECRET_KEY}' | base64 -d`
     );
     stripeKey = stdout.trim();
     log.debug("getStripeKey: loaded from kubectl", { keyLength: stripeKey.length });


### PR DESCRIPTION
## Summary
- **Logger**: flat JSONL format (`datetime`, `level`, `message`, `codeLocation`), forced `.jsonl` extension, startup rotation + 10 MB size rotation, keeps 5 previous files
- **Startup**: all `console.log`/`console.error` replaced with `log.info`/`log.warn`/`log.fatal` — TUI starts with zero console noise
- **Stripe**: fix K8s secret name `fenrir-secrets` → `fenrir-app-secrets` — key now loads successfully (`keyLength: 107`)

## Test plan
- [x] `just spear run` — clean console, TUI renders immediately
- [x] `tmp/logs/odins-spear.jsonl` — clean flat JSONL format
- [x] 3 sequential runs produce `.jsonl`, `.1.jsonl`, `.2.jsonl` (rotation works)
- [x] Stripe key loads with `hasKey: true`
- [x] Frontend `tsc --noEmit` — clean
- [x] `just spear test` — 504/504 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)