### PR TITLE
fix(coverage): clean stale reports before starting

### DIFF
--- a/quality/scripts/coverage.mjs
+++ b/quality/scripts/coverage.mjs
@@ -418,7 +418,27 @@ function runUnitCoverage() {
   log("  - LCOV:  quality/reports/coverage/vitest/lcov.info");
 }
 
+function cleanReports() {
+  const reportsRoot = path.join(REPO_ROOT, "quality/reports");
+  const toDelete = [
+    "test-report-playwright",
+    "test-report-vitest",
+    "quality-report.html",
+    "cull-list.json",
+    "coverage",
+  ];
+  for (const name of toDelete) {
+    const target = path.join(reportsRoot, name);
+    if (existsSync(target)) {
+      rmSync(target, { recursive: true, force: true });
+    }
+  }
+  log("Cleaned previous reports");
+}
+
 async function main() {
+  cleanReports();
+
   if (unitOnly) {
     log("Running in --unit-only mode (Vitest coverage only)");
     runUnitCoverage();


### PR DESCRIPTION
## Summary
- Deletes all previous report artifacts at the start of every `/coverage-report` run
- Cleaned: test-report-playwright/, test-report-vitest/, quality-report.html, cull-list.json, coverage/

## Test plan
- [ ] Run `/coverage-report` — no stale data from previous runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)