### PR TITLE
feat(trial): wire trial init to auth callback, remove from CardForm + import handler (#1637)

### DIFF
--- a/development/frontend/src/__tests__/trial/trial-1627-loki.test.tsx
+++ b/development/frontend/src/__tests__/trial/trial-1627-loki.test.tsx
@@ -272,7 +272,9 @@ const FAKE_CARD = {
   bonusMet: false,
 };
 
-describe("Issue #1627 — handleConfirmImport trial init guard", () => {
+// Issue #1637: Trial init moved from import handler to auth callback.
+// DashboardPage handleConfirmImport must NOT call /api/trial/init.
+describe("Issue #1637 — handleConfirmImport does NOT call /api/trial/init", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
@@ -294,7 +296,7 @@ describe("Issue #1627 — handleConfirmImport trial init guard", () => {
     localStorage.clear();
   });
 
-  it("calls /api/trial/init when first card is imported (guard flag not set)", async () => {
+  it("never calls /api/trial/init when cards are imported (trial init belongs to auth callback)", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => expect(capturedOnConfirmImport).not.toBeNull());
@@ -303,28 +305,6 @@ describe("Issue #1627 — handleConfirmImport trial init guard", () => {
       capturedOnConfirmImport!([FAKE_CARD]);
     });
 
-    // Allow async init to flush
-    await waitFor(() => {
-      const trialInitCalls = fetchSpy.mock.calls.filter(([url]) =>
-        String(url).includes("/api/trial/init"),
-      );
-      expect(trialInitCalls.length).toBeGreaterThan(0);
-    });
-  });
-
-  it("does NOT call /api/trial/init when guard flag is already set", async () => {
-    // Pre-set the toast guard — trial already started previously
-    localStorage.setItem("fenrir:trial-start-toast-shown", "true");
-
-    render(<DashboardPage />);
-
-    await waitFor(() => expect(capturedOnConfirmImport).not.toBeNull());
-
-    await act(async () => {
-      capturedOnConfirmImport!([FAKE_CARD]);
-    });
-
-    // Give time for any async calls to fire
     await new Promise((r) => setTimeout(r, 100));
 
     const trialInitCalls = fetchSpy.mock.calls.filter(([url]) =>
@@ -333,28 +313,12 @@ describe("Issue #1627 — handleConfirmImport trial init guard", () => {
     expect(trialInitCalls).toHaveLength(0);
   });
 
-  it("sets the guard flag in localStorage on first import", async () => {
+  it("never calls /api/trial/init even on repeat imports", async () => {
     render(<DashboardPage />);
 
     await waitFor(() => expect(capturedOnConfirmImport).not.toBeNull());
 
-    await act(async () => {
-      capturedOnConfirmImport!([FAKE_CARD]);
-    });
-
-    expect(localStorage.getItem("fenrir:trial-start-toast-shown")).toBe("true");
-  });
-
-  it("does NOT set guard flag when import is called a second time (already set)", async () => {
-    localStorage.setItem("fenrir:trial-start-toast-shown", "true");
-
-    render(<DashboardPage />);
-
-    await waitFor(() => expect(capturedOnConfirmImport).not.toBeNull());
-
-    // Call once; guard already set so no trial init should fire
     await act(async () => { capturedOnConfirmImport!([FAKE_CARD]); });
-    // Call again; still no trial init
     await act(async () => { capturedOnConfirmImport!([FAKE_CARD]); });
 
     await new Promise((r) => setTimeout(r, 100));
@@ -363,6 +327,18 @@ describe("Issue #1627 — handleConfirmImport trial init guard", () => {
       String(url).includes("/api/trial/init"),
     );
     expect(trialInitCalls).toHaveLength(0);
+  });
+
+  it("does NOT write LS_TRIAL_START_TOAST_SHOWN guard flag on import (removed in #1637)", async () => {
+    render(<DashboardPage />);
+
+    await waitFor(() => expect(capturedOnConfirmImport).not.toBeNull());
+
+    await act(async () => {
+      capturedOnConfirmImport!([FAKE_CARD]);
+    });
+
+    expect(localStorage.getItem("fenrir:trial-start-toast-shown")).toBeNull();
   });
 });
 
@@ -370,7 +346,8 @@ describe("Issue #1627 — handleConfirmImport trial init guard", () => {
 // Section 3: Auth callback page does NOT call /api/trial/init
 // ══════════════════════════════════════════════════════════════════════════════
 
-describe("Issue #1627 — AuthCallbackPage does not call /api/trial/init", () => {
+// These error-path cases are still correct: trial init is only called on successful exchange.
+describe("Issue #1627/#1637 — AuthCallbackPage does NOT call /api/trial/init on auth errors", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {

--- a/development/frontend/src/__tests__/trial/trial-1637-auth-callback-init.test.tsx
+++ b/development/frontend/src/__tests__/trial/trial-1637-auth-callback-init.test.tsx
@@ -1,0 +1,235 @@
+/**
+ * Tests for Issue #1637 — Trial starts on Google login
+ *
+ * Validates that AuthCallbackPage calls /api/trial/init after a successful
+ * token exchange and handles the 409 (trial expired) response by showing
+ * the "trial-expired" state with a "Continue to the ledger" link.
+ *
+ * @ref Issue #1637
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import AuthCallbackPage from "@/app/ledger/auth/callback/page";
+
+// ── Module mocks ──────────────────────────────────────────────────────────────
+
+const mockSearchParamsGet = vi.fn();
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => ({ get: mockSearchParamsGet }),
+}));
+
+vi.mock("@/lib/auth/session", () => ({
+  setSession: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/sign-in-url", () => ({
+  validateReturnTo: vi.fn((url: string | null) => url ?? "/ledger"),
+}));
+
+vi.mock("@/lib/analytics/track", () => ({
+  track: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/household", () => ({
+  getAnonHouseholdId: vi.fn(() => null),
+}));
+
+vi.mock("@/lib/merge-anonymous", () => ({
+  mergeAnonymousCards: vi.fn(() => ({ merged: 0 })),
+  isMergeComplete: vi.fn(() => true),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Builds a minimal base64url-encoded JWT id_token for testing.
+ * Not cryptographically valid but passes the format check in decodeIdToken.
+ */
+function makeFakeIdToken(sub: string, email: string, name: string): string {
+  const encode = (obj: object) =>
+    btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=/g, "");
+  const header = encode({ alg: "RS256", typ: "JWT" });
+  const payload = encode({ sub, email, name, picture: "", exp: 9_999_999_999 });
+  return `${header}.${payload}.fake-signature`;
+}
+
+const PKCE_DATA = {
+  verifier: "test-verifier-1637",
+  state: "test-state-1637",
+  callbackUrl: "/ledger",
+};
+
+const FAKE_ID_TOKEN = makeFakeIdToken(
+  "google-sub-1637",
+  "user@example.com",
+  "Test User"
+);
+
+function setupSearchParams() {
+  mockSearchParamsGet.mockImplementation((key: string) => {
+    if (key === "code") return "auth-code-1637";
+    if (key === "state") return "test-state-1637";
+    return null;
+  });
+}
+
+function setupPkce() {
+  sessionStorage.setItem("fenrir:pkce", JSON.stringify(PKCE_DATA));
+}
+
+/** Returns a mock fetch that handles token exchange and trial init separately. */
+function mockFetchForTrialInit(trialInitStatus: number) {
+  return vi.spyOn(globalThis, "fetch").mockImplementation(async (input) => {
+    const url = String(input);
+    if (url.includes("/api/auth/token")) {
+      return new Response(
+        JSON.stringify({
+          access_token: "fake-at",
+          id_token: FAKE_ID_TOKEN,
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    if (url.includes("/api/trial/init")) {
+      return new Response(
+        JSON.stringify(
+          trialInitStatus === 409
+            ? { error: "trial_expired", message: "Contact customer service" }
+            : { startDate: new Date().toISOString(), expiresAt: new Date().toISOString(), isNew: true }
+        ),
+        { status: trialInitStatus, headers: { "Content-Type": "application/json" } }
+      );
+    }
+    return new Response("", { status: 200 });
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Issue #1637 — AuthCallbackPage trial init after Google login", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  let locationReplaceMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    sessionStorage.clear();
+    // Prevent actual navigation in JSDOM
+    locationReplaceMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      value: {
+        origin: "http://localhost",
+        replace: locationReplaceMock,
+        href: "http://localhost/ledger/auth/callback",
+      },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    sessionStorage.clear();
+  });
+
+  it("calls /api/trial/init after successful token exchange", async () => {
+    fetchSpy = mockFetchForTrialInit(200);
+    setupSearchParams();
+    setupPkce();
+
+    render(<AuthCallbackPage />);
+
+    await waitFor(
+      () => {
+        const trialInitCalls = fetchSpy.mock.calls.filter(([url]) =>
+          String(url).includes("/api/trial/init")
+        );
+        expect(trialInitCalls.length).toBeGreaterThan(0);
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it("shows trial-expired state with contact message when /api/trial/init returns 409", async () => {
+    fetchSpy = mockFetchForTrialInit(409);
+    setupSearchParams();
+    setupPkce();
+
+    render(<AuthCallbackPage />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/trial ended/i)).toBeInTheDocument();
+        expect(
+          screen.getByText(/your free trial has ended/i)
+        ).toBeInTheDocument();
+        expect(
+          screen.getByText(/contact customer service/i)
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it("shows 'Continue to the ledger' link on trial-expired state (not 'Return to the gate')", async () => {
+    fetchSpy = mockFetchForTrialInit(409);
+    setupSearchParams();
+    setupPkce();
+
+    render(<AuthCallbackPage />);
+
+    await waitFor(
+      () => {
+        const continueLink = screen.queryByRole("link", {
+          name: /continue to the ledger/i,
+        });
+        expect(continueLink).toBeInTheDocument();
+        expect(continueLink).toHaveAttribute("href", "/ledger");
+
+        // "Return to the gate" should NOT be shown (that's for auth errors)
+        const returnLink = screen.queryByRole("link", {
+          name: /return to the gate/i,
+        });
+        expect(returnLink).not.toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+  });
+
+  it("does NOT show 'The Bifröst trembled' error heading on trial-expired (409)", async () => {
+    fetchSpy = mockFetchForTrialInit(409);
+    setupSearchParams();
+    setupPkce();
+
+    render(<AuthCallbackPage />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/trial ended/i)).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+
+    expect(screen.queryByText(/the bifröst trembled/i)).not.toBeInTheDocument();
+  });
+
+  it("does NOT redirect to destination when trial init returns 409 (user stays on trial-expired page)", async () => {
+    fetchSpy = mockFetchForTrialInit(409);
+    setupSearchParams();
+    setupPkce();
+
+    render(<AuthCallbackPage />);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText(/trial ended/i)).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
+
+    expect(locationReplaceMock).not.toHaveBeenCalled();
+  });
+});

--- a/development/frontend/src/__tests__/trial/trial-settings-section-render.test.tsx
+++ b/development/frontend/src/__tests__/trial/trial-settings-section-render.test.tsx
@@ -141,11 +141,11 @@ describe("TrialSettingsSection — Subscribe price button visibility (Issue #103
     expect(container.textContent).toContain("Thy trial hath not yet begun");
   });
 
-  it("shows sign-in CTA link for status 'none'", () => {
+  it("shows Google sign-in CTA link for status 'none'", () => {
     setStatus("none");
     renderSection();
 
-    const cta = screen.getByRole("link", { name: /sign in to begin thy karl trial/i });
+    const cta = screen.getByRole("link", { name: /sign in with google to begin thy karl trial/i });
     expect(cta).toBeDefined();
   });
 

--- a/development/frontend/src/app/ledger/auth/callback/page.tsx
+++ b/development/frontend/src/app/ledger/auth/callback/page.tsx
@@ -62,7 +62,7 @@ function decodeIdToken(idToken: string): IdTokenClaims {
 
 // ── Component ─────────────────────────────────────────────────────────────────
 
-type CallbackStatus = "exchanging" | "success" | "error";
+type CallbackStatus = "exchanging" | "success" | "error" | "trial-expired";
 
 function AuthCallbackContent() {
   const searchParams = useSearchParams();
@@ -200,9 +200,6 @@ function AuthCallbackContent() {
           track("auth-login");
         }
 
-        // Trial initialization is NOT done on sign-in (issue #1627).
-        // Trial starts exclusively when the first card is added (CardForm / handleConfirmImport).
-
         // Clean up PKCE transient data only after successful exchange.
         sessionStorage.removeItem(PKCE_SESSION_KEY);
 
@@ -216,6 +213,31 @@ function AuthCallbackContent() {
           if (result.merged > 0) {
             sessionStorage.setItem("fenrir:merge-result", JSON.stringify(result));
           }
+        }
+
+        // Initialize trial for this Google account (issue #1637).
+        // Idempotent for active/converted trials.
+        // On 409 (expired restart blocked): show message — user continues in Thrall tier.
+        try {
+          const trialResponse = await fetch("/api/trial/init", {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+              Authorization: `Bearer ${session.id_token}`,
+            },
+            body: JSON.stringify({}),
+          });
+          if (trialResponse.status === 409) {
+            if (isMountedRef.current) {
+              setErrorMessage(
+                "Your free trial has ended. Contact customer service to discuss options."
+              );
+              setCallbackStatus("trial-expired");
+            }
+            return;
+          }
+        } catch {
+          // Trial init is best-effort — don't block login flow
         }
 
         // Don't show the success state - keep the exchanging state visible
@@ -273,6 +295,23 @@ function AuthCallbackContent() {
               className="mt-2 text-base text-gold hover:text-primary hover:brightness-110 font-heading tracking-wide underline underline-offset-4"
             >
               Return to the gate
+            </a>
+          </>
+        )}
+
+        {callbackStatus === "trial-expired" && (
+          <>
+            <p className="font-heading text-base text-destructive uppercase tracking-wide">
+              Trial Ended
+            </p>
+            <p className="text-muted-foreground font-body text-sm max-w-xs">
+              {errorMessage}
+            </p>
+            <a
+              href="/ledger"
+              className="mt-2 text-base text-gold hover:text-primary hover:brightness-110 font-heading tracking-wide underline underline-offset-4"
+            >
+              Continue to the ledger
             </a>
           </>
         )}

--- a/development/frontend/src/app/ledger/page.tsx
+++ b/development/frontend/src/app/ledger/page.tsx
@@ -26,9 +26,6 @@
 import { Suspense, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { toast } from "sonner";
-import { LS_TRIAL_START_TOAST_SHOWN } from "@/lib/trial-utils";
-import { clearTrialStatusCache } from "@/hooks/useTrialStatus";
-import { ensureFreshToken } from "@/lib/auth/refresh-session";
 import { useAuth } from "@/hooks/useAuth";
 import { useEntitlement } from "@/hooks/useEntitlement";
 import { useIsKarlOrTrial } from "@/hooks/useIsKarlOrTrial";
@@ -154,35 +151,6 @@ function DashboardPageContent() {
     const count = importedCards.length;
     toast.success(`${count} card${count !== 1 ? "s" : ""} added to your ledger.`);
 
-    // Trial start toast — fires once on first card import (Issue #621)
-    const toastShown = localStorage.getItem(LS_TRIAL_START_TOAST_SHOWN);
-    if (!toastShown) {
-      localStorage.setItem(LS_TRIAL_START_TOAST_SHOWN, "true");
-
-      // Initialize trial via API (idempotent for active trials; requires auth)
-      void (async () => {
-        try {
-          const token = await ensureFreshToken();
-          if (token) {
-            await fetch("/api/trial/init", {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                Authorization: `Bearer ${token}`,
-              },
-              body: JSON.stringify({}),
-            });
-            clearTrialStatusCache();
-          }
-        } catch {
-          // Trial init is best-effort — don't block import flow
-        }
-      })();
-
-      toast("Your 30-day trial has begun — explore all features", {
-        duration: 8000,
-      });
-    }
   }
 
   // Whether we have at least one card (drives CTA visibility rules)

--- a/development/frontend/src/components/cards/CardForm.tsx
+++ b/development/frontend/src/components/cards/CardForm.tsx
@@ -48,9 +48,6 @@ import { toast } from "sonner";
 import type { Card, CardStatus } from "@/lib/types";
 import { saveCard, deleteCard, closeCard, getCards } from "@/lib/storage";
 import { checkMilestone } from "@/lib/milestone-utils";
-import { LS_TRIAL_START_TOAST_SHOWN } from "@/lib/trial-utils";
-import { clearTrialStatusCache } from "@/hooks/useTrialStatus";
-import { ensureFreshToken } from "@/lib/auth/refresh-session";
 import { canAddCard } from "@/lib/entitlement/card-limit";
 import { useEntitlement } from "@/hooks/useEntitlement";
 import { useTrialStatus } from "@/hooks/useTrialStatus";
@@ -351,36 +348,6 @@ export function CardForm({ initialValues, householdId }: CardFormProps) {
           });
         }
 
-        // Trial start toast — fires once on first card creation (Issue #621)
-        const toastShown = localStorage.getItem(LS_TRIAL_START_TOAST_SHOWN);
-        if (!toastShown) {
-          localStorage.setItem(LS_TRIAL_START_TOAST_SHOWN, "true");
-
-          // Initialize trial via API (idempotent for active trials; requires auth)
-          void (async () => {
-            try {
-              const token = await ensureFreshToken();
-              if (token) {
-                await fetch("/api/trial/init", {
-                  method: "POST",
-                  headers: {
-                    "Content-Type": "application/json",
-                    Authorization: `Bearer ${token}`,
-                  },
-                  body: JSON.stringify({}),
-                });
-                // Clear trial status cache so badge picks up new state
-                clearTrialStatusCache();
-              }
-            } catch {
-              // Trial init is best-effort — don't block card creation
-            }
-          })();
-
-          toast("Your 30-day trial has begun — explore all features", {
-            duration: 8000,
-          });
-        }
       }
 
 

--- a/development/frontend/src/components/trial/TrialSettingsSection.tsx
+++ b/development/frontend/src/components/trial/TrialSettingsSection.tsx
@@ -108,7 +108,7 @@ export function TrialSettingsSection() {
             Thy trial hath not yet begun, wanderer
           </p>
           <p className="text-[12px] text-muted-foreground font-body leading-relaxed">
-            Sign in or add a credit card to begin thy 30&#8209;day Karl Trial — free
+            Sign in with your Google account to begin thy 30&#8209;day Karl Trial — free
             to start, no charge until thou subscribest.
           </p>
         </div>
@@ -123,9 +123,9 @@ export function TrialSettingsSection() {
             "border border-gold rounded-sm",
             "self-start",
           ].join(" ")}
-          aria-label="Sign in to begin thy Karl Trial"
+          aria-label="Sign in with Google to begin thy Karl Trial"
         >
-          Sign in to begin
+          Sign in with Google
         </a>
       </section>
     );


### PR DESCRIPTION
Fixes #1637

## Summary

- **auth/callback/page.tsx**: Trial init wired after successful Google token exchange. Calls POST /api/trial/init with Authorization: Bearer <id_token>. On 409 (expired trial): shows trial-expired state with message 'Your free trial has ended. Contact customer service to discuss options.' and a 'Continue to the ledger' link. On network errors: swallows silently, proceeds to redirect.
- **CardForm.tsx**: Removed trial init block entirely. Removed unused imports.
- **ledger/page.tsx**: Removed trial init block from handleConfirmImport.
- **TrialSettingsSection.tsx**: Updated status === 'none' copy to reference Google account sign-in (not device/fingerprint).
- **Tests**: 13 Vitest tests covering 409 handling, trial init in auth callback, no trial init in import handler, settings section rendering.

## Test Results

- tsc: PASS
- build: PASS  
- vitest: 2298 tests, 158 files, all passing