### PR TITLE
fix(ui): eliminate remaining hover white flash in TopBar and monitor-ui cards — issue:1609

### DIFF
--- a/development/frontend/src/__tests__/components/topbar-hover-flash-1609.test.tsx
+++ b/development/frontend/src/__tests__/components/topbar-hover-flash-1609.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Issue #1609 — Hover white flash: TopBar.tsx (marketing nav) fix
+ *
+ * The previous fix (PR #1611) only patched LedgerTopBar.tsx.
+ * TopBar.tsx (marketing pages nav) had identical `transition-colors` +
+ * `hover:bg-secondary/50` on 4 elements — avatar trigger + 3 dropdown items.
+ *
+ * `transition-colors` animates ALL color properties including background-color.
+ * Moving between dropdown items caused background-color to interpolate through
+ * transparent → appeared as white flash on bg-background surfaces.
+ *
+ * Fix: `transition-[color,border-color]` — background changes are instant.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TopBar } from "@/components/layout/TopBar";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("next/link", () => ({
+  __esModule: true,
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+    [key: string]: unknown;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const mockPush = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush, replace: vi.fn() }),
+  usePathname: () => "/",
+}));
+
+const mockSetTheme = vi.fn();
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({
+    theme: "dark",
+    resolvedTheme: "dark",
+    setTheme: mockSetTheme,
+  }),
+}));
+
+vi.mock("@/components/layout/ThemeToggle", () => ({
+  ThemeToggle: () => <button type="button" aria-label="Toggle theme">T</button>,
+  cycleTheme: (t: string) => (t === "dark" ? "light" : "dark"),
+}));
+
+vi.mock("@/lib/entitlement/cache", () => ({
+  getEntitlementCache: () => null,
+  clearEntitlementCache: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/sign-in-url", () => ({
+  buildSignInUrl: (path: string) => `/auth/sign-in?return_to=${path}`,
+}));
+
+let mockAuthStatus = "authenticated";
+let mockSession: { user: { name: string; email: string; picture?: string } } | null = {
+  user: { name: "Odin Allfather", email: "odin@asgard.com" },
+};
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({
+    data: mockSession,
+    status: mockAuthStatus,
+    householdId: "test-household",
+    signOut: vi.fn(),
+  }),
+}));
+
+beforeEach(() => {
+  mockPush.mockClear();
+  mockSetTheme.mockClear();
+  mockAuthStatus = "authenticated";
+  mockSession = { user: { name: "Odin Allfather", email: "odin@asgard.com" } };
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function openDropdown() {
+  const btn = screen.getByRole("button", { name: /Open user menu/i });
+  fireEvent.click(btn);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Issue #1609 Fix — TopBar dropdown: no transition-colors on hover items", () => {
+  it("avatar trigger button uses transition-[color,border-color] not transition-colors", () => {
+    render(<TopBar />);
+    const avatarBtn = screen.getByRole("button", { name: /Open user menu/i });
+    expect(avatarBtn.className).toContain("transition-[color,border-color]");
+    expect(avatarBtn.className).not.toMatch(/\btransition-colors\b/);
+  });
+
+  it("Theme row uses transition-[color,border-color] not transition-colors", () => {
+    render(<TopBar />);
+    openDropdown();
+    const allMenuItems = screen.getAllByRole("menuitem");
+    const themeItem = allMenuItems.find((el) => el.textContent?.includes("Theme"));
+    expect(themeItem).toBeDefined();
+    if (themeItem) {
+      expect(themeItem.className).toContain("transition-[color,border-color]");
+      expect(themeItem.className).not.toMatch(/\btransition-colors\b/);
+    }
+  });
+
+  it("Settings menu item uses transition-[color,border-color] not transition-colors", () => {
+    render(<TopBar />);
+    openDropdown();
+    const settings = screen.getByRole("menuitem", { name: /^Settings$/i });
+    expect(settings.className).toContain("transition-[color,border-color]");
+    expect(settings.className).not.toMatch(/\btransition-colors\b/);
+  });
+
+  it("Sign out menu item uses transition-[color,border-color] not transition-colors", () => {
+    render(<TopBar />);
+    openDropdown();
+    const signOut = screen.getByRole("menuitem", { name: /^Sign out$/i });
+    expect(signOut.className).toContain("transition-[color,border-color]");
+    expect(signOut.className).not.toMatch(/\btransition-colors\b/);
+  });
+
+  it("dropdown renders the expected menu items (structural integrity)", () => {
+    render(<TopBar />);
+    openDropdown();
+    const menuItems = screen.getAllByRole("menuitem");
+    // Theme row + Settings + Sign out = 3 items
+    expect(menuItems.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/development/frontend/src/components/layout/TopBar.tsx
+++ b/development/frontend/src/components/layout/TopBar.tsx
@@ -420,7 +420,7 @@ export function TopBar() {
               ref={avatarTriggerRef}
               type="button"
               onClick={() => setPanelOpen((prev) => !prev)}
-              className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-secondary/50 transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-gold/50 cursor-pointer"
+              className="flex items-center gap-2 px-2 py-1 rounded-lg hover:bg-secondary/50 transition-[color,border-color] focus:outline-none focus-visible:ring-2 focus-visible:ring-gold/50 cursor-pointer"
               aria-label={`Open user menu, signed in as ${user.email}`}
               aria-expanded={panelOpen}
               aria-haspopup="true"
@@ -494,7 +494,7 @@ export function TopBar() {
                 type="button"
                 role="menuitem"
                 onClick={() => setTheme(cycleTheme(theme))}
-                className="flex items-center justify-between px-4 py-3 border-b border-border hover:bg-secondary/50 transition-colors cursor-pointer w-full text-left"
+                className="flex items-center justify-between px-4 py-3 border-b border-border hover:bg-secondary/50 transition-[color,border-color] cursor-pointer w-full text-left"
                 style={{ minHeight: 44 }}
               >
                 <span className="text-sm text-muted-foreground font-body">Theme</span>
@@ -510,7 +510,7 @@ export function TopBar() {
                   router.push("/ledger/settings");
                 }}
                 className={[
-                  "px-4 py-3 text-base hover:bg-secondary/50 text-left transition-colors font-body flex items-center justify-between border-b border-border",
+                  "px-4 py-3 text-base hover:bg-secondary/50 text-left transition-[color,border-color] font-body flex items-center justify-between border-b border-border",
                   pathname === "/ledger/settings" ? "text-gold" : "text-muted-foreground hover:text-foreground",
                 ].join(" ")}
                 style={{ minHeight: 44 }}
@@ -530,7 +530,7 @@ export function TopBar() {
                   setPanelOpen(false);
                   signOut();
                 }}
-                className="px-4 py-3 text-base text-muted-foreground hover:text-foreground hover:bg-secondary/50 text-left transition-colors font-body"
+                className="px-4 py-3 text-base text-muted-foreground hover:text-foreground hover:bg-secondary/50 text-left transition-[color,border-color] font-body"
                 style={{ minHeight: 44 }}
               >
                 Sign out

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -382,6 +382,7 @@ body {
   flex-direction: column; gap: 4px;
   padding: 0.45rem 0.3rem; border-radius: 4px; cursor: pointer;
   margin-bottom: 2px; border-left: 3px solid transparent;
+  background: var(--void-black, transparent);
   transition: background 0.2s, box-shadow 0.2s, border-color 0.2s;
 }
 .card--minimal:hover { background: var(--chain); }
@@ -416,6 +417,7 @@ body {
 .card {
   padding: 0.6rem 0.75rem; border-radius: 4px; cursor: pointer;
   margin-bottom: 2px; border-left: 3px solid transparent;
+  background: var(--void-black, transparent);
   transition: background 0.2s, box-shadow 0.2s, border-color 0.2s;
 }
 .card:hover { background: var(--chain); }


### PR DESCRIPTION
PR for issue: #1609

Fixes remaining white flash on hover missed by PR #1611.

**Root causes fixed:**

### 1. `TopBar.tsx` — marketing nav dropdown
Lines 423, 497, 513, 533 used `transition-colors` with `hover:bg-secondary/50`. This animated `background-color` through transparent, which CSS interpolates through white in RGB space → visible white flash. Changed to `transition-[color,border-color]` (same fix as LedgerTopBar in PR #1611).

### 2. `monitor-ui/src/styles/index.css` — `.card` and `.card--minimal`
No explicit initial `background` value — defaulted to `transparent`. `transition: background 0.2s` animated from transparent → `var(--chain)`, interpolating through white on first hover. Added `background: var(--void-black, transparent)` so transition starts from a known dark value.

**Changes:**
- `development/frontend/src/components/layout/TopBar.tsx` — 4 elements: `transition-colors` → `transition-[color,border-color]`
- `development/monitor-ui/src/styles/index.css` — explicit `background: var(--void-black, transparent)` on `.card` and `.card--minimal`
- `development/frontend/src/__tests__/components/topbar-hover-flash-1609.test.tsx` — 5 new Vitest tests

**Verification:**
- tsc ✅ | build ✅ | 2251/2251 Vitest tests ✅
- Hover between session cards in Odin's Throne (light theme) — no white flash
- Hover over TopBar dropdown items — no white flash