### PR TITLE
chore(doc-sync): sync security/ docs — issue #1577

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -4,17 +4,17 @@ Owned by **Heimdall** (`.claude/agents/heimdall.md`).
 
 This directory contains all security documentation for the Fenrir Ledger project: audit reports, architecture diagrams, checklists, and advisories.
 
-## Current State (as of 2026-03-17)
+## Current State (as of 2026-03-20)
 
 - **Infrastructure**: GKE Autopilot (not Vercel). See `infrastructure/k8s/app/` for deployment manifests.
 - **Subscription platform**: Stripe Direct only. Patreon has been fully removed.
 - **Prompt injection**: Fixed in PR #171 — CSV wrapped in XML-style system/user role separation with explicit RAW DATA instruction.
 - **Stripe webhook**: SHA-256 HMAC via `stripe.webhooks.constructEvent()`.
 - **CSP**: Includes all required Google and Stripe domains.
-- **KV store**: Upstash Redis, configured via `KV_REST_API_URL` and `KV_REST_API_TOKEN`.
+- **Entitlement store**: Firestore (migrated from Upstash Redis in issue #1521 — `KV_REST_API_URL` and `KV_REST_API_TOKEN` no longer used or deployed).
 - **Firestore sync (issue #1126)**: ~~2 CRITICAL IDOR vulnerabilities~~ → **RESOLVED**. IDOR in `/api/sync/pull` (PR #1203) and `/api/sync/push` (PR #1207) fixed — both routes now derive `householdId` from the server-side user record, not the client. See report below.
 - **Open findings (Firestore audit)**: 1 HIGH (invite validate PII leakage), 3 MEDIUM (no rate limiting on invite/sync routes, Admin SDK bypasses rules), 3 LOW (error handling, entropy docs, tier disclosure), 3 INFO (emulator-only rules, soft-delete, no collection group).
-- **Open findings (older reports)**: 3 LOW (distributed rate limiting, webhook deduplication, email validation), 3 INFO (trust chain comment, KV delete race, publishable key monitoring), plus external pentest CRITICAL (Next.js CVEs #475) and HIGH (SheetJS #476).
+- **Open findings (older reports)**: 3 LOW (distributed rate limiting, webhook deduplication, email validation), 3 INFO (trust chain comment, publishable key monitoring), plus external pentest CRITICAL (Next.js CVEs #475 — **RESOLVED**: upgraded to Next.js 16.x) and HIGH (SheetJS #476 — still open).
 
 ---
 
@@ -23,7 +23,7 @@ This directory contains all security documentation for the Fenrir Ledger project
 | Date | Scope | Risk Summary | Status | Path |
 |------|-------|-------------|--------|------|
 | 2026-03-17 | **Firestore Sync & Household Data Access** (issue #1126) | **2C / 1H / 3M / 3L / 3I** | **[Active] CRITICAL IDOR fixed in PRs #1203 + #1207; HIGH + MEDIUM findings open** | [reports/2026-03-17-firestore-sync-audit.md](reports/2026-03-17-firestore-sync-audit.md) |
-| 2026-03-10 | **Comprehensive External Pen Test** — Consolidated from 4 parallel audits (#470–473) | **1C / 1H / 3M / 3L / 5I** | **[Active] CRITICAL Next.js CVEs require immediate patching; HIGH SheetJS unpatched — see issues** | [reports/2026-03-09-external-pentest.md](reports/2026-03-09-external-pentest.md) |
+| 2026-03-10 | **Comprehensive External Pen Test** — Consolidated from 4 parallel audits (#470–473) | **1C / 1H / 3M / 3L / 5I** | **[Active] CRITICAL Next.js CVEs RESOLVED (Next.js upgraded to 16.x); HIGH SheetJS unpatched — see issues** | [reports/2026-03-09-external-pentest.md](reports/2026-03-09-external-pentest.md) |
 | 2026-03-02 | Google API Integration | 0C / 3H / 3M / 3L / 3I | Active — findings partially open | [reports/2026-03-02-google-api-integration.md](reports/2026-03-02-google-api-integration.md) |
 | 2026-03-04 | Stripe Direct Integration | 0C / 0H / 0M / 3L / 3I | Active — CRITICAL/MEDIUM resolved | [reports/2026-03-04-stripe-direct-integration.md](reports/2026-03-04-stripe-direct-integration.md) |
 | 2026-03-05 | LLM Prompt Injection Remediation (#157) | 0C / 0H / 0M / 0L / 2I | Active | [reports/2026-03-05-llm-prompt-injection-remediation.md](reports/2026-03-05-llm-prompt-injection-remediation.md) |
@@ -65,10 +65,10 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Document | Description | Last Reviewed |
 |----------|-------------|---------------|
-| [architecture/auth-architecture.md](architecture/auth-architecture.md) | Full OAuth 2.0 PKCE flow, session storage model, token expiration, incremental Drive consent, trust boundaries, JWKS verification, Stripe subscription auth model, and Firestore sync authorization model | 2026-03-17 |
-| [architecture/data-flow-diagrams.md](architecture/data-flow-diagrams.md) | Security-focused data flow diagrams for OAuth PKCE, URL import (Path A), CSV upload (Path C), Google Picker (Path B), Stripe checkout, and Firestore sync pull/push; marks trust boundaries, SSRF surfaces, and injection points | 2026-03-17 |
-| [architecture/trust-boundaries.md](architecture/trust-boundaries.md) | Six trust zones (browser, GKE server, Google infra, Stripe infra, Upstash Redis, Firestore); secret locations; what data crosses each boundary; localStorage XSS implications and Firestore householdId constraints | 2026-03-17 |
-| [architecture/threat-model.md](architecture/threat-model.md) | Assets, threat actors, attack surfaces, mitigations in place, and residual risks; includes Firestore sync attack surfaces and IDOR mitigations | 2026-03-17 |
+| [architecture/auth-architecture.md](architecture/auth-architecture.md) | Full OAuth 2.0 PKCE flow, session storage model, token expiration, incremental Drive consent, trust boundaries, JWKS verification, Stripe subscription auth model, and Firestore sync authorization model | 2026-03-20 |
+| [architecture/data-flow-diagrams.md](architecture/data-flow-diagrams.md) | Security-focused data flow diagrams for OAuth PKCE, URL import (Path A), CSV upload (Path C), Google Picker (Path B), Stripe checkout, and Firestore sync pull/push; marks trust boundaries, SSRF surfaces, and injection points | 2026-03-20 |
+| [architecture/trust-boundaries.md](architecture/trust-boundaries.md) | Five trust zones (browser, GKE server, Google infra, Stripe infra, Firestore); secret locations; what data crosses each boundary; localStorage XSS implications and Firestore householdId constraints | 2026-03-20 |
+| [architecture/threat-model.md](architecture/threat-model.md) | Assets, threat actors, attack surfaces, mitigations in place, and residual risks; includes Firestore sync attack surfaces and IDOR mitigations | 2026-03-20 |
 
 ---
 
@@ -76,8 +76,8 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Document | Description | Last Reviewed |
 |----------|-------------|---------------|
-| [checklists/api-route-checklist.md](checklists/api-route-checklist.md) | Pre-merge checklist for adding or modifying API routes: requireAuth pattern, Firestore householdId validation, input validation, error handling, secret hygiene, SSRF prevention; includes Stripe webhook exemption | 2026-03-17 |
-| [checklists/deployment-security.md](checklists/deployment-security.md) | Pre-deployment checklist for GKE Autopilot: secret hygiene (including Firestore env vars), CSP verification, OAuth config, Stripe config, dependency audit, build verification, post-deployment checks | 2026-03-17 |
+| [checklists/api-route-checklist.md](checklists/api-route-checklist.md) | Pre-merge checklist for adding or modifying API routes: requireAuth pattern, Firestore householdId validation, input validation, error handling, secret hygiene, SSRF prevention; includes Stripe webhook exemption | 2026-03-20 |
+| [checklists/deployment-security.md](checklists/deployment-security.md) | Pre-deployment checklist for GKE Autopilot: secret hygiene (including Firestore env vars), CSP verification, OAuth config, Stripe config, dependency audit, build verification, post-deployment checks | 2026-03-20 |
 
 ---
 
@@ -106,9 +106,9 @@ The following findings from active reports remain open. Assign to FiremanDecko f
 
 | ID | Report | Severity | Title | Status | Issue |
 |----|--------|----------|-------|--------|-------|
-| **CRITICAL-001** | **2026-03-09-external-pentest** | **CRITICAL** | **Next.js Multiple Critical CVEs (GHSA-3h52, GHSA-g5qg, GHSA-xv57, GHSA-4342, GHSA-9g9p, GHSA-f82v)** | **Open** | #475 |
+| ~~CRITICAL-001~~ | ~~2026-03-09-external-pentest~~ | ~~CRITICAL~~ | ~~Next.js Multiple Critical CVEs (GHSA-3h52, GHSA-g5qg, GHSA-xv57, GHSA-4342, GHSA-9g9p, GHSA-f82v)~~ | **RESOLVED — Next.js upgraded to 16.x** | #475 |
 | **HIGH-001** | **2026-03-09-external-pentest** | **HIGH** | **SheetJS Unpatched Prototype Pollution & ReDoS (GHSA-4r6h, GHSA-5pgg)** | Open | #476 |
-| MEDIUM-001 | 2026-03-09-external-pentest | MEDIUM | CSP allows unsafe-inline scripts/styles | Open | #477 |
+| MEDIUM-001 | 2026-03-09-external-pentest | MEDIUM | CSP allows unsafe-inline scripts/styles | Open — nonce-based CSP attempted and reverted (incompatible with PPR + CDN caching; see `src/middleware.ts`) | #477 |
 | MEDIUM-002 | 2026-03-09-external-pentest | MEDIUM | CSV fetch follows redirects without validation (SSRF) | Open | #478 |
 | MEDIUM-003 | 2026-03-09-external-pentest | MEDIUM | CSV sanitization regex bypass via Unicode | Open | #479 |
 | LOW-001 | 2026-03-09-external-pentest | LOW | Minimatch ReDoS in ESLint deps | Open | #480 |
@@ -132,5 +132,5 @@ The following findings from active reports remain open. Assign to FiremanDecko f
 | SEV-005 | 2026-03-04-stripe-direct-integration | LOW | Stripe webhook no event deduplication | Open |
 | SEV-006 | 2026-03-04-stripe-direct-integration | LOW | Checkout email validation (anonymous path removed — verify) | Open |
 | SEV-007 | 2026-03-04-stripe-direct-integration | INFO | googleSub trust chain comment missing | Open |
-| SEV-008 | 2026-03-04-stripe-direct-integration | INFO | deleteStripeEntitlement partial KV delete risk | Open |
+| ~~SEV-008~~ | ~~2026-03-04-stripe-direct-integration~~ | ~~INFO~~ | ~~deleteStripeEntitlement partial KV delete risk~~ | **N/A — Upstash Redis removed (issue #1521); entitlements now in Firestore** |
 | SEV-009 | 2026-03-04-stripe-direct-integration | INFO | Stripe publishable key in .env.example without client usage | Monitoring |

--- a/security/architecture/auth-architecture.md
+++ b/security/architecture/auth-architecture.md
@@ -1,7 +1,7 @@
 # Auth Architecture — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-17 (added Firestore sync auth model — Section 10)
+**Last reviewed**: 2026-03-20 (updated entitlement store from Upstash Redis to Firestore — issue #1521)
 **References**: ADR-005, ADR-006, ADR-008, ADR-010
 
 ---
@@ -17,7 +17,7 @@ There is no server-side session. All session state lives in the browser
 the Google `id_token` JWT against Google's public JWKS keys.
 
 Subscription management is handled by Stripe Direct. There is no Patreon integration.
-Entitlements are stored in Upstash Redis (KV store).
+Entitlements are stored in Firestore (migrated from Upstash Redis in issue #1521).
 
 ---
 
@@ -254,9 +254,9 @@ Google `sub` claim.
 
 The Stripe integration creates a **layered model**:
 - Google `id_token` in `localStorage` — identity on every API request
-- Stripe subscription status in Upstash Redis — entitlement lookup
+- Stripe subscription status in Firestore — entitlement lookup
 
-No Stripe secrets are stored in KV. The Stripe secret key is a server-side
+No Stripe secrets are stored in Firestore. The Stripe secret key is a server-side
 process.env variable used server-to-server only.
 
 ### 5.2 Checkout Flow
@@ -303,13 +303,19 @@ This is a stronger cryptographic guarantee than the previous Patreon HMAC-MD5 de
 
 ### 5.4 Entitlement Storage
 
-| Key Pattern | Value | TTL | Purpose |
-|---|---|---|---|
-| `entitlement:{googleSub}` | `StripeEntitlement` JSON | 30 days | Primary lookup by Google user |
-| `stripe-customer:{customerId}` | `{googleSub}` string | 30 days | Reverse index for webhook routing |
+Entitlements are stored in Firestore (migrated from Upstash Redis in issue #1521).
+There is no KV/TTL mechanism — entitlement records are persistent documents.
 
-No tokens are encrypted at rest (unlike Patreon). No user credentials are stored.
-The Stripe subscription ID and status are the only data in KV.
+| Firestore Path | Type | Purpose |
+|---|---|---|
+| `entitlements/{googleSub}` | `FirestoreEntitlement` | Primary lookup by Google user |
+| `entitlements/stripe:{customerId}` | `FirestoreEntitlement` | Lookup for anonymous Stripe users |
+
+Reverse lookup (Stripe customer → Google sub) is done by querying the `users` collection
+where `stripeCustomerId == customerId`.
+
+No user credentials are stored. The Stripe subscription ID and status are the only data
+in the entitlement documents.
 
 ### 5.5 Accepted Webhook Exemption
 
@@ -355,17 +361,18 @@ compensating control is SHA-256 HMAC via `stripe.webhooks.constructEvent()`.
 │    STRIPE_SECRET_KEY                                                 │
 │    STRIPE_WEBHOOK_SECRET                                             │
 │    STRIPE_PRICE_ID                                                   │
-│    KV_REST_API_URL                                                   │
-│    KV_REST_API_TOKEN                                                 │
-└─────────────────────────────────┬───────────────────────────────────┘
+└─────────────────────────────────────────────────────────────────────┘
                                    │
 ┌─────────────────────────────────▼───────────────────────────────────┐
-│  UPSTASH REDIS (trusted persistent store)                           │
+│  FIRESTORE (trusted persistent store)                               │
 │                                                                      │
-│  entitlement:{googleSub}          → StripeEntitlement               │
-│  stripe-customer:{stripeId}       → googleSub (reverse index)       │
+│  entitlements/{googleSub}         → FirestoreEntitlement            │
+│  entitlements/stripe:{id}         → FirestoreEntitlement            │
+│  households/{householdId}/cards   → FirestoreCard[]                 │
+│  users/{googleSub}                → UserRecord                      │
 │                                                                      │
-│  No token encryption required — no credentials stored               │
+│  Upstash Redis was removed in issue #1521. Entitlements now live    │
+│  in Firestore. No token encryption required — no credentials stored │
 └─────────────────────────────────────────────────────────────────────┘
 ```
 

--- a/security/architecture/data-flow-diagrams.md
+++ b/security/architecture/data-flow-diagrams.md
@@ -1,7 +1,7 @@
 # Security Data Flow Diagrams — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-17 (added Firestore sync flows — sections 7 and 8)
+**Last reviewed**: 2026-03-20 (updated Stripe checkout flow — entitlements now in Firestore, not Upstash Redis; issue #1521)
 
 Trust boundary notation:
 - `[TB]` — Trust boundary crossing (browser ↔ server)
@@ -245,7 +245,7 @@ Browser (authenticated)
   │    stripe.webhooks.constructEvent(rawBody, signature, STRIPE_WEBHOOK_SECRET)
   │    ← SHA-256 HMAC verification
   │    handle checkout.session.completed:
-  │      session.metadata.googleSub → setStripeEntitlement(googleSub, entitlement) → KV
+  │      session.metadata.googleSub → setStripeEntitlement(googleSub, entitlement) → Firestore
   │
   └─ Browser redirects to success_url: /settings?stripe=success
 ```
@@ -267,7 +267,7 @@ Browser (authenticated)
 | Token proxy | None (fixed URL) | None | None | N/A (public, rate-limited) |
 | Stripe checkout | None (Stripe SDK) | None | None | requireAuth |
 | Stripe webhook | None | None | None | N/A (SHA-256 HMAC) |
-| Stripe membership | None | None | None (KV only) | requireAuth |
+| Stripe membership | None | None | None (Firestore only) | requireAuth |
 | Firestore sync pull | None | None | None (Firestore) | requireAuth + Karl tier |
 | Firestore sync push | None | None (Zod validated) | None (Firestore) | requireAuth + Karl tier |
 

--- a/security/architecture/threat-model.md
+++ b/security/architecture/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-17 (added Firestore sync assets and attack surfaces)
+**Last reviewed**: 2026-03-20 (updated entitlement store references from Upstash Redis to Firestore — issue #1521)
 **Methodology**: STRIDE-lite with OWASP Top 10 mapping
 
 ---
@@ -21,7 +21,7 @@
 | `GOOGLE_PICKER_API_KEY` | MEDIUM | Server env, served to browser auth-gated | Attacker can display Picker UI with Fenrir's quota |
 | Card portfolio data | MEDIUM | localStorage per-user | Financial metadata exposure (no PAN/CVV stored) |
 | User PII (email, name, picture) | MEDIUM | localStorage["fenrir:auth"].user | Identity exposure |
-| Stripe entitlements in KV | MEDIUM | Upstash Redis | Attacker can grant or revoke subscription tier |
+| Stripe entitlements in Firestore | MEDIUM | Firestore entitlements collection | Attacker can grant or revoke subscription tier if Admin SDK authorization is bypassed |
 | Card portfolio in Firestore | HIGH | Firestore per-household collection | Attacker can read/overwrite any household's full card portfolio if IDOR present |
 | Household membership in Firestore | MEDIUM | Firestore households collection | Attacker can enumerate members, manipulate household composition |
 
@@ -191,9 +191,9 @@
 - SHA-256 HMAC webhook signature verification (`stripe.webhooks.constructEvent()`)
 - Raw body read before JSON parsing for webhook signature validation
 - `STRIPE_WEBHOOK_SECRET` never logged or returned to clients
-- Stripe entitlements in KV with 30-day TTL
-- Reverse index (`stripe-customer:{id}`) for webhook-to-user mapping
-- No token encryption in KV (unlike previous platforms) — only subscription status stored
+- Stripe entitlements in Firestore (persistent documents, no TTL)
+- Reverse lookup via `users` collection (`stripeCustomerId` field) for webhook-to-user mapping
+- No token encryption in Firestore — only subscription status stored
 
 ---
 
@@ -204,7 +204,7 @@
 | Refresh token in localStorage | HIGH | Long-lived token accessible to XSS; no server-side revocation | Move to HttpOnly cookie or shorten TTL |
 | Drive token in localStorage | MEDIUM | Persisted despite 1-hour TTL; widens XSS window | Keep in React state only |
 | `unsafe-inline` in CSP | MEDIUM | Allows inline script execution; reduces XSS protection | Move to nonce-based CSP |
-| Non-distributed rate limiting | MEDIUM | In-memory rate limiter doesn't work across Pod instances | Upstash Redis |
+| Non-distributed rate limiting | MEDIUM | In-memory rate limiter doesn't work across Pod instances | Implement Redis or Firestore-backed rate limiting |
 | Anonymous data merge without Zod | LOW | Malformed localStorage data merged without validation | Add `CardsArraySchema.safeParse()` |
 | No refresh token rotation | LOW | Refresh token never rotated; stolen token remains valid | Implement token refresh + rotation via server proxy |
 | LLM singleton caches stale key | LOW | API key rotation may not take effect until cold start | Document; add version check to invalidate singleton |

--- a/security/architecture/trust-boundaries.md
+++ b/security/architecture/trust-boundaries.md
@@ -1,7 +1,7 @@
 # Trust Boundaries — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-17 (updated for Firestore sync — added Zone 6)
+**Last reviewed**: 2026-03-20 (removed Zone 5 Upstash Redis — entitlements migrated to Firestore in issue #1521; updated stale vercel.app hostname references)
 
 ---
 
@@ -10,7 +10,9 @@
 Fenrir Ledger has two primary trust zones: the browser (untrusted) and the Next.js
 server (trusted). A third zone, Google's infrastructure, is treated as trusted for
 OAuth token responses and JWKS key material. A fourth zone, Stripe's infrastructure,
-is trusted for payment processing and subscription lifecycle events.
+is trusted for payment processing and subscription lifecycle events. Subscription
+entitlements were formerly stored in Upstash Redis (Zone 5); they are now stored in
+Firestore (Zone 6) following the KV infrastructure removal in issue #1521.
 
 ```
 ┌──────────────────────────────────────────────────────────────┐
@@ -63,26 +65,21 @@ is trusted for payment processing and subscription lifecycle events.
 └──────────────────────────────────────────────────────────────┘
 
 ┌──────────────────────────────────────────────────────────────┐
-│  ZONE 5: Upstash Redis (Trusted Persistent Store)            │
-│                                                              │
-│  - entitlement:{googleSub}       → StripeEntitlement         │
-│  - stripe-customer:{stripeId}    → googleSub (reverse index) │
-│                                                              │
-│  Accessed only from ZONE 2 (server). Browser has no direct   │
-│  access. No user credentials stored in KV.                   │
-└──────────────────────────────────────────────────────────────┘
-
-┌──────────────────────────────────────────────────────────────┐
-│  ZONE 6: Google Firestore (Trusted Persistent Store)         │
+│  ZONE 5: Google Firestore (Trusted Persistent Store)         │
 │                                                              │
 │  - households/{householdId}/cards → FirestoreCard[]          │
 │  - users/{googleSub}              → UserRecord               │
 │  - households/{householdId}       → HouseholdRecord          │
+│  - entitlements/{googleSub}       → FirestoreEntitlement     │
+│  - entitlements/stripe:{id}       → FirestoreEntitlement     │
 │                                                              │
 │  Accessed via Firebase Admin SDK from ZONE 2 only. Admin SDK │
 │  bypasses Firestore security rules — all authorization is    │
 │  enforced at the API route layer. Browser has no direct      │
 │  Firestore access.                                           │
+│                                                              │
+│  Note: Upstash Redis (formerly Zone 5) was removed in        │
+│  issue #1521. Entitlements are now stored here instead of KV.│
 │                                                              │
 │  CRITICAL CONSTRAINT: householdId MUST be derived from the  │
 │  server-side user record (getUser(googleSub).householdId),   │
@@ -102,8 +99,6 @@ is trusted for payment processing and subscription lifecycle events.
 | `STRIPE_SECRET_KEY` | `process.env` (server) | No | Used only in Stripe API calls (server-side) |
 | `STRIPE_WEBHOOK_SECRET` | `process.env` (server) | No | Used only for webhook signature verification |
 | `STRIPE_PRICE_ID` | `process.env` (server) | No | Stripe price ID for subscription |
-| `KV_REST_API_URL` | `process.env` (server) | No | Upstash Redis connection |
-| `KV_REST_API_TOKEN` | `process.env` (server) | No | Upstash Redis auth token |
 | `GOOGLE_PICKER_API_KEY` | `process.env` (server) | Yes — served on request | Auth-gated; GCP referrer restriction required |
 | `NEXT_PUBLIC_GOOGLE_CLIENT_ID` | `process.env` (public) | Yes — by design | OAuth Client ID is public; embedded in auth URL |
 | `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | `process.env` (public) | Yes — by design | Stripe publishable key is safe for client exposure |
@@ -171,7 +166,7 @@ Every request to an API route crosses this boundary. The following data crosses:
 ## localStorage as an Untrusted Store
 
 `localStorage` is **origin-scoped** but not **script-scoped**. Any JavaScript
-executing on the same origin (`https://fenrir-ledger.vercel.app`) can read
+executing on the same origin (the production GKE Ingress hostname) can read
 `localStorage`. This includes:
 
 1. First-party application code (intended)
@@ -181,7 +176,7 @@ executing on the same origin (`https://fenrir-ledger.vercel.app`) can read
 
 ### What an XSS payload could steal
 
-A successful XSS attack on fenrir-ledger.vercel.app could read:
+A successful XSS attack on the production GKE hostname could read:
 - `fenrir:auth` → full Google access token + id_token (valid for ~1 hour)
 - `fenrir:drive-token` → Google Drive access token (valid for ~1 hour)
 - `fenrir_ledger:{sub}:cards` → all credit card financial metadata
@@ -238,9 +233,9 @@ This means:
 
 ## Stripe Entitlement Data
 
-Unlike card data, subscription entitlements are stored server-side in Upstash Redis.
-The browser fetches the current tier from `/api/stripe/membership` on demand and
-caches it in React state only (not localStorage). This means:
+Subscription entitlements are stored server-side in Firestore (formerly Upstash Redis,
+migrated in issue #1521). The browser fetches the current tier from `/api/stripe/membership`
+on demand and caches it in React state only (not localStorage). This means:
 
 - An XSS attack cannot read entitlement data from localStorage
 - Entitlement data is protected by the full server trust boundary

--- a/security/checklists/api-route-checklist.md
+++ b/security/checklists/api-route-checklist.md
@@ -1,7 +1,7 @@
 # API Route Security Checklist — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-17 (added Firestore householdId validation rule)
+**Last reviewed**: 2026-03-20 (updated distributed rate limiting guidance — Upstash Redis removed in issue #1521)
 
 Use this checklist whenever adding, modifying, or reviewing an API route under
 `development/frontend/src/app/api/`.
@@ -83,7 +83,7 @@ Every route handler MUST pass all items in this section before merge.
 
 - [ ] **Unauthenticated routes implement rate limiting**
   - At minimum: in-memory rate limit via `rateLimit()` from `src/lib/rate-limit.ts`
-  - For production: prefer Upstash Redis for distributed rate limiting
+  - For production: prefer a distributed rate limiter (Firestore or external Redis) — Upstash Redis has been removed (issue #1521)
 
 - [ ] **Routes that call external services (LLM, Google APIs) are rate-limited**
   - Consider per-user rate limits (keyed on `auth.user.sub`) in addition to per-IP

--- a/security/checklists/deployment-security.md
+++ b/security/checklists/deployment-security.md
@@ -1,7 +1,7 @@
 # Deployment Security Checklist — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-17 (added Firestore env vars to required list)
+**Last reviewed**: 2026-03-20 (removed KV_REST_API_URL and KV_REST_API_TOKEN — Upstash Redis removed in issue #1521)
 
 Run this checklist before every production deployment. Items marked [AUTOMATED] are
 covered by the Playwright test suite or CI. Items marked [MANUAL] require human review.
@@ -34,7 +34,6 @@ covered by the Playwright test suite or CI. Items marked [MANUAL] require human 
   - `FENRIR_ANTHROPIC_API_KEY`
   - `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PRICE_ID`
   - `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
-  - `KV_REST_API_URL`, `KV_REST_API_TOKEN`
   - `APP_BASE_URL` (production URL for Stripe redirects)
   - `UPTIME_CHECK_HOST` (Google Cloud Monitoring uptime check target)
   - `FIRESTORE_PROJECT_ID`, `FIRESTORE_DATABASE_ID` (Firestore cloud sync)

--- a/security/reports/2026-03-09-external-pentest.md
+++ b/security/reports/2026-03-09-external-pentest.md
@@ -1,8 +1,10 @@
 # Fenrir Ledger — Comprehensive External Penetration Test Report
 **Date:** 2026-03-10
-**Scope:** https://fenrir-ledger.vercel.app (production Vercel deployment)
+**Scope:** https://fenrir-ledger.vercel.app (production deployment at time of audit — infrastructure has since migrated to GKE Autopilot; see `infrastructure/k8s/app/`)
 **Test Type:** Black-box external security audit
 **Tester:** Heimdall Security Specialist
+
+> **Infrastructure note (2026-03-20):** This audit was performed against the Vercel deployment. The application now runs on GKE Autopilot. Finding statuses below reflect current state: CRITICAL-001 is **RESOLVED** (Next.js upgraded to 16.x); HIGH-001 (SheetJS) remains **open**.
 
 ---
 
@@ -27,7 +29,7 @@ This comprehensive penetration test consolidates findings from four parallel sec
 
 | Severity | Count | Status | Action |
 |----------|-------|--------|--------|
-| **CRITICAL** | 1 | Requires immediate patching | Upgrade Next.js to 15.5.12+ |
+| **CRITICAL** | 1 | **RESOLVED** — Next.js upgraded to 16.x | ~~Upgrade Next.js to 15.5.12+~~ |
 | **HIGH** | 1 | No upstream fix; requires mitigation | Replace SheetJS or add input validation |
 | **MEDIUM** | 3 | Design issues; recommend remediation | CSP improvement, SSRF redirect validation, CSV sanitization bypass |
 | **LOW** | 3 | Defense-in-depth concerns; non-critical | File truncation disclosure, event deduplication, card number validation |
@@ -72,11 +74,13 @@ An attacker could potentially:
 2. Bypass middleware authentication checks to access protected API endpoints
 3. Trigger SSRF via malicious redirect middleware configuration to scan internal networks
 
-**Remediation:**
+**Status (2026-03-20): RESOLVED.** Next.js upgraded to 16.x (package.json: `^16.1.6`), which is above the vulnerable range (10.0.0–15.5.9).
+
+**Remediation (historical):**
 1. **Immediate (Production):** Upgrade `next` to 15.5.12 or later
 2. **Command:** `npm audit fix --force` (in development/frontend/)
 3. **Testing:** Run full test suite after upgrade; verify Image Optimization routes still function correctly
-4. **Deployment:** Push to production via Vercel; verify no build errors
+4. **Deployment:** Deploy to GKE Autopilot; verify no build errors
 5. **Timeline:** Complete within 7 days
 
 ---

--- a/security/reports/2026-03-17-firestore-sync-audit.md
+++ b/security/reports/2026-03-17-firestore-sync-audit.md
@@ -107,7 +107,7 @@ const members = memberUsers.map((m) => ({
 
 - **File**: `development/frontend/src/app/api/household/invite/validate/route.ts`, `development/frontend/src/app/api/household/join/route.ts`
 - **Category**: A07 Identification and Authentication Failures (OWASP)
-- **Description**: The `rateLimit()` utility exists at `src/lib/auth/rate-limit.ts` but is not applied to the invite validation or join endpoints. An attacker could systematically enumerate invite codes at the rate of Firestore query throughput. With 32^6 = ~1.07 billion combinations and no rate limit, automated enumeration is possible (though slow at human-facing latency).
+- **Description**: The `rateLimit()` utility exists at `src/lib/rate-limit.ts` but is not applied to the invite validation or join endpoints. An attacker could systematically enumerate invite codes at the rate of Firestore query throughput. With 32^6 = ~1.07 billion combinations and no rate limit, automated enumeration is possible (though slow at human-facing latency).
 - **Impact**: Given 1 billion combinations and even 1 request/second throughput, full enumeration would take ~34 years. However, targeted attacks against short-lived codes (knowing approximate generation time) and the PII exposure in SEV-003 raise the effective risk. Additionally, flooding the endpoint causes unnecessary Firestore read costs and latency.
 - **Remediation**: Apply `rateLimit()` on both endpoints keyed by authenticated user ID (e.g., `invite-validate:<userId>`). Limit: 10 attempts per 10 minutes. Return 429 on excess. Also consider adding a Firestore composite index on `inviteCode` + `inviteCodeExpiresAt` for efficient lookups.
 


### PR DESCRIPTION
## Summary

- **Upstash Redis removed**: All references to `KV_REST_API_URL`, `KV_REST_API_TOKEN`, and Upstash Redis as an entitlement store updated to Firestore throughout `security/` docs (infrastructure removed in #1521; `kv/entitlement-store.ts` already migrated to Firestore)
- **Next.js CRITICAL CVEs resolved**: `CRITICAL-001` from external pentest marked RESOLVED — Next.js upgraded to `^16.1.6` (above the vulnerable 10.0.0–15.5.9 range); note added to pentest report and open findings tracker
- **Trust zone consolidation**: Zone 5 (Upstash Redis) removed from trust-boundaries; Firestore now covers both card data and entitlements as a single zone
- **Stale Vercel hostname**: `fenrir-ledger.vercel.app` references in `trust-boundaries.md` updated to "production GKE hostname"
- **Minor fixes**: `rate-limit.ts` path corrected in Firestore audit report; distributed rate limiting guidance in API route checklist updated; SEV-008 KV delete race marked N/A; MEDIUM-001 CSP architectural constraint (PPR + CDN caching incompatibility with nonces) noted in tracker

## Test plan

- [x] `pnpm run verify:tsc` passes (no app code changed — doc-only)
- [x] All `security/*.md` links verified against actual files on disk
- [x] `.sync-report.md` written for coordinator

Closes #1577

🤖 Generated with [Claude Code](https://claude.com/claude-code)