### PR TITLE
fix(spear): move trial adjust UI to HouseholdsTab

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -253,10 +253,6 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
         onCardsView={(householdId, filterUserId, ownerEmail) => {
           setCardDrilldown({ householdId, filterUserId, breadcrumbFrom: ownerEmail, ownerEmail });
         }}
-        onTrialAdjust={() => {
-          const cmd = getCommands().find((c) => c.name === "trial-adjust");
-          if (cmd) handleTrialInput(cmd);
-        }}
       />
     );
   } else {
@@ -266,6 +262,10 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
         initialHouseholdId={jumpHouseholdId}
         onCardsView={(householdId, householdName) => {
           setCardDrilldown({ householdId, filterUserId: null, breadcrumbFrom: householdName, ownerEmail: householdName });
+        }}
+        onTrialAdjust={() => {
+          const cmd = getCommands().find((c) => c.name === "trial-adjust");
+          if (cmd) handleTrialInput(cmd);
         }}
       />
     );

--- a/development/odins-spear/src/components/HelpOverlay.tsx
+++ b/development/odins-spear/src/components/HelpOverlay.tsx
@@ -45,10 +45,9 @@ const SECTIONS: Section[] = [
     ],
   },
   {
-    title: "Trial Actions  (user selected)",
+    title: "User Actions  (user selected)",
     tabs: "users",
     shortcuts: [
-      { key: "a",  desc: "Open trial-adjust dialog (shift trial start date)" },
       { key: "s",  desc: "Cancel active Stripe subscription" },
     ],
   },
@@ -56,6 +55,7 @@ const SECTIONS: Section[] = [
     title: "Household Actions  (household selected)",
     tabs: "households",
     shortcuts: [
+      { key: "a",  desc: "Open trial-adjust dialog (shift trial start date)" },
       { key: "d",  desc: "Delete selected household" },
       { key: "u",  desc: "List household members" },
     ],

--- a/development/odins-spear/src/tabs/HouseholdsTab.tsx
+++ b/development/odins-spear/src/tabs/HouseholdsTab.tsx
@@ -223,7 +223,7 @@ export function HouseholdDetailView({ detail }: HouseholdDetailViewProps): React
       {/* Action hints */}
       <Box marginTop={1}>
         <Text color={DIM}>
-          {`[c] cards  [k] kick  [o] xfer owner  [i] regen invite  ${household.tier === "karl" ? "[s] cancel sub  " : ""}[x] delete  [Ctrl+R] reload`}
+          {`[a] adjust trial  [c] cards  [k] kick  [o] xfer owner  [i] regen invite  ${household.tier === "karl" ? "[s] cancel sub  " : ""}[x] delete  [Ctrl+R] reload`}
         </Text>
       </Box>
     </Box>
@@ -469,6 +469,7 @@ interface HouseholdsTabProps {
   cmdStatus: string | null;
   initialHouseholdId?: string | null;
   onCardsView?: (householdId: string, householdName: string) => void;
+  onTrialAdjust?: () => void;
 }
 
 type LoadState = "idle" | "loading" | "loaded" | "error";
@@ -478,7 +479,7 @@ type LoadState = "idle" | "loading" | "loaded" | "error";
  * Left panel: scrollable list with tier badge + member count.
  * Right panel: full household detail with members, Stripe info.
  */
-export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView }: HouseholdsTabProps): React.JSX.Element {
+export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView, onTrialAdjust }: HouseholdsTabProps): React.JSX.Element {
   log.debug("HouseholdsTab render");
 
   const selection = useSelection();
@@ -675,6 +676,11 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView }: Ho
         return;
       }
       setConfirm({ kind: "xfer", memberId: target.userId, email: target.email });
+      return;
+    }
+
+    if (input === "a") {
+      onTrialAdjust?.();
       return;
     }
 

--- a/development/odins-spear/src/tabs/UsersTab.tsx
+++ b/development/odins-spear/src/tabs/UsersTab.tsx
@@ -230,7 +230,7 @@ function UserDetailPanel({
       {actionMode === "none" ? (
         <Box>
           <Text color={GRAY}>
-            {"[x] Delete  [t] Tier  [a] adjust trial"}
+            {"[x] Delete  [t] Tier"}
             {detail?.stripeSubscriptionId ? "  [s] Cancel sub" : ""}
             {detail?.household ? "  [h] Household  [c] Cards" : ""}
           </Text>
@@ -269,7 +269,6 @@ interface UsersTabProps {
   onInputCapture?: (captured: boolean) => void;
   onJumpToHousehold?: (householdId: string) => void;
   onCardsView?: (householdId: string, filterUserId: string, ownerEmail: string) => void;
-  onTrialAdjust?: () => void;
 }
 
 export function UsersTab({
@@ -277,7 +276,6 @@ export function UsersTab({
   onInputCapture,
   onJumpToHousehold,
   onCardsView,
-  onTrialAdjust,
 }: UsersTabProps): React.JSX.Element {
   log.debug("UsersTab render");
 
@@ -663,10 +661,6 @@ export function UsersTab({
       }
       if (input === "c" && detail?.household && user.householdId) {
         onCardsView?.(user.householdId, user.id, user.email);
-        return;
-      }
-      if (input === "a") {
-        onTrialAdjust?.();
         return;
       }
     }


### PR DESCRIPTION
## Summary
- Agent #1732 updated the command registry but never moved the UI wiring
- Moved `[a] adjust trial` key handler, hint text, and `onTrialAdjust` prop from UsersTab to HouseholdsTab
- Updated HelpOverlay to show trial adjust under Household Actions
- tsc clean

## Test plan
- [x] tsc passes
- [ ] `just spear run` → select household → press `a` → trial adjust dialog appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)