### PR TITLE
fix(test): update trial path assertions for /trial/status

### DIFF
--- a/development/frontend/src/__tests__/lib/firestore.test.ts
+++ b/development/frontend/src/__tests__/lib/firestore.test.ts
@@ -814,6 +814,6 @@ describe("FIRESTORE_PATHS — no entitlement path (issue #1633)", () => {
   });
 
   it("builds trial subcollection path correctly (issue #1634)", () => {
-    expect(FIRESTORE_PATHS.trial("user-abc")).toBe("households/user-abc/trial");
+    expect(FIRESTORE_PATHS.trial("user-abc")).toBe("households/user-abc/trial/status");
   });
 });

--- a/development/frontend/src/__tests__/lib/trial-store.test.ts
+++ b/development/frontend/src/__tests__/lib/trial-store.test.ts
@@ -47,7 +47,7 @@ import { TRIAL_DURATION_DAYS } from "@/lib/trial-utils";
 // ── Test data ────────────────────────────────────────────────────────────────
 
 const USER_ID = "google-sub-abc123";
-const TRIAL_PATH = `households/${USER_ID}/trial`;
+const TRIAL_PATH = `households/${USER_ID}/trial/status`;
 
 function activeTrialSnap(overrides: Partial<StoredTrial> = {}) {
   const trial: StoredTrial = {
@@ -79,7 +79,7 @@ describe("getTrial", () => {
     mockDocRef.get.mockResolvedValue(missingSnap);
   });
 
-  it("reads from /households/{userId}/trial path", async () => {
+  it("reads from /households/{userId}/trial/status path", async () => {
     mockDocRef.get.mockResolvedValueOnce(activeTrialSnap());
 
     await getTrial(USER_ID);

--- a/development/frontend/src/__tests__/trial/trial-convert-route.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-convert-route.test.ts
@@ -53,7 +53,7 @@ import { POST } from "@/app/api/trial/convert/route";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const USER_ID = "google-sub-convert-456";
-const TRIAL_PATH = `households/${USER_ID}/trial`;
+const TRIAL_PATH = `households/${USER_ID}/trial/status`;
 
 function activeTrialSnap() {
   return {
@@ -113,7 +113,7 @@ describe("POST /api/trial/convert", () => {
     expect(mockDocRef.update).toHaveBeenCalledOnce();
   });
 
-  it("writes convertedDate to /households/{userId}/trial", async () => {
+  it("writes convertedDate to /households/{userId}/trial/status", async () => {
     await POST(makeRequest());
 
     expect(mockDb.doc).toHaveBeenCalledWith(TRIAL_PATH);

--- a/development/frontend/src/__tests__/trial/trial-init-route.test.ts
+++ b/development/frontend/src/__tests__/trial/trial-init-route.test.ts
@@ -57,7 +57,7 @@ import { POST } from "@/app/api/trial/init/route";
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 const USER_ID = "google-sub-test-123";
-const TRIAL_PATH = `households/${USER_ID}/trial`;
+const TRIAL_PATH = `households/${USER_ID}/trial/status`;
 
 const missingSnap = { exists: false, data: () => null };
 
@@ -136,7 +136,7 @@ describe("POST /api/trial/init", () => {
     expect(mockDocRef.set).toHaveBeenCalledOnce();
   });
 
-  it("writes trial to /households/{userId}/trial", async () => {
+  it("writes trial to /households/{userId}/trial/status", async () => {
     await POST(makeRequest());
 
     expect(mockDb.doc).toHaveBeenCalledWith(TRIAL_PATH);


### PR DESCRIPTION
## Summary
- 4 test files still asserted the old 3-segment Firestore path `households/{userId}/trial`
- Updated to `households/{userId}/trial/status` to match PR #1724

## Test plan
- [x] All 4 affected test files pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)