### PR TITLE
Issue #1562 - fix: right-align status icon with pin icon on job cards

### DIFF
--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -540,7 +540,7 @@ body {
    Matches card-pin-btn — inline, border, color-only hover. */
 .card-status-icon-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 2px 3px;
+  padding: 2px 3px; margin-left: auto;
   background: transparent; border: 1px solid var(--rune-border);
   border-radius: 2px; cursor: default;
   line-height: 1; transition: color 0.15s, border-color 0.15s;
@@ -589,7 +589,7 @@ body {
 /* ── Pin toggle button in card sidebar ── */
 .card-pin-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 1px 3px; margin-left: auto;
+  padding: 1px 3px;
   background: transparent; border: 1px solid transparent;
   border-radius: 2px; color: var(--text-void); cursor: pointer;
   line-height: 1; transition: color 0.15s, border-color 0.15s;


### PR DESCRIPTION
PR for issue: #1562

Right-aligns the status icon (.card-status-icon-btn) alongside the pin icon in job card headers.

**Changes:**
- `development/monitor-ui/src/styles/index.css` — added `margin-left: auto` to `.card-status-icon-btn`; removed redundant `margin-left: auto` from `.card-pin-btn`

**Verification:**
- tsc + build pass
- Visual: status icon sits right-aligned next to pin icon for all states

Fixes #1562