### PR TITLE
fix(spear): update trial adjust Firestore path to households/{userId}/trial/status — #1726

### DIFF
--- a/development/odins-spear/src/commands/trial.ts
+++ b/development/odins-spear/src/commands/trial.ts
@@ -10,7 +10,7 @@ import {
   describeTrialState,
 } from "./trial-helpers.js";
 
-/** Read a trial document from /households/{userId}/trial. */
+/** Read a trial document from /households/{userId}/trial/status. */
 async function readTrialDoc(
   userId: string
 ): Promise<{ startDate: string; convertedDate?: string } | null> {
@@ -19,20 +19,20 @@ async function readTrialDoc(
     .collection("households")
     .doc(userId)
     .collection("trial")
-    .doc("trial")
+    .doc("status")
     .get();
   if (!snap.exists) return null;
   return snap.data() as { startDate: string; convertedDate?: string };
 }
 
-/** Write a startDate update to /households/{userId}/trial. Creates the doc if absent. */
+/** Write a startDate update to /households/{userId}/trial/status. Creates the doc if absent. */
 async function writeTrialStartDate(userId: string, startDate: string): Promise<void> {
   if (!firestoreClient) throw new Error("Firestore client not connected");
   const ref = firestoreClient
     .collection("households")
     .doc(userId)
     .collection("trial")
-    .doc("trial");
+    .doc("status");
   const snap = await ref.get();
   if (snap.exists) {
     await ref.update({ startDate });


### PR DESCRIPTION
PR for issue: #1726

Updates trial adjust (and all trial commands) to read/write from `households/{userId}/trial/status` instead of the stale `households/{userId}/trial/trial` path.

## Changes

- `development/odins-spear/src/commands/trial.ts`: Changed `.doc("trial")` → `.doc("status")` in both `readTrialDoc` and `writeTrialStartDate`, aligning with `FIRESTORE_PATHS.trial()` introduced in PR #1724.

## Verification

- tsc PASS
- build PASS
- No tests (odins-spear policy: tests are banned)

Closes #1726