### PR TITLE
Issue #1597 - fix: H key auto-selects household in Odins Spear

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -40,6 +40,7 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
   const selection = useSelection();
 
   const [activeTab, setActiveTab] = useState(0);
+  const [jumpHouseholdId, setJumpHouseholdId] = useState<string | null>(null);
   const [overlay, setOverlay] = useState<OverlayMode>({ kind: "none" });
   const [cmdStatus, setCmdStatusMsg] = useState<string | null>(null);
   const [connState, setConnState] = useState<ConnStatus>(initialConnStatus);
@@ -248,7 +249,7 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
       <UsersTab
         cmdStatus={cmdStatus}
         onInputCapture={setInputCaptured}
-        onJumpToHousehold={() => { setActiveTab(1); }}
+        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(1); }}
         onCardsView={(householdId, filterUserId, ownerEmail) => {
           setCardDrilldown({ householdId, filterUserId, breadcrumbFrom: ownerEmail, ownerEmail });
         }}
@@ -262,6 +263,7 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     mainContent = (
       <HouseholdsTab
         cmdStatus={cmdStatus}
+        initialHouseholdId={jumpHouseholdId}
         onCardsView={(householdId, householdName) => {
           setCardDrilldown({ householdId, filterUserId: null, breadcrumbFrom: householdName, ownerEmail: householdName });
         }}

--- a/development/odins-spear/src/tabs/HouseholdsTab.tsx
+++ b/development/odins-spear/src/tabs/HouseholdsTab.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback, useRef } from "react";
 import { Box, Text, useInput } from "ink";
 import { log } from "@fenrir/logger";
 import { firestoreClient } from "../lib/firestore.js";
@@ -498,6 +498,7 @@ function generateRandomCode(): string {
 
 interface HouseholdsTabProps {
   cmdStatus: string | null;
+  initialHouseholdId?: string | null;
   onCardsView?: (householdId: string, householdName: string) => void;
 }
 
@@ -508,7 +509,7 @@ type LoadState = "idle" | "loading" | "loaded" | "error";
  * Left panel: scrollable list with tier badge + member count.
  * Right panel: full household detail with members, entitlements, Stripe info.
  */
-export function HouseholdsTab({ cmdStatus, onCardsView }: HouseholdsTabProps): React.JSX.Element {
+export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView }: HouseholdsTabProps): React.JSX.Element {
   log.debug("HouseholdsTab render");
 
   const selection = useSelection();
@@ -521,6 +522,9 @@ export function HouseholdsTab({ cmdStatus, onCardsView }: HouseholdsTabProps): R
   const [detailLoading, setDetailLoading] = useState(false);
   const [status, setStatus]         = useState<string | null>(cmdStatus);
   const [confirm, setConfirm]       = useState<ConfirmAction | null>(null);
+
+  // Track whether the initialHouseholdId has been applied — reset on each mount
+  const initialApplied = useRef(false);
 
   // Reload function — exported for Ctrl+R
   const doLoad = useCallback(() => {
@@ -545,6 +549,23 @@ export function HouseholdsTab({ cmdStatus, onCardsView }: HouseholdsTabProps): R
   useEffect(() => {
     doLoad();
   }, [doLoad]);
+
+  // Auto-select a household when navigating from the Users tab via H key
+  useEffect(() => {
+    if (!initialHouseholdId || initialApplied.current) return;
+    if (loadState !== "loaded" || households.length === 0) return;
+
+    const idx = households.findIndex((h) => h.id === initialHouseholdId);
+    if (idx >= 0) {
+      log.debug("HouseholdsTab: auto-selecting household from H key", { id: initialHouseholdId, idx });
+      setSelectedIdx(idx);
+      setScrollOffset(Math.max(0, Math.min(idx, households.length - LIST_HEIGHT)));
+    } else {
+      log.debug("HouseholdsTab: initialHouseholdId not found in list", { id: initialHouseholdId });
+      setStatus(`Household not found`);
+    }
+    initialApplied.current = true;
+  }, [initialHouseholdId, loadState, households]);
 
   // Load detail when selection changes
   useEffect(() => {

--- a/development/odins-spear/src/tabs/UsersTab.tsx
+++ b/development/odins-spear/src/tabs/UsersTab.tsx
@@ -266,7 +266,7 @@ function UserDetailPanel({
 interface UsersTabProps {
   cmdStatus: string | null;
   onInputCapture?: (captured: boolean) => void;
-  onJumpToHousehold?: () => void;
+  onJumpToHousehold?: (householdId: string) => void;
   onCardsView?: (householdId: string, filterUserId: string, ownerEmail: string) => void;
   onTrialAdjust?: () => void;
 }
@@ -642,8 +642,12 @@ export function UsersTab({
         setActionMode("sub_cancel_confirm");
         return;
       }
-      if (input === "h" && detail?.household) {
-        onJumpToHousehold?.();
+      if (input === "h") {
+        if (detail?.household && user.householdId) {
+          onJumpToHousehold?.(user.householdId);
+        } else {
+          setStatusMsg("No household \u2014 this user is solo");
+        }
         return;
       }
       if (input === "c" && detail?.household && user.householdId) {


### PR DESCRIPTION
Fixes #1597

## Summary

- `UsersTab.tsx`: Updated `onJumpToHousehold` prop signature from `() => void` to `(householdId: string) => void`; H key now passes `user.householdId` to the callback; shows 'No household — this user is solo' status message when user has no household
- `HouseholdsTab.tsx`: Added `initialHouseholdId?: string | null` prop; `useEffect` with a `useRef` guard auto-selects the matching household once when households data loads; adjusts scroll offset to show the selected item
- `app.tsx`: Added `jumpHouseholdId` state; `onJumpToHousehold` callback now sets `jumpHouseholdId` alongside `setActiveTab(1)`; passes `initialHouseholdId={jumpHouseholdId}` to `HouseholdsTab`

## Test plan

- Odins Spear is a TUI package — validated via tsc + build per UNBREAKABLE rules (no Vitest for odins-spear)
- tsc: no new errors in changed src files (app.tsx, HouseholdsTab.tsx, UsersTab.tsx)
- frontend: tsc + build PASS
- AC1: H key on user with householdId switches tab AND auto-selects household (useRef guard prevents re-selection)
- AC2: H key on user without householdId shows status message, no navigation
- AC3: Scroll offset adjusted to show selected household in list

🤖 Generated with [Claude Code](https://claude.com/claude-code)