### PR TITLE
Issue #1753 - feat: download button for pinned completed sessions

### DIFF
--- a/development/monitor-ui/src/components/JobCard.tsx
+++ b/development/monitor-ui/src/components/JobCard.tsx
@@ -4,6 +4,7 @@ import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_LABELS } from "../li
 import { StatusIconSvg } from "./StatusIcon";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 import type { DisplayMode } from "./Sidebar";
+import { downloadLog } from "../lib/localStorageLogs";
 
 interface Props {
   job: DisplayJob;
@@ -149,6 +150,9 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
             {onTogglePin && (
               <CardPinButtonLabeled isPinned={isPinned} onTogglePin={onTogglePin} />
             )}
+            {isPinned && job.status === "succeeded" && (
+              <CardDownloadButtonLabeled sessionId={job.sessionId} />
+            )}
           </>
         ) : (
           <>
@@ -177,6 +181,9 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
             )}
             {onTogglePin && (
               <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
+            )}
+            {isPinned && job.status === "succeeded" && (
+              <CardDownloadButton sessionId={job.sessionId} />
             )}
             <CardCopySessionIdButton sessionId={job.sessionId} />
           </>
@@ -365,5 +372,47 @@ function CardPinIcon({ filled }: { filled: boolean }) {
         </>
       )}
     </svg>
+  );
+}
+
+function CardDownloadIcon() {
+  return (
+    <svg width="11" height="11" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M7 2v7M4 6l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2 11h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function CardDownloadButton({ sessionId }: { sessionId: string }) {
+  return (
+    <button
+      className="card-pin-btn"
+      onClick={(e) => {
+        e.stopPropagation();
+        downloadLog(sessionId);
+      }}
+      title="Download session log"
+      aria-label="Download session log"
+    >
+      <CardDownloadIcon />
+    </button>
+  );
+}
+
+function CardDownloadButtonLabeled({ sessionId }: { sessionId: string }) {
+  return (
+    <button
+      className="card-extended-action-btn"
+      onClick={(e) => {
+        e.stopPropagation();
+        downloadLog(sessionId);
+      }}
+      title="Download session log"
+      aria-label="Download session log"
+    >
+      <CardDownloadIcon />
+      <span>Download Log</span>
+    </button>
   );
 }

--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -84,6 +84,7 @@ import { NorseVerdictInscription, isVerdictMessage } from "./NorseVerdictInscrip
 import { DecreeBlock, isDecreeBlock } from "./DecreeBlock";
 import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
 import { StatusIconSvg } from "./StatusIcon";
+import { downloadLog } from "../lib/localStorageLogs";
 
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 
@@ -194,6 +195,9 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
               <PinIcon filled={isPinned} />
             </button>
           )
+        )}
+        {isPinned && job.status === "succeeded" && (
+          <DownloadSessionButton sessionId={job.sessionId} />
         )}
       </span>
     </div>
@@ -1029,6 +1033,28 @@ function CopySessionIdButton({ sessionId }: { sessionId: string }) {
       aria-label={copied ? "Session ID copied" : "Copy session ID"}
     >
       {copied ? <CheckIcon /> : <ClipboardIcon />}
+    </button>
+  );
+}
+
+function DownloadIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+      <path d="M7 2v7M4 6l3 3 3-3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M2 11h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function DownloadSessionButton({ sessionId }: { sessionId: string }) {
+  return (
+    <button
+      className="copy-session-btn"
+      onClick={() => downloadLog(sessionId)}
+      title="Download session log"
+      aria-label="Download session log"
+    >
+      <DownloadIcon />
     </button>
   );
 }


### PR DESCRIPTION
PR for issue: #1753

Add download icon/button for pinned sessions that completed successfully in Odin's Throne.

**Changes:**
- Session header: download button matching other header button heights
- Session list sidebar: bordered download button matching other list action button sizes
- Conditional visibility: only shown for pinned + successful sessions

**Verification:**
- Open Odin's Throne, pin a completed session, verify download button appears in header and list
- Verify button is hidden for non-pinned or non-successful sessions

Fixes #1753