### PR TITLE
fix(templates): trust vitest exit code, stop grepping for FAIL

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -147,8 +147,12 @@ All agents run tsc, build, AND the full Vitest suite before handoff.
 Do NOT run Playwright E2E tests — Vitest only. E2E runs via CI.
   cd /workspace/repo/development/frontend && pnpm run verify:tsc
   cd /workspace/repo/development/frontend && pnpm run verify:build
-  cd /workspace/repo/development/frontend && npx vitest run --reporter=verbose
-On failure: fix, commit+push, re-run that step. Repeat until green.
+  cd /workspace/repo/development/frontend && npx vitest run
+**Trust the exit code.** Exit 0 = all tests pass. Non-zero = failures.
+Do NOT grep vitest output for FAIL, do NOT parse ANSI escape codes.
+Just run the command and check whether it succeeded or failed.
+On failure: read the output to see which tests failed, fix them, commit+push, re-run.
+Repeat until the command exits 0.
 Do NOT proceed to handoff with ANY failing Vitest tests.
 **All verify steps MUST run in the foreground (blocking).** NEVER use `run_in_background`
 for tsc, build, or Vitest commands. You MUST confirm each step passes before proceeding

--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -44,7 +44,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
 **Step 3b — Write Vitest tests for new code:**
 - Write unit tests for new utilities, hooks, helpers in `development/frontend/src/__tests__/`
 - Write integration tests for new API routes, component renders
-- Run: `cd <REPO_ROOT>/development/frontend && npx vitest run src/__tests__/<feature>/ --reporter=verbose`
+- Run: `cd <REPO_ROOT>/development/frontend && npx vitest run src/__tests__/<feature>/`
 - Commit+push tests with implementation.
 - Loki will add E2E tests later — you own Vitest tests.
 - **NEVER write tests for monitor-ui (Odin's Throne) or odins-spear.** `development/monitor-ui/` and

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -74,7 +74,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
 - **Commit+push tests before running them:**
   git add -A && git commit -m 'wip: add tests for issue:<NUMBER>' && git push origin <BRANCH>
 - Run ALL Vitest tests (not just your feature tests):
-  `cd <REPO_ROOT>/development/frontend && npx vitest run --reporter=verbose`
+  `cd <REPO_ROOT>/development/frontend && npx vitest run`
 - Fix ALL failing tests — yours AND any pre-existing failures you find. Update todos.
 - Do NOT proceed until the FULL Vitest suite is green.
 - Do NOT write or run any Playwright E2E tests. Vitest only. E2E is on lockdown.


### PR DESCRIPTION
## Summary
- Agents were parsing ANSI escape codes (`grep -oP "\\[41m\\[1m FAIL"`) to detect vitest failures instead of just checking exit codes
- Simplified all templates to `npx vitest run` (no `--reporter=verbose`) 
- Added explicit "Trust the exit code" instruction to sandbox preamble

## Test plan
- [x] Orchestrator-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)