### PR TITLE
docs(ux): doc-sync luna — fix stale nav section, add 3 missing interaction spec links

### DIFF
--- a/ux/README.md
+++ b/ux/README.md
@@ -55,6 +55,9 @@ What follows is the full visual and verbal soul of Fenrir Ledger. Freya shaped t
 - [wireframes/monitor-ui/theme-switcher-interaction-spec.md](wireframes/monitor-ui/theme-switcher-interaction-spec.md) -- Monitor UI theme switcher: light/dark toggle, CSS variable strategy
 - [wireframes/monitor-ui/session-header-title-interaction-spec.md](wireframes/monitor-ui/session-header-title-interaction-spec.md) -- Session header descriptive title: issue title resolution
 - [wireframes/monitor-ui/verdict-inscription-interaction-spec.md](wireframes/monitor-ui/verdict-inscription-interaction-spec.md) -- Norse verdict inscription: detection, agent variants, carve-in animation
+- [wireframes/monitor-ui/wss-icon-tooltip-interaction-spec.md](wireframes/monitor-ui/wss-icon-tooltip-interaction-spec.md) -- WSS icon: remove bounding box, wolf-voice tooltip per connection state (Issue #1443)
+- [wireframes/settings-tabs/settings-tabs-interaction-spec.md](wireframes/settings-tabs/settings-tabs-interaction-spec.md) -- Settings tab layout: tab switching, URL hash persistence, karl-bling tabs, mobile select pattern
+- [wireframes/spear/cancel-button-interaction-spec.md](wireframes/spear/cancel-button-interaction-spec.md) -- Odin's Spear cancel controls: styled button affordance for JobCard and SessionHeader (Issue #1475)
 - [wireframes/sync/sync-interaction-spec.md](wireframes/sync/sync-interaction-spec.md) -- Cloud sync UX: indicator states, settings section, tier gating
 
 ### Wireframes (78 HTML5 documents — synced 2026-03-17)

--- a/ux/wireframes.md
+++ b/ux/wireframes.md
@@ -618,19 +618,11 @@ Key layout decisions:
 
 ## Navigation Structure
 
-Sidebar (always visible, collapsible):
-- Logo: `ᛟ FENRIR LEDGER` + `Credit Card Tracker` subtitle
-- Nav items (grow as routes ship):
-  - Cards (active: `/`)
-  - Valhalla (Sprint 3: `/valhalla`)
-  - The Ravens (Sprint 4: `/settings`)
-- `[Collapse]` button pinned to sidebar bottom — collapses to icon-only rail
+> **Note (Sprint 8, Issue #403):** The persistent sidebar described here was removed. The current shell has no fixed sidebar. Navigation now lives in a top-bar dropdown with a rotary theme toggle. See [`wireframes/chrome/sidebar-removal-dropdown-settings.html`](wireframes/chrome/sidebar-removal-dropdown-settings.html) and [`wireframes/chrome/sidebar-removal-interaction-spec.md`](wireframes/chrome/sidebar-removal-interaction-spec.md) for the canonical current shell spec.
 
 Content header (per-page):
 - Page title left (Cinzel, gold)
 - `[ADD CARD]` primary CTA right (cards page only)
-
-Mobile: sidebar hidden by default; hamburger toggle opens overlay drawer.
 
 ---
 


### PR DESCRIPTION
## Summary

- **`ux/wireframes.md`**: Removed stale "Navigation Structure" section that described the old persistent collapsible sidebar (removed in Issue #403 / Sprint 8). Replaced with a clear note pointing to the canonical current shell specs (`sidebar-removal-dropdown-settings.html` and `sidebar-removal-interaction-spec.md`).
- **`ux/README.md`**: Added 3 interaction spec files that existed on disk but were missing from the index:
  - `wireframes/monitor-ui/wss-icon-tooltip-interaction-spec.md` (Issue #1443)
  - `wireframes/settings-tabs/settings-tabs-interaction-spec.md`
  - `wireframes/spear/cancel-button-interaction-spec.md` (Issue #1475)

## Test plan

- [ ] Verify `ux/README.md` index links to all 3 newly added specs (files exist on disk)
- [ ] Verify `ux/wireframes.md` no longer describes the removed sidebar as if it exists
- [ ] Confirm no other files in `ux/` were modified

Closes #1574

🤖 Generated with [Claude Code](https://claude.com/claude-code)