### PR TITLE
fix(agents): extend no-tests rule to odins-spear

### DIFF
--- a/.claude/agents/fireman-decko.md
+++ b/.claude/agents/fireman-decko.md
@@ -153,7 +153,7 @@ FiremanDecko writes tests alongside implementation. Loki augments gaps only.
 - Place tests in `development/frontend/src/__tests__/` alongside the feature
 - Loki will review and add only what's missing — no duplication
 - **Never write Playwright E2E tests** — that's Loki's domain (and he writes few)
-- **Never write tests for monitor-ui** — `development/monitor-ui/` has no test infrastructure
+- **Never write tests for monitor-ui or odins-spear** — `development/monitor-ui/` and `development/odins-spear/` have no test infrastructure agents should use
 
 ### jest-dom Assertion Library (UNBREAKABLE)
 

--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -90,9 +90,9 @@ machines, auth checks, data transformations — ALL of these are Vitest, never P
 
 ### No Tests for Monitor UI (UNBREAKABLE)
 
-**Do NOT write tests for `development/monitor-ui/`.** The monitor UI (Odin's Throne) has
-no test infrastructure — no vitest, no testing-library, no `__tests__/` directory.
-All tests are for the main frontend app (`development/frontend/`) only.
+**Do NOT write tests for `development/monitor-ui/` or `development/odins-spear/`.** These packages
+have no test infrastructure that agents should use. All tests are for the main frontend app
+(`development/frontend/`) only.
 
 ### Banned Test Categories (UNBREAKABLE — Do NOT Write)
 
@@ -191,7 +191,7 @@ When in a worktree: run tests against the provided port (not 9653), read
 
 PASS requires: code review passes, build passes, tsc passes, GH Actions pass,
 AND new Playwright tests written and passing — EXCEPT:
-- **monitor-ui changes** (`development/monitor-ui/`): tsc + build only, no tests. PASS with 0 tests.
+- **monitor-ui / odins-spear changes** (`development/monitor-ui/`, `development/odins-spear/`): tsc + build only, no tests. PASS with 0 tests.
 - **Static/CSS-only changes** (no logic, no behaviour): build verification only, no tests. PASS with 0 tests.
 Do NOT FAIL an issue solely because no Playwright tests were written if the change falls into one of these exception categories.
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -151,10 +151,10 @@ Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
 On failure: fix, commit+push, re-run that step. Repeat until green.
 Do NOT proceed to handoff with ANY failing Vitest tests.
 
-NO MONITOR-UI TESTS (UNBREAKABLE):
-NEVER write tests for `development/monitor-ui/` (Odin's Throne). It has NO test
-infrastructure — no vitest, no testing-library, no __tests__/ directory. All tests
-target `development/frontend/` only. For monitor-ui issues, validate via tsc + build only.
+NO MONITOR-UI / ODINS-SPEAR TESTS (UNBREAKABLE):
+NEVER write tests for `development/monitor-ui/` (Odin's Throne) or `development/odins-spear/`.
+These packages have no test infrastructure that agents should use. All tests target
+`development/frontend/` only. For monitor-ui or odins-spear issues, validate via tsc + build only.
 
 STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -47,8 +47,8 @@ Then create your todo list via TodoWrite. Every todo below is required:
 - Run: `cd <REPO_ROOT>/development/frontend && npx vitest run src/__tests__/<feature>/ --reporter=verbose`
 - Commit+push tests with implementation.
 - Loki will add E2E tests later — you own Vitest tests.
-- **NEVER write tests for monitor-ui (Odin's Throne).** `development/monitor-ui/` has NO test
-  infrastructure — no vitest, no testing-library, no __tests__/ directory. Tests are frontend-only.
+- **NEVER write tests for monitor-ui (Odin's Throne) or odins-spear.** `development/monitor-ui/` and
+  `development/odins-spear/` have no test infrastructure that agents should use. Tests are frontend-only.
 
 **Step 4 — Full verify: tsc + build + Vitest (each = separate Bash tool call + separate todo):**
   cd <REPO_ROOT>/development/frontend && pnpm run verify:tsc

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -65,10 +65,10 @@ Then create your todo list via TodoWrite. Every todo below is required:
   **Rule of thumb:** If the test breaks when someone edits a config file, copy,
   or infrastructure template — it should NOT exist. Only test code that RUNS.
 
-- **NEVER write tests for monitor-ui (Odin's Throne).** `development/monitor-ui/` has NO test
-  infrastructure — no vitest, no testing-library, no __tests__/ directory. All tests target
-  `development/frontend/` only. If the issue is a monitor-ui change, skip Vitest entirely and
-  validate via tsc + build only.
+- **NEVER write tests for monitor-ui (Odin's Throne) or odins-spear.** `development/monitor-ui/` and
+  `development/odins-spear/` have no test infrastructure that agents should use. All tests target
+  `development/frontend/` only. If the issue is a monitor-ui or odins-spear change, skip Vitest
+  entirely and validate via tsc + build only.
 - Follow ALL Test Standards from the agent definition — budgets, pyramid, locators, data isolation.
 - Use the handoff's "How to verify" and "Edge cases" to guide test design.
 - **Commit+push tests before running them:**


### PR DESCRIPTION
## Summary
- `development/odins-spear/` is NOT Odin's Throne (`development/monitor-ui/`) — they're separate packages
- Extended the no-tests rule to cover both: agents validate via tsc + build only
- Updated all 5 agent/template files that reference the rule

## Test plan
- [ ] CI passes (docs-only change, no code affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)