### PR TITLE
feat(quality): HTML test reports for Vitest and Playwright

### DIFF
--- a/development/frontend/playwright.config.ts
+++ b/development/frontend/playwright.config.ts
@@ -8,9 +8,10 @@ export default defineConfig({
   forbidOnly: false,
   retries: 0,
   workers: process.env.CI ? 2 : (process.env.PW_WORKERS ? Number(process.env.PW_WORKERS) : 4),
-  reporter: process.env.CI
-    ? [["list"], ["html", { outputFolder: "playwright-report", open: "never" }]]
-    : "list",
+  reporter: [
+    ["list"],
+    ["html", { outputFolder: "../../quality/reports/test-report-playwright", open: "never" }],
+  ],
   use: {
     baseURL: process.env.SERVER_URL || "http://localhost:9653",
     trace: "off",

--- a/development/frontend/vitest.config.ts
+++ b/development/frontend/vitest.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
     maxWorkers: 4,
     testTimeout: 10000,
     hookTimeout: 5000,
+    reporters: ['default', 'html'],
+    outputFile: {
+      html: '../../quality/reports/test-report-vitest/index.html',
+    },
     coverage: {
       provider: 'v8',
       reportsDirectory: '../../quality/reports/coverage/vitest',


### PR DESCRIPTION
## Summary
- Vitest html reporter → `quality/reports/test-report-vitest/`
- Playwright html reporter → `quality/reports/test-report-playwright/` (always, not just CI)

## Test plan
- [x] Vitest HTML report verified locally — 156 files, 2304 tests
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)