### PR TITLE
Issue #1663 - fix: pin button border + uniform action button sizes

### DIFF
--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -571,9 +571,9 @@ body {
    Matches card-pin-btn — inline, border, color-only hover. */
 .card-status-icon-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 2px 3px; margin-left: auto;
+  width: 1.6rem; height: 1.6rem; padding: 0; margin-left: auto;
   background: transparent; border: 1px solid var(--rune-border);
-  border-radius: 2px; cursor: default;
+  border-radius: 3px; cursor: default;
   line-height: 1; transition: color 0.15s, border-color 0.15s;
   flex-shrink: 0;
 }
@@ -620,9 +620,9 @@ body {
 /* ── Pin toggle button in card sidebar ── */
 .card-pin-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  padding: 1px 3px;
-  background: transparent; border: 1px solid transparent;
-  border-radius: 2px; color: var(--text-void); cursor: pointer;
+  width: 1.6rem; height: 1.6rem; padding: 0;
+  background: transparent; border: 1px solid var(--rune-border);
+  border-radius: 3px; color: var(--text-void); cursor: pointer;
   line-height: 1; transition: color 0.15s, border-color 0.15s;
   flex-shrink: 0;
 }


### PR DESCRIPTION
Fixes #1663

## Summary
- `.card-pin-btn`: added `border: 1px solid var(--rune-border)` to match other action buttons in the row
- `.card-status-icon-btn`: standardized to `width: 1.6rem; height: 1.6rem; padding: 0; border-radius: 3px` for uniform sizing
- Both buttons now have matching dimensions and border treatment in the card sidebar action row

## Validation
- tsc: PASS (no errors)
- vite build: PASS (62.64 kB CSS, 287.78 kB JS)
- No Vitest tests written (monitor-ui has no test infrastructure — CSS-only change)