### PR TITLE
fix(trial): surface auto-init errors + bust stale cache — #1589

### DIFF
--- a/development/frontend/src/__tests__/trial/trial-phantom-1589.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-phantom-1589.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Tests for phantom trial fixes — Issue #1589
+ *
+ * Covers:
+ *  - /api/trial/status returns 500 when auto-init Firestore write fails
+ *    (previously silently fell through with status "none")
+ *  - /api/trial/status includes cacheVersion in every 200 response
+ *  - cacheVersion equals TRIAL_CACHE_VERSION (2, the Firestore era)
+ *  - useTrialStatus busts module-level cache when stored version mismatches
+ *  - useTrialStatus persists cacheVersion to localStorage after successful fetch
+ *
+ * @ref Issue #1589
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { NextRequest } from "next/server";
+import { renderHook, waitFor } from "@testing-library/react";
+
+// ── Route handler mocks ────────────────────────────────────────────────────────
+
+const mockDocRef = vi.hoisted(() => ({
+  get: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+}));
+
+const mockCollectionRef = vi.hoisted(() => ({
+  where: vi.fn().mockReturnThis(),
+  limit: vi.fn().mockReturnThis(),
+  get: vi.fn(),
+}));
+
+const mockDb = vi.hoisted(() => ({
+  doc: vi.fn(() => mockDocRef),
+  collection: vi.fn(() => mockCollectionRef),
+}));
+
+vi.mock("@/lib/firebase/firestore", () => ({
+  getFirestore: () => mockDb,
+}));
+
+const mockRateLimit = vi.hoisted(() => vi.fn(() => ({ success: true, remaining: 29 })));
+vi.mock("@/lib/rate-limit", () => ({
+  rateLimit: mockRateLimit,
+}));
+
+vi.mock("@/lib/logger", () => ({
+  log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+// ── Hook mocks ─────────────────────────────────────────────────────────────────
+
+const VALID_FINGERPRINT = "a".repeat(64);
+
+const mockComputeFingerprint = vi.hoisted(() =>
+  vi.fn(() => Promise.resolve(VALID_FINGERPRINT)),
+);
+vi.mock("@/lib/trial-utils", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/trial-utils")>();
+  return {
+    ...actual,
+    computeFingerprint: mockComputeFingerprint,
+  };
+});
+
+const mockEnsureFreshToken = vi.hoisted(() =>
+  vi.fn<() => Promise<string | null>>(() => Promise.resolve(null)),
+);
+vi.mock("@/lib/auth/refresh-session", () => ({
+  ensureFreshToken: mockEnsureFreshToken,
+}));
+
+// ── Import after mocks ─────────────────────────────────────────────────────────
+
+import { POST } from "@/app/api/trial/status/route";
+import { useTrialStatus, clearTrialStatusCache } from "@/hooks/useTrialStatus";
+import { TRIAL_CACHE_VERSION, LS_TRIAL_CACHE_VERSION } from "@/lib/trial-utils";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const missingSnap = { exists: false, data: () => null };
+
+function existingSnap(trial: Record<string, unknown>) {
+  return { exists: true, data: () => ({ ...trial, expiresAt: {} }) };
+}
+
+function makeRequest(body: Record<string, unknown> = {}): NextRequest {
+  return new NextRequest("http://localhost:9653/api/trial/status", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": "127.0.0.1",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+function daysAgo(n: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  return d.toISOString();
+}
+
+// ── Route handler tests ────────────────────────────────────────────────────────
+
+describe("POST /api/trial/status — issue #1589 fixes", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDocRef.get.mockResolvedValue(missingSnap);
+    mockDocRef.set.mockResolvedValue(undefined);
+    mockDocRef.update.mockResolvedValue(undefined);
+    mockCollectionRef.get.mockResolvedValue({ empty: true, docs: [] });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Auto-init failure: return 500, not silent "none"
+  // ═══════════════════════════════════════════════════════════════════════
+
+  it("returns 500 when auto-init Firestore write fails (not silent none)", async () => {
+    // getTrial: not found → triggers auto-init
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap) // getTrial in status route
+      .mockResolvedValueOnce(missingSnap); // getTrial inside initTrial
+    // Firestore SET fails
+    mockDocRef.set.mockRejectedValueOnce(new Error("Firestore quota exceeded"));
+
+    const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
+    const body = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("internal_error");
+  });
+
+  it("auto-init failure does NOT return status none (phantom prevention)", async () => {
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap)
+      .mockResolvedValueOnce(missingSnap);
+    mockDocRef.set.mockRejectedValueOnce(new Error("Permission denied"));
+
+    const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
+    const body = await res.json();
+
+    // Must not return a 200 with status "none" — that could mask a write failure
+    expect(res.status).not.toBe(200);
+    expect(body.status).toBeUndefined();
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // cacheVersion included in 200 responses
+  // ═══════════════════════════════════════════════════════════════════════
+
+  it("includes cacheVersion in 200 response for existing trial", async () => {
+    mockDocRef.get.mockResolvedValueOnce(existingSnap({ startDate: daysAgo(0) }));
+
+    const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.cacheVersion).toBe(TRIAL_CACHE_VERSION);
+    expect(body.cacheVersion).toBe(2);
+  });
+
+  it("includes cacheVersion in 200 response after successful auto-init", async () => {
+    mockDocRef.get
+      .mockResolvedValueOnce(missingSnap)
+      .mockResolvedValueOnce(missingSnap);
+    mockDocRef.set.mockResolvedValueOnce(undefined);
+
+    const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.cacheVersion).toBe(TRIAL_CACHE_VERSION);
+  });
+
+  it("cacheVersion equals 2 (Firestore-era constant)", () => {
+    expect(TRIAL_CACHE_VERSION).toBe(2);
+  });
+});
+
+// ── useTrialStatus hook tests ──────────────────────────────────────────────────
+
+describe("useTrialStatus — cache version invalidation (issue #1589)", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let localStorageMock: Record<string, string>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    clearTrialStatusCache();
+
+    // Mock localStorage
+    localStorageMock = {};
+    vi.spyOn(Storage.prototype, "getItem").mockImplementation(
+      (key) => localStorageMock[key] ?? null,
+    );
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation((key, value) => {
+      localStorageMock[key] = String(value);
+    });
+
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () =>
+      new Response(
+        JSON.stringify({ status: "active", remainingDays: 30, cacheVersion: 2 }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("persists cacheVersion to localStorage after a successful fetch", async () => {
+    renderHook(() => useTrialStatus());
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    expect(localStorageMock[LS_TRIAL_CACHE_VERSION]).toBe("2");
+  });
+
+  it("busts module-level cache when stored version is stale (e.g. version 1 from Redis era)", async () => {
+    // Simulate stale Redis-era version in localStorage
+    localStorageMock[LS_TRIAL_CACHE_VERSION] = "1";
+
+    // Render hook — should bypass the module cache and fetch fresh
+    renderHook(() => useTrialStatus());
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+
+    // After fetch, localStorage should be updated to the current version
+    expect(localStorageMock[LS_TRIAL_CACHE_VERSION]).toBe("2");
+  });
+
+  it("does not bypass cache when stored version matches current version", async () => {
+    // Pre-populate localStorage with current version
+    localStorageMock[LS_TRIAL_CACHE_VERSION] = String(TRIAL_CACHE_VERSION);
+
+    // First render: populates module-level cache
+    const { unmount } = renderHook(() => useTrialStatus());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+    unmount();
+
+    // Second render with same version: should use cache (no second fetch)
+    renderHook(() => useTrialStatus());
+    // Wait a tick
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("fetches again after clearTrialStatusCache even if version matches", async () => {
+    localStorageMock[LS_TRIAL_CACHE_VERSION] = String(TRIAL_CACHE_VERSION);
+
+    renderHook(() => useTrialStatus());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+    clearTrialStatusCache();
+
+    renderHook(() => useTrialStatus());
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(2));
+  });
+});

--- a/development/frontend/src/__tests__/trial/trial-status-route.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-status-route.test.ts
@@ -330,19 +330,17 @@ describe("POST /api/trial/status", () => {
   // Auto-init failure: Firestore unavailable
   // ═══════════════════════════════════════════════════════════════════════
 
-  it("returns none status when both getTrial and auto-init fail due to Firestore error", async () => {
-    // getTrial fails — Firestore error (caught, returns null)
-    mockDocRef.get.mockRejectedValueOnce(new Error("Firestore unavailable"));
+  it("returns 500 when getTrial fails and auto-init Firestore write also fails", async () => {
+    // getTrial fails — error is caught in getTrial, returns null
+    // initTrial is then attempted; its Firestore SET also fails → throws
+    mockDocRef.get.mockRejectedValue(new Error("Firestore unavailable"));
+    mockDocRef.set.mockRejectedValue(new Error("Firestore unavailable"));
 
     const res = await POST(makeRequest({ fingerprint: VALID_FINGERPRINT }));
     const body = await res.json();
 
-    // getTrial error is caught and returns null, then initTrial is called
-    // but the outer try-catch wraps both; status depends on implementation
-    expect([200, 500]).toContain(res.status);
-    if (res.status === 200) {
-      // If auto-init also fails, should return "none"
-      expect(["none", "active"]).toContain(body.status);
-    }
+    // Auto-init failure is now surfaced as a 500 (fixes #1589: no silent "none")
+    expect(res.status).toBe(500);
+    expect(body.error).toBe("internal_error");
   });
 });

--- a/development/frontend/src/app/api/trial/status/route.ts
+++ b/development/frontend/src/app/api/trial/status/route.ts
@@ -17,7 +17,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { rateLimit } from "@/lib/rate-limit";
 import { log } from "@/lib/logger";
-import { isValidFingerprint } from "@/lib/trial-utils";
+import { isValidFingerprint, TRIAL_CACHE_VERSION } from "@/lib/trial-utils";
 import { getTrial, initTrial, computeTrialStatus } from "@/lib/kv/trial-store";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -87,8 +87,15 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         trial = await initTrial(fingerprint);
       } catch (initErr) {
         const msg = initErr instanceof Error ? initErr.message : String(initErr);
-        log.error("POST /api/trial/status: auto-init failed", { fingerprint, error: msg });
-        // Fall through with trial === null — computeTrialStatus returns "none"
+        log.error("POST /api/trial/status: auto-init failed — returning 500", { fingerprint, error: msg });
+        // Surface the error: a failed Firestore write means we cannot guarantee
+        // the trial state is accurate. Return 500 so the client retries rather
+        // than silently showing "no trial" for a write that may have partially
+        // succeeded (fixes phantom-trial issue #1589).
+        return NextResponse.json(
+          { error: "internal_error", error_description: "Failed to initialize trial." },
+          { status: 500 },
+        );
       }
     }
     const result = computeTrialStatus(trial);
@@ -99,9 +106,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       remainingDays: result.remainingDays,
     });
 
-    return NextResponse.json(result, {
-      headers: { "Cache-Control": "no-store" },
-    });
+    return NextResponse.json(
+      { ...result, cacheVersion: TRIAL_CACHE_VERSION },
+      { headers: { "Cache-Control": "no-store" } },
+    );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     log.error("POST /api/trial/status failed", { error: message });

--- a/development/frontend/src/hooks/useTrialStatus.ts
+++ b/development/frontend/src/hooks/useTrialStatus.ts
@@ -14,7 +14,11 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { computeFingerprint } from "@/lib/trial-utils";
+import {
+  computeFingerprint,
+  LS_TRIAL_CACHE_VERSION,
+  TRIAL_CACHE_VERSION,
+} from "@/lib/trial-utils";
 import { ensureFreshToken } from "@/lib/auth/refresh-session";
 import type { TrialStatus, TrialStatusResponse } from "@/lib/trial-utils";
 
@@ -75,7 +79,17 @@ export function useTrialStatus(): UseTrialStatusReturn {
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const fetchStatus = useCallback(async () => {
-    // Check cache first
+    // Bust the module-level cache if the stored cache version differs from the
+    // current expected version. This handles post-migration scenarios where the
+    // server's backend changed (e.g. Redis → Firestore in #1516/#1589) and the
+    // in-memory cache may contain phantom trial data from the old store.
+    const storedVersion =
+      typeof window !== "undefined" ? localStorage.getItem(LS_TRIAL_CACHE_VERSION) : null;
+    if (storedVersion !== String(TRIAL_CACHE_VERSION)) {
+      cachedStatus = null;
+    }
+
+    // Check cache first (only if version is current)
     if (cachedStatus && Date.now() - cachedStatus.fetchedAt < CACHE_TTL_MS) {
       setData(cachedStatus.data);
       setIsLoading(false);
@@ -112,6 +126,12 @@ export function useTrialStatus(): UseTrialStatusReturn {
       }
 
       const result = (await response.json()) as TrialStatusResponse;
+
+      // Persist the server's cache version so future page loads can detect
+      // version mismatches without having to hit the network first.
+      if (typeof window !== "undefined" && result.cacheVersion !== undefined) {
+        localStorage.setItem(LS_TRIAL_CACHE_VERSION, String(result.cacheVersion));
+      }
 
       // Update cache
       cachedStatus = { data: result, fetchedAt: Date.now() };

--- a/development/frontend/src/lib/trial-utils.ts
+++ b/development/frontend/src/lib/trial-utils.ts
@@ -29,6 +29,24 @@ export const LS_TRIAL_EXPIRY_MODAL_SHOWN = "fenrir:trial-expiry-modal-shown";
 /** Boolean — whether the post-trial upgrade banner has been dismissed. */
 export const LS_POST_TRIAL_BANNER_DISMISSED = "fenrir:post-trial-banner-dismissed";
 
+/**
+ * Last-seen trial cache version stored in localStorage.
+ * When the server returns a higher version, the client busts its module-level
+ * cache and re-fetches — preventing phantom trial data after backend migrations.
+ */
+export const LS_TRIAL_CACHE_VERSION = "fenrir:trial-cache-version";
+
+/**
+ * Current server-side trial cache version.
+ * Increment this when a backend migration could make cached trial state stale
+ * (e.g. the Redis → Firestore migration in #1516 bumped this to 2).
+ *
+ * Version history:
+ *   1 — Redis-backed trial store
+ *   2 — Firestore-backed trial store (#1516)
+ */
+export const TRIAL_CACHE_VERSION = 2;
+
 /** Thrall-tier card visibility limit. Cards beyond this count are locked. */
 export const THRALL_CARD_LIMIT = 5;
 
@@ -44,6 +62,12 @@ export interface TrialStatusResponse {
   remainingDays: number;
   status: TrialStatus;
   convertedDate?: string;
+  /**
+   * Server-side cache version. When the client sees a version different from
+   * its stored value, it busts the module-level cache and re-fetches.
+   * See `TRIAL_CACHE_VERSION` and `LS_TRIAL_CACHE_VERSION`.
+   */
+  cacheVersion?: number;
 }
 
 /** Trial duration in days. */


### PR DESCRIPTION
## Summary

Fixes phantom trial shown in UI after the Redis→Firestore migration (#1516):

- **Auto-init error surfacing**: `/api/trial/status` previously swallowed Firestore write failures in auto-init and silently returned `status: "none"`. A failed write now returns **500** so the client retries rather than trusting a potentially half-written state.
- **Client cache version invalidation**: Added `TRIAL_CACHE_VERSION = 2` (Firestore era) and `LS_TRIAL_CACHE_VERSION` localStorage key. The API embeds `cacheVersion` in every 200 response; `useTrialStatus` busts its module-level cache whenever the stored version mismatches, forcing a fresh server fetch after backend migrations.
- **Test coverage**: 9 new tests in `trial-phantom-1589.test.ts`; updated existing Firestore-error test in `trial-status-route.test.ts` to assert 500 (not 200).

## Root Cause

1. Client module-level cache had no migration-awareness — stale `{ status: "active" }` from the Redis era persisted until the 4-minute TTL expired.
2. If a user hit `/api/trial/status` after the Firestore migration with no existing record, auto-init could fail silently, returning `"none"` while the cache still showed `"active"`.

## Test Plan

- [x] `pnpm run verify:tsc` — clean
- [x] `pnpm run verify:build` — clean
- [x] `npx vitest run` — 2236 tests, 150 files, all pass
- [x] New tests: `trial-phantom-1589.test.ts` (9 tests) all green
- [x] Updated: `trial-status-route.test.ts` Firestore-error case now asserts 500

## Acceptance Criteria

- [x] Trial status in UI matches Firestore state (no phantom trials)
- [x] If no Firestore trial record exists, UI reflects that accurately
- [x] Trial init creates a Firestore document when a new trial starts
- [x] Stale client-side trial cache is invalidated after Redis→Firestore migration
- [x] Auto-init errors in /api/trial/status are properly handled (return 500, not silent none)
- [x] tsc + build + Vitest pass

Closes #1589

🤖 Generated with [Claude Code](https://claude.com/claude-code)