### PR TITLE
fix(settings): visible selected tab indicator for Thrall users — closes #1698

### DIFF
--- a/development/frontend/src/__tests__/karl-bling/settings-tab-thrall-1698.test.tsx
+++ b/development/frontend/src/__tests__/karl-bling/settings-tab-thrall-1698.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Settings page tabs — Thrall selected tab visual indicator (Issue #1698)
+ *
+ * Validates that the selected tab uses `border-b-foreground` (not
+ * `border-b-background`) so Thrall users see a visible underline.
+ *
+ * For Karl/trial users, karl-bling.css overrides the border with gold via
+ * the `[data-tier="karl"] .karl-bling-tab[aria-selected="true"]` rule.
+ * For Thrall users, the Tailwind `border-b-foreground` class is the only
+ * indicator, making this class critical for accessibility.
+ *
+ * @see app/ledger/settings/page.tsx  — tab buttons
+ * @see app/karl-bling.css  — .karl-bling-tab rules for karl/trial
+ * @see Issue #1698
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SettingsPage from "@/app/ledger/settings/page";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/analytics/track", () => ({ track: vi.fn() }));
+
+vi.mock("@/components/entitlement/StripeSettings", () => ({
+  StripeSettings: () => <div data-testid="stripe-settings" />,
+}));
+
+vi.mock("@/components/trial/TrialSettingsSection", () => ({
+  TrialSettingsSection: () => <div data-testid="trial-section" />,
+}));
+
+vi.mock("@/components/household/HouseholdSettingsSection", () => ({
+  HouseholdSettingsSection: () => <div data-testid="household-section" />,
+}));
+
+vi.mock("@/components/sync/SyncSettingsSection", () => ({
+  SyncSettingsSection: () => <div data-testid="sync-section" />,
+}));
+
+vi.mock("@/components/easter-eggs/EasterEggModal", () => ({
+  EasterEggModal: () => null,
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("Settings page tabs — Thrall selected tab visual indicator (Issue #1698)", () => {
+  it("selected tab has border-b-foreground class (visible underline for Thrall users)", () => {
+    render(<SettingsPage />);
+    const accountTab = screen.getByRole("tab", { name: /^Account$/i });
+    expect(accountTab.getAttribute("aria-selected")).toBe("true");
+    expect(accountTab.className).toContain("border-b-foreground");
+  });
+
+  it("selected tab does NOT have border-b-background (which would be invisible)", () => {
+    render(<SettingsPage />);
+    const accountTab = screen.getByRole("tab", { name: /^Account$/i });
+    expect(accountTab.getAttribute("aria-selected")).toBe("true");
+    expect(accountTab.className).not.toContain("border-b-background");
+  });
+
+  it("unselected tabs do not have border-b-foreground", () => {
+    render(<SettingsPage />);
+    const householdTab = screen.getByRole("tab", { name: /^Household$/i });
+    const settingsTab = screen.getByRole("tab", { name: /^Settings$/i });
+    expect(householdTab.getAttribute("aria-selected")).toBe("false");
+    expect(settingsTab.getAttribute("aria-selected")).toBe("false");
+    expect(householdTab.className).not.toContain("border-b-foreground");
+    expect(settingsTab.className).not.toContain("border-b-foreground");
+  });
+
+  it("switching tabs moves border-b-foreground to the newly selected tab", () => {
+    render(<SettingsPage />);
+    const householdTab = screen.getByRole("tab", { name: /^Household$/i });
+    fireEvent.click(householdTab);
+    expect(householdTab.getAttribute("aria-selected")).toBe("true");
+    expect(householdTab.className).toContain("border-b-foreground");
+    const accountTab = screen.getByRole("tab", { name: /^Account$/i });
+    expect(accountTab.getAttribute("aria-selected")).toBe("false");
+    expect(accountTab.className).not.toContain("border-b-foreground");
+  });
+});

--- a/development/frontend/src/app/ledger/settings/page.tsx
+++ b/development/frontend/src/app/ledger/settings/page.tsx
@@ -312,7 +312,7 @@ export default function SettingsPage() {
               onKeyDown={(e) => handleKeyDown(e, index)}
               className={`karl-bling-tab relative px-5 py-3 text-sm font-heading font-semibold tracking-wide border border-transparent border-b-0 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${
                 isSelected
-                  ? "border-border border-b-2 border-b-background -mb-px text-foreground bg-background"
+                  ? "border-border border-b-2 border-b-foreground -mb-px text-foreground bg-background"
                   : "text-muted-foreground hover:text-foreground"
               }`}
             >


### PR DESCRIPTION
Fixes #1698

## Summary
- Selected settings tab used `border-b-background` which is invisible for Thrall (free tier) users since the border color matches the page background
- Changed to `border-b-foreground` so Thrall users see a visible underline indicator on the active tab
- Karl/trial users retain gold border styling via `[data-tier="karl"] .karl-bling-tab[aria-selected="true"]` CSS override in `karl-bling.css`

## Test Results
- 4 Vitest component tests added (`settings-tab-thrall-1698.test.tsx`)
- Full Vitest suite: 2360 tests, all passing
- tsc: PASS
- build: PASS