### PR TITLE
fix(spear): consistent dialog feedback — success closes with toast, failure stays open

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -43,6 +43,8 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
   const [jumpHouseholdId, setJumpHouseholdId] = useState<string | null>(null);
   const [overlay, setOverlay] = useState<OverlayMode>({ kind: "none" });
   const [cmdStatus, setCmdStatusMsg] = useState<string | null>(null);
+  const [dialogExecuting, setDialogExecuting] = useState(false);
+  const [dialogError, setDialogError] = useState<string | null>(null);
   const [connState, setConnState] = useState<ConnStatus>(initialConnStatus);
   const [countState, setCountState] = useState<Counts>(initialCounts);
   const [inputCaptured, setInputCaptured] = useState(false);
@@ -89,45 +91,51 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
 
   const handleDestructive = useCallback((cmd: PaletteCommand) => {
     log.debug("SpearInner: handleDestructive called", { name: cmd.name });
+    setDialogExecuting(false);
+    setDialogError(null);
     setOverlay({ kind: "confirm", cmd });
   }, []);
 
   const handleTrialInput = useCallback((cmd: PaletteCommand) => {
     log.debug("SpearInner: handleTrialInput called", { name: cmd.name });
+    setDialogExecuting(false);
+    setDialogError(null);
     setOverlay({ kind: "trial-input", cmd });
   }, []);
 
   const handleTrialInputConfirm = useCallback(async (cmd: PaletteCommand, dayInput: string) => {
     log.debug("SpearInner: handleTrialInputConfirm called", { name: cmd.name, dayInput });
-    closeOverlay();
+    setDialogExecuting(true);
+    setDialogError(null);
     try {
       const lines = await cmd.execute({ ...cmdCtx, input: dayInput });
       log.debug("SpearInner: handleTrialInputConfirm done", { lineCount: lines.length });
-      setOverlay({ kind: "results", title: cmd.name, lines });
+      // Success: close dialog and show a status toast
+      closeOverlay();
+      setCmdStatusMsg(`${cmd.name}: ${lines[0] ?? "done"}`);
     } catch (err) {
       log.error("SpearInner: handleTrialInputConfirm error", err as Error);
-      setOverlay({
-        kind: "results",
-        title: cmd.name,
-        lines: [`ERROR: ${(err as Error).message ?? String(err)}`],
-      });
+      // Failure: keep dialog open with inline error
+      setDialogExecuting(false);
+      setDialogError((err as Error).message ?? String(err));
     }
   }, [cmdCtx, closeOverlay]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleConfirmExecute = useCallback(async (cmd: PaletteCommand) => {
     log.debug("SpearInner: handleConfirmExecute called", { name: cmd.name });
-    closeOverlay();
+    setDialogExecuting(true);
+    setDialogError(null);
     try {
       const lines = await cmd.execute(cmdCtx);
       log.debug("SpearInner: handleConfirmExecute done", { lineCount: lines.length });
-      setOverlay({ kind: "results", title: cmd.name, lines });
+      // Success: close dialog and show a status toast
+      closeOverlay();
+      setCmdStatusMsg(`${cmd.name}: ${lines[0] ?? "done"}`);
     } catch (err) {
       log.error("SpearInner: handleConfirmExecute error", err as Error);
-      setOverlay({
-        kind: "results",
-        title: cmd.name,
-        lines: [`ERROR: ${(err as Error).message ?? String(err)}`],
-      });
+      // Failure: keep dialog open with inline error
+      setDialogExecuting(false);
+      setDialogError((err as Error).message ?? String(err));
     }
   }, [cmdCtx, closeOverlay]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -221,6 +229,8 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
           closeOverlay();
           setCmdStatusMsg("Cancelled");
         }}
+        executing={dialogExecuting}
+        error={dialogError}
       />
     );
   } else if (overlay.kind === "confirm") {
@@ -229,7 +239,12 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
         action={overlay.cmd.name}
         desc={overlay.cmd.desc}
         onConfirm={() => { void handleConfirmExecute(overlay.cmd); }}
-        onCancel={closeOverlay}
+        onCancel={() => {
+          closeOverlay();
+          setCmdStatusMsg("Cancelled");
+        }}
+        executing={dialogExecuting}
+        error={dialogError}
       />
     );
   } else if (cardDrilldown) {

--- a/development/odins-spear/src/components/ConfirmDialog.tsx
+++ b/development/odins-spear/src/components/ConfirmDialog.tsx
@@ -21,12 +21,16 @@ export interface ConfirmDialogProps {
   desc: string;
   onConfirm: () => void;
   onCancel: () => void;
+  /** True while the command is executing — disables confirm, shows spinner */
+  executing?: boolean;
+  /** Inline error message to show when execution failed */
+  error?: string | null;
 }
 
 // ─── Component ───────────────────────────────────────────────────────────────
 
-export function ConfirmDialog({ action, desc, onConfirm, onCancel }: ConfirmDialogProps): React.JSX.Element {
-  log.debug("ConfirmDialog render", { action, descLength: desc.length });
+export function ConfirmDialog({ action, desc, onConfirm, onCancel, executing = false, error = null }: ConfirmDialogProps): React.JSX.Element {
+  log.debug("ConfirmDialog render", { action, descLength: desc.length, executing });
 
   const [typed, setTyped] = useState("");
 
@@ -36,12 +40,18 @@ export function ConfirmDialog({ action, desc, onConfirm, onCancel }: ConfirmDial
     log.debug("ConfirmDialog useInput", { keyEscape: key.escape, keyReturn: key.return });
 
     if (key.escape) {
-      log.debug("ConfirmDialog: escape pressed, cancelling");
-      onCancel();
+      if (!executing) {
+        log.debug("ConfirmDialog: escape pressed, cancelling");
+        onCancel();
+      }
       return;
     }
 
     if (key.return) {
+      if (executing) {
+        log.debug("ConfirmDialog: return pressed while executing — ignoring");
+        return;
+      }
       if (isReady) {
         log.debug("ConfirmDialog: confirmed");
         onConfirm();
@@ -97,12 +107,24 @@ export function ConfirmDialog({ action, desc, onConfirm, onCancel }: ConfirmDial
 
       <Box height={1} />
 
+      {/* Inline error (shown when command failed — dialog stays open) */}
+      {error ? (
+        <Box marginTop={1}>
+          <Text color={RED} bold>Error: </Text>
+          <Text color={RED}>{error}</Text>
+        </Box>
+      ) : null}
+
       {/* Footer */}
       <Box flexDirection="row" gap={3}>
-        <Text color={isReady ? GREEN : GRAY} bold={isReady}>
-          {isReady ? "Enter to CONFIRM" : "type 'delete' then Enter"}
-        </Text>
-        <Text color={GOLD}>Esc to cancel</Text>
+        {executing ? (
+          <Text color={GREEN}>Executing…</Text>
+        ) : (
+          <Text color={isReady ? GREEN : GRAY} bold={isReady}>
+            {isReady ? "Enter to CONFIRM" : "type 'delete' then Enter"}
+          </Text>
+        )}
+        {!executing && <Text color={GOLD}>Esc to cancel</Text>}
       </Box>
     </Box>
   );

--- a/development/odins-spear/src/components/TrialInputDialog.tsx
+++ b/development/odins-spear/src/components/TrialInputDialog.tsx
@@ -25,6 +25,10 @@ export interface TrialInputDialogProps {
   action: string;
   onConfirm: (dayInput: string) => void;
   onCancel: () => void;
+  /** True while the command is executing — disables confirm, shows spinner */
+  executing?: boolean;
+  /** Inline error message to show when execution failed */
+  error?: string | null;
 }
 
 // ─── Component ────────────────────────────────────────────────────────────────
@@ -33,8 +37,10 @@ export function TrialInputDialog({
   action,
   onConfirm,
   onCancel,
+  executing = false,
+  error = null,
 }: TrialInputDialogProps): React.JSX.Element {
-  log.debug("TrialInputDialog render", { action });
+  log.debug("TrialInputDialog render", { action, executing });
 
   const [dayInput, setDayInput] = useState("");
   const valid = isValidDayInput(dayInput);
@@ -43,12 +49,18 @@ export function TrialInputDialog({
     log.debug("TrialInputDialog useInput", { keyEscape: key.escape, keyReturn: key.return });
 
     if (key.escape) {
-      log.debug("TrialInputDialog: escape pressed, cancelling");
-      onCancel();
+      if (!executing) {
+        log.debug("TrialInputDialog: escape pressed, cancelling");
+        onCancel();
+      }
       return;
     }
 
     if (key.return) {
+      if (executing) {
+        log.debug("TrialInputDialog: return pressed while executing — ignoring");
+        return;
+      }
       if (valid) {
         log.debug("TrialInputDialog: confirmed with input", { dayInput });
         onConfirm(dayInput);
@@ -105,14 +117,26 @@ export function TrialInputDialog({
         <Text color={RED}>Enter a non-zero integer (e.g. +5 or -3)</Text>
       ) : null}
 
+      {/* Inline error (shown when command failed — dialog stays open) */}
+      {error ? (
+        <Box marginTop={1}>
+          <Text color={RED} bold>Error: </Text>
+          <Text color={RED}>{error}</Text>
+        </Box>
+      ) : null}
+
       <Box height={1} />
 
       {/* Footer */}
       <Box flexDirection="row" gap={3}>
-        <Text color={valid ? GREEN : DIM} bold={valid}>
-          {valid ? "Enter to apply" : "type a non-zero integer"}
-        </Text>
-        <Text color={GOLD}>Esc to cancel</Text>
+        {executing ? (
+          <Text color={GREEN}>Executing…</Text>
+        ) : (
+          <Text color={valid ? GREEN : DIM} bold={valid}>
+            {valid ? "Enter to apply" : "type a non-zero integer"}
+          </Text>
+        )}
+        {!executing && <Text color={GOLD}>Esc to cancel</Text>}
       </Box>
     </Box>
   );

--- a/development/odins-spear/src/tabs/HouseholdsTab.tsx
+++ b/development/odins-spear/src/tabs/HouseholdsTab.tsx
@@ -236,9 +236,11 @@ interface ConfirmBarProps {
   action: ConfirmAction;
   onConfirm: () => void;
   onCancel: () => void;
+  /** Inline error shown when action failed — bar stays open for retry or cancel */
+  error?: string | null;
 }
 
-function ConfirmBar({ action, onConfirm, onCancel }: ConfirmBarProps): React.JSX.Element {
+function ConfirmBar({ action, onConfirm, onCancel, error = null }: ConfirmBarProps): React.JSX.Element {
   let label: string;
   switch (action.kind) {
     case "kick":        label = `Kick ${action.email}?`; break;
@@ -255,8 +257,7 @@ function ConfirmBar({ action, onConfirm, onCancel }: ConfirmBarProps): React.JSX
 
   return (
     <Box
-      flexDirection="row"
-      gap={2}
+      flexDirection="column"
       borderStyle="single"
       borderTop={true}
       borderBottom={false}
@@ -265,9 +266,14 @@ function ConfirmBar({ action, onConfirm, onCancel }: ConfirmBarProps): React.JSX
       borderColor={RED}
       paddingX={2}
     >
-      <Text color={RED} bold>{label}</Text>
-      <Text color={GREEN} bold>[y] yes</Text>
-      <Text color={GOLD}>[n/Esc] cancel</Text>
+      <Box flexDirection="row" gap={2}>
+        <Text color={RED} bold>{label}</Text>
+        <Text color={GREEN} bold>[y] yes</Text>
+        <Text color={GOLD}>[n/Esc] cancel</Text>
+      </Box>
+      {error ? (
+        <Text color={RED}>Error: {error}</Text>
+      ) : null}
     </Box>
   );
 }
@@ -388,11 +394,13 @@ async function executeAction(
   detail: HouseholdDetail | null,
   setStatus: (s: string) => void,
   reload: () => void,
+  setConfirm: (c: ConfirmAction | null) => void,
+  setConfirmError: (e: string | null) => void,
   returnTo?: () => void
 ): Promise<void> {
   log.debug("executeAction called", { kind: action.kind, hhId: hh.id });
   if (!firestoreClient) {
-    setStatus("ERROR: Firestore not connected");
+    setConfirmError("Firestore not connected");
     return;
   }
 
@@ -405,6 +413,9 @@ async function executeAction(
           const d = hhSnap.data() as Record<string, unknown>;
           const members = (d["memberIds"] as string[] | undefined) ?? [];
           await hhRef.update({ memberIds: members.filter((id) => id !== action.memberId) });
+          // Success: close confirm bar, set status toast
+          setConfirm(null);
+          setConfirmError(null);
           setStatus(`Kicked ${action.email} from household`);
           reload();
         }
@@ -414,6 +425,9 @@ async function executeAction(
         await firestoreClient.collection("households").doc(hh.id).update({ ownerId: action.memberId });
         await firestoreClient.collection("users").doc(action.memberId).update({ role: "owner" });
         await firestoreClient.collection("users").doc(hh.ownerId).update({ role: "member" });
+        // Success: close confirm bar, set status toast
+        setConfirm(null);
+        setConfirmError(null);
         setStatus(`Transferred ownership to ${action.email}`);
         reload();
         break;
@@ -425,6 +439,9 @@ async function executeAction(
           inviteCode: newCode,
           inviteCodeExpiresAt: expiresAt,
         });
+        // Success: close confirm bar, set status toast
+        setConfirm(null);
+        setConfirmError(null);
         setStatus(`New invite code: ${newCode}`);
         reload();
         break;
@@ -432,14 +449,23 @@ async function executeAction(
       case "cancel-sub": {
         const subId = detail?.stripeSubscriptionId ?? null;
         if (!subId) {
+          // No-op with explanation — treat as immediate close (no retry possible)
+          setConfirm(null);
+          setConfirmError(null);
           setStatus("No Stripe subscription ID — cannot cancel");
           return;
         }
+        // Success: close confirm bar, set status toast
+        setConfirm(null);
+        setConfirmError(null);
         setStatus(`Sub ${subId} — cancel via Stripe dashboard or API`);
         break;
       }
       case "delete": {
         await firestoreClient.collection("households").doc(hh.id).delete();
+        // Success: close confirm bar, navigate away, set status toast
+        setConfirm(null);
+        setConfirmError(null);
         setStatus(`Deleted household ${hh.name}`);
         // Navigate away first — entity no longer exists — then refresh the list
         returnTo?.();
@@ -450,7 +476,8 @@ async function executeAction(
   } catch (err) {
     const msg = (err as Error).message ?? String(err);
     log.error("executeAction failed", err as Error);
-    setStatus(`ERROR: ${msg}`);
+    // Failure: keep confirm bar open, show error inline
+    setConfirmError(msg);
   }
 }
 
@@ -492,6 +519,7 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView, onTr
   const [detailLoading, setDetailLoading] = useState(false);
   const [status, setStatus]         = useState<string | null>(cmdStatus);
   const [confirm, setConfirm]       = useState<ConfirmAction | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
 
   // Track whether the initialHouseholdId has been applied — reset on each mount
   const initialApplied = useRef(false);
@@ -696,15 +724,18 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView, onTr
     const hh = selectedIdx >= 0 ? households[selectedIdx] : null;
     if (!hh) { setConfirm(null); return; }
     const pendingAction = confirm;
-    setConfirm(null);
+    // Don't pre-clear confirm here — executeAction controls it.
+    // On success it calls setConfirm(null); on failure it calls setConfirmError(msg).
+    setConfirmError(null); // clear any prior error when retrying
     // For delete, supply a returnTo that clears the selection — the entity won't exist after success.
     // Non-destructive actions (kick, xfer, etc.) preserve the current selection.
     const returnTo = pendingAction.kind === "delete" ? () => { setSelectedIdx(-1); } : undefined;
-    void executeAction(pendingAction, hh, detail, setStatus, doLoad, returnTo);
+    void executeAction(pendingAction, hh, detail, setStatus, doLoad, setConfirm, setConfirmError, returnTo);
   }, [confirm, selectedIdx, households, detail, doLoad]);
 
   const handleCancel = useCallback(() => {
     setConfirm(null);
+    setConfirmError(null);
   }, []);
 
   // Visible list slice
@@ -834,6 +865,7 @@ export function HouseholdsTab({ cmdStatus, initialHouseholdId, onCardsView, onTr
           action={confirm}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
+          error={confirmError}
         />
       ) : status && selectedIdx >= 0 ? (
         <Box paddingX={2} borderStyle="single" borderTop={true} borderBottom={false} borderLeft={false} borderRight={false} borderColor={DIM}>

--- a/development/odins-spear/src/tabs/UsersTab.tsx
+++ b/development/odins-spear/src/tabs/UsersTab.tsx
@@ -504,12 +504,15 @@ export function UsersTab({
         await firestoreClient.collection("users").doc(user.id).delete();
         setUsers((prev) => prev.filter((u) => u.id !== user.id));
         setSelectedIdx(-1);
+        // Success: close confirm bar, show status toast
+        setActionMode("none");
         setStatusMsg(`Deleted ${user.id}`);
       } catch (err) {
+        // Failure: keep confirm bar open, show error inline
         setStatusMsg(`Error: ${(err as Error).message}`);
       }
     },
-    []
+    [] // setters are stable
   );
 
   // Update tier
@@ -533,12 +536,17 @@ export function UsersTab({
             prev.map((u) => (u.id === user.id ? { ...u, tier } : u))
           );
         }
+        // Success: close input bar, show status toast
+        setActionMode("none");
+        setTierInput("");
+        setTierError(null);
         setStatusMsg(`Updated tier to ${tier}`);
       } catch (err) {
-        setStatusMsg(`Error: ${(err as Error).message}`);
+        // Failure: keep input bar open, show error inline
+        setTierError(`Error: ${(err as Error).message}`);
       }
     },
-    []
+    [] // setters are stable
   );
 
   useInput((input, key) => {
@@ -556,9 +564,8 @@ export function UsersTab({
           setTierError("Invalid tier. Enter: karl, trial, or thrall");
           return;
         }
-        setActionMode("none");
-        setTierInput("");
-        setTierError(null);
+        // Don't close the bar here — doUpdateTier controls actionMode.
+        // On success it clears actionMode/tierInput/tierError; on failure it sets tierError.
         const user = users[selectedIdx];
         if (user) void doUpdateTier(user, valid);
         return;
@@ -580,9 +587,10 @@ export function UsersTab({
         return;
       }
       if (input === "y") {
+        // Don't close the bar here — doDeleteUser controls actionMode.
+        // On success it clears actionMode; on failure it sets statusMsg and keeps bar open.
         const user = users[selectedIdx];
         if (user) void doDeleteUser(user);
-        setActionMode("none");
       }
       return;
     }


### PR DESCRIPTION
## Summary

PR for issue: #1734

- **`ConfirmDialog` + `TrialInputDialog`**: added `executing` and `error` props — shows inline error message when a command fails, disables confirm/cancel input while executing
- **`app.tsx`**: `handleConfirmExecute` and `handleTrialInputConfirm` no longer pre-close the dialog before running the command; on success → close dialog + `setCmdStatusMsg` toast; on failure → `setDialogError` keeps dialog open with inline error
- **`UsersTab`**: `doDeleteUser` and `doUpdateTier` now own their `actionMode` transitions — on success close bar + toast; on failure keep confirm/input bar open with inline error (no more premature `setActionMode("none")` in keyhandlers)
- **`HouseholdsTab`**: `executeAction` now takes `setConfirm` + `setConfirmError`; on success clears confirm bar; on failure keeps `ConfirmBar` open with inline error rendered below the prompt

## How to verify

- tsc + build both PASS (no tests — odins-spear policy)
- Trigger a command that succeeds → dialog closes, status toast appears in tab content area
- Trigger a command that fails → dialog stays open with red inline error, user can retry [y] or cancel [Esc/n]

🤖 Generated with [Claude Code](https://claude.com/claude-code)