### PR TITLE
fix(trial): correct Firestore document path — 3 segments to 4

### DIFF
--- a/development/frontend/src/lib/firebase/firestore-types.ts
+++ b/development/frontend/src/lib/firebase/firestore-types.ts
@@ -141,8 +141,8 @@ export const FIRESTORE_PATHS = {
   /** /households/{householdId}/stripe/subscription — Stripe billing subcollection (issue #1648) */
   stripeSubscription: (householdId: string) =>
     `households/${householdId}/stripe/subscription` as const,
-  /** /households/{userId}/trial — permanent trial record (never auto-deleted) */
-  trial: (userId: string) => `households/${userId}/trial` as const,
+  /** /households/{userId}/trial/status — permanent trial record (never auto-deleted) */
+  trial: (userId: string) => `households/${userId}/trial/status` as const,
 } as const;
 
 // ─── Invite code helpers ──────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- `FIRESTORE_PATHS.trial()` returned `households/{userId}/trial` (3 segments)
- Firestore `.doc()` requires even number of path components (collection/doc pairs)
- Changed to `households/{userId}/trial/status` (4 segments)
- This was the root cause of trial init silently failing on every sign-in

Pod logs confirmed:
```
getTrial failed: "documentPath" must point to a document, but was
"households/110414050811994350775/trial". Your path does not contain
an even number of components.
```

## Test plan
- [x] tsc passes
- [ ] Deploy and verify trial init succeeds via HAR

🤖 Generated with [Claude Code](https://claude.com/claude-code)