### PR TITLE
Issue #1607 - fix: expanded layout header + labeled action buttons

### DIFF
--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -82,7 +82,7 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
     );
   }
 
-  const shortSessionId = job.sessionId.length > 8 ? job.sessionId.slice(0, 8) + "…" : job.sessionId;
+  const isExtended = displayMode === "extended";
 
   return (
     <div
@@ -105,8 +105,13 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
             <img className="card-avatar" src={avatar} alt={job.agentName} />
           </button>
         )}
-        <span className="card-issue-title" title={cardTitle}>
-          {cardTitle}
+        {isExtended && (
+          <span className="card-extended-issue-badge" aria-label={`Issue ${job.issue}`}>
+            #{job.issue}
+          </span>
+        )}
+        <span className="card-issue-title" title={isExtended ? (job.issueTitle ?? displayTitle) : cardTitle}>
+          {isExtended ? (job.issueTitle ?? displayTitle) : cardTitle}
         </span>
       </div>
       <div className="card-meta-new">
@@ -115,47 +120,78 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
         </span>
         <span>Step {job.step}</span>
         {job.fixture && <span className="card-fixture-badge" title="Fixture (replayed log)">ᚠ</span>}
-        {job.status === "running" && onCancelJob ? (
-          <button
-            className={`card-status-icon-btn card-status-icon-btn--cancel${pulse}`}
-            style={{ color: sColor }}
-            title="Invoke Ragnarök — click to cancel this job"
-            aria-label="Cancel running job"
-            onClick={(e) => {
-              e.stopPropagation();
-              onCancelJob(job.sessionId);
-            }}
-          >
-            <StatusIconSvg status={job.status} />
-          </button>
+        {isExtended ? (
+          <>
+            {job.status === "running" && onCancelJob ? (
+              <button
+                className={`card-extended-action-btn card-extended-action-btn--cancel card-extended-action-first${pulse}`}
+                style={{ color: sColor }}
+                title="Invoke Ragnarök — click to cancel this job"
+                aria-label="Cancel running job"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCancelJob(job.sessionId);
+                }}
+              >
+                <StatusIconSvg status={job.status} />
+                <span>{sLabel}</span>
+              </button>
+            ) : (
+              <span
+                className={`card-extended-status-label card-extended-action-first${pulse}`}
+                style={{ color: sColor }}
+                aria-label={`Status: ${sLabel}`}
+                title={sLabel}
+              >
+                <StatusIconSvg status={job.status} />
+                <span>{sLabel}</span>
+              </span>
+            )}
+            <CardCopySessionIdButton sessionId={job.sessionId} labeled />
+            {onTogglePin && (
+              <CardPinButtonLabeled isPinned={isPinned} onTogglePin={onTogglePin} />
+            )}
+          </>
         ) : (
-          <span
-            className={`card-status-icon-btn${pulse}`}
-            style={{ color: sColor }}
-            title={sLabel}
-            aria-label={`Status: ${sLabel}`}
-          >
-            <StatusIconSvg status={job.status} />
-          </span>
+          <>
+            {job.status === "running" && onCancelJob ? (
+              <button
+                className={`card-status-icon-btn card-status-icon-btn--cancel${pulse}`}
+                style={{ color: sColor }}
+                title="Invoke Ragnarök — click to cancel this job"
+                aria-label="Cancel running job"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onCancelJob(job.sessionId);
+                }}
+              >
+                <StatusIconSvg status={job.status} />
+              </button>
+            ) : (
+              <span
+                className={`card-status-icon-btn${pulse}`}
+                style={{ color: sColor }}
+                title={sLabel}
+                aria-label={`Status: ${sLabel}`}
+              >
+                <StatusIconSvg status={job.status} />
+              </span>
+            )}
+            {onTogglePin && (
+              <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
+            )}
+            <CardCopySessionIdButton sessionId={job.sessionId} />
+          </>
         )}
-        {onTogglePin && (
-          <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
-        )}
-        <CardCopySessionIdButton sessionId={job.sessionId} />
       </div>
-      {displayMode === "extended" && (
+      {isExtended && (job.startTime || job.completionTime) && (
         <div className="card-extended-meta">
-          <span className="card-extended-session-id" title={job.sessionId}>
-            {shortSessionId}
-          </span>
           <span className="card-extended-elapsed" title="Elapsed time">
             {formatElapsed(job.startTime, job.completionTime)}
           </span>
-          {(job.startTime || job.completionTime) && (
-            <span className="card-extended-timestamp" title="Last activity">
-              {formatTimestamp(job.completionTime ?? job.startTime)}
-            </span>
-          )}
+          <span className="card-extended-timestamp" title="Last activity">
+            {formatTimestamp(job.completionTime ?? job.startTime)}
+          </span>
         </div>
       )}
       {isTerminating && (
@@ -212,7 +248,53 @@ function CardPinButton({ isPinned, onTogglePin }: { isPinned: boolean; onToggleP
   );
 }
 
-function CardCopySessionIdButton({ sessionId }: { sessionId: string }) {
+function CardPinButtonLabeled({ isPinned, onTogglePin }: { isPinned: boolean; onTogglePin: () => void }) {
+  const [confirming, setConfirming] = useState(false);
+
+  useEffect(() => {
+    setConfirming(false);
+  }, [isPinned]);
+
+  if (confirming) {
+    return (
+      <button
+        className="card-extended-action-btn card-extended-action-btn--confirm"
+        onClick={(e) => {
+          e.stopPropagation();
+          onTogglePin();
+          setConfirming(false);
+        }}
+        onBlur={() => setConfirming(false)}
+        title="Confirm: remove from Odin\u2019s memory"
+        aria-label="Confirm unpin"
+      >
+        ✕ Unpin?
+      </button>
+    );
+  }
+
+  return (
+    <button
+      className={`card-extended-action-btn${isPinned ? " card-extended-action-btn--pinned" : ""}`}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (isPinned) {
+          setConfirming(true);
+        } else {
+          onTogglePin();
+        }
+      }}
+      title={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
+      aria-label={isPinned ? "Unpin from Odin\u2019s memory" : "Pin to Odin\u2019s memory"}
+      aria-pressed={isPinned}
+    >
+      <CardPinIcon filled={isPinned} />
+      <span>Pin Session</span>
+    </button>
+  );
+}
+
+function CardCopySessionIdButton({ sessionId, labeled }: { sessionId: string; labeled?: boolean }) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy(e: React.MouseEvent) {
@@ -224,6 +306,20 @@ function CardCopySessionIdButton({ sessionId }: { sessionId: string }) {
     } catch {
       // Clipboard API unavailable — no-op
     }
+  }
+
+  if (labeled) {
+    return (
+      <button
+        className={`card-extended-action-btn${copied ? " card-extended-action-btn--copied" : ""}`}
+        onClick={handleCopy}
+        title={copied ? "Copied!" : `Copy session ID: ${sessionId}`}
+        aria-label={copied ? "Session ID copied" : "Copy Session ID"}
+      >
+        {copied ? <CardCheckIcon /> : <CardClipboardIcon />}
+        <span>{copied ? "Copied!" : "Copy Session ID"}</span>
+      </button>
+    );
   }
 
   return (

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -671,6 +671,55 @@ body {
   flex-shrink: 0;
 }
 
+/* ── Extended mode: issue number badge in card header ── */
+.card-extended-issue-badge {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.68rem;
+  font-weight: 700;
+  color: var(--gold-bright);
+  flex-shrink: 0;
+  white-space: nowrap;
+  opacity: 0.85;
+}
+
+/* ── Extended mode: first action item pushed to right in flex row ── */
+.card-extended-action-first {
+  margin-left: auto;
+}
+
+/* ── Extended mode: labeled action buttons (status, copy, pin) ── */
+.card-extended-action-btn {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 1px 5px;
+  background: transparent; border: 1px solid var(--rune-border);
+  border-radius: 2px; cursor: pointer;
+  font-size: 0.6rem; font-family: 'JetBrains Mono', monospace;
+  color: var(--text-rune); white-space: nowrap;
+  line-height: 1; transition: color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+.card-extended-action-btn:hover { border-color: currentColor; color: var(--text-saga); }
+.card-extended-action-btn--cancel { cursor: pointer; }
+.card-extended-action-btn--cancel:hover { color: var(--error-strong); border-color: var(--error-strong); }
+.card-extended-action-btn--pinned { color: var(--gold); border-color: var(--gold-dim-border); }
+.card-extended-action-btn--pinned:hover { color: var(--error-strong); border-color: var(--error-strong); background: rgba(239, 68, 68, 0.08); }
+.card-extended-action-btn--confirm { color: var(--error-strong); border-color: var(--error-strong); background: rgba(239, 68, 68, 0.08); }
+.card-extended-action-btn--copied { color: var(--teal-asgard); border-color: var(--teal-asgard); }
+.card-extended-action-btn:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+.card-extended-action-btn.pulse { animation: pulse 1.5s ease-in-out infinite; }
+
+/* ── Extended mode: non-clickable status label ── */
+.card-extended-status-label {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 1px 5px;
+  border: 1px solid var(--rune-border);
+  border-radius: 2px; cursor: default;
+  font-size: 0.6rem; font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap; line-height: 1;
+  flex-shrink: 0;
+}
+.card-extended-status-label.pulse { animation: pulse 1.5s ease-in-out infinite; }
+
 /* ── Header pin confirm label ── */
 .pin-btn-confirming {
   color: var(--error-strong) !important; border-color: var(--error-strong) !important;


### PR DESCRIPTION
PR for issue: #1607

Fixes expanded layout in Odin's Throne to keep issue # on same line as title and expand action icons to labeled buttons.

**Changes:**
- `development/monitor-ui/src/components/JobCard.tsx` — in extended mode: split issue # badge from title so it's always visible on row 1; replace icon-only status/copy/pin with labeled action buttons (`{status}`, `Copy Session ID`, `Pin Session`)
- `development/monitor-ui/src/styles/index.css` — add `.card-extended-issue-badge`, `.card-extended-action-btn` (+ variants: `--cancel`, `--pinned`, `--confirm`, `--copied`), `.card-extended-status-label`, `.card-extended-action-first` CSS classes for the extended layout

**Verification:**
- Open Odin's Throne, drag sidebar to >400px (extended mode), verify issue # stays on same row as title
- Verify action icons are now labeled buttons: status label with icon, Copy Session ID (with clipboard/check feedback), Pin Session
- Toggle back to compact/normal — verify unchanged

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>