### PR TITLE
Fix CI pnpm version conflict blocking deploys

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -50,7 +50,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "10"
           run_install: false
 
       - name: Get pnpm store directory
@@ -180,7 +179,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "10"
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -340,7 +340,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "10"
           run_install: false
 
       - name: Get pnpm store directory
@@ -547,7 +546,6 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: "10"
           run_install: false
 
       - name: Get pnpm store directory


### PR DESCRIPTION
## Summary
- Removed `version: "10"` from pnpm/action-setup in deploy.yml and ci-tests.yml
- Action now reads version from `packageManager` field in package.json
- Fixes: `Error: Multiple versions of pnpm specified`
- This was blocking all app deploys since the pnpm workspaces migration (#1520)

## Test plan
- [ ] CI tests pass (no pnpm version error)
- [ ] Deploy workflow reaches app build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)