### PR TITLE
fix(doc-sync): use documentation label + no chain continuation

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -70,6 +70,12 @@ loop mode is guaranteed to be **1 tool call** — no Read, no fetch, just spawn 
 | `ux` | luna | firemandecko | loki |
 | `security` | heimdall | loki | -- |
 | `research` | freya or firemandecko | -- | -- |
+| `documentation` | *(from `--agent` flag)* | -- | -- |
+
+**`documentation` label:** Single-agent, no chain. The agent MUST be specified via
+`--agent` flag (parsed from issue body: "Agent: <name>"). There is NO Loki QA step.
+The agent merges its own PR and closes the issue directly. Do NOT run chain
+continuation (`/fire-next-up --resume`) for documentation issues.
 
 If agent cannot be inferred, error and tell user to use `--agent`.
 
@@ -159,6 +165,10 @@ CHAIN CONTINUATION (UNBREAKABLE):
 Every agent template includes a final chain continuation step. It is MANDATORY when
 conditions are met (success verdict) and FORBIDDEN when they are not (failure/partial).
 
+- **Documentation issues (label: `documentation`):** NO chain continuation. The agent
+  merges its own PR and closes the issue directly:
+  `gh pr merge <PR_NUMBER> --squash --delete-branch && gh issue close <NUMBER>`
+  Do NOT run `/fire-next-up --resume`. There is no Loki QA step for doc-sync work.
 - Non-final agents (Luna, FiremanDecko, Heimdall): run `/fire-next-up --resume #<NUMBER>`
   as the final step ONLY when all verify steps pass and the handoff comment is posted.
   This dispatches the next agent in the chain on the same branch.

--- a/.claude/skills/doc-sync/SKILL.md
+++ b/.claude/skills/doc-sync/SKILL.md
@@ -52,16 +52,32 @@ Roles and their owned directories:
 
 Each role issue should:
 - Title: "Doc sync: <Agent Name>"
-- Labels: enhancement, low
-- Body: "Run /doc-sync --role <role>. Update all markdown in <DEST>. Remove stale content, ensure README index is accurate."
-- Include "skip-refinement" in the body
+- Labels: documentation, low
+- Body must include ALL of these lines:
+  - "Run /doc-sync --role <role>. Update all markdown in <DEST>. Remove stale content, ensure README index is accurate."
+  - "Agent: <agent-name> (dispatch with --agent <agent-name>)"
+  - "Chain: single agent, NO Loki QA step. Merge PR directly on completion."
+  - "skip-refinement"
 
 The consolidator issue should:
 - Title: "Consolidate doc-sync outputs into top-level README.md"
-- Labels: enhancement, low
+- Labels: documentation, low
 - Be blocked by all 5 role issues
-- Body: "Read all {DEST}/.sync-report.md files and update root README.md based on the hints."
-- Include "skip-refinement" in the body
+- Body must include ALL of these lines:
+  - "Read all {DEST}/.sync-report.md files and update root README.md based on the hints."
+  - "Agent: firemandecko (dispatch with --agent firemandecko)"
+  - "Chain: single agent, NO Loki QA step. Merge PR directly on completion."
+  - "skip-refinement"
+
+IMPORTANT — Doc-sync chain rules:
+- Use `documentation` label, NOT `enhancement` — this prevents the standard
+  FiremanDecko → Loki chain inference from kicking in.
+- Each role issue is dispatched with `--agent <role-agent>` explicitly — the agent
+  is the role's own agent (freya, luna, firemandecko, loki, heimdall), NOT the
+  default chain agent.
+- There is NO Loki QA step. Doc-sync agents merge their own PR and close the issue
+  directly. The sandbox preamble's CHAIN CONTINUATION rule does NOT apply — doc-sync
+  agents must NOT run `/fire-next-up --resume`.
 
 Wave 0: All 5 role issues (parallel — no dependencies between them)
 Wave 1: Consolidator (blocked by all 5 role issues)


### PR DESCRIPTION
## Summary
- Doc-sync issues now use `documentation` label instead of `enhancement`
- Prevents standard FiremanDecko → Loki chain inference from kicking in
- Added `documentation` to dispatch agent inference table — requires `--agent` flag
- Added documentation exception to sandbox preamble chain continuation rule
- Doc-sync agents merge their own PR + close issue directly (no `/fire-next-up --resume`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)