### PR TITLE
fix(epics): use GraphQL for sub-issue linking

### DIFF
--- a/.claude/skills/epic-manager/epic-manager.mjs
+++ b/.claude/skills/epic-manager/epic-manager.mjs
@@ -184,7 +184,11 @@ if (flagAdd) {
   }
 
   // Link as GitHub sub-issue (populates "Sub-issues progress" on project board)
-  run(`gh issue edit ${rootIssue} --add-sub-issue ${flagAdd} 2>/dev/null`);
+  const parentId = run(`gh issue view ${rootIssue} --json id -q .id`);
+  const childId = run(`gh issue view ${flagAdd} --json id -q .id`);
+  if (parentId && childId) {
+    run(`gh api graphql -f query='mutation { addSubIssue(input: { issueId: "${parentId.trim()}", subIssueId: "${childId.trim()}" }) { subIssue { number } } }' 2>/dev/null`);
+  }
 
   console.log(`  ✅ Added #${flagAdd} "${newTitle}" at wave ${newWave} to tracker #${rootIssue}`);
   if (flagBlockedBy.length > 0) console.log(`     blocked_by: [${flagBlockedBy.join(", ")}]`);

--- a/.claude/skills/plan-w-team/SKILL.md
+++ b/.claude/skills/plan-w-team/SKILL.md
@@ -236,8 +236,10 @@ After creating the tracker issue, link every child issue as a **GitHub sub-issue
 of the tracker. This populates the "Sub-issues progress" column on the project board.
 
 ```bash
+PARENT_ID=$(gh issue view <TRACKER_NUMBER> --repo declanshanaghy/fenrir-ledger --json id -q .id)
 for N in <issue1> <issue2> <issue3> ...; do
-  gh issue edit <TRACKER_NUMBER> --repo declanshanaghy/fenrir-ledger --add-sub-issue "$N"
+  CHILD_ID=$(gh issue view $N --repo declanshanaghy/fenrir-ledger --json id -q .id)
+  gh api graphql -f query="mutation { addSubIssue(input: { issueId: \"$PARENT_ID\", subIssueId: \"$CHILD_ID\" }) { subIssue { number } } }"
 done
 ```
 


### PR DESCRIPTION
## Summary
- `gh issue edit --add-sub-issue` doesn't exist — use GraphQL `addSubIssue` mutation
- Updated plan-w-team SKILL.md and epic-manager.mjs
- Linked all sub-issues for #1638 (9 issues) and #313 (14 issues)

## Test plan
- [x] Sub-issues linked for #1638 and #313 via GraphQL
- [ ] Check project board — Sub-issues progress column should now show progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)