### PR TITLE
Root-level pnpm workspace scripts for verify/build/test

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -68,12 +68,10 @@ jobs:
 
       - name: TypeScript check
         id: tsc
-        working-directory: development/frontend
         run: pnpm run verify:tsc
 
       - name: Run unit tests
         id: unit
-        working-directory: development/frontend
         run: pnpm run verify:unit
 
       - name: Install Playwright browsers
@@ -82,7 +80,6 @@ jobs:
 
       - name: Run Playwright E2E tests
         id: e2e
-        working-directory: development/frontend
         env:
           SERVER_URL: https://www.fenrirledger.com
         run: pnpm run verify:e2e
@@ -196,5 +193,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Verify odins-spear
-        working-directory: development/odins-spear
-        run: pnpm run verify
+        run: pnpm run verify:spear

--- a/development/monitor/package.json
+++ b/development/monitor/package.json
@@ -10,8 +10,9 @@
     "compile": "tsc",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "pnpm run verify:tsc",
-    "verify:tsc": "tsc --noEmit"
+    "verify": "pnpm run verify:tsc && pnpm run verify:build",
+    "verify:tsc": "tsc --noEmit",
+    "verify:build": "tsc --noEmit"
   },
   "dependencies": {
     "@hono/node-server": "^1.13.7",

--- a/development/odins-spear/package.json
+++ b/development/odins-spear/package.json
@@ -10,8 +10,9 @@
     "lint": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "pnpm run verify:tsc && pnpm run verify:unit",
+    "verify": "pnpm run verify:tsc && pnpm run verify:build && pnpm run verify:unit",
     "verify:tsc": "tsc --noEmit",
+    "verify:build": "tsc --noEmit",
     "verify:unit": "vitest run"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,22 @@
   "packageManager": "pnpm@10.32.1",
   "scripts": {
     "build": "pnpm -r run build",
-    "test": "pnpm --filter fenrir-ledger run test"
+    "test": "pnpm -r run test",
+    "verify": "pnpm -r run verify",
+    "verify:tsc": "pnpm -r run verify:tsc",
+    "verify:build": "pnpm -r run verify:build",
+    "verify:unit": "pnpm -r run verify:unit",
+    "verify:e2e": "pnpm --filter fenrir-ledger run verify:e2e",
+    "build:frontend": "pnpm --filter fenrir-ledger run build",
+    "build:monitor": "pnpm --filter odin-throne-monitor run build",
+    "build:monitor-ui": "pnpm --filter odin-throne-ui run build",
+    "build:spear": "pnpm --filter odins-spear run build",
+    "verify:frontend": "pnpm --filter fenrir-ledger run verify",
+    "verify:monitor": "pnpm --filter odin-throne-monitor run verify",
+    "verify:monitor-ui": "pnpm --filter odin-throne-ui run verify",
+    "verify:spear": "pnpm --filter odins-spear run verify",
+    "test:frontend": "pnpm --filter fenrir-ledger run test",
+    "test:monitor": "pnpm --filter odin-throne-monitor run test",
+    "test:spear": "pnpm --filter odins-spear run test"
   }
 }


### PR DESCRIPTION
## Summary
- Add root-level `pnpm run verify`, `verify:tsc`, `verify:build`, `verify:unit` that run across all workspace packages via `pnpm -r`
- Add per-package shortcuts: `verify:frontend`, `verify:monitor`, `verify:monitor-ui`, `verify:spear` (same for `build:*` and `test:*`)
- Update CI workflow to use root-level commands (remove `working-directory` directives)
- Add `verify:build` to monitor and odins-spear packages for consistency

## Test plan
- [x] `pnpm run verify:tsc` from root runs tsc across all 4 packages
- [x] `pnpm run verify:unit` from root runs vitest across packages that have it
- [x] `pnpm run verify:spear` targets only odins-spear
- [ ] CI workflow runs correctly without `working-directory`

🤖 Generated with [Claude Code](https://claude.com/claude-code)