### PR TITLE
fix(agents): enforce foreground-only verify steps — issue:1626

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -150,6 +150,9 @@ Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
   cd /workspace/repo/development/frontend && npx vitest run --reporter=verbose
 On failure: fix, commit+push, re-run that step. Repeat until green.
 Do NOT proceed to handoff with ANY failing Vitest tests.
+**All verify steps MUST run in the foreground (blocking).** NEVER use `run_in_background`
+for tsc, build, or Vitest commands. You MUST confirm each step passes before proceeding
+to the next step or to merge/handoff. Background verify = unverified merge = bug.
 
 NO MONITOR-UI / ODINS-SPEAR TESTS (UNBREAKABLE):
 NEVER write tests for `development/monitor-ui/` (Odin's Throne) or `development/odins-spear/`.

--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -48,6 +48,9 @@ Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
   cd /workspace/repo/development/frontend && pnpm run verify:unit
 On failure: fix, commit+push, re-run that step. Repeat until green.
 Do NOT proceed to handoff with ANY failing Vitest tests.
+**All verify steps MUST run in the foreground (blocking).** NEVER use `run_in_background`
+for tsc, build, or Vitest commands. You MUST confirm each step passes before proceeding
+to the next step or to merge/handoff. Background verify = unverified merge = bug.
 
 STRICT SCOPE (UNBREAKABLE):
 Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,


### PR DESCRIPTION
## Summary
- Add explicit rule banning `run_in_background` for tsc, build, and Vitest verify commands
- Applied to both `sandbox-preamble.md` and the embedded preamble in `dispatch/SKILL.md`

## Context
Loki backgrounded `verify:build` during #1624 and merged the PR before confirming the build result. The build passed, but the agent never verified it before merging.

## Test plan
- [x] Orchestrator-only change (no app code), no tests needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)