### PR TITLE
fix(spear): remove stale / hint and duplicate Ctrl+R from household view — issue #1742

### DIFF
--- a/development/odins-spear/src/components/TopBar.tsx
+++ b/development/odins-spear/src/components/TopBar.tsx
@@ -52,8 +52,6 @@ export function TopBar({ activeTab, onTabSwitch: _onTabSwitch }: TopBarProps): R
       {/* Right: shortcut hints */}
       <Box flexDirection="row" gap={3}>
         <Text color={GRAY}>{"["}</Text>
-        <Text color={GOLD}>{"/"}</Text>
-        <Text color={GRAY}>{"] Command  ["}</Text>
         <Text color={GOLD}>{"^R"}</Text>
         <Text color={GRAY}>{"] Reload  ["}</Text>
         <Text color={GOLD}>{"?"}</Text>

--- a/development/odins-spear/src/tabs/HouseholdsTab.tsx
+++ b/development/odins-spear/src/tabs/HouseholdsTab.tsx
@@ -223,7 +223,7 @@ export function HouseholdDetailView({ detail }: HouseholdDetailViewProps): React
       {/* Action hints */}
       <Box marginTop={1}>
         <Text color={DIM}>
-          {`[a] adjust trial  [c] cards  [k] kick  [o] xfer owner  [i] regen invite  ${household.tier === "karl" ? "[s] cancel sub  " : ""}[x] delete  [Ctrl+R] reload`}
+          {`[a] adjust trial  [c] cards  [k] kick  [o] xfer owner  [i] regen invite  ${household.tier === "karl" ? "[s] cancel sub  " : ""}[x] delete`}
         </Text>
       </Box>
     </Box>


### PR DESCRIPTION
PR for issue: #1742

## Summary
- Removed stale `[/] Command` hint from TopBar header (command palette was removed in #1736)
- Removed duplicate `[Ctrl+R] reload` hint from HouseholdsTab detail action bar (Ctrl+R is a global shortcut already shown in the header)
- Ctrl+R key handler is untouched — only the duplicate hint text is removed

## Test plan
- [ ] Header shows `[^R] Reload  [?] Help` (no `[/] Command`)
- [ ] Household detail action hints do not include `[Ctrl+R] reload`
- [ ] Ctrl+R still reloads the current view (handler intact)
- [ ] tsc + build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)