### PR TITLE
Issue #1617 - fix: profile menu tab navigation on settings page

### DIFF
--- a/development/frontend/src/__tests__/layout/settings-dropdown-nav-1481.test.tsx
+++ b/development/frontend/src/__tests__/layout/settings-dropdown-nav-1481.test.tsx
@@ -274,6 +274,54 @@ describe("Issue #1481 — ProfileDropdown nav pushes correct routes", () => {
   });
 });
 
+// ── Issue #1617 — Same-page navigation: direct hash update when already on settings ──
+
+describe("Issue #1617 — ProfileDropdown same-page tab navigation", () => {
+  beforeEach(() => {
+    mockAuthStatus = "authenticated";
+    mockSession = { user: { name: "Odin Allfather", email: "odin@asgard.com" } };
+    mockPathname = "/ledger/settings";
+    mockPush.mockClear();
+    window.location.hash = "";
+  });
+
+  afterEach(() => {
+    window.location.hash = "";
+  });
+
+  it("clicking Account on settings page sets window.location.hash to #account (not router.push)", () => {
+    render(<LedgerTopBar />);
+    openDropdown();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Account$/i }));
+    expect(window.location.hash).toBe("#account");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("clicking Household on settings page sets window.location.hash to #household (not router.push)", () => {
+    render(<LedgerTopBar />);
+    openDropdown();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Household$/i }));
+    expect(window.location.hash).toBe("#household");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("clicking Settings on settings page sets window.location.hash to #settings (not router.push)", () => {
+    render(<LedgerTopBar />);
+    openDropdown();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Settings$/i }));
+    expect(window.location.hash).toBe("#settings");
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("clicking Account from other pages still uses router.push", () => {
+    mockPathname = "/ledger";
+    render(<LedgerTopBar />);
+    openDropdown();
+    fireEvent.click(screen.getByRole("menuitem", { name: /^Account$/i }));
+    expect(mockPush).toHaveBeenCalledWith("/ledger/settings#account");
+  });
+});
+
 // ── SettingsPage hashchange listener ─────────────────────────────────────────
 
 describe("Issue #1481 — SettingsPage responds to hashchange events", () => {

--- a/development/frontend/src/components/layout/LedgerTopBar.tsx
+++ b/development/frontend/src/components/layout/LedgerTopBar.tsx
@@ -286,7 +286,11 @@ function ProfileDropdown({ onClose, onSignOut }: ProfileDropdownProps) {
         role="menuitem"
         onClick={() => {
           onClose();
-          router.push("/ledger/settings#account");
+          if (onSettingsPage) {
+            window.location.hash = "account";
+          } else {
+            router.push("/ledger/settings#account");
+          }
         }}
         className={[
           "px-4 py-3 text-base hover:bg-secondary/50 text-left transition-[color,border-color] font-body flex items-center gap-2 border-b border-border relative",
@@ -311,7 +315,11 @@ function ProfileDropdown({ onClose, onSignOut }: ProfileDropdownProps) {
         role="menuitem"
         onClick={() => {
           onClose();
-          router.push("/ledger/settings#household");
+          if (onSettingsPage) {
+            window.location.hash = "household";
+          } else {
+            router.push("/ledger/settings#household");
+          }
         }}
         className={[
           "px-4 py-3 text-base hover:bg-secondary/50 text-left transition-[color,border-color] font-body flex items-center gap-2 border-b border-border relative",
@@ -336,7 +344,11 @@ function ProfileDropdown({ onClose, onSignOut }: ProfileDropdownProps) {
         role="menuitem"
         onClick={() => {
           onClose();
-          router.push("/ledger/settings#settings");
+          if (onSettingsPage) {
+            window.location.hash = "settings";
+          } else {
+            router.push("/ledger/settings#settings");
+          }
         }}
         className={[
           "px-4 py-3 text-base hover:bg-secondary/50 text-left transition-[color,border-color] font-body flex items-center gap-2 border-b border-border relative",


### PR DESCRIPTION
PR for issue: #1617

Fixes profile menu Account/Household/Settings links to switch tabs even when already on the settings page.

**Root cause:** `router.push("/ledger/settings#account")` via Next.js App Router does not fire the browser `hashchange` event when already on `/ledger/settings`. The settings page tab-switch logic relies on `window.addEventListener("hashchange", ...)`, so clicking the dropdown items was a no-op when already on settings.

**Changes:**
- `development/frontend/src/components/layout/LedgerTopBar.tsx` — In `ProfileDropdown`, clicking Account/Household/Settings when already on the settings page now sets `window.location.hash` directly (fires `hashchange`) instead of `router.push()`. Navigation from other pages continues to use `router.push()`.
- `development/frontend/src/__tests__/layout/settings-dropdown-nav-1481.test.tsx` — Added Issue #1617 test block (4 tests) covering same-page hash navigation behaviour.

**Verification:**
- Navigate to Settings page, open profile menu, click Account — tab switches to Account
- Navigate to Settings page, open profile menu, click Household — tab switches to Household
- Navigate to Settings page, open profile menu, click Settings — tab switches to Settings
- Navigate to My Cards, open profile menu, click Account — should navigate to settings with Account tab