### PR TITLE
Issue #1755 - fix: standardize session header button styles

### DIFF
--- a/development/monitor-ui/src/components/LogViewer.tsx
+++ b/development/monitor-ui/src/components/LogViewer.tsx
@@ -139,13 +139,13 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
       <span className="header-badges">
         {job.status === "running" && onCancelJob ? (
           <button
-            className={`job-status-icon-btn job-status-icon-btn--cancel${job.status === "running" ? " pulse" : ""}`}
-            style={{ color: STATUS_COLORS[job.status] }}
+            className={`header-action-btn header-action-btn--cancel${job.status === "running" ? " pulse" : ""}`}
             title="Click to cancel this job"
             aria-label="Cancel running job"
             onClick={() => onCancelJob(job.sessionId)}
           >
             <StatusIconSvg status={job.status} />
+            <span>Cancel</span>
           </button>
         ) : (
           <span
@@ -170,17 +170,18 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
         {showPin && onTogglePin && (
           confirmingUnpin ? (
             <button
-              className="pin-btn pin-btn-confirming"
+              className="header-action-btn header-action-btn--confirm"
               onClick={() => { onTogglePin(); setConfirmingUnpin(false); }}
               onBlur={() => setConfirmingUnpin(false)}
               title="Confirm: remove from Odin\u2019s memory"
               aria-label="Confirm unpin"
             >
-              <span className="pin-confirm-label">✕ unpin?</span>
+              <span>✕</span>
+              <span>Unpin</span>
             </button>
           ) : (
             <button
-              className={`pin-btn${isPinned ? " pinned" : ""}`}
+              className={`header-action-btn${isPinned ? " header-action-btn--pinned" : ""}`}
               onClick={() => {
                 if (isPinned) {
                   setConfirmingUnpin(true);
@@ -193,6 +194,7 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
               aria-pressed={isPinned}
             >
               <PinIcon filled={isPinned} />
+              <span>{isPinned ? "Pinned" : "Pin"}</span>
             </button>
           )
         )}
@@ -1027,12 +1029,13 @@ function CopySessionIdButton({ sessionId }: { sessionId: string }) {
 
   return (
     <button
-      className={`copy-session-btn${copied ? " copied" : ""}`}
+      className={`header-action-btn${copied ? " header-action-btn--copied" : ""}`}
       onClick={handleCopy}
       title={copied ? "Copied!" : "Copy session ID"}
       aria-label={copied ? "Session ID copied" : "Copy session ID"}
     >
       {copied ? <CheckIcon /> : <ClipboardIcon />}
+      <span>{copied ? "Copied" : "Copy"}</span>
     </button>
   );
 }

--- a/development/monitor-ui/src/styles/index.css
+++ b/development/monitor-ui/src/styles/index.css
@@ -617,6 +617,54 @@ body {
   .pin-btn { min-width: 1.6rem; min-height: 1.6rem; }
 }
 
+/* ── Session header unified action buttons ──────────
+   Applied to all clickable buttons in SessionHeader.
+   Icon + one-word label, consistent border/color/hover. */
+.header-action-btn {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 2px 6px; height: 1.6rem;
+  background: transparent; border: 1px solid var(--rune-border);
+  border-radius: 3px; color: var(--text-rune); cursor: pointer;
+  font-size: 0.6rem; font-family: 'JetBrains Mono', monospace;
+  white-space: nowrap; line-height: 1;
+  transition: color 0.15s, border-color 0.15s;
+  flex-shrink: 0;
+}
+.header-action-btn:hover {
+  color: var(--gold); border-color: var(--gold-dim-border);
+}
+.header-action-btn:focus-visible {
+  outline: 2px solid var(--gold); outline-offset: 2px;
+}
+/* Cancel variant — hover danger red */
+.header-action-btn--cancel:hover {
+  color: var(--error-strong); border-color: var(--error-strong);
+}
+/* Copied state */
+.header-action-btn--copied {
+  color: var(--teal-asgard); border-color: var(--teal-asgard);
+}
+/* Pinned state */
+.header-action-btn--pinned {
+  color: var(--gold); border-color: var(--gold);
+  background: rgba(201, 146, 10, 0.10);
+}
+.header-action-btn--pinned:hover {
+  color: var(--error-strong); border-color: var(--error-strong);
+  background: rgba(239, 68, 68, 0.08);
+}
+/* Confirm unpin state */
+.header-action-btn--confirm {
+  color: var(--error-strong); border-color: var(--error-strong);
+  background: rgba(239, 68, 68, 0.08);
+}
+/* Pulse animation for running jobs */
+.header-action-btn.pulse { animation: pulse 1.5s ease-in-out infinite; }
+/* Mobile touch target */
+@media (max-width: 639px) {
+  .header-action-btn { min-height: 44px; }
+}
+
 /* ── Pin toggle button in card sidebar ── */
 .card-pin-btn {
   display: inline-flex; align-items: center; justify-content: center;


### PR DESCRIPTION
PR for issue: #1755

Standardize all session header buttons in Odin's Throne for consistent styling.

**Changes:**
- Added `.header-action-btn` unified CSS class with consistent border (`1px solid var(--rune-border)`), color (`var(--text-rune)`), and gold hover effect
- State modifier classes: `--cancel`, `--copied`, `--pinned`, `--confirm` for per-button state styling
- Updated Cancel button: uses `header-action-btn header-action-btn--cancel` + "Cancel" label (removed inconsistent inline status color)
- Updated Copy button: uses `header-action-btn` + "Copy"/"Copied" label (replaces `copy-session-btn` in header context)
- Updated Pin button: uses `header-action-btn` + "Pin"/"Pinned" label (replaces `pin-btn` in header, removes scale transform hover)
- Updated Confirm-unpin button: uses `header-action-btn header-action-btn--confirm` + "Unpin" label (replaces `pin-btn pin-btn-confirming`)
- All buttons now: same height (1.6rem), same border style, same gold hover, icon + one-word label

**Verification:**
- Open Odin's Throne, check session header buttons are visually consistent
- Verify all buttons have icon + one-word label
- Verify hover effects are uniform (gold border/text on hover, red on cancel/unpin hover)