### PR TITLE
Issue #1614 - fix: action state preservation + delete shortcut standardization

### DIFF
--- a/development/odins-spear/src/tabs/HouseholdsTab.tsx
+++ b/development/odins-spear/src/tabs/HouseholdsTab.tsx
@@ -422,7 +422,8 @@ async function executeAction(
   action: ConfirmAction,
   hh: HouseholdListItem,
   setStatus: (s: string) => void,
-  reload: () => void
+  reload: () => void,
+  returnTo?: () => void
 ): Promise<void> {
   log.debug("executeAction called", { kind: action.kind, hhId: hh.id });
   if (!firestoreClient) {
@@ -474,6 +475,8 @@ async function executeAction(
       case "delete": {
         await firestoreClient.collection("households").doc(hh.id).delete();
         setStatus(`Deleted household ${hh.name}`);
+        // Navigate away first — entity no longer exists — then refresh the list
+        returnTo?.();
         reload();
         break;
       }
@@ -526,6 +529,10 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView }: Ho
   // Track whether the initialHouseholdId has been applied — reset on each mount
   const initialApplied = useRef(false);
 
+  // Capture selected household ID at render time (before effects that clear context run)
+  // so we can restore selection when returning from an overlay.
+  const restoreHouseholdRef = useRef<string | null>(selection.selectedHouseholdId);
+
   // Reload function — exported for Ctrl+R
   const doLoad = useCallback(() => {
     log.debug("HouseholdsTab doLoad");
@@ -566,6 +573,24 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView }: Ho
     }
     initialApplied.current = true;
   }, [initialHouseholdId, loadState, households]);
+
+  // Restore selection when returning from an overlay (non-destructive actions).
+  // initialHouseholdId takes priority; this only fires once per mount.
+  // If the previously selected household no longer exists (was deleted), findIndex
+  // returns -1 and selection stays cleared — correct behaviour for delete.
+  useEffect(() => {
+    if (loadState !== "loaded" || households.length === 0) return;
+    if (!restoreHouseholdRef.current) return;
+    if (initialHouseholdId) return; // explicit jump takes priority
+    const restoreId = restoreHouseholdRef.current;
+    restoreHouseholdRef.current = null; // consume — only restore once
+    const idx = households.findIndex((h) => h.id === restoreId);
+    if (idx >= 0) {
+      log.debug("HouseholdsTab: restoring selection", { householdId: restoreId, idx });
+      setSelectedIdx(idx);
+      setScrollOffset(Math.max(0, Math.min(idx, households.length - LIST_HEIGHT)));
+    }
+  }, [loadState, households, initialHouseholdId]);
 
   // Load detail when selection changes
   useEffect(() => {
@@ -697,8 +722,12 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView }: Ho
     if (!confirm) return;
     const hh = selectedIdx >= 0 ? households[selectedIdx] : null;
     if (!hh) { setConfirm(null); return; }
+    const pendingAction = confirm;
     setConfirm(null);
-    void executeAction(confirm, hh, setStatus, doLoad);
+    // For delete, supply a returnTo that clears the selection — the entity won't exist after success.
+    // Non-destructive actions (kick, xfer, etc.) preserve the current selection.
+    const returnTo = pendingAction.kind === "delete" ? () => { setSelectedIdx(-1); } : undefined;
+    void executeAction(pendingAction, hh, setStatus, doLoad, returnTo);
   }, [confirm, selectedIdx, households, doLoad]);
 
   const handleCancel = useCallback(() => {

--- a/development/odins-spear/src/tabs/UsersTab.tsx
+++ b/development/odins-spear/src/tabs/UsersTab.tsx
@@ -229,7 +229,7 @@ function UserDetailPanel({
       {actionMode === "none" ? (
         <Box>
           <Text color={GRAY}>
-            {"[d] Delete  [t] Tier  [a] adjust trial"}
+            {"[x] Delete  [t] Tier  [a] adjust trial"}
             {user.stripeCustomerId ? "  [s] Cancel sub" : ""}
             {detail?.household ? "  [h] Household  [c] Cards" : ""}
           </Text>
@@ -302,6 +302,10 @@ export function UsersTab({
 
   // Load users on mount
   useEffect(() => {
+    // Capture selected user ID synchronously (before effects that clear context run)
+    // so we can restore the selection after loading if we're returning from an overlay.
+    const restoreUserId = selection.selectedUserId;
+
     void (async () => {
       log.debug("UsersTab: loading users");
       setLoading(true);
@@ -357,13 +361,25 @@ export function UsersTab({
 
         log.debug("UsersTab: users loaded", { count: enriched.length });
         setUsers(enriched);
+
+        // Restore selection when returning from an overlay (non-destructive actions).
+        // If the previously selected user no longer exists (was deleted), findIndex
+        // returns -1 and selection stays cleared — correct behaviour for delete.
+        if (restoreUserId) {
+          const idx = enriched.findIndex((u) => u.id === restoreUserId);
+          if (idx >= 0) {
+            log.debug("UsersTab: restoring selection", { userId: restoreUserId, idx });
+            setSelectedIdx(idx);
+            setScrollOffset(Math.max(0, Math.min(idx, enriched.length - LIST_HEIGHT)));
+          }
+        }
       } catch (err) {
         log.error("UsersTab: load error", err as Error);
         setError((err as Error).message);
       }
       setLoading(false);
     })();
-  }, []);
+  }, []); // intentionally mount-only; restoreUserId captured synchronously above
 
   // Load detail when selection changes
   useEffect(() => {
@@ -628,7 +644,7 @@ export function UsersTab({
       const user = users[selectedIdx];
       if (!user) return;
 
-      if (input === "d") {
+      if (input === "x") {
         setActionMode("delete_confirm");
         return;
       }


### PR DESCRIPTION
PR for issue: #1614

Fixes three bugs in Odin's Spear:
1. Non-destructive actions (adjust trial, tier change, etc.) no longer reset selection state
2. Delete actions use a `returnTo` callback to navigate away after success
3. Delete shortcut standardized to `x` everywhere (`d` freed up)

**Changes:**
- `development/odins-spear/src/tabs/UsersTab.tsx` — Restore selected user on remount (overlay return); change `d` → `x` for delete shortcut and action bar label
- `development/odins-spear/src/tabs/HouseholdsTab.tsx` — Add `returnTo` param to `executeAction`; `handleConfirm` passes `() => setSelectedIdx(-1)` for delete; capture `restoreHouseholdRef` on mount to restore selection after overlay

**Verification:**
- Select user, run Adjust Trial End — selection preserved after action
- Delete user with x — navigates to empty state (returnTo)
- Verify x is delete on all tabs (users, households)
- Verify d no longer triggers delete anywhere