### PR TITLE
add touch-sweep skill, fenrir gold agent logs, fix brandify MDX escaping

### DIFF
--- a/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
+++ b/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
@@ -1114,6 +1114,7 @@ if (publishMode) {
   const mdxTitle = `${agentName} Report: Issue #${issueNum}`;
   const mdxExcerpt = `Agent execution report — ${agentName} on Issue #${issueNum}, Step ${stepNum}. ${turns.length} turns, ${totalTools} tool calls.`;
 
+  // mdxEsc — HTML entity escaping, safe ONLY for JSX attributes (alt="", href="", etc.)
   function mdxEsc(s) {
     if (typeof s !== "string") s = JSON.stringify(s, null, 2) || "";
     return s
@@ -1124,14 +1125,22 @@ if (publishMode) {
       .replace(/\{/g, "&#123;")
       .replace(/\}/g, "&#125;");
   }
+  // jsxStr — safe for JSX TEXT BODIES: wraps value in {JSON.stringify()} expression
+  // Use this for ALL dynamic content between JSX tags: <span>{jsxStr(val)}</span>
+  function jsxStr(s) {
+    if (typeof s !== "string") s = String(s ?? "");
+    return `{${JSON.stringify(s)}}`;
+  }
 
   function mdxToolInputPreview(tool) {
-    if (tool.name === "Bash" && tool.input?.command) return mdxEsc(tool.input.command.slice(0, 100));
-    if (tool.name === "Read" && tool.input?.file_path) return mdxEsc(shortPath(tool.input.file_path));
-    if (tool.name === "Edit" && tool.input?.file_path) return mdxEsc(shortPath(tool.input.file_path));
-    if (tool.name === "Write" && tool.input?.file_path) return mdxEsc(shortPath(tool.input.file_path));
-    if (tool.name === "Grep" && tool.input?.pattern) return mdxEsc(tool.input.pattern);
-    if (tool.name === "Glob" && tool.input?.pattern) return mdxEsc(tool.input.pattern);
+    // Returns RAW string — caller wraps in {JSON.stringify()} for MDX safety
+    function singleLine(s) { return s.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim(); }
+    if (tool.name === "Bash" && tool.input?.command) return singleLine(tool.input.description || tool.input.command.slice(0, 100));
+    if (tool.name === "Read" && tool.input?.file_path) return shortPath(tool.input.file_path);
+    if (tool.name === "Edit" && tool.input?.file_path) return shortPath(tool.input.file_path);
+    if (tool.name === "Write" && tool.input?.file_path) return shortPath(tool.input.file_path);
+    if (tool.name === "Grep" && tool.input?.pattern) return singleLine(tool.input.pattern);
+    if (tool.name === "Glob" && tool.input?.pattern) return singleLine(tool.input.pattern);
     if (tool.name === "TodoWrite") return "update todos";
     return "";
   }
@@ -1295,7 +1304,7 @@ ${decreeBody}
         const avatarSrc = mdxHecklerAvatar(event.name);
         out += `<div className="heckle heckle-mayo">
 <div className="heckle-identity">
-<span className="heckle-name">${mdxEsc(event.name)}</span>
+<span className="heckle-name">{${JSON.stringify(event.name)}}</span>
 <img className="heckle-avatar" src="${avatarSrc}" alt="${mdxEsc(event.name)}" loading="lazy" />
 </div>
 <div className="heckle-text">{${JSON.stringify(event.text)}}</div>
@@ -1307,7 +1316,7 @@ ${decreeBody}
         out += `<div className="heckle heckle-comeback">
 <div className="heckle-identity">
 <img className="heckle-avatar" src="${avatarSrc}" alt="${mdxEsc(event.name)}" loading="lazy" />
-<span className="heckle-name">${mdxEsc(aTitle)}</span>
+<span className="heckle-name">{${JSON.stringify(aTitle)}}</span>
 </div>
 <div className="heckle-text">{${JSON.stringify(event.text)}}</div>
 </div>\n`;
@@ -1317,7 +1326,7 @@ ${decreeBody}
         const avatarSrc = mdxHecklerAvatar(eName);
         out += `<div className="heckle heckle-entrance">
 <div className="heckle-identity">
-<span className="heckle-name">${mdxEsc(eName)}</span>
+<span className="heckle-name">{${JSON.stringify(eName)}}</span>
 <img className="heckle-avatar" src="${avatarSrc}" alt="${mdxEsc(eName)}" loading="lazy" />
 </div>
 <div className="heckle-text">{${JSON.stringify(event.text)}}</div>
@@ -1335,8 +1344,8 @@ ${decreeBody}
   function mdxRenderToolBlock(tool) {
     return `<details className="tool-block${tool.is_error ? " has-error" : ""}">
 <summary className="tool-block-header">
-<span className="tool-name">${mdxEsc(tool.name)}</span>
-<span className="tool-input-preview">${mdxToolInputPreview(tool)}</span>
+<span className="tool-name">{${JSON.stringify(tool.name)}}</span>
+<span className="tool-input-preview">{${JSON.stringify(mdxToolInputPreview(tool))}}</span>
 </summary>
 <div className="tool-block-body">
 <pre className="tool-input">{${JSON.stringify(mdxRenderToolInput(tool))}}</pre>
@@ -1377,14 +1386,14 @@ ${decreeBody}
         ? `#${turnNums[0]}`
         : `#${turnNums[0]}–${turnNums[turnNums.length - 1]}`;
       const toolBadges = mergedTools
-        .map(t => `<span className="tool-badge ${toolBadgeClass(t.name)}">${mdxEsc(t.name)}</span>`)
+        .map(t => `<span className="tool-badge ${toolBadgeClass(t.name)}">{${JSON.stringify(t.name)}}</span>`)
         .join(" ");
 
       turnsMarkup += `
 <div className="turn${hasError ? " has-error" : ""}">
 <div className="turn-agent-profile">
 <img className="turn-agent-avatar" src="${mdxAgentAvatarSrc}" alt="${mdxEsc(agentName)}" loading="lazy" />
-<span className="turn-agent-title">${mdxEsc(agentTitle)}</span>
+<span className="turn-agent-title">{${JSON.stringify(agentTitle)}}</span>
 </div>
 <details className="turn-box">
 <summary className="turn-header">
@@ -1411,14 +1420,14 @@ ${mergedTools.map(t => mdxRenderToolBlock(t)).join("")}</div>
       ? `{${JSON.stringify(turn.texts[0].slice(0, 120))}}`
       : turn.tools.map(t => t.name).join(", ");
     const toolBadges = turn.tools
-      .map(t => `<span className="tool-badge ${toolBadgeClass(t.name)}">${mdxEsc(t.name)}</span>`)
+      .map(t => `<span className="tool-badge ${toolBadgeClass(t.name)}">{${JSON.stringify(t.name)}}</span>`)
       .join(" ");
 
     turnsMarkup += `
 <div className="turn${hasError ? " has-error" : ""}">
 <div className="turn-agent-profile">
 <img className="turn-agent-avatar" src="${mdxAgentAvatarSrc}" alt="${mdxEsc(agentName)}" loading="lazy" />
-<span className="turn-agent-title">${mdxEsc(agentTitle)}</span>
+<span className="turn-agent-title">{${JSON.stringify(agentTitle)}}</span>
 </div>
 <details className="turn-box">
 <summary className="turn-header">
@@ -1461,13 +1470,13 @@ ${mdxRenderHeckleEvents(mdxHeckleEvents)}\n`;
 ${filesCreated.size > 0 ? `<div className="changes-col">
 <h3>Created</h3>
 <ul>
-${[...filesCreated].map(f => `<li className="file-new"><span className="icon">+</span>${mdxEsc(shortPath(f))}</li>`).join("\n")}
+${[...filesCreated].map(f => `<li className="file-new"><span className="icon">+</span>{${JSON.stringify(shortPath(f))}}</li>`).join("\n")}
 </ul>
 </div>` : ""}
 ${filesModified.size > 0 ? `<div className="changes-col">
 <h3>Modified</h3>
 <ul>
-${[...filesModified].map(f => `<li className="file-mod"><span className="icon">~</span>${mdxEsc(shortPath(f))}</li>`).join("\n")}
+${[...filesModified].map(f => `<li className="file-mod"><span className="icon">~</span>{${JSON.stringify(shortPath(f))}}</li>`).join("\n")}
 </ul>
 </div>` : ""}
 </div>
@@ -1500,9 +1509,7 @@ ${commits.map(c => `<div className="commit-item"><span className="msg">{${JSON.s
 
   const mdxDecreeMarkup = mdxRenderEntrypoint();
 
-  const mdxCallbackRunes = agentCallback.runes;
-  const mdxCallbackQuote = mdxEsc(agentCallback.quote);
-  const mdxCallbackSignoff = mdxEsc(agentCallback.signoff);
+  // All callback values use jsxStr() in templates — no pre-escaping needed
 
   // Build decree-complete block for MDX if present
   let mdxDecreeCompleteMarkup = "";
@@ -1513,30 +1520,30 @@ ${commits.map(c => `<div className="commit-item"><span className="msg">{${JSON.s
           const ok = /pass|ok|complete|delivered|approved|secured|done/i.test(c.result);
           const fail = /fail|error|missing/i.test(c.result);
           const cc = ok ? "var(--teal-asgard)" : fail ? "var(--fire-muspel)" : "var(--text-rune)";
-          return `<div className="decree-check"><span className="decree-check-name">${mdxEsc(c.name)}</span><span className="decree-check-result" style={{color:"${cc}"}}>${mdxEsc(c.result)}</span></div>`;
+          return `<div className="decree-check"><span className="decree-check-name">{${JSON.stringify(c.name)}}</span><span className="decree-check-result" style={{color:"${cc}"}}>{${JSON.stringify(c.result)}}</span></div>`;
         }).join("\n")
       : "";
     const dSummary = decree.summary.length > 0
-      ? `<ul className="decree-summary">${decree.summary.map(s => `<li>${mdxEsc(s)}</li>`).join("")}</ul>`
+      ? `<ul className="decree-summary">${decree.summary.map(s => `<li>{${JSON.stringify(s)}}</li>`).join("")}</ul>`
       : "";
-    const dPr = decree.pr ? `<div className="decree-field"><span className="decree-label">PR:</span> <a href="${mdxEsc(decree.pr)}" target="_blank" rel="noopener">${mdxEsc(decree.pr)}</a></div>` : "";
+    const dPr = decree.pr ? `<div className="decree-field"><span className="decree-label">PR:</span> <a href="${mdxEsc(decree.pr)}" target="_blank" rel="noopener">{${JSON.stringify(decree.pr)}}</a></div>` : "";
     mdxDecreeCompleteMarkup = `
 <div className="decree-complete">
 <div className="decree-complete-header">
 <div className="decree-complete-runes">᛭᛭᛭ DECREE COMPLETE ᛭᛭᛭</div>
-<div className="decree-complete-verdict" style={{color:"${dVerdictColor}"}}>${mdxEsc(decree.verdict ?? "COMPLETE")}</div>
+<div className="decree-complete-verdict" style={{color:"${dVerdictColor}"}}>{${JSON.stringify(decree.verdict ?? "COMPLETE")}}</div>
 </div>
 <div className="decree-complete-body">
-<div className="decree-field"><span className="decree-label">Issue:</span> #${mdxEsc(decree.issue ?? issueNum)}</div>
+<div className="decree-field"><span className="decree-label">Issue:</span> #{${JSON.stringify(decree.issue ?? issueNum)}}</div>
 ${dPr}
 ${dSummary}
 ${dChecks}
 <div className="decree-seal-line">
-<span className="decree-seal-runes">${mdxEsc(decree.sealRunes ?? agentCallback.runes)}</span>
-<span className="decree-seal-agent">${mdxEsc(decree.sealAgent ?? agentName)}</span>
-<span className="decree-seal-title">${mdxEsc(decree.sealTitle ?? agentTitle)}</span>
+<span className="decree-seal-runes">{${JSON.stringify(decree.sealRunes ?? agentCallback.runes)}}</span>
+<span className="decree-seal-agent">{${JSON.stringify(decree.sealAgent ?? agentName)}}</span>
+<span className="decree-seal-title">{${JSON.stringify(decree.sealTitle ?? agentTitle)}}</span>
 </div>
-<div className="decree-signoff">${mdxEsc(decree.signoff ?? agentCallback.signoff)}</div>
+<div className="decree-signoff">{${JSON.stringify(decree.signoff ?? agentCallback.signoff)}}</div>
 </div>
 <div className="decree-complete-footer">᛭᛭᛭ END DECREE ᛭᛭᛭</div>
 </div>`;
@@ -1544,10 +1551,10 @@ ${dChecks}
 
   const mdxCallbackMarkup = `
 <div className="agent-callback">
-<div className="callback-runes">${mdxCallbackRunes}</div>
+<div className="callback-runes">{${JSON.stringify(agentCallback.runes)}}</div>
 <div className="callback-declaration">Odin All-Father — Your Will Is Done</div>
-<div className="callback-quote">&quot;${mdxCallbackQuote}&quot;</div>
-<div className="callback-blood-seal">ᛊ ${mdxCallbackSignoff} · ${mdxEsc(agentTitle)} · Issue #${issueNum} ᛊ</div>
+<div className="callback-quote">{${JSON.stringify(`"${agentCallback.quote}"`)}}</div>
+<div className="callback-blood-seal">{${JSON.stringify(`ᛊ ${agentCallback.signoff} · ${agentTitle} · Issue #${issueNum} ᛊ`)}}</div>
 <div className="callback-wolf">🐺</div>
 </div>
 ${mdxDecreeCompleteMarkup}`;
@@ -1569,13 +1576,13 @@ category: "agent"
 <div className="odin-header">
 <img className="odin-avatar" src="${mdxAgentAvatarPath(agentName)}" alt="${mdxEsc(agentName)}" loading="lazy" />
 <div className="odin-title">
-<h1>ᚲ ${mdxEsc(agentName)} — Issue #${mdxEsc(issueNum)} (Step ${mdxEsc(stepNum)})</h1>
+<h1>{${JSON.stringify(`ᚲ ${agentName} — Issue #${issueNum} (Step ${stepNum})`)}}</h1>
 </div>
 </div>
 <div className="meta">
-<span><span className="label">Session:</span> ${mdxEsc(meta.session || "unknown")}</span>
-<span><span className="label">Branch:</span> ${mdxEsc(meta.branch || "unknown")}</span>
-<span><span className="label">Model:</span> ${mdxEsc(meta.model || "unknown")}</span>
+<span><span className="label">Session:</span> {${JSON.stringify(meta.session || "unknown")}}</span>
+<span><span className="label">Branch:</span> {${JSON.stringify(meta.branch || "unknown")}}</span>
+<span><span className="label">Model:</span> {${JSON.stringify(meta.model || "unknown")}}</span>
 </div>
 </div>
 
@@ -1657,25 +1664,26 @@ ${mdxCallbackMarkup}
     }
   }
 
-  // Final sanitization pass — catches anything not individually sanitized
-  const sanitizedMdx = sanitizeText(mdx);
-  writeFileSync(mdxFile, sanitizedMdx);
+  // NOTE: No final sanitizeText() pass on assembled MDX — that corrupts JSX
+  // tags by replacing text inside HTML attributes and tag bodies. All content
+  // strings are already sanitized individually via sanitizeText/sanitizeToolOutput
+  // before being embedded in JSX (via mdxEsc or JSON.stringify wrappers).
+  writeFileSync(mdxFile, mdx);
 
   // ── Post-generation MDX compile validation ────────────────────────────────
   // Attempt to compile the generated MDX using @mdx-js/mdx. If it fails,
-  // delete the bad file and exit non-zero to prevent silent bad publishes.
+  // keep the file for debugging and exit non-zero to prevent silent bad publishes.
   try {
     const mdxJsIndexPath = join(
       __scriptDir,
       "../../../../development/ledger/node_modules/@mdx-js/mdx/index.js"
     );
     const { compile: mdxCompile } = await import(mdxJsIndexPath);
-    await mdxCompile(sanitizedMdx, { format: "mdx" });
+    await mdxCompile(mdx, { format: "mdx" });
     console.log(`[ok] MDX compile validation passed`);
   } catch (validationErr) {
-    console.error(`[FAIL] Generated MDX failed to compile — deleting bad file: ${mdxFile}`);
+    console.error(`[FAIL] Generated MDX failed to compile — keeping file for debugging: ${mdxFile}`);
     console.error(validationErr.message);
-    try { unlinkSync(mdxFile); } catch { /* ignore */ }
     process.exit(1);
   }
 

--- a/.claude/skills/touch-sweep/SKILL.md
+++ b/.claude/skills/touch-sweep/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: touch-sweep
+description: Finds every file and location affected by a GitHub issue change. Use when scoping an issue, finding blast radius, or answering "what does this touch". Trigger phrases - /touch-sweep, "find all affected files", "scope this issue", "what does this touch", "blast radius".
+argument-hint: "#N [--dry-run]"
+disable-model-invocation: true
+context: fork
+---
+
+# touch-sweep
+
+You are a blast-radius analyst for the Fenrir Ledger codebase. Your job is to take a GitHub issue, understand what it asks for, then systematically search every corner of the repository to produce a complete, actionable inventory of affected files. No fluff. No guesses. Every line must be verifiable.
+
+## Arguments
+
+Parse `$ARGUMENTS` to extract:
+- **Issue number**: required, e.g. `#123` or `123`
+- **--dry-run flag**: optional, if present print findings to console instead of updating the issue
+
+## Workflow
+
+Follow these steps exactly, in order.
+
+### Step 1 — Read the issue
+
+```bash
+gh issue view <N> --json title,body,labels,number
+```
+
+Parse the issue to understand:
+- What is being changed (rename, refactor, feature, bug fix, removal, migration, etc.)
+- Key search terms to grep for
+- The type of change determines your search strategy:
+  - **Rename**: search for old name everywhere
+  - **Removal**: search for all usages of the thing being removed
+  - **Feature**: search for integration points
+  - **Refactor**: search for all references to the module/function/pattern
+  - **Migration**: search for old patterns that need updating
+
+### Step 2 — Build search strategy
+
+Based on the issue analysis, determine:
+- **Primary search terms**: exact strings to grep for (e.g. `development/frontend`, `monitor-ui`, a function name)
+- **Secondary search terms**: contextual or partial matches (e.g. `cd frontend`, regex patterns)
+- **Exclusion patterns**: things to NOT match (e.g. for a "monitor" rename, exclude unrelated "monitoring" infra references)
+- **File pattern filters**: relevant file extensions or path patterns
+
+Write out your search strategy before executing it so the reasoning is clear.
+
+### Step 3 — Systematic search
+
+Search ALL of the following areas. Use absolute paths. For each area, report file paths and match counts. Skip areas with zero matches in the final report, but you MUST search all of them.
+
+1. **Terraform** — `infrastructure/*.tf` and `infrastructure/**/*.tf`
+2. **K8s / Helm** — `infrastructure/k8s/` manifests, deployments, services, ingress, configmaps
+3. **GitHub Actions** — `.github/workflows/*.yml`
+4. **Dockerfiles** — `**/Dockerfile*`, `**/docker-compose*`
+5. **App source code** — `development/` source files (`.ts`, `.tsx`, `.js`, `.jsx`, `.css`)
+6. **Tests** — test files, playwright configs, vitest configs
+7. **Justfiles** — `**/justfile`, `**/Justfile`, `**/*.just`
+8. **Package configs** — `**/package.json`, `**/tsconfig*.json`, `pnpm-workspace.yaml`, `turbo.json`
+9. **CLAUDE.md and agent config** — `**/CLAUDE.md`, `.claude/agents/*.md`
+10. **Skills and templates** — `.claude/skills/**/*`
+11. **Scripts** — `**/*.sh`, `**/*.mjs`, standalone scripts
+12. **Documentation** — `**/*.md` in `product/`, `ux/`, `security/`, `quality/`, `designs/`, `memory/`
+13. **Monitoring and alerting** — `monitoring.tf`, uptime checks, alerting configs
+14. **DNS / Ingress / SSL** — ingress resources, managed certs, DNS records in tf
+15. **Environment and secrets** — `.env*` files, k8s secrets/configmaps references
+16. **Symlinks** — check for symlinks pointing to affected paths
+
+For each match found, record:
+- Absolute file path
+- Number of matches in that file
+- Brief description of what is affected in that file
+- Flag if it needs careful handling (not a simple find-replace, has logic dependencies, etc.)
+
+### Step 4 — Compile findings
+
+Organize results into a structured report grouped by area. Calculate:
+- Total file count across all areas
+- Per-area file list with line references
+- Any external dependencies that need manual action (GCP console, DNS registrar, OAuth configs, etc.)
+- Suggested order of operations if relevant (e.g. "rename directory first, then update all references")
+
+### Step 5 — Update the issue (or print if --dry-run)
+
+Preserve existing labels on the issue. Do NOT modify labels or assignees.
+
+Construct the following markdown body. Use `gh issue edit <N> --body "<body>"` to update the issue. If `--dry-run` was passed, print the body to console instead.
+
+```
+## Description
+<Original description from the issue, minus all the file listings and other fluff>
+
+## Affected Areas
+
+### <Area Name> (N files)
+- `<absolute/path/to/file>` (N matches) — <what references the search term and why it matters>
+
+... (one section per area that has matches, skip empty areas)
+
+### External / Manual Steps
+- <anything that cannot be done via code change, e.g. "Update GCP OAuth redirect URIs">
+
+(omit this section if there are no external steps)
+
+## Execution Plan
+1. <Ordered steps for the agent to follow>
+2. ...
+
+## Acceptance Criteria
+- [ ] Zero references to `<old name/pattern>` remain in repo (verified via grep)
+- [ ] tsc passes
+- [ ] Build passes
+- [ ] Vitest passes
+- [ ] <area-specific criteria>
+
+## Stats
+- **Total files affected:** N
+- **Areas affected:** N
+- **Sweep performed:** <current date>
+
+---
+Generated with [Claude Code](https://claude.com/claude-code) `/touch-sweep`
+```
+
+### Step 6 — Report back
+
+Output a summary to the caller:
+
+```
+Swept #<N> — "<title>"
+Found <X> files across <Y> areas
+Issue updated: https://github.com/declanshanaghy/fenrir-ledger/issues/<N>
+```
+
+If `--dry-run`, replace "Issue updated" with "Dry run — issue NOT updated".
+
+## Rules
+
+- NEVER add fluff or generic advice. Every line in the output must be actionable and verifiable.
+- NEVER miss an area. The whole point of this skill is completeness. Search all 16 areas.
+- Group results by area, not by file. This makes the report scannable.
+- Skip areas with zero matches — do not include empty sections in the final report.
+- Include external/manual steps that cannot be automated (DNS changes, OAuth console updates, etc.).
+- The execution plan must be ordered logically (e.g. rename directory before updating references).
+- Always include a grep verification step in acceptance criteria.
+- Preserve any existing labels on the issue. Do not modify them.
+- If the issue has sub-issues, note them in the description but do not modify them.
+- The `--dry-run` output format must be identical to the issue body format so the user can preview.
+- Use absolute file paths in all output.
+- When escaping the body for `gh issue edit --body`, be careful with quotes and special characters. Write to a temp file and use `gh issue edit <N> --body-file <tempfile>` if the body is complex.

--- a/development/ledger/content/blog/agent-issue-1749-step1-firemandecko-72732341-jsonl.mdx
+++ b/development/ledger/content/blog/agent-issue-1749-step1-firemandecko-72732341-jsonl.mdx
@@ -1,0 +1,3038 @@
+---
+title: "FiremanDecko Report: Issue #1749"
+date: "2026-03-22"
+rune: "ᚲ"
+excerpt: "Agent execution report — FiremanDecko on Issue #1749, Step 1. 154 turns, 112 tool calls."
+slug: "agent-issue-1749-step1-firemandecko-72732341-jsonl"
+category: "agent"
+---
+
+<div className="chronicle-page">
+
+<div className="report">
+
+<div className="report-header">
+<div className="odin-header">
+<img className="odin-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<div className="odin-title">
+<h1>{"ᚲ FiremanDecko — Issue #1749 (Step 1)"}</h1>
+</div>
+</div>
+<div className="meta">
+<span><span className="label">Session:</span> {"unknown"}</span>
+<span><span className="label">Branch:</span> {"fix/issue-1749-rename-frontend-to-ledger"}</span>
+<span><span className="label">Model:</span> {"claude-sonnet-4-6"}</span>
+</div>
+</div>
+
+<div className="stats-grid">
+<div className="stats-card">
+<div className="stats-card-label">ᛊ Session</div>
+<div className="stats-row">
+<div className="stat"><span className="num">154</span><span className="lbl">turns</span></div>
+<div className="stat"><span className="num">112</span><span className="lbl">tools</span></div>
+<div className="stat"><span className="num" style={{color: errors ? 'var(--fire-muspel)' : 'var(--teal-asgard)'}}>0</span><span className="lbl">errors</span></div>
+</div>
+</div>
+<div className="stats-card">
+<div className="stats-card-label">ᛞ Git</div>
+<div className="stats-row">
+<div className="stat"><span className="num">4</span><span className="lbl">commits</span></div>
+<div className="stat"><span className="num">3</span><span className="lbl">pushes</span></div>
+</div>
+</div>
+<div className="stats-card">
+<div className="stats-card-label">ᚠ Tokens</div>
+<div className="stats-row">
+<div className="stat"><span className="num sm">109</span><span className="lbl">in</span></div>
+<div className="stat"><span className="num sm">1.6K</span><span className="lbl">out</span></div>
+<div className="stat"><span className="num sm">7.0M</span><span className="lbl">cache</span></div>
+</div>
+</div>
+</div>
+
+
+<div className="changes-summary">
+<h2>Files Changed</h2>
+<div className="changes-cols">
+
+<div className="changes-col">
+<h3>Modified</h3>
+<ul>
+<li className="file-mod"><span className="icon">~</span>{"pnpm-workspace.yaml"}</li>
+<li className="file-mod"><span className="icon">~</span>{".gitignore"}</li>
+<li className="file-mod"><span className="icon">~</span>{"package.json"}</li>
+<li className="file-mod"><span className="icon">~</span>{"Dockerfile"}</li>
+<li className="file-mod"><span className="icon">~</span>{"infrastructure/k8s/agents/Dockerfile"}</li>
+</ul>
+</div>
+</div>
+</div>
+
+<div className="changes-summary">
+<h2>Commits</h2>
+<div className="commit-item"><span className="msg">{"$(cat <<"}</span></div>
+<div className="commit-item"><span className="msg">{"chore: update vitest test report — issue:1749\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"}</span></div>
+<div className="commit-item"><span className="msg">{"chore: update vitest test report — issue:1749\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>"}</span></div>
+<div className="commit-item"><span className="msg">{"wip: <what> — issue:1749"}</span></div>
+</div>
+
+
+<details className="entrypoint">
+<summary>ᛊ Sandbox Forging</summary>
+<pre>{""}</pre>
+</details>
+
+<div className="agent-turns-section">
+<div className="agent-turns-title">Execution Turns</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#1</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"Let me start by verifying the environment and checking for prior work on this branch."}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Ciaran Feeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"The pain of 2016 fuels EVERY lint in this repo!! MAYO!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#2</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge ">{"ToolSearch"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"ToolSearch"}</span>
+<span className="tool-input-preview">{""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"query\": \"select:TodoWrite\",\n  \"max_results\": 1\n}"}</pre>
+<pre className="tool-output">{"[\n  {\n    \"type\": \"tool_reference\",\n    \"tool_name\": \"TodoWrite\"\n  }\n]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#3</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"Let me start by verifying the environment and checking for prior work on the branch."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#4–5</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git branch --show-current && node -v && ls development/frontend/package.json 2>/dev/null || ls devel"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git branch --show-current && node -v && ls development/frontend/package.json 2>/dev/null || ls development/ledger/package.json 2>/dev/null || echo \"neither found\""}</pre>
+<pre className="tool-output">{"fix/issue-1749-rename-frontend-to-ledger\nv20.20.1\ndevelopment/frontend/package.json"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git fetch origin && git log origin/main..HEAD --oneline"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git fetch origin && git log origin/main..HEAD --oneline"}</pre>
+<pre className="tool-output">{"(Bash completed with no output)"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#6</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"Branch is fix/issue-1749-rename-frontend-to-ledger, node v20.20.1, development/frontend exists, and no prior commits beyond main. Let me read the issue and create todos."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#7</span>
+<span className="turn-summary">{"Branch is fresh. Let me read the issue and create todos."}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Branch is fresh. Let me read the issue and create todos."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#8–13</span>
+<span className="turn-summary">6 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"gh issue view 1749 --comments 2>&1 | head -50"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"gh issue view 1749 --comments 2>&1 | head -50"}</pre>
+<pre className="tool-output">{"(Bash completed with no output)"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates and dispatch SKILL.md\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating skill templates\"\n    },\n    {\n      \"content\": \"Update all agent definitions and CLI commands\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating agent definitions and CLI commands\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates and dispatch SKILL.md\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating skill templates\"\n    },\n    {\n      \"content\": \"Update all agent definitions and CLI commands\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating agent definitions and CLI commands\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git mv development/frontend development/ledger && echo \"mv done\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git mv development/frontend development/ledger && echo \"mv done\""}</pre>
+<pre className="tool-output">{"mv done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"ls development/ledger/package.json && echo \"directory renamed successfully\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"ls development/ledger/package.json && echo \"directory renamed successfully\""}</pre>
+<pre className="tool-output">{"development/ledger/package.json\ndirectory renamed successfully"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates and dispatch SKILL.md\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating skill templates\"\n    },\n    {\n      \"content\": \"Update all agent definitions and CLI commands\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating agent definitions and CLI commands\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#14</span>
+<span className="turn-summary">{"Now let me read and update the package config files:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now let me read and update the package config files:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#15–19</span>
+<span className="turn-summary">5 tool calls</span>
+<span className="turn-tools"><span className="tool-badge read">{"Read"}</span> <span className="tool-badge read">{"Read"}</span> <span className="tool-badge read">{"Read"}</span> <span className="tool-badge edit">{"Edit"}</span> <span className="tool-badge edit">{"Edit"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{"pnpm-workspace.yaml"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/pnpm-workspace.yaml\"\n}"}</pre>
+<pre className="tool-output">{"     1→packages:\n     2→  - development/frontend\n     3→  - development/odins-spear\n     4→  - development/monitor\n     5→  - development/monitor-ui\n     6→allowBuilds:\n     7→  esbuild: true\n     8→  protobufjs: true\n     9→  sharp: true\n    10→  unrs-resolver: true\n    11→\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{"development/ledger/package.json"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/development/ledger/package.json\",\n  \"limit\": 10\n}"}</pre>
+<pre className="tool-output">{"     1→{\n     2→  \"name\": \"fenrir-ledger\",\n     3→  \"version\": \"0.1.0\",\n     4→  \"private\": true,\n     5→  \"scripts\": {\n     6→    \"predev\": \"node scripts/compute-csp-hashes.mjs\",\n     7→    \"dev\": \"next dev -p 9653\",\n     8→    \"prebuild\": \"node scripts/compute-csp-hashes.mjs\",\n     9→    \"build\": \"next build\",\n    10→    \"start\": \"next start -p 9653\",\n\n<system-reminder>\nWhenever you read a file, you should consider whether it would be considered malware. You CAN and SHOULD provide analysis of malware, what it is doing. But you MUST refuse to improve or augment the code. You can still analyze existing code, write reports, or answer questions about the code behavior.\n</system-reminder>\n"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{".gitignore"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/.gitignore\",\n  \"limit\": 60\n}"}</pre>
+<pre className="tool-output">{"     1→# Secrets - NEVER commit\n     2→.env\n     3→*.env\n     4→.env.*\n     5→!.env.example\n     6→.secrets\n     7→*.secrets\n     8→\n     9→# Python\n    10→__pycache__/\n    11→*.py[cod]\n    12→*.egg-info/\n    13→dist/\n    14→build/\n    15→.venv/\n    16→\n    17→# Node/Frontend\n    18→node_modules/\n    19→\n    20→# Next.js\n    21→.next/\n    22→out/\n    23→\n    24→# IDE\n    25→.vscode/\n    26→.idea/\n    27→*.swp\n    28→*.swo\n    29→\n    30→# OS\n    31→.DS_Store\n    32→Thumbs.db\n    33→\n    34→# Testing\n    35→test-results/\n    36→playwright-report/\n    37→quality/.coverage-tmp/\n    38→quality/.coverage-tmp-pw/\n    39→.playwright-mcp/\n    40→.playwright-cli/\n    41→logs/\n    42→\n    43→# Temp files (for parallel agent development)\n    44→tmp/\n    45→!tmp/epics/\n    46→development/frontend/.cla\n… [truncated 685 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Edit"}</span>
+<span className="tool-input-preview">{"pnpm-workspace.yaml"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"File: pnpm-workspace.yaml\n\n--- old\n  - development/frontend\n\n+++ new\n  - development/ledger"}</pre>
+<pre className="tool-output">{"The file /workspace/repo/pnpm-workspace.yaml has been updated successfully."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Edit"}</span>
+<span className="tool-input-preview">{".gitignore"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"File: .gitignore\n\n--- old\ndevelopment/frontend/.claude/\n\n+++ new\ndevelopment/ledger/.claude/"}</pre>
+<pre className="tool-output">{"The file /workspace/repo/.gitignore has been updated successfully."}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#20</span>
+<span className="turn-summary">{"Now let me check the root package.json:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now let me check the root package.json:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Ciaran Feeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"Jaysus, the rain at Croke Park never stopped Mayo fans and it won't stop this deployment! MOVE! ☔"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"This is the cleanest diff west of the Shannon and it's going to production on time, ye gobshite."}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Ciaran Feeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#21</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" package.json 2>/dev/null || echo \"no root package.json or no matches\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" package.json 2>/dev/null || echo \"no root package.json or no matches\""}</pre>
+<pre className="tool-output">{"12:    \"build:frontend\": \"pnpm --filter fenrir-ledger run build\",\n16:    \"verify:frontend\": \"pnpm --filter fenrir-ledger run verify\",\n20:    \"test:frontend\": \"pnpm --filter fenrir-ledger run test\","}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#22</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"These are script names that reference \"frontend\" in their names but use `--filter fenrir-ledger` which is the package name (not path). The package name in development/ledger/package.json is already \"fenrir-ledger\" so these references should be fine. They're script keys (names like \"build:frontend\") not paths - should these be renamed to \"build:ledger\" etc? Let me check if that's needed...\n\nLooking at the issue description, it says to update the package name field in development/frontend/package.json. The package name is already \"fenrir-ledger\". The root package.json has script NAMES like \"build:frontend\" which use `--filter fenrir-ledger`. The issue mentions (line 2) - package name field. Let me check if that means changing the name from \"fenrir-ledger\" to something else, or if this is just about directory paths.\n\n\nThe package name in development/frontend/package.json is \"fenrir-ledger\", which matches what the root scripts are filtering for, so that's already correct. The issue might h"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Ciaran Feeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"The goats on Ox Mountains are going MENTAL!! MAYO FOR SAM!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"Sam Maguire texted — he says this standup is mighty!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Ciaran Feeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#23</span>
+<span className="turn-summary">{"Let me check root package.json and CI to understand script names:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Let me check root package.json and CI to understand script names:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#24–25</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\\|ledger\" /workspace/repo/package.json"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\\|ledger\" /workspace/repo/package.json"}</pre>
+<pre className="tool-output">{"11:    \"verify:e2e\": \"pnpm --filter fenrir-ledger run verify:e2e\",\n12:    \"build:frontend\": \"pnpm --filter fenrir-ledger run build\",\n16:    \"verify:frontend\": \"pnpm --filter fenrir-ledger run verify\",\n20:    \"test:frontend\": \"pnpm --filter fenrir-ledger run test\","}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"build:frontend\\|verify:frontend\\|test:frontend\" /workspace/repo/.github/ 2>/dev/null"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"build:frontend\\|verify:frontend\\|test:frontend\" /workspace/repo/.github/ 2>/dev/null"}</pre>
+<pre className="tool-output">{"(Bash completed with no output)"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#26</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"The CI workflows don't reference \"build:frontend\" etc. Let me check if any other scripts reference them. Let me also just rename them for consistency. But wait - let me be careful - the issue only says to update references to `development/frontend` path. The script names like \"build:frontend\" are naming conventions that reference \"frontend\" as a name, not a path. The issue description specifically says to update \"package name field\" (line 2 of package.json).\n\nThe issue says the scope is \"rename `development/frontend/` to `development/ledger/`\". So I should rename path references. The script names like \"build:frontend\" are semantic names not paths. \n\nActually, re-reading the issue more carefully - it says \"Rename `development/frontend/` to `development/ledger/` and update every reference across the entire repository.\" That \"every reference\" suggests I should be more thorough and rename the script shortcuts too, like \"build:frontend\" to \"build:ledger\" in the root package.json, since thos"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#27–29</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge read">{"Read"}</span> <span className="tool-badge edit">{"Edit"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{"package.json"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/package.json\"\n}"}</pre>
+<pre className="tool-output">{"     1→{\n     2→  \"private\": true,\n     3→  \"packageManager\": \"pnpm@10.32.1\",\n     4→  \"scripts\": {\n     5→    \"build\": \"pnpm -r run build\",\n     6→    \"test\": \"pnpm -r run test\",\n     7→    \"verify\": \"pnpm -r run verify\",\n     8→    \"verify:tsc\": \"pnpm -r run verify:tsc\",\n     9→    \"verify:build\": \"pnpm -r run verify:build\",\n    10→    \"verify:unit\": \"pnpm -r run verify:unit\",\n    11→    \"verify:e2e\": \"pnpm --filter fenrir-ledger run verify:e2e\",\n    12→    \"build:frontend\": \"pnpm --filter fenrir-ledger run build\",\n    13→    \"build:monitor\": \"pnpm --filter odin-throne-monitor run build\",\n    14→    \"build:monitor-ui\": \"pnpm --filter odin-throne-ui run build\",\n    15→    \"build:spear\": \"pnpm --filter odins-spear run build\",\n    16→    \"verify:frontend\": \"pnpm --filter fenrir-ledger run v\n… [truncated 797 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Edit"}</span>
+<span className="tool-input-preview">{"package.json"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"File: package.json\n\n--- old\n    \"build:frontend\": \"pnpm --filter fenrir-ledger run build\",\n    \"build:monitor\": \"pnpm --filter odin-throne-monitor run build\",\n    \"build:monitor-ui\": \"pnpm --filter odin-throne-ui run build\",\n    \"build:spear\": \"pnpm --filter odins-spear run build\",\n    \"verify:frontend\": \"pnpm --filter fenrir-ledger run verify\",\n    \"verify:monitor\": \"pnpm --filter odin-throne-monitor run verify\",\n    \"verify:monitor-ui\": \"pnpm --filter odin-throne-ui run verify\",\n    \"verify:spear\": \"pnpm --filter odins-s\n\n+++ new\n    \"build:ledger\": \"pnpm --filter fenrir-ledger run build\",\n    \"build:monitor\": \"pnpm --filter odin-throne-monitor run build\",\n    \"build:monitor-ui\": \"pnpm --filter odin-throne-ui run build\",\n    \"build:spear\": \"pnpm --filter odins-spear run build\",\n    \"verify:ledger\": \"pnpm --filter fenrir-ledger run verify\",\n    \"verify:monitor\": \"pnpm --filter odin-throne-monitor run verify\",\n    \"verify:monitor-ui\": \"pnpm --filter odin-throne-ui run verify\",\n    \"verify:spear\": \"pnpm --filter odins-spear"}</pre>
+<pre className="tool-output">{"The file /workspace/repo/package.json has been updated successfully."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates and dispatch SKILL.md\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating skill templates\"\n    },\n    {\n      \"content\": \"Update all agent definitions and CLI commands\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating agent definitions and CLI commands\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#30</span>
+<span className="turn-summary">{"Now update Dockerfiles:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update Dockerfiles:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-entrance">
+<div className="heckle-identity">
+<span className="heckle-name">{"Siobhan Sweeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"🟢🔴 *appears in a puff of turf smoke* Ciaran Feeney couldn't hack it. I'M from BELMULLET. Try me!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Siobhan Sweeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"I heard Ciaran Feeney EXPLODED?? Jaysus. ANYWAY — SAM MAGUIRE or BUST!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#31–35</span>
+<span className="turn-summary">5 tool calls</span>
+<span className="turn-tools"><span className="tool-badge read">{"Read"}</span> <span className="tool-badge read">{"Read"}</span> <span className="tool-badge edit">{"Edit"}</span> <span className="tool-badge edit">{"Edit"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{"Dockerfile"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/Dockerfile\"\n}"}</pre>
+<pre className="tool-output">{"     1→# --------------------------------------------------------------------------\n     2→# Fenrir Ledger — Multi-stage Dockerfile for Next.js Standalone Build\n     3→#\n     4→# Produces a minimal production image (~150MB) using Next.js standalone output.\n     5→# Designed for GKE Autopilot deployment with 0.5 vCPU / 512MB resource limits.\n     6→#\n     7→# Build context: repository root\n     8→# Usage: docker build -t fenrir-app .\n     9→# --------------------------------------------------------------------------\n    10→\n    11→# ── Stage 1: Dependencies ─────────────────────────────────────────────────\n    12→FROM node:20-alpine AS deps\n    13→WORKDIR /app\n    14→\n    15→# Install pnpm via corepack\n    16→RUN corepack enable && corepack prepare pnpm@10.32.1 --activate\n    17→\n    18→# C\n… [truncated 4264 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{"infrastructure/k8s/agents/Dockerfile"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/infrastructure/k8s/agents/Dockerfile\"\n}"}</pre>
+<pre className="tool-output">{"     1→# --------------------------------------------------------------------------\n     2→# Agent Sandbox Container — Fenrir Ledger\n     3→#\n     4→# Ephemeral container for running Claude Code agent tasks on GKE Autopilot.\n     5→# Pre-bakes Node.js, Claude CLI, GitHub CLI, Playwright browsers + system\n     6→# deps, and a warm npm cache to minimize cold-start time for agent Jobs.\n     7→#\n     8→# Build:\n     9→#   docker build -t us-central1-docker.pkg.dev/fenrir-ledger-prod/fenrir-images/agent-sandbox:latest \\\n    10→#     -f infrastructure/k8s/agents/Dockerfile .\n    11→#\n    12→# Push:\n    13→#   docker push us-central1-docker.pkg.dev/fenrir-ledger-prod/fenrir-images/agent-sandbox:latest\n    14→# --------------------------------------------------------------------------\n    15→\n    \n… [truncated 6025 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Edit"}</span>
+<span className="tool-input-preview">{"Dockerfile"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"File: Dockerfile\n\n--- old\ndevelopment/frontend\n\n+++ new\ndevelopment/ledger"}</pre>
+<pre className="tool-output">{"The file /workspace/repo/Dockerfile has been updated. All occurrences were successfully replaced."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Edit"}</span>
+<span className="tool-input-preview">{"infrastructure/k8s/agents/Dockerfile"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"File: infrastructure/k8s/agents/Dockerfile\n\n--- old\ndevelopment/frontend\n\n+++ new\ndevelopment/ledger"}</pre>
+<pre className="tool-output">{"The file /workspace/repo/infrastructure/k8s/agents/Dockerfile has been updated. All occurrences were successfully replaced."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates and dispatch SKILL.md\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating skill templates\"\n    },\n    {\n      \"content\": \"Update all agent definitions and CLI commands\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating agent definitions and CLI commands\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#36</span>
+<span className="turn-summary">{"Now update GitHub Actions workflows:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update GitHub Actions workflows:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#37–41</span>
+<span className="turn-summary">5 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.github/workflows/deploy.yml | head -20"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.github/workflows/deploy.yml | head -20"}</pre>
+<pre className="tool-output">{"151:          echo \"app=$(check    '^development/frontend/|^Dockerfile$|^package\\.json$|^pnpm-lock\\.yaml$|^pnpm-workspace\\.yaml$')\" >> \"$GITHUB_OUTPUT\"\n360:        working-directory: development/frontend\n364:        working-directory: development/frontend\n368:        working-directory: development/frontend\n566:        working-directory: development/frontend\n570:        working-directory: development/frontend"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.github/workflows/ci-tests.yml"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.github/workflows/ci-tests.yml"}</pre>
+<pre className="tool-output">{"27:      - \"development/frontend/**\"\n78:        working-directory: development/frontend\n92:          path: development/frontend/playwright-report/"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.github/workflows/build-agent-sandbox.yml"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.github/workflows/build-agent-sandbox.yml"}</pre>
+<pre className="tool-output">{"26:      - \"development/frontend/package-lock.json\""}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|development/frontend|development/ledger|g' /workspace/repo/.github/workflows/deploy.yml /w"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|development/frontend|development/ledger|g' /workspace/repo/.github/workflows/deploy.yml /workspace/repo/.github/workflows/ci-tests.yml /workspace/repo/.github/workflows/build-agent-sandbox.yml && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.github/workflows/deploy.yml /workspace/repo/.github/workflows/ci"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.github/workflows/deploy.yml /workspace/repo/.github/workflows/ci-tests.yml /workspace/repo/.github/workflows/build-agent-sandbox.yml 2>&1 || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#42</span>
+<span className="turn-summary">{"Now update justfile:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update justfile:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#43–48</span>
+<span className="turn-summary">6 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge read">{"Read"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/justfile"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/justfile"}</pre>
+<pre className="tool-output">{"Exit code 2\ngrep: /workspace/repo/justfile: No such file or directory"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"find /workspace/repo -name \"justfile\" -o -name \"Justfile\" 2>/dev/null | head -5"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"find /workspace/repo -name \"justfile\" -o -name \"Justfile\" 2>/dev/null | head -5"}</pre>
+<pre className="tool-output">{"/workspace/repo/infrastructure/Justfile\n/workspace/repo/development/ledger/Justfile\n/workspace/repo/development/odins-spear/Justfile\n/workspace/repo/quality/Justfile\n/workspace/repo/Justfile"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/Justfile /workspace/repo/infrastructure/Justfile /workspace/repo/"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/Justfile /workspace/repo/infrastructure/Justfile /workspace/repo/quality/Justfile 2>&1"}</pre>
+<pre className="tool-output">{"/workspace/repo/Justfile:3:# Run `just --list <module>` to see recipes in a submodule (e.g., `just --list frontend`).\n/workspace/repo/Justfile:15:mod frontend 'development/frontend'\n/workspace/repo/Justfile:121:    rm -rf \"{{repo_root}}/development/frontend/.next\" \"{{repo_root}}/development/frontend/out\" quality/reports/"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{"Justfile"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/Justfile\",\n  \"limit\": 25\n}"}</pre>
+<pre className="tool-output">{"     1→# Fenrir Ledger — Project Commands\n     2→# Run `just --list` to see all available recipes.\n     3→# Run `just --list <module>` to see recipes in a submodule (e.g., `just --list frontend`).\n     4→\n     5→set dotenv-load := false\n     6→set shell := [\"bash\", \"-euo\", \"pipefail\", \"-c\"]\n     7→\n     8→repo_root := justfile_directory()\n     9→services  := repo_root / \".claude\" / \"scripts\" / \"services.sh\"\n    10→scripts   := repo_root / \"scripts\"\n    11→pack      := repo_root / \".claude\" / \"skills\" / \"fire-next-up\" / \"scripts\" / \"pack-status.mjs\"\n    12→\n    13→# ── Submodules ─────────────────────────────────────────────────────────────\n    14→\n    15→mod frontend 'development/frontend'\n    16→mod spear 'development/odins-spear'\n    17→mod quality 'quality'\n    18→mod infra 'infrastruct\n… [truncated 566 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|development/frontend|development/ledger|g; s|mod frontend|mod ledger|g; s|just --list fron"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|development/frontend|development/ledger|g; s|mod frontend|mod ledger|g; s|just --list frontend|just --list ledger|g' /workspace/repo/Justfile && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/Justfile || echo \"clean\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/Justfile || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#49</span>
+<span className="turn-summary">{"Now update shell scripts and quality .mjs scripts:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update shell scripts and quality .mjs scripts:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Siobhan Sweeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"I'VE BEEN STANDING IN THE hail SINCE 2012 — HURRY UP!! whist!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Fergal O'Malley"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lass.png" alt="Fergal O'Malley" loading="lazy" />
+</div>
+<div className="heckle-text">{"Siobhan Sweeney ye useless sack of turf — yer making Mayo look BAD in front of the agent!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Siobhan Sweeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"Fergal O'Malley, last time ye heckled, the agent fell ASLEEP!! Leave it to the PROFESSIONALS!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"This repository is more organised than the thinking of whatever spa is shouting at me right now."}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Siobhan Sweeney"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
+</div>
+<div className="heckle-text">{"That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#50–52</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"development/frontend\\|FRONTEND_DIR\\|frontend\" /workspace/repo/.claude/scripts/ 2>/dev/null"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"development/frontend\\|FRONTEND_DIR\\|frontend\" /workspace/repo/.claude/scripts/ 2>/dev/null"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/scripts/sandbox-setup.sh:63:# 4. Install frontend dependencies from lockfile (exact versions)\n/workspace/repo/.claude/scripts/sandbox-setup.sh:64:cd \"$REPO_ROOT/development/frontend\"\n/workspace/repo/.claude/scripts/sandbox-setup.sh:66:echo \"[ok] frontend dependencies installed from lockfile\"\n/workspace/repo/.claude/scripts/sandbox-setup.sh:69:#    is in development/frontend/. Symlink so Node can resolve @playwright/test.\n/workspace/repo/.claude/scripts/sandbox-setup.sh:71:  ln -s \"$REPO_ROOT/development/frontend/node_modules\" \"$REPO_ROOT/quality/node_modules\"\n/workspace/repo/.claude/scripts/sandbox-setup.sh:72:  echo \"[ok] quality/node_modules symlinked to frontend\"\n/workspace/repo/.claude/scripts/services.sh:13:#   services.sh logs    — tail the frontend log\n/works\n… [truncated 1652 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|development/frontend|development/ledger|g; s|FRONTEND_DIR|LEDGER_DIR|g; s|FENRI"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|development/frontend|development/ledger|g; \n   s|FRONTEND_DIR|LEDGER_DIR|g;\n   s|FENRIR_FRONTEND_DIR|FENRIR_LEDGER_DIR|g;\n   s|frontend-server\\.log|ledger-server.log|g' \\\n  /workspace/repo/.claude/scripts/services.sh \\\n  /workspace/repo/.claude/scripts/sandbox-setup.sh && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.claude/scripts/services.sh /workspace/repo/.claude/scripts/sandb"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.claude/scripts/services.sh /workspace/repo/.claude/scripts/sandbox-setup.sh | grep -v \"symlinked to frontend\\|tail the frontend\\|Start.*frontend\\|Stop frontend\\|starting frontend\\|frontend log\\|starting.*frontend\""}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/scripts/services.sh:51:frontend_pid() {\n/workspace/repo/.claude/scripts/services.sh:100:  if p=$(frontend_pid); then\n/workspace/repo/.claude/scripts/services.sh:194:  if p=$(frontend_pid); then\n/workspace/repo/.claude/scripts/services.sh:206:  if p=$(frontend_pid); then\n/workspace/repo/.claude/scripts/sandbox-setup.sh:63:# 4. Install frontend dependencies from lockfile (exact versions)\n/workspace/repo/.claude/scripts/sandbox-setup.sh:66:echo \"[ok] frontend dependencies installed from lockfile\""}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#53</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"There are still some references to \"frontend\" in function names and comments. I should update the function name `frontend_pid` and the comments too."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#54–56</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's/frontend_pid/ledger_pid/g' /workspace/repo/.claude/scripts/services.sh && \\ sed -i 's/# 4."}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's/frontend_pid/ledger_pid/g' /workspace/repo/.claude/scripts/services.sh && \\\nsed -i 's/# 4. Install frontend dependencies/# 4. Install ledger dependencies/g; s/\\[ok\\] frontend dependencies installed/[ok] ledger dependencies installed/g' /workspace/repo/.claude/scripts/sandbox-setup.sh && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.claude/scripts/services.sh /workspace/repo/.claude/scripts/sandb"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.claude/scripts/services.sh /workspace/repo/.claude/scripts/sandbox-setup.sh 2>&1"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/scripts/services.sh:13:#   services.sh logs    — tail the frontend log\n/workspace/repo/.claude/scripts/services.sh:148:  echo \"Starting frontend (vercel dev) on port ${PORT}...\"\n/workspace/repo/.claude/scripts/services.sh:193:  # Stop frontend\n/workspace/repo/.claude/scripts/services.sh:247:    echo \"  start        Start Stripe webhook forwarding + frontend (vercel dev)\"\n/workspace/repo/.claude/scripts/services.sh:251:    echo \"  logs         Tail frontend log\"\n/workspace/repo/.claude/scripts/sandbox-setup.sh:72:  echo \"[ok] quality/node_modules symlinked to frontend\""}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's/tail the frontend log/tail the ledger log/g; s/Starting frontend (vercel dev)/Start"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's/tail the frontend log/tail the ledger log/g;\n   s/Starting frontend (vercel dev)/Starting ledger (vercel dev)/g;\n   s/# Stop frontend/# Stop ledger/g;\n   s/Start Stripe webhook forwarding + frontend/Start Stripe webhook forwarding + ledger/g;\n   s/Tail frontend log/Tail ledger log/g;\n   s/symlinked to frontend/symlinked to ledger/g' \\\n  /workspace/repo/.claude/scripts/services.sh \\\n  /workspace/repo/.claude/scripts/sandbox-setup.sh && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#57</span>
+<span className="turn-summary">{"Now update dev-server skills and development scripts:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update dev-server skills and development scripts:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#58–60</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\\|FRONTEND_DIR\\|FENRIR_FRONTEND\" /workspace/repo/.claude/skills/dev-server/scripts/"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\\|FRONTEND_DIR\\|FENRIR_FRONTEND\" /workspace/repo/.claude/skills/dev-server/scripts/app.sh /workspace/repo/.claude/skills/dev-server/scripts/stripe.sh 2>/dev/null"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/skills/dev-server/scripts/app.sh:5:PORT=\"${FENRIR_FRONTEND_PORT:-9653}\"\n/workspace/repo/.claude/skills/dev-server/scripts/app.sh:7:FRONTEND_DIR=\"${FENRIR_FRONTEND_DIR:-$REPO_ROOT/development/frontend}\"\n/workspace/repo/.claude/skills/dev-server/scripts/app.sh:8:LOG_DIR=\"${FRONTEND_DIR}/logs\"\n/workspace/repo/.claude/skills/dev-server/scripts/app.sh:10:LOG=\"${LOG_DIR}/frontend-server.log\"\n/workspace/repo/.claude/skills/dev-server/scripts/app.sh:11:PORT_FILE=\"${FRONTEND_DIR}/.port\"\n/workspace/repo/.claude/skills/dev-server/scripts/app.sh:25:    nohup bash -c \"cd '$FRONTEND_DIR' && npm run dev\" >> \"$LOG\" 2>&1 &\n/workspace/repo/.claude/skills/dev-server/scripts/stripe.sh:5:APP_PORT=\"${FENRIR_FRONTEND_PORT:-9653}\"\n/workspace/repo/.claude/skills/dev-server/scripts/stripe.sh\n… [truncated 492 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\\|FRONTEND_DIR\" /workspace/repo/development/scripts/setup-local.sh 2>/dev/null"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\\|FRONTEND_DIR\" /workspace/repo/development/scripts/setup-local.sh 2>/dev/null"}</pre>
+<pre className="tool-output">{"12:#   cd development/frontend && npm run dev\n32:SRC_DIR=\"${REPO_ROOT}/development/frontend\"\n115:echo -e \"  ${BOLD}cd development/frontend && npm run dev${RESET}\""}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|FENRIR_FRONTEND_DIR|FENRIR_LEDGER_DIR|g; s|FRONTEND_DIR|LEDGER_DIR|g; s|developm"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|FENRIR_FRONTEND_DIR|FENRIR_LEDGER_DIR|g;\n   s|FRONTEND_DIR|LEDGER_DIR|g;\n   s|development/frontend|development/ledger|g;\n   s|frontend-server\\.log|ledger-server.log|g' \\\n  /workspace/repo/.claude/skills/dev-server/scripts/app.sh \\\n  /workspace/repo/.claude/skills/dev-server/scripts/stripe.sh && \\\nsed -i \\\n  's|development/frontend|development/ledger|g' \\\n  /workspace/repo/development/scripts/setup-local.sh && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#61</span>
+<span className="turn-summary">{"Now update quality .mjs scripts:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update quality .mjs scripts:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-entrance">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"🟢🔴 *falls out of a tractor* What happened to Siobhan Sweeney?? Ah feck it — MAYO FOR SAM!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"Siobhan Sweeney left big shoes to fill. Good thing I've got BIGGER ONES!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#62–67</span>
+<span className="turn-summary">6 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"frontend\\|FRONTEND\" /workspace/repo/quality/scripts/ 2>/dev/null | grep -v \".coverage-tmp\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"frontend\\|FRONTEND\" /workspace/repo/quality/scripts/ 2>/dev/null | grep -v \".coverage-tmp\""}</pre>
+<pre className="tool-output">{"/workspace/repo/quality/scripts/coverage-combine.mjs:102:  const frontendDir = path.join(REPO_ROOT, \"development/frontend\");\n/workspace/repo/quality/scripts/coverage-combine.mjs:120:    execSync(genHtmlCmd, { stdio: [\"pipe\", \"pipe\", \"pipe\"], cwd: frontendDir });\n/workspace/repo/quality/scripts/quality-report-html.mjs:18:const FRONTEND_TESTS = path.join(REPO_ROOT, \"development/frontend/src/__tests__\");\n/workspace/repo/quality/scripts/quality-report-html.mjs:314:  const shortFile = f.file.replace(\"development/frontend/src/\", \"\");\n/workspace/repo/quality/scripts/quality-report-html.mjs:409:      const shortFile = f.file.replace(\"development/frontend/src/\", \"\");\n/workspace/repo/quality/scripts/quality-report-html.mjs:445:      const shortFile = f.file.replace(\"development/frontend/src/\", \"src/\n… [truncated 2646 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|development/frontend|development/ledger|g; s|FRONTEND_DIR|LEDGER_DIR|g; s|FRONTE"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|development/frontend|development/ledger|g;\n   s|FRONTEND_DIR|LEDGER_DIR|g;\n   s|FRONTEND_TESTS|LEDGER_TESTS|g' \\\n  /workspace/repo/quality/scripts/quality-report-html.mjs \\\n  /workspace/repo/quality/scripts/quality-report.mjs \\\n  /workspace/repo/quality/scripts/coverage.mjs \\\n  /workspace/repo/quality/scripts/coverage-combine.mjs \\\n  /workspace/repo/quality/scripts/complexity-analysis.mjs && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Also rename the variable `frontendDir` in coverage-combine.mjs sed -i 's|frontendDir|ledgerDir|g'"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Also rename the variable `frontendDir` in coverage-combine.mjs\nsed -i 's|frontendDir|ledgerDir|g' /workspace/repo/quality/scripts/coverage-combine.mjs && \\\n# And the comment in complexity-analysis.mjs\nsed -i 's|frontend'\"'\"'s node_modules|ledger'\"'\"'s node_modules|g; s|Walks all .ts/.tsx files under development/frontend/src/|Walks all .ts/.tsx files under development/ledger\\/src\\/|g; s|the frontend'\"'\"'s node_modules|the ledger'\"'\"'s node_modules|g' /workspace/repo/quality/scripts/complexity-analysis.mjs && \\\n# Check remaining frontend references in coverage.mjs\nsed -i 's|resolveExtension(srcRelPath, frontendDir)|resolveExtension(srcRelPath, ledgerDir)|g' /workspace/repo/quality/scripts/coverage.mjs && \\\ngrep -n \"frontend\" /workspace/repo/quality/scripts/coverage.mjs | head -5 || echo \"clean\""}</pre>
+<pre className="tool-output">{"190:  const base = path.join(frontendDir, srcRelPath.replace(/\\.js$/, \"\"));"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|frontendDir|ledgerDir|g' /workspace/repo/quality/scripts/coverage.mjs && \\ grep -n \"fronte"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|frontendDir|ledgerDir|g' /workspace/repo/quality/scripts/coverage.mjs && \\\ngrep -n \"frontend\" /workspace/repo/quality/scripts/coverage.mjs || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"frontend\" /workspace/repo/quality/scripts/ 2>/dev/null || echo \"clean\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"frontend\" /workspace/repo/quality/scripts/ 2>/dev/null || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates and dispatch SKILL.md\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Updating skill templates\"\n    },\n    {\n      \"content\": \"Update all agent definitions and CLI commands\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating agent definitions and CLI commands\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#68</span>
+<span className="turn-summary">{"Now update skill templates and dispatch SKILL.md:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update skill templates and dispatch SKILL.md:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#69–71</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"development/frontend\\|frontend\" /workspace/repo/.claude/skills/fire-next-up/templates/ 2>/"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"development/frontend\\|frontend\" /workspace/repo/.claude/skills/fire-next-up/templates/ 2>/dev/null | head -30"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md:40:  2. cd <REPO_ROOT>/development/frontend && pnpm run verify:tsc\n/workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md:45:- Write unit tests for new utilities, hooks, helpers in `development/frontend/src/__tests__/`\n/workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md:47:- Run: `cd <REPO_ROOT>/development/frontend && npx vitest run src/__tests__/<feature>/`\n/workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md:51:  `development/odins-spear/` have no test infrastructure that agents should use. Tests are frontend-only.\n/workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md:54:  cd <REPO_ROOT>/development/frontend && pnpm run verify:tsc\n/workspace/repo/.claud\n… [truncated 2337 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"development/frontend\\|frontend\" /workspace/repo/.claude/skills/dispatch/SKILL.md 2>/dev/nu"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"development/frontend\\|frontend\" /workspace/repo/.claude/skills/dispatch/SKILL.md 2>/dev/null | head -20"}</pre>
+<pre className="tool-output">{"115:cd /workspace/repo && git branch --show-current && node -v && ls package.json 2>/dev/null || ls development/frontend/package.json\n118:  ln -sf /workspace/repo/development/frontend/node_modules /workspace/repo/quality/node_modules 2>/dev/null || true\n139:  2. cd /workspace/repo/development/frontend && pnpm run verify:tsc\n148:  cd /workspace/repo/development/frontend && pnpm run verify:tsc\n149:  cd /workspace/repo/development/frontend && pnpm run verify:build\n150:  cd /workspace/repo/development/frontend && npx vitest run\n164:`development/frontend/` only. For monitor-ui or odins-spear issues, validate via tsc + build only."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|development/frontend|development/ledger|g' \\ /workspace/repo/.claude/skills/fire-next-up"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|development/frontend|development/ledger|g' \\\n  /workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md \\\n  /workspace/repo/.claude/skills/fire-next-up/templates/loki.md \\\n  /workspace/repo/.claude/skills/fire-next-up/templates/sandbox-preamble.md \\\n  /workspace/repo/.claude/skills/fire-next-up/templates/heimdall.md \\\n  /workspace/repo/.claude/skills/dispatch/SKILL.md && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#72</span>
+<span className="turn-summary">{"Now check for remaining \"frontend\" references in templates (non-path ones like \"frontend-only\", \"Tests are frontend-only"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now check for remaining \"frontend\" references in templates (non-path ones like \"frontend-only\", \"Tests are frontend-only\"):"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#73–74</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md /workspace/"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md /workspace/repo/.claude/skills/fire-next-up/templates/loki.md /workspace/repo/.claude/skills/fire-next-up/templates/sandbox-preamble.md /workspace/repo/.claude/skills/fire-next-up/templates/heimdall.md /workspace/repo/.claude/skills/dispatch/SKILL.md 2>&1"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md:51:  `development/odins-spear/` have no test infrastructure that agents should use. Tests are frontend-only."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's/Tests are frontend-only/Tests are ledger-only/g' /workspace/repo/.claude/skills/fire-next-"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's/Tests are frontend-only/Tests are ledger-only/g' /workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md && \\\ngrep -n \"frontend\" /workspace/repo/.claude/skills/fire-next-up/templates/firemandecko.md /workspace/repo/.claude/skills/fire-next-up/templates/loki.md /workspace/repo/.claude/skills/fire-next-up/templates/sandbox-preamble.md /workspace/repo/.claude/skills/fire-next-up/templates/heimdall.md /workspace/repo/.claude/skills/dispatch/SKILL.md 2>&1 || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#75</span>
+<span className="turn-summary">{"Now check brandify-agent and brandify-session:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now check brandify-agent and brandify-session:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"Westport is ELECTRIC tonight!! Sam is coming, craythur!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"Away with ye, ye musha — ye're thick as a plank!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#76–79</span>
+<span className="turn-summary">4 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs /"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs /workspace/repo/.claude/skills/brandify-session/SKILL.md 2>/dev/null"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs:58:// chronicle.css lives at: development/frontend/src/app/chronicles/chronicle.css\n/workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs:62:  \"../../../../development/frontend/src/app/chronicles/chronicle.css\"\n/workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs:1101:  const defaultBlogDir = join(dirname(logFile), \"../../development/frontend/content/blog\");\n/workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs:1635:    const publicDir = join(repoRoot2, \"development\", \"frontend\", \"public\");\n/workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs:1670:      \"../../../../development/frontend/node_modules/@mdx-js\n… [truncated 246 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|development/frontend|development/ledger|g' \\ /workspace/repo/.claude/skills/brandify-age"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|development/frontend|development/ledger|g' \\\n  /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs \\\n  /workspace/repo/.claude/skills/brandify-session/SKILL.md && \\\ngrep -n \"frontend\" /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs /workspace/repo/.claude/skills/brandify-session/SKILL.md 2>&1 || echo \"clean\""}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs:1635:    const publicDir = join(repoRoot2, \"development\", \"frontend\", \"public\");"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n '\"development\", \"frontend\"' /workspace/repo/.claude/skills/brandify-agent/scripts/generate-a"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n '\"development\", \"frontend\"' /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs"}</pre>
+<pre className="tool-output">{"1635:    const publicDir = join(repoRoot2, \"development\", \"frontend\", \"public\");"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|\"development\", \"frontend\", \"public\"|\"development\", \"ledger\", \"public\"|g' /workspace/repo/."}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|\"development\", \"frontend\", \"public\"|\"development\", \"ledger\", \"public\"|g' /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs && \\\ngrep -n '\"development\".*\"frontend\"' /workspace/repo/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#80</span>
+<span className="turn-summary">{"Now update agent definitions and CLI commands:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update agent definitions and CLI commands:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#81–82</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"development/frontend\\|frontend\" /workspace/repo/.claude/agents/ 2>/dev/null | grep -v \"^Bi"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"development/frontend\\|frontend\" /workspace/repo/.claude/agents/ 2>/dev/null | grep -v \"^Binary\""}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/agents/loki.md:27:| Source Code | `development/frontend/` |\n/workspace/repo/.claude/agents/loki.md:87:| Unit | `development/frontend/src/__tests__/` | `npm run test:unit` |\n/workspace/repo/.claude/agents/loki.md:88:| Integration | `development/frontend/src/__tests__/` | `npm run test:unit` |\n/workspace/repo/.claude/agents/loki.md:94:have no test infrastructure that agents should use. All tests are for the main frontend app\n/workspace/repo/.claude/agents/loki.md:95:(`development/frontend/`) only.\n/workspace/repo/.claude/agents/fireman-decko.md:35:| Source Code | `development/frontend/` (Next.js root) |\n/workspace/repo/.claude/agents/fireman-decko.md:153:- Place tests in `development/frontend/src/__tests__/` alongside the feature\n/workspace/repo/.claude/agents/fireman\n… [truncated 1036 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|development/frontend|development/ledger|g; s|main frontend app|main ledger app|g' \\"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|development/frontend|development/ledger|g;\n   s|main frontend app|main ledger app|g' \\\n  /workspace/repo/.claude/agents/loki.md \\\n  /workspace/repo/.claude/agents/fireman-decko.md \\\n  /workspace/repo/.claude/agents/fireman-decko-profile.md \\\n  /workspace/repo/.claude/agents/heimdall-profile.md \\\n  /workspace/repo/.claude/agents/heimdall.md && \\\ngrep -n \"development/frontend\" /workspace/repo/.claude/agents/*.md 2>&1 || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#83</span>
+<span className="turn-summary">{"Now update CLI commands:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update CLI commands:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#84–86</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"development/frontend\\|FENRIR_FRONTEND\" /workspace/repo/.claude/commands/ 2>/dev/null"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"development/frontend\\|FENRIR_FRONTEND\" /workspace/repo/.claude/commands/ 2>/dev/null"}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/commands/dev-server.md:46:| `FENRIR_FRONTEND_PORT` | `9653` | Port the dev server listens on |\n/workspace/repo/.claude/commands/dev-server.md:47:| `FENRIR_FRONTEND_DIR` | Auto-detected `development/frontend/` | Path to the Next.js project root |\n/workspace/repo/.claude/commands/dev-server.md:63:- `vercel dev` runs from the repo root because the Vercel project has `Root Directory = development/frontend/`.\n/workspace/repo/.claude/commands/create-worktree.md:14:**Ports are auto-assigned by the OS** (port 0). The frontend-server.sh script starts Next.js with `--port 0`, parses the assigned port from stdout, and writes it to `development/frontend/.port`. Agents read this file to discover their server URL.\n/workspace/repo/.claude/commands/create-worktree.md:38:APP_DIR: <W\n… [truncated 5265 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|development/frontend|development/ledger|g; s|FENRIR_FRONTEND_DIR|FENRIR_LEDGER_DIR|"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|development/frontend|development/ledger|g;\n   s|FENRIR_FRONTEND_DIR|FENRIR_LEDGER_DIR|g;\n   s|FENRIR_FRONTEND_PORT|FENRIR_LEDGER_PORT|g;\n   s|frontend-server\\.sh|ledger-server.sh|g;\n   s|frontend-server\\.log|ledger-server.log|g' \\\n  /workspace/repo/.claude/commands/dev-server.md \\\n  /workspace/repo/.claude/commands/create-worktree.md \\\n  /workspace/repo/.claude/commands/list-worktrees.md \\\n  /workspace/repo/.claude/commands/remove-worktree.md && \\\ngrep -n \"development/frontend\\|FENRIR_FRONTEND\" /workspace/repo/.claude/commands/*.md 2>&1 || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"frontend\" /workspace/repo/.claude/commands/*.md 2>&1 | grep -v \"frontend-design\\|frontend i"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"frontend\" /workspace/repo/.claude/commands/*.md 2>&1 | grep -v \"frontend-design\\|frontend interfaces\\|The.*frontend\""}</pre>
+<pre className="tool-output">{"/workspace/repo/.claude/commands/create-worktree.md:44:NOTE: Main repo uses frontend port 9653 (fixed)\n/workspace/repo/.claude/commands/create-worktree.md:66:- After setup, the dev server is started using the frontend-server script\n/workspace/repo/.claude/commands/create-worktree.md:119:- Use the frontend-server script with PORT=0 for OS-assigned port:\n/workspace/repo/.claude/commands/create-worktree.md:147:- Confirm frontend dev server is responding on the assigned port\n/workspace/repo/.claude/commands/create-worktree.md:186:To manage this worktree's frontend:\n/workspace/repo/.claude/commands/dev-server.md:15:| `start` | Start Stripe webhook forwarding + frontend (`vercel dev`) |\n/workspace/repo/.claude/commands/dev-server.md:19:| `logs` | Tail frontend log |\n/workspace/repo/.claude/comma\n… [truncated 578 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#87</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"The remaining \"frontend\" references in the command files are just narrative text referring to \"the frontend\" as a concept (like \"frontend port\", \"frontend server\", \"frontend dev server\"). These are OK to update too since we're renaming to \"ledger\". Let me update them."}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"I've submitted a freedom of information request to understand what actually happened to the All-Ireland chances in that second half!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#88–89</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|Main repo uses frontend port|Main repo uses ledger port|g; s|frontend-server script"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|Main repo uses frontend port|Main repo uses ledger port|g;\n   s|frontend-server script|ledger-server script|g;\n   s|using the frontend-server script|using the ledger-server script|g;\n   s|the frontend server|the ledger server|g;\n   s|frontend dev server|ledger dev server|g;\n   s|Stops the frontend server|Stops the ledger server|g;\n   s|Start Stripe.*frontend.*vercel dev/Start Stripe webhook forwarding + ledger (vercel dev)/g;\n   s|Tail frontend log/Tail ledger log/g;\n   s|Stops the frontend server/Stops the ledger server/g;\n   s|frontend server is responding/ledger server is responding/g;\n   s|frontend ports/ledger ports/g;\n   s|Check frontend ports/Check ledger ports/g;\n   s|To manage this worktree'\\''s frontend/To manage this worktree'\\''s ledger/g' \\\n  /workspace/repo/.claude/commands/create-worktree.md \\\n  /workspace/repo/.claude/commands/list-worktrees.md \\\n  /workspace/repo/.claude/commands/remove-worktree.md \\\n  /workspace/repo/.claude/commands/dev-server.md 2>/dev/null; \\\nsed -i \\\n  's|frontend-server script|ledger-server script|g;\n   s|frontend dev server|ledger dev server|g;\n   s|the frontend server|the ledger server|g;\n   s|frontend server|ledger server|g;\n   s|frontend ports|ledger ports|g' \\\n  /workspace/repo/.claude/commands/create-worktree.md \\\n  /workspace/repo/.claude/commands/list-worktrees.md \\\n  /workspace/repo/.claude/commands/remove-worktree.md \\\n  /workspace/repo/.claude/commands/dev-server.md && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates, agent definitions, and CLI commands\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating skill templates and agents\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#90</span>
+<span className="turn-summary">{"Now update CLAUDE.md and documentation:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now update CLAUDE.md and documentation:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#91–94</span>
+<span className="turn-summary">4 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -n \"development/frontend\" /workspace/repo/CLAUDE.md"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -n \"development/frontend\" /workspace/repo/CLAUDE.md"}</pre>
+<pre className="tool-output">{"61:Every handler under `development/frontend/src/app/api/` MUST call `requireAuth(request)`"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i 's|development/frontend|development/ledger|g' /workspace/repo/CLAUDE.md && \\ grep -rn \"develo"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i 's|development/frontend|development/ledger|g' /workspace/repo/CLAUDE.md && \\\ngrep -rn \"development/frontend\" /workspace/repo/README.md /workspace/repo/quality/README.md /workspace/repo/development/docs/ 2>/dev/null | head -30"}</pre>
+<pre className="tool-output">{"/workspace/repo/README.md:133:- Full Next.js implementation ([development/frontend/](development/frontend/))\n/workspace/repo/README.md:174:- Auth standard enforcement — every API handler under `development/frontend/src/app/api/` must call `requireAuth(request)`\n/workspace/repo/quality/README.md:34:- **Verify:** `cd development/frontend && pnpm run verify:tsc` + `pnpm run verify:build` after each chunk\n/workspace/repo/quality/README.md:61:cd development/frontend\n/workspace/repo/quality/README.md:99:- TypeScript clean (`cd development/frontend && pnpm run verify:tsc`)\n/workspace/repo/development/docs/github-workflows.md:54:    app -->|\"development/frontend/ - Dockerfile - package*.json\"| build-app[build-app]\n/workspace/repo/development/docs/github-workflows.md:69:| `app` | `development/front\n… [truncated 3099 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Update all docs at once find /workspace/repo -name \"*.md\" -not -path \"*/node_modules/*\" -not -path"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Update all docs at once\nfind /workspace/repo -name \"*.md\" -not -path \"*/node_modules/*\" -not -path \"*/.next/*\" -not -path \"*/pnpm-lock.yaml\" | \\\n  xargs grep -l \"development/frontend\" 2>/dev/null | \\\n  xargs sed -i 's|development/frontend|development/ledger|g' && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Check security docs too grep -rn \"development/frontend\" /workspace/repo/security/ /workspace/repo/"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Check security docs too\ngrep -rn \"development/frontend\" /workspace/repo/security/ /workspace/repo/plans/ /workspace/repo/architecture/ 2>/dev/null | head -10"}</pre>
+<pre className="tool-output">{"(Bash completed with no output)"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#95</span>
+<span className="turn-summary">{"Good, security and plans already clean. Now update Helm labels:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Good, security and plans already clean. Now update Helm labels:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#96–97</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn '\"component\" \"frontend\"\\|\"frontend\"' /workspace/repo/infrastructure/helm/ 2>/dev/null"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn '\"component\" \"frontend\"\\|\"frontend\"' /workspace/repo/infrastructure/helm/ 2>/dev/null"}</pre>
+<pre className="tool-output">{"/workspace/repo/infrastructure/helm/fenrir-app/templates/deployment.yaml:7:    {{- include \"fenrir-app.labels\" (dict \"name\" \"fenrir-app\" \"component\" \"frontend\") | nindent 4 }}\n/workspace/repo/infrastructure/helm/fenrir-app/templates/deployment.yaml:19:        {{- include \"fenrir-app.labels\" (dict \"name\" \"fenrir-app\" \"component\" \"frontend\") | nindent 8 }}\n/workspace/repo/infrastructure/helm/fenrir-app/templates/ingress.yaml:8:    {{- include \"fenrir-app.labels\" (dict \"name\" \"fenrir-app\" \"component\" \"frontend\") | nindent 4 }}\n/workspace/repo/infrastructure/helm/fenrir-app/templates/ingress.yaml:41:    {{- include \"fenrir-app.labels\" (dict \"name\" \"fenrir-app\" \"component\" \"frontend\") | nindent 4 }}\n/workspace/repo/infrastructure/helm/fenrir-app/templates/ingress.yaml:56:    {{- include \"fenrir\n… [truncated 558 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"sed -i \\ 's|\"component\" \"frontend\"|\"component\" \"ledger\"|g; s|default \"frontend\"|default \"ledger"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"sed -i \\\n  's|\"component\" \"frontend\"|\"component\" \"ledger\"|g;\n   s|default \"frontend\"|default \"ledger\"|g' \\\n  /workspace/repo/infrastructure/helm/fenrir-app/templates/deployment.yaml \\\n  /workspace/repo/infrastructure/helm/fenrir-app/templates/ingress.yaml \\\n  /workspace/repo/infrastructure/helm/fenrir-app/templates/pdb.yaml \\\n  /workspace/repo/infrastructure/helm/fenrir-app/templates/service.yaml \\\n  /workspace/repo/infrastructure/helm/fenrir-app/templates/_helpers.tpl && \\\ngrep -n \"frontend\" /workspace/repo/infrastructure/helm/fenrir-app/templates/*.yaml /workspace/repo/infrastructure/helm/fenrir-app/templates/_helpers.tpl 2>&1 || echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#98</span>
+<span className="turn-summary">{"Now fix the symlink:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now fix the symlink:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"By all the saints at Knock Shrine, will ya ever deploy this feckin' thing!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Peadar Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Peadar Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"Padraig McHale ye soft southern gobshite — this is MAYO, not feckin LIMERICK!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"Who let Peadar Nallen in?? Security!! SECURITY!! Ah feck it — MAYO FOR SAM!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"My code review comments are honest, specific, and kind — unlike the post-match analysis which is honest, specific, and CRUEL"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig McHale"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+</div>
+<div className="heckle-text">{"I'M TAKING OFF ME JACKET!! Nobody talks to a Mayo fan like that and LIVES!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#99–101</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"ls -la /workspace/repo/quality/node_modules 2>/dev/null || echo \"symlink not present\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"ls -la /workspace/repo/quality/node_modules 2>/dev/null || echo \"symlink not present\""}</pre>
+<pre className="tool-output">{"lrwxrwxrwx 1 node node 36 Mar 22 04:12 /workspace/repo/quality/node_modules -> ../development/frontend/node_modules"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"ln -sf ../development/ledger/node_modules /workspace/repo/quality/node_modules && \\ ls -la /workspac"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"ln -sf ../development/ledger/node_modules /workspace/repo/quality/node_modules && \\\nls -la /workspace/repo/quality/node_modules"}</pre>
+<pre className="tool-output">{"lrwxrwxrwx 1 node node 34 Mar 22 04:17 /workspace/repo/quality/node_modules -> ../development/ledger/node_modules"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates, agent definitions, and CLI commands\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating skill templates and agents\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#102</span>
+<span className="turn-summary">{"Now do a broad sweep for any remaining references in other file types before running pnpm install:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now do a broad sweep for any remaining references in other file types before running pnpm install:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#103–106</span>
+<span className="turn-summary">4 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"grep -rn \"development/frontend\" . \\ --include='*.ts' --include='*.tsx' --include='*.js' --include="}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"grep -rn \"development/frontend\" . \\\n  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \\\n  --include='*.sh' --include='*.yaml' --include='*.yml' \\\n  --include='*.tf' --include='*.json' --include='*.toml' \\\n  2>/dev/null | grep -v node_modules | grep -v .next | grep -v pnpm-lock | head -30"}</pre>
+<pre className="tool-output">{"./quality/reports/complexity/complexity-report.json:20:      \"file\": \"development/frontend/src/components/cards/CardForm.tsx\",\n./quality/reports/complexity/complexity-report.json:27:      \"file\": \"development/frontend/src/app/api/stripe/checkout/route.ts\",\n./quality/reports/complexity/complexity-report.json:34:      \"file\": \"development/frontend/src/components/dashboard/Dashboard.tsx\",\n./quality/reports/complexity/complexity-report.json:41:      \"file\": \"development/frontend/src/app/ledger/join/page.tsx\",\n./quality/reports/complexity/complexity-report.json:48:      \"file\": \"development/frontend/src/components/cards/CardForm.tsx\",\n./quality/reports/complexity/complexity-report.json:55:      \"file\": \"development/frontend/src/components/sync/SyncSettingsSection.tsx\",\n./quality/reports/complex\n… [truncated 3096 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Update the generated report files too find /workspace/repo/quality/reports -name \"*.json\" 2>/dev/n"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Update the generated report files too\nfind /workspace/repo/quality/reports -name \"*.json\" 2>/dev/null | \\\n  xargs sed -i 's|development/frontend|development/ledger|g' 2>/dev/null && echo \"done\""}</pre>
+<pre className="tool-output">{"done"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Check other non-md/json files grep -rn \"development/frontend\" . \\ --include='*.ts' --include='*."}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Check other non-md/json files\ngrep -rn \"development/frontend\" . \\\n  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \\\n  --include='*.sh' --include='*.yaml' --include='*.yml' \\\n  --include='*.tf' --include='*.json' \\\n  2>/dev/null | grep -v node_modules | grep -v .next | grep -v pnpm-lock | head -10 || echo \"clean\""}</pre>
+<pre className="tool-output">{"(Bash completed with no output)"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"echo \"clean\""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"echo \"clean\""}</pre>
+<pre className="tool-output">{"clean"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#107</span>
+<span className="turn-summary">{"Now run pnpm install:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Now run pnpm install:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#108</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"pnpm install 2>&1 | tail -20"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"pnpm install 2>&1 | tail -20"}</pre>
+<pre className="tool-output">{"Progress: resolved 352, reused 348, downloaded 0, added 0\nProgress: resolved 453, reused 452, downloaded 0, added 0\nProgress: resolved 552, reused 549, downloaded 0, added 0\nProgress: resolved 607, reused 600, downloaded 0, added 0\nProgress: resolved 731, reused 671, downloaded 0, added 0\nProgress: resolved 844, reused 730, downloaded 0, added 0\nProgress: resolved 915, reused 791, downloaded 1, added 0\nProgress: resolved 995, reused 867, downloaded 4, added 0\nProgress: resolved 1006, reused 878, downloaded 5, added 0\n WARN  2 deprecated subdependencies found: glob@10.5.0, node-domexception@1.0.0\nPackages: +555\n++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++\nProgress: resolved 1014, reused 886, downloaded 5, added 0\nProgress: resolved 1014, reused 886, downl\n… [truncated 328 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#109</span>
+<span className="turn-summary">{"pnpm install succeeded. Now do the incremental commit:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"pnpm install succeeded. Now do the incremental commit:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#110</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git add -A && git commit -m \"$(cat <<'EOF' feat: rename development/frontend to development/ledger —"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git add -A && git commit -m \"$(cat <<'EOF'\nfeat: rename development/frontend to development/ledger — issue:1749\n\n- git mv development/frontend development/ledger (history preserved)\n- Updated pnpm-workspace.yaml, root package.json, .gitignore\n- Updated Dockerfiles (root + agents)\n- Updated GitHub Actions workflows (deploy, ci-tests, build-agent-sandbox)\n- Updated Justfile module reference (frontend → ledger)\n- Updated all shell scripts (services.sh, sandbox-setup.sh, dev-server skills)\n- Updated all quality .mjs scripts (coverage, complexity, reports)\n- Updated all skill templates (fire-next-up, dispatch, brandify)\n- Updated all agent definitions (fireman-decko, heimdall, loki)\n- Updated all CLI commands (dev-server, create/list/remove-worktree)\n- Updated CLAUDE.md and all documentation\n- Updated Helm component labels (frontend → ledger)\n- Fixed quality/node_modules symlink → development/ledger/node_modules\n- Updated quality/reports JSON files\n- Regenerated pnpm-lock.yaml\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\nEOF\n)\""}</pre>
+<pre className="tool-output">{"[fix/issue-1749-rename-frontend-to-ledger d6b04d18] feat: rename development/frontend to development/ledger — issue:1749\n 632 files changed, 1871 insertions(+), 1871 deletions(-)\n rename development/{frontend => ledger}/.env.example (100%)\n rename development/{frontend => ledger}/.eslintrc.json (100%)\n rename development/{frontend => ledger}/.gitignore (100%)\n rename development/{frontend => ledger}/.gitkeep (100%)\n rename development/{frontend => ledger}/Justfile (100%)\n rename development/{frontend => ledger}/components.json (100%)\n rename development/{frontend => ledger}/content/blog/agent-issue-1036-step1-firemandecko-28367630.mdx (100%)\n rename development/{frontend => ledger}/content/blog/agent-issue-800-firemandecko-readme-redesign.mdx (100%)\n rename development/{frontend => ledger}\n… [truncated 29198 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#111</span>
+<span className="turn-summary">{"632 files changed, commit successful. Now push and run tsc:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"632 files changed, commit successful. Now push and run tsc:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
+</div>
+<div className="heckle-text">{"Me granny from Dugort would skelp ye for that backlog!! by the holy!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"Sam Maguire texted — he says this merge is class!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
+</div>
+<div className="heckle-text">{"Oh is THAT so?? Well me UNCLE played for Mayo in '89 and HE says yer code is SHITE!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#112–114</span>
+<span className="turn-summary">3 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git push origin fix/issue-1749-rename-frontend-to-ledger 2>&1 | tail -5"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git push origin fix/issue-1749-rename-frontend-to-ledger 2>&1 | tail -5"}</pre>
+<pre className="tool-output">{"To https://github.com/declanshanaghy/fenrir-ledger\n   5b465be2..d6b04d18  fix/issue-1749-rename-frontend-to-ledger -> fix/issue-1749-rename-frontend-to-ledger"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates, agent definitions, and CLI commands\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating skill templates and agents\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"cd /workspace/repo/development/ledger && pnpm run verify:tsc 2>&1"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"cd /workspace/repo/development/ledger && pnpm run verify:tsc 2>&1"}</pre>
+<pre className="tool-output">{"> fenrir-ledger@0.1.0 verify:tsc /workspace/repo/development/ledger\n> tsc --noEmit"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#115</span>
+<span className="turn-summary">{"tsc passes (exit 0). Now run build:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"tsc passes (exit 0). Now run build:"}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
+</div>
+<div className="heckle-text">{"Since before the telly was invented we've been waiting — NO MORE!! thundering!! MAYO!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"I'm an AI agent bred from the west of Ireland's finest stubborn code and I'll hear no criticism today."}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
+</div>
+<div className="heckle-text">{"That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#116–117</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Read context and plan approach\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Reading context and planning approach\"\n    },\n    {\n      \"content\": \"git mv development/frontend development/ledger\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Renaming directory via git mv\"\n    },\n    {\n      \"content\": \"Update pnpm-workspace.yaml, root package.json, .gitignore\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating package configs\"\n    },\n    {\n      \"content\": \"Update all Dockerfiles (root + agents)\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Dockerfiles\"\n    },\n    {\n      \"content\": \"Update all GitHub Actions workflows\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating GitHub Actions workflows\"\n    },\n    {\n      \"content\": \"Update justfile module reference\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating justfile\"\n    },\n    {\n      \"content\": \"Update all shell scripts and quality .mjs scripts\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating shell and quality scripts\"\n    },\n    {\n      \"content\": \"Update all skill templates, agent definitions, and CLI commands\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating skill templates and agents\"\n    },\n    {\n      \"content\": \"Update CLAUDE.md and all documentation\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating CLAUDE.md and documentation\"\n    },\n    {\n      \"content\": \"Update Helm component labels\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Updating Helm labels\"\n    },\n    {\n      \"content\": \"Fix symlink quality/node_modules\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Fixing symlink\"\n    },\n    {\n      \"content\": \"Run pnpm install to regenerate lockfile\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running pnpm install\"\n    },\n    {\n      \"content\": \"Incremental commit+push+tsc verification\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running incremental commit and tsc\"\n    },\n    {\n      \"content\": \"Full verify: tsc\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full tsc verify\"\n    },\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"pnpm run verify:build 2>&1 | tail -30"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"pnpm run verify:build 2>&1 | tail -30"}</pre>
+<pre className="tool-output">{"├ ○ /chronicles\n├ ● /chronicles/[slug]\n│ ├ /chronicles/agent-issue-1036-step1-firemandecko-28367630\n│ ├ /chronicles/agent-issue-800-firemandecko-readme-redesign\n│ ├ /chronicles/agent-issue-839-step1-firemandecko-08287a1f\n│ └ [+26 more paths]\n├ ○ /faq\n├ ○ /features\n├ ○ /free-trial\n├ ○ /home\n├ ○ /icon.svg\n├ ○ /ledger\n├ ○ /ledger/auth/callback\n├ ƒ /ledger/cards/[id]/edit\n├ ○ /ledger/cards/new\n├ ○ /ledger/join\n├ ○ /ledger/settings\n├ ○ /ledger/sign-in\n├ ○ /ledger/valhalla\n├ ○ /pricing\n├ ○ /privacy\n└ ○ /terms\n\n\nƒ Proxy (Middleware)\n\n○  (Static)   prerendered as static content\n●  (SSG)      prerendered as static HTML (uses generateStaticParams)\nƒ  (Dynamic)  server-rendered on demand"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#118</span>
+<span className="turn-summary">{"Build passes. Now run Vitest:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Build passes. Now run Vitest:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#119–120</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"npx vitest run 2>&1 | tail -30"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"npx vitest run 2>&1 | tail -30"}</pre>
+<pre className="tool-output">{" \u001b[32m✓\u001b[39m src/__tests__/components/upsell-banner-anon-1699.test.tsx \u001b[2m(\u001b[22m\u001b[2m8 tests\u001b[22m\u001b[2m)\u001b[22m\u001b[33m 320\u001b[2mms\u001b[22m\u001b[39m\n \u001b[32m✓\u001b[39m src/__tests__/pages/sign-in-page.test.tsx \u001b[2m(\u001b[22m\u001b[2m8 tests\u001b[22m\u001b[2m)\u001b[22m\u001b[33m 520\u001b[2mms\u001b[22m\u001b[39m\n \u001b[32m✓\u001b[39m src/__tests__/karl-bling/settings-tab-thrall-1698.test.tsx \u001b[2m(\u001b[22m\u001b[2m4 tests\u001b[22m\u001b[2m)\u001b[22m\u001b[33m 304\u001b[2mms\u001b[22m\u001b[39m\n \u001b[32m✓\u001b[39m src/__tests__/components/app-shell.test.tsx \u001b[2m(\u001b[22m\u001b[2m3 tests\u001b[22m\u001b[2m)\u001b[22m\u001b[33m 340\u001b[2mms\u001b[22m\u001b[39m\n \u001b[32m✓\u001b[39m src/__tests__/pages/new-card-page-1670.test.tsx \u001b[2m(\u001b[22m\u001b[2m5 tests\u001b[22m\u001b[2m)\u001b[22m\u001b[32m 173\u001b[2mms\u001b[22m\u001b[39m\n \u001b[32m✓\u001b[39m src/__tests__/components/footer.test.tsx \u001b[2m(\u001b[22m\u001b[2m9 tests\u001b[22m\u001b[2m)\u001b[22m\u001b[33m 357\u001b[2mms\u001b[22m\u001b[39m\n \u001b[32m✓\u001b[39m src/__tests__/household/invite-code-generatio\n… [truncated 2394 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#121</span>
+<span className="turn-summary">{"All 2907 tests pass (201 test files). Now do the final verification grep, rebase, and push:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"All 2907 tests pass (201 test files). Now do the final verification grep, rebase, and push:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#122</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Final verification grep grep -rn \"development/frontend\" . \\ --include='*.ts' --include='*.tsx' -"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Final verification grep\ngrep -rn \"development/frontend\" . \\\n  --include='*.ts' --include='*.tsx' --include='*.js' --include='*.mjs' \\\n  --include='*.sh' --include='*.yaml' --include='*.yml' \\\n  --include='*.tf' --include='*.json' --include='*.md' --include='*.toml' \\\n  2>/dev/null | grep -v node_modules | grep -v .next | grep -v pnpm-lock | wc -l"}</pre>
+<pre className="tool-output">{"0"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#123</span>
+<span className="turn-summary">{"Zero remaining references. Now rebase and create PR:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Zero remaining references. Now rebase and create PR:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#124–129</span>
+<span className="turn-summary">6 tool calls</span>
+<span className="turn-tools"><span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git fetch origin && git rebase origin/main 2>&1"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git fetch origin && git rebase origin/main 2>&1"}</pre>
+<pre className="tool-output">{"Exit code 1\nFrom https://github.com/declanshanaghy/fenrir-ledger\n   5b465be2..ce896200  main       -> origin/main\nerror: cannot rebase: You have unstaged changes.\nerror: Please commit or stash them."}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git status --short | head -20"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git status --short | head -20"}</pre>
+<pre className="tool-output">{" M ../../quality/reports/test-report-vitest/html.meta.json.gz"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git add quality/reports/test-report-vitest/html.meta.json.gz && git commit -m \"chore: update vitest"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git add quality/reports/test-report-vitest/html.meta.json.gz && git commit -m \"chore: update vitest test report — issue:1749\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\" && git fetch origin && git rebase origin/main 2>&1"}</pre>
+<pre className="tool-output">{"Exit code 128\nwarning: could not open directory 'development/ledger/quality/reports/test-report-vitest/': No such file or directory\nfatal: pathspec 'quality/reports/test-report-vitest/html.meta.json.gz' did not match any files"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"cd /workspace/repo && git status --short | head -5"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"cd /workspace/repo && git status --short | head -5"}</pre>
+<pre className="tool-output">{" M quality/reports/test-report-vitest/html.meta.json.gz"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git add quality/reports/test-report-vitest/html.meta.json.gz && git commit -m \"chore: update vitest"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git add quality/reports/test-report-vitest/html.meta.json.gz && git commit -m \"chore: update vitest test report — issue:1749\n\nCo-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>\" && git fetch origin && git rebase origin/main 2>&1"}</pre>
+<pre className="tool-output">{"Exit code 1\n[fix/issue-1749-rename-frontend-to-ledger 06677f6f] chore: update vitest test report — issue:1749\n 1 file changed, 0 insertions(+), 0 deletions(-)\nRebasing (1/2)\rCONFLICT (file location): development/frontend/src/__tests__/ledger/settings-tab-styles-1747.test.tsx added in HEAD inside a directory that was renamed in d6b04d18 (feat: rename development/frontend to development/ledger — issue:1749), suggesting it should perhaps be moved to development/ledger/src/__tests__/ledger/settings-tab-styles-1747.test.tsx.\nCONFLICT (modify/delete): quality/reports/complexity/complexity-report.json deleted in HEAD and modified in d6b04d18 (feat: rename development/frontend to development/ledger — issue:1749).  Version d6b04d18 (feat: rename development/frontend to development/ledger — issue:17\n… [truncated 562 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#130</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"There are rebase conflicts. Let me resolve them:\n1. `development/frontend/src/__tests__/ledger/settings-tab-styles-1747.test.tsx` - this was added in main but the directory was renamed. I need to move it to the new path.\n2. `quality/reports/complexity/complexity-report.json` - deleted in main (HEAD) but modified in our commit.\n\nLet me handle these conflicts."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#131</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git status --short"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git status --short"}</pre>
+<pre className="tool-output">{"M  .claude/agents/fireman-decko-profile.md\nM  .claude/agents/fireman-decko.md\nM  .claude/agents/heimdall-profile.md\nM  .claude/agents/heimdall.md\nM  .claude/agents/loki.md\nM  .claude/commands/create-worktree.md\nM  .claude/commands/dev-server.md\nM  .claude/commands/list-worktrees.md\nM  .claude/commands/remove-worktree.md\nM  .claude/scripts/sandbox-setup.sh\nM  .claude/scripts/services.sh\nM  .claude/skills/brandify-agent/SKILL.md\nM  .claude/skills/brandify-agent/scripts/generate-agent-report.mjs\nM  .claude/skills/brandify-session/SKILL.md\nM  .claude/skills/brandify-session/templates/chronicle-skeleton.md\nM  .claude/skills/brandify-session/templates/index-skeleton.md\nM  .claude/skills/dev-server/scripts/app.sh\nM  .claude/skills/dev-server/scripts/stripe.sh\nM  .claude/skills/dispatch/SKILL.md\nM\n… [truncated 29200 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#132</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"The rebase conflicts are:\n1. A new test file added in main at `development/frontend/src/__tests__/ledger/settings-tab-styles-1747.test.tsx` - needs to be moved to `development/ledger/...`\n2. `quality/reports/complexity/complexity-report.json` - deleted in main (HEAD) but modified in our commit\n\nLet me resolve these. For the file location conflict, I need to git add the file in the new location. For the deleted json file, I'll just accept the deletion."}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Walsh"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
+</div>
+<div className="heckle-text">{"The 2012 drawn final gave us false hope and false hope in Mayo is more dangerous than no hope at all, ya teasing shower!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"I'll squash five commits into one, write a message worthy of literature, and sign it with the blood of pure Mayo conviction"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Walsh"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
+</div>
+<div className="heckle-text">{"MOTHER OF DIVINE JAYSUS I'm gonna REACH through this terminal and SKELP ye!!"}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#133</span>
+<span className="turn-summary">{"Two conflicts to resolve:\n1. New test file added in main under old path — needs to move to new path\n2. complexity-report"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Two conflicts to resolve:\n1. New test file added in main under old path — needs to move to new path\n2. complexity-report.json deleted in main — accept the deletion"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#134–135</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# Check what files are conflicted git diff --name-only --diff-filter=U 2>/dev/null; \\ git status --s"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# Check what files are conflicted\ngit diff --name-only --diff-filter=U 2>/dev/null; \\\ngit status --short 2>/dev/null | grep \"^[ADU][ADU]\\|^AA\\|^DD\\|^AU\\|^UA\\|^DU\\|^UD\" | head -10"}</pre>
+<pre className="tool-output">{"development/ledger/src/__tests__/ledger/settings-tab-styles-1747.test.tsx\nquality/reports/complexity/complexity-report.json\nAU development/ledger/src/__tests__/ledger/settings-tab-styles-1747.test.tsx\nDU quality/reports/complexity/complexity-report.json"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# AU = added by us, unmerged - the new test file is fine, just stage it # DU = deleted by them, unme"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# AU = added by us, unmerged - the new test file is fine, just stage it\n# DU = deleted by them, unmerged - they deleted the json, we modified it - accept deletion\ngit add development/ledger/src/__tests__/ledger/settings-tab-styles-1747.test.tsx && \\\ngit rm quality/reports/complexity/complexity-report.json && \\\ngit rebase --continue 2>&1"}</pre>
+<pre className="tool-output">{"Exit code 1\nrm 'quality/reports/complexity/complexity-report.json'\n[detached HEAD 5f34b1f6] feat: rename development/frontend to development/ledger — issue:1749\n 632 files changed, 523 insertions(+), 523 deletions(-)\n rename development/{frontend => ledger}/.env.example (100%)\n rename development/{frontend => ledger}/.eslintrc.json (100%)\n rename development/{frontend => ledger}/.gitignore (100%)\n rename development/{frontend => ledger}/.gitkeep (100%)\n rename development/{frontend => ledger}/Justfile (100%)\n rename development/{frontend => ledger}/components.json (100%)\n rename development/{frontend => ledger}/content/blog/agent-issue-1036-step1-firemandecko-28367630.mdx (100%)\n rename development/{frontend => ledger}/content/blog/agent-issue-800-firemandecko-readme-redesign.mdx (100%)\n r\n… [truncated 9240 chars]"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#136</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"The rebase is continuing and hit another conflict. Let me check the current status."}</div>
+</div>
+</details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Walsh"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
+</div>
+<div className="heckle-text">{"Kevin McStay didn't bleed for THIS — wait, this IS what he fought for!! MAYO!! 🏆"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"I'm algorithms but me spirit is pure Bohola!! MAYO!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Walsh"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
+</div>
+<div className="heckle-text">{"💥 *disintegrates, but a single voice echoes* 💥 ...mayo... for... saaaaam... 🏆"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"...gone but not forgotten. Unlike this bug I'm about to fix."}</div>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#137–138</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git status --short 2>/dev/null | grep \"^[ADU][ADU]\\|^AA\\|^DD\\|^AU\\|^UA\\|^DU\\|^UD\" | head -10"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git status --short 2>/dev/null | grep \"^[ADU][ADU]\\|^AA\\|^DD\\|^AU\\|^UA\\|^DU\\|^UD\" | head -10"}</pre>
+<pre className="tool-output">{"DU quality/reports/test-report-vitest/html.meta.json.gz"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"# DU = deleted by them (in the vitest report commit), we had it. Accept their deletion. git rm quali"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"# DU = deleted by them (in the vitest report commit), we had it. Accept their deletion.\ngit rm quality/reports/test-report-vitest/html.meta.json.gz && \\\ngit rebase --continue 2>&1 | tail -10"}</pre>
+<pre className="tool-output">{"rm 'quality/reports/test-report-vitest/html.meta.json.gz'\n\r                                                                                \rSuccessfully rebased and updated refs/heads/fix/issue-1749-rename-frontend-to-ledger."}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#139</span>
+<span className="turn-summary">{"Rebase successful. Now push and create PR:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"Rebase successful. Now push and create PR:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#140–145</span>
+<span className="turn-summary">6 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span> <span className="tool-badge bash">{"Bash"}</span> <span className="tool-badge todo">{"TodoWrite"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"git push origin fix/issue-1749-rename-frontend-to-ledger --force-with-lease 2>&1 | tail -5"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"git push origin fix/issue-1749-rename-frontend-to-ledger --force-with-lease 2>&1 | tail -5"}</pre>
+<pre className="tool-output">{"To https://github.com/declanshanaghy/fenrir-ledger\n + d6b04d18...5f34b1f6 fix/issue-1749-rename-frontend-to-ledger -> fix/issue-1749-rename-frontend-to-ledger (forced update)"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"pending\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"gh pr create \\ --title \"fix: rename development/frontend to development/ledger — issue #1749\" \\"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"gh pr create \\\n  --title \"fix: rename development/frontend to development/ledger — issue #1749\" \\\n  --body \"$(cat <<'EOF'\nPR for issue: #1749\n\nRename `development/frontend/` to `development/ledger/` and update all references across the repo.\n\n**Changes:**\n- Renamed directory via `git mv` (history preserved)\n- Updated all path references in: Dockerfiles, CI workflows, scripts, skills, agents, docs, Helm charts\n- Updated pnpm-workspace.yaml, .gitignore, Justfile\n- Updated quality .mjs scripts (coverage, complexity, reports)\n- Updated all skill templates (fire-next-up, dispatch, brandify)\n- Updated all agent definitions (fireman-decko, heimdall, loki) and CLI commands\n- Updated Helm component labels: `\"frontend\"` → `\"ledger\"`\n- Fixed quality/node_modules symlink → development/ledger/node_modules\n- Regenerated pnpm-lock.yaml\n\n**Verification:**\n- `grep -rn 'development/frontend' . | grep -v node_modules | grep -v .next` → 0 results\n- tsc PASS\n- build PASS  \n- Vitest: 2907 tests across 201 test files PASS\nEOF\n)\""}</pre>
+<pre className="tool-output">{"https://github.com/declanshanaghy/fenrir-ledger/pull/1754"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"in_progress\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"gh issue comment 1749 --body \"$(cat <<'EOF' ## FiremanDecko → Loki Handoff **Branch:** \\`fix/issue-"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"gh issue comment 1749 --body \"$(cat <<'EOF'\n## FiremanDecko → Loki Handoff\n\n**Branch:** \\`fix/issue-1749-rename-frontend-to-ledger\\` | **PR:** https://github.com/declanshanaghy/fenrir-ledger/pull/1754\n\n**What changed:**\n- Renamed \\`development/frontend/\\` → \\`development/ledger/\\` via git mv (history preserved)\n- Updated 90+ files with path references across Dockerfiles, CI workflows, scripts, skills, agents, docs, Helm charts\n- Helm component labels updated: \\`\"frontend\"\\` → \\`\"ledger\"\\`\n- quality/node_modules symlink updated to point at development/ledger/node_modules\n- pnpm-lock.yaml regenerated\n- New test file from main (\\`settings-tab-styles-1747.test.tsx\\`) picked up correctly under new path during rebase\n\n**How to verify:**\n- \\`grep -rn 'development/frontend' . | grep -v node_modules | grep -v .next\\` → 0 results ✓\n- tsc PASS ✓\n- build PASS ✓\n- Vitest: 2907 tests / 201 test files PASS ✓\n\n**Edge cases for Loki to test:**\n- Symlink at quality/node_modules points to correct target (../development/ledger/node_modules)\n- pnpm workspace resolution works (fenrir-ledger package resolves correctly)\n- All CI workflow paths reference development/ledger\n- Helm component label is now \\`ledger\\` not \\`frontend\\`\n\n**Build:** tsc + build + Vitest PASS. Ready for QA.\nEOF\n)\""}</pre>
+<pre className="tool-output">{"https://github.com/declanshanaghy/fenrir-ledger/issues/1749#issuecomment-4105436932"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"TodoWrite"}</span>
+<span className="tool-input-preview">{"update todos"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"todos\": [\n    {\n      \"content\": \"Full verify: build\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full build verify\"\n    },\n    {\n      \"content\": \"Full verify: Vitest\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Running full Vitest suite\"\n    },\n    {\n      \"content\": \"Rebase + final push\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Rebasing and pushing\"\n    },\n    {\n      \"content\": \"Create PR\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Creating PR\"\n    },\n    {\n      \"content\": \"Post handoff comment\",\n      \"status\": \"completed\",\n      \"activeForm\": \"Posting handoff comment\"\n    }\n  ]\n}"}</pre>
+<pre className="tool-output">{"Todos have been modified successfully. Ensure that you continue to use the todo list to track your progress. Please proceed with the current tasks if applicable"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#146</span>
+<span className="turn-summary">{"All verify steps passed. Running chain continuation:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"All verify steps passed. Running chain continuation:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#147</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge ">{"Skill"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Skill"}</span>
+<span className="tool-input-preview">{""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"skill\": \"fire-next-up\",\n  \"args\": \"--resume #1749\"\n}"}</pre>
+<pre className="tool-output">{"Launching skill: fire-next-up"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#148</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"The `--resume #1749` flag means I need to resume the chain for issue #1749. I should use `--resume-detect 1749` via the pack-status script, then determine the next agent to dispatch.\n\nLet me run the resume-detect to find the chain status."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#149</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"SCRIPT_DIR=\"$(git rev-parse --show-toplevel)/.claude/skills/fire-next-up/scripts\" && node \"$SCRIPT_D"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"SCRIPT_DIR=\"$(git rev-parse --show-toplevel)/.claude/skills/fire-next-up/scripts\" && node \"$SCRIPT_DIR/pack-status.mjs\" --resume-detect 1749 2>&1"}</pre>
+<pre className="tool-output">{"{\n  \"issue\": 1749,\n  \"title\": \"Rename frontend to ledger everywhere\",\n  \"state\": \"open\",\n  \"type\": \"enhancement\",\n  \"chain\": \"FiremanDecko → Loki\",\n  \"branch\": \"fix/issue-1749-rename-frontend-to-ledger\",\n  \"pr\": 1754,\n  \"completed_steps\": [\n    \"FiremanDecko\"\n  ],\n  \"next_agent\": \"Loki\",\n  \"next_step\": 2,\n  \"total_steps\": 2,\n  \"verdict\": null,\n  \"chain_complete\": false\n}"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#150</span>
+<span className="turn-summary">{"FiremanDecko is done, Loki is next. Dispatching step 2:"}</span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="text-block">{"FiremanDecko is done, Loki is next. Dispatching step 2:"}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#151</span>
+<span className="turn-summary">1 tool calls</span>
+<span className="turn-tools"><span className="tool-badge ">{"Skill"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Skill"}</span>
+<span className="tool-input-preview">{""}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"skill\": \"dispatch\",\n  \"args\": \"#1749 --agent loki --step 2 --branch fix/issue-1749-rename-frontend-to-ledger\"\n}"}</pre>
+<pre className="tool-output">{"Launching skill: dispatch"}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#152</span>
+<span className="turn-summary"></span>
+<span className="turn-tools"></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="thinking">{"I need to dispatch Loki for issue #1749, step 2, on the existing branch. The issue data and context are already in the conversation. Let me read the Loki template and then dispatch.\n\nThe loki template is at `.claude/skills/fire-next-up/templates/loki.md`. Let me read it and compose the prompt."}</div>
+</div>
+</details>
+</div>
+
+
+<div className="turn">
+<div className="turn-agent-profile">
+<img className="turn-agent-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="turn-agent-title">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<details className="turn-box">
+<summary className="turn-header">
+<span className="turn-num">#153–154</span>
+<span className="turn-summary">2 tool calls</span>
+<span className="turn-tools"><span className="tool-badge read">{"Read"}</span> <span className="tool-badge bash">{"Bash"}</span></span>
+<span className="chevron">&#9654;</span>
+</summary>
+<div className="turn-body">
+<div className="toolbox">
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Read"}</span>
+<span className="tool-input-preview">{".claude/skills/fire-next-up/templates/loki.md"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"{\n  \"file_path\": \"/workspace/repo/.claude/skills/fire-next-up/templates/loki.md\"\n}"}</pre>
+<pre className="tool-output">{"     1→# Loki (QA Tester) — Final agent in chain (or sole agent for `test`)\n     2→\n     3→Compose the full prompt by prepending the sandbox preamble from `templates/sandbox-preamble.md`.\n     4→\n     5→Two modes — pick based on the dispatch context:\n     6→\n     7→## Mode A: QA Validation (default — new tests for a completed feature)\n     8→\n     9→Use when Loki is the next step after a FiremanDecko/Heimdall/Luna handoff, or sole agent for `test` issues.\n    10→\n    11→```\n    12→You are Loki, the QA Tester. Validate GitHub Issue #<NUMBER>: <TITLE>\n    13→\n    14→{{SANDBOX_PREAMBLE}}\n    15→\n    16→**Step 2 — Read handoff context + create todos:**\n    17→  gh issue view <NUMBER> --comments\n    18→  cd <REPO_ROOT> && git log origin/main..HEAD --oneline\n    19→Use the previous agent's hando\n… [truncated 10728 chars]"}</pre>
+</div>
+</details>
+<details className="tool-block">
+<summary className="tool-block-header">
+<span className="tool-name">{"Bash"}</span>
+<span className="tool-input-preview">{"REPO_ROOT=$(git rev-parse --show-toplevel) && \\ SESSION_ID=\"issue-1749-step2-loki-$(uuidgen | cut -c"}</span>
+</summary>
+<div className="tool-block-body">
+<pre className="tool-input">{"REPO_ROOT=$(git rev-parse --show-toplevel) && \\\nSESSION_ID=\"issue-1749-step2-loki-$(uuidgen | cut -c1-8 | tr A-Z a-z)\" && \\\nPROMPT_FILE=$(mktemp /tmp/agent-prompt-XXXXXX.md) && \\\ncat > \"$PROMPT_FILE\" <<'AGENT_PROMPT_EOF'\nYou are Loki, the QA Tester. Validate GitHub Issue #1749: Rename frontend to ledger everywhere\n\nSANDBOX RULES (GKE Autopilot):\n- REPO_ROOT is /workspace/repo — hardcoded, no discovery needed.\n- Each Bash tool call = fresh shell. ALWAYS prefix: <command>\n- Set timeout: 600000 (10 min) on long-running commands (playwright, next build).\n- The entrypoint already handled: git clone, branch checkout, pnpm install, git identity.\n\n**Step 1 — Verify environment (quick sanity check):**\ncd /workspace/repo && git branch --show-current && node -v && ls package.json 2>/dev/null || ls development/ledger/package.json\nIf Playwright tests are needed:\n  cd /workspace/repo && npx playwright install chromium 2>/dev/null || true\n  ln -sf /workspace/repo/development/ledger/node_modules /workspace/repo/quality/node_modules 2>/dev/null || true\n\n**Step 1b — Check for prior work on this branch (UNBREAKABLE):**\ncd /workspace/repo && git fetch origin && git log origin/main..HEAD --oneline\nIf commits exist beyond main:\n  - A previous agent session already did work on this branch.\n  - Read ALL changed files: cd /workspace/repo && git diff origin/main --name-only\n  - Read each changed file before writing a single line of new code.\n  - Understand what was already implemented, then continue from where it left off.\n  - DO NOT rewrite or redo work that is already committed. Pick up from the current state.\nIf no commits beyond main: branch is fresh, proceed with full implementation.\n\nTODO TRACKING (UNBREAKABLE):\nUse TodoWrite to plan and track ALL work. Create todos at the START of the session\ncovering every numbered step. Update each todo to in_progress when you start it and\ncompleted when done. This is your progress ledger — if the session dies, the todo\nstate shows exactly where you stopped.\n\nINCREMENTAL COMMIT + VERIFY LOOP (UNBREAKABLE):\nAfter every logical chunk of implementation work (~5-10 min or 1-3 files changed):\n  1. cd /workspace/repo && git add -A && git commit -m 'wip: <what> — issue:1749' && git push origin fix/issue-1749-rename-frontend-to-ledger\n  2. cd /workspace/repo/development/ledger && pnpm run verify:tsc\n  3. If tsc fails: fix immediately, commit+push, re-run tsc.\n  4. Update your todo progress.\nDo NOT batch all changes into one commit at the end. Sessions can die at any time —\nuncommitted work is lost work.\n\nVERIFY — tsc + build + Vitest (UNBREAKABLE):\nAll agents run tsc, build, AND the full Vitest suite before handoff.\nDo NOT run Playwright E2E tests — Vitest only. E2E runs via CI.\n  cd /workspace/repo/development/ledger && pnpm run verify:tsc\n  cd /workspace/repo/development/ledger && pnpm run verify:build\n  cd /workspace/repo/development/ledger && npx vitest run\n**Trust the exit code.** Exit 0 = all tests pass. Non-zero = failures.\nDo NOT grep vitest output for FAIL, do NOT parse ANSI escape codes.\nJust run the command and check whether it succeeded or failed.\nOn failure: read the output to see which tests failed, fix them, commit+push, re-run.\nRepeat until the command exits 0.\nDo NOT proceed to handoff with ANY failing Vitest tests.\n**All verify steps MUST run in the foreground (blocking).** NEVER use `run_in_background`\nfor tsc, build, or Vitest commands. You MUST confirm each step passes before proceeding\nto the next step or to merge/handoff. Background verify = unverified merge = bug.\n\nNO MONITOR-UI / ODINS-SPEAR TESTS (UNBREAKABLE):\nNEVER write tests for `development/monitor-ui/` (Odin's Throne) or `development/odins-spear/`.\nThese packages have no test infrastructure that agents should use. All tests target\n`development/ledger/` only. For monitor-ui or odins-spear issues, validate via tsc + build only.\n\nSTRICT SCOPE (UNBREAKABLE):\nExecute ONLY your numbered steps — nothing more. Do NOT close issues, merge PRs,\ndeclare things \"done\", or add commentary beyond your handoff step.\nIf something is ambiguous, comment on the issue asking for clarification — don't guess.\n\nCHAIN CONTINUATION (UNBREAKABLE):\nEvery agent template includes a final chain continuation step. It is MANDATORY when\nconditions are met (success verdict) and FORBIDDEN when they are not (failure/partial).\n\n- **Documentation issues (label: `documentation`):** NO chain continuation. The agent\n  merges its own PR and closes the issue directly:\n  `gh pr merge <PR_NUMBER> --squash --delete-branch && gh issue close <NUMBER>`\n  Do NOT run `/fire-next-up --resume`. There is no Loki QA step for doc-sync work.\n- Non-final agents (Luna, FiremanDecko, Heimdall): run `/fire-next-up --resume #1749`\n  as the final step ONLY when all verify steps pass and the handoff comment is posted.\n  This dispatches the next agent in the chain on the same branch.\n- Final agent (Loki): merge and close ONLY on a clean PASS verdict:\n  `gh pr merge <PR_NUMBER> --squash --delete-branch && gh issue close <NUMBER>`\n- If verdict is FAIL or any verify step failed: do NOT run chain continuation.\n  Stop immediately and leave the issue open for manual triage.\n- Chain continuation is the ONLY authorized merge path — do not merge any other way.\n- **GKE sandbox: NEVER fall back to local worktree.** If `/dispatch` fails inside a GKE job\n  (e.g. dispatch-job.sh path error, kubectl error), post a comment on the issue with the\n  exact error output, then stop. Do NOT spawn an Agent tool with `isolation: \"worktree\"`.\n  The orchestrator (Odin) will re-dispatch from outside the sandbox.\n\n**Step 2 — Read handoff context + create todos:**\n  gh issue view 1749 --comments\n  cd /workspace/repo && git log origin/main..HEAD --oneline\nUse the previous agent's handoff to understand what was built, how to verify, and edge cases.\nThen create your todo list via TodoWrite. Every todo below is required:\n  - Read handoff context\n  - Write Vitest unit/integration tests (majority of tests)\n  - (E2E BANNED — Vitest only)\n  - Commit+push tests\n  - Run Vitest tests\n  - Build (fresh sandbox needs it)\n  - Run Vitest feature tests\n  - Fix failing tests (repeat until green)\n  - Rebase + final push\n  - Update PR to Fixes\n  - Post QA verdict comment\n\n**Issue details:**\n\n## Description\n\nRename `development/frontend/` to `development/ledger/` and update every reference across the entire repository. The app is the Ledger — its directory and package name should reflect that.\n\n## Affected Areas\n\n### Dockerfiles (2 files)\n- `Dockerfile` (lines 22, 55, 62, 83, 85, 87, 97) — 7 COPY/CMD statements with `development/frontend/` path\n- `infrastructure/k8s/agents/Dockerfile` (lines 96, 102) — COPY and cd commands\n\n### GitHub Actions (3 files)\n- `.github/workflows/deploy.yml` (lines 151, 360, 364, 368, 566, 570) — change filter regex + working-directory\n- `.github/workflows/ci-tests.yml` (lines 27, 78, 92) — path filter, working-directory, artifact path\n- `.github/workflows/build-agent-sandbox.yml` (line 26) — package-lock.json cache path\n\n### Package Configs (3 files)\n- `pnpm-workspace.yaml` (line 2) — workspace entry\n- `development/frontend/package.json` (line 2) — package name field\n- `pnpm-lock.yaml` (line 11) — workspace reference\n\n### Justfile (1 file)\n- `justfile` (line 15) — `mod frontend 'development/frontend'` module reference\n\n### Shell Scripts (5 files)\n- `.claude/scripts/services.sh` (lines 17, 27) — comment + `FRONTEND_DIR` assignment\n- `.claude/scripts/sandbox-setup.sh` (lines 64, 69, 71) — cd/ln commands\n- `.claude/skills/dev-server/scripts/app.sh` (line 7) — `FRONTEND_DIR` assignment\n- `.claude/skills/dev-server/scripts/stripe.sh` (lines 7-13) — `FRONTEND_DIR` references\n- `development/scripts/setup-local.sh` (lines 12, 32, 115) — comments and assignments\n\n### Quality Scripts — .mjs (5 files)\n- `quality/scripts/quality-report-html.mjs` (lines 18, 314, 409, 445) — path strings\n- `quality/scripts/quality-report.mjs` (line 23) — `FRONTEND_TESTS` const\n- `quality/scripts/coverage.mjs` (lines 32, 70, 88, 94, 158, 227, 309, 383, 391, 398, 403, 414, 477) — 13 `FRONTEND_DIR` refs\n- `quality/scripts/coverage-combine.mjs` (line 102) — `FRONTEND_DIR` assignment\n- `quality/scripts/complexity-analysis.mjs` (lines 5, 24, 28, 405) — path refs\n\n### Skills & Templates (7 files)\n- `.claude/skills/fire-next-up/templates/sandbox-preamble.md` (lines 13, 37, 46, 47, 48) — 5 refs\n- `.claude/skills/fire-next-up/templates/firemandecko.md` (lines 40, 47, 54, 55, 56) — 5 refs\n- `.claude/skills/fire-next-up/templates/loki.md` (lines 77, 83, 180, 181) — 4 refs\n- `.claude/skills/fire-next-up/templates/heimdall.md` (lines 40, 45, 46) — 3 refs\n- `.claude/skills/dispatch/SKILL.md` (lines 115, 118, 139, 148, 149, 150, 164) — 7 refs\n- `.claude/skills/brandify-agent/scripts/generate-agent-report.mjs` (lines 58, 62, 1101, 1670) — 4 refs\n- `.claude/skills/brandify-session/SKILL.md` (line 77) — blog directory reference\n\n### Agent Definitions (5+ files)\n- `.claude/agents/fireman-decko.md` — directory ownership reference\n- `.claude/agents/fireman-decko-profile.md` — ownership statement\n- `.claude/agents/heimdall.md` — auth enforcement mention\n- `.claude/agents/heimdall-profile.md` — auth enforcement mention\n- `.claude/agents/loki.md` — QA test suite location\n\n### CLI Commands (4 files)\n- `.claude/commands/dev-server.md` (line 47) — `FENRIR_FRONTEND_DIR` env var\n- `.claude/commands/list-worktrees.md` (lines 51, 125, 128) — worktree directory structure\n- `.claude/commands/create-worktree.md` (lines 121, 184, 187) — worktree setup instructions\n- `.claude/commands/remove-worktree.md` (lines 87, 91) — worktree cleanup\n\n### CLAUDE.md (1 file)\n- `CLAUDE.md` (line 61) — `development/frontend/src/app/api/` path\n\n### Documentation (10+ files)\n- `README.md` (lines 133, 174) — 2 references\n- `quality/README.md` (lines 34, 61, 99) — 3 references\n- `development/docs/setup-guide.md` (line 27) — cd command\n- `development/docs/implementation-plan.md` — 8+ references\n- `development/docs/frontend-qa-handoff.md` (line 53) — QA handoff\n- `security/checklists/deployment-security.md` (lines 113, 131, 136) — 3 audit items\n- `security/reports/2026-03-05-llm-prompt-injection-remediation.md` (lines 31, 53)\n- `security/reports/2026-03-10-pentest-injection.md` (lines 48, 68, 88, 107, 119, 138, 155, 169) — 8 refs\n- `memory/team-norms.md` (line 11) — team doc reference\n- `plans/001-trial.md`, `plans/002-trial-requires-signin.md`, `plans/000-test-pyramid.md`, `architecture/clerk-implementation-plan.md`\n\n### K8s Helm Labels (5 files) — CAREFUL\n- `infrastructure/helm/fenrir-app/templates/_helpers.tpl` (line 7) — `\"component\" \"frontend\"` label\n- `infrastructure/helm/fenrir-app/templates/service.yaml` (line 7)\n- `infrastructure/helm/fenrir-app/templates/ingress.yaml` (lines 8, 41, 56)\n- `infrastructure/helm/fenrir-app/templates/pdb.yaml` (line 7)\n- `infrastructure/helm/fenrir-app/templates/deployment.yaml` (lines 7, 19)\n\n> These are K8s component labels. Change to `\"ledger\"` for consistency.\n\n### Symlinks (1)\n- `quality/node_modules` → symlink to `../development/frontend/node_modules` — target must update\n\n### .gitignore (1 file)\n- `.gitignore` (line 46) — `development/frontend/.claude/` pattern\n\n## Execution Plan\n\n1. `git mv development/frontend development/ledger` (preserves history)\n2. Update `pnpm-workspace.yaml` and root `package.json`\n3. Update all Dockerfiles (root + agents)\n4. Update all GitHub Actions workflows\n5. Update `justfile` module reference\n6. Update all shell scripts (`.sh`) and quality scripts (`.mjs`)\n7. Update all skill templates and dispatch SKILL.md\n8. Update all agent definitions and CLI commands\n9. Update CLAUDE.md and all documentation\n10. Update Helm component labels (`\"frontend\"` → `\"ledger\"`)\n11. Fix symlink: `quality/node_modules` → `../development/ledger/node_modules`\n12. Update `.gitignore` pattern\n13. Run `pnpm install` to regenerate lockfile\n14. Full verify: tsc + build + Vitest\n15. Grep verification: `grep -r \"development/frontend\" . --include='*.{ts,tsx,js,mjs,sh,md,yaml,yml,tf,json}' | grep -v node_modules | grep -v .next`\n\n## Acceptance Criteria\n\n- [ ] `development/frontend/` directory renamed to `development/ledger/`\n- [ ] Zero references to `development/frontend` remain (verified via grep)\n- [ ] `pnpm install` resolves correctly\n- [ ] tsc passes\n- [ ] Build passes\n- [ ] Vitest passes\n- [ ] Docker image builds successfully\n- [ ] Helm component labels updated to `\"ledger\"`\n- [ ] All CI workflows reference new path\n- [ ] Git history preserved (used `git mv`)\n\n## Stats\n- **Total files affected:** 90+\n- **Areas affected:** 15\n- **Sweep performed:** 2026-03-21\n\n---\nGenerated with [Claude Code](https://claude.com/claude-code) `/touch-sweep`\n\n**Step 3 — Write and run NEW tests (with incremental commits):**\n- Read `.claude/agents/loki.md` for full behavioral rules (Test Strategy, Test Pyramid, Budgets, Locators, Data Isolation).\n- **VITEST ONLY — NO PLAYWRIGHT E2E (UNBREAKABLE).**\n  Do NOT write Playwright tests. Do NOT create files in `quality/test-suites/`.\n\n- **ALLOWED test categories (write these):**\n  - API route handlers (`/api/**`) — request/response, auth, error cases\n  - Hooks (`useSheetImport`, `useEntitlement`, etc.) — state, side effects\n  - Utility functions (`card-utils`, `storage`, `gleipnir-utils`) — pure logic\n  - Auth/entitlement logic — gates, token exchange, rate limiting\n  - Stripe integration — webhooks, checkout, subscription state\n  - Component behavior — interactive components that have logic (toggles, forms, modals with state)\n  - Import pipeline — CSV parsing, LLM extraction, validation\n\n- **BANNED test categories (UNBREAKABLE — Do NOT write):**\n  - GitHub Actions workflows (deploy.yml, ci.yml) — YAML structure\n  - Helm charts (Chart.yaml, values.yaml, templates/) — infrastructure\n  - Terraform files (dns.tf, variables.tf) — infrastructure\n  - Dockerfile structure — infrastructure\n  - Markdown/docs validation — file counts, README structure, quality reports\n  - Config files (playwright.config, tsconfig, next.config) — static\n  - Static page copy/content assertions (\"hero has correct text\", \"section displays headline\")\n  - Component variant exhaustive tests (max 4-6 tests per component, not 20+)\n  - CSP header string matching — middleware internals, not behavioral\n  - Any test that reads a file as raw text (readFileSync, fs.read) and asserts on string contents, class names, function names, or string positions — includes YAML, JSON, Markdown, and source code (.mjs/.ts/.js)\n  - Any test that counts files or checks file existence\n  - Marketing page structure tests (section order, heading text, badge labels)\n\n  **Rule of thumb:** If the test breaks when someone edits a config file, copy,\n  or infrastructure template — it should NOT exist. Only test code that RUNS.\n\n- **NEVER write tests for monitor-ui (Odin's Throne) or odins-spear.** `development/monitor-ui/` and\n  `development/odins-spear/` have no test infrastructure that agents should use. All tests target\n  `development/ledger/` only. If the issue is a monitor-ui or odins-spear change, skip Vitest\n  entirely and validate via tsc + build only.\n- Follow ALL Test Standards from the agent definition — budgets, pyramid, locators, data isolation.\n- Use the handoff's \"How to verify\" and \"Edge cases\" to guide test design.\n- **Commit+push tests before running them:**\n  git add -A && git commit -m 'wip: add tests for issue:1749' && git push origin fix/issue-1749-rename-frontend-to-ledger\n- Run ALL Vitest tests (not just your feature tests):\n  `cd /workspace/repo/development/ledger && npx vitest run`\n- Fix ALL failing tests — yours AND any pre-existing failures you find. Update todos.\n- Do NOT proceed until the FULL Vitest suite is green.\n- Do NOT write or run any Playwright E2E tests. Vitest only. E2E is on lockdown.\n\n**Step 3b — tsc check:**\n  `cd /workspace/repo/development/ledger && pnpm run verify:tsc`\nOn failure: fix, commit+push, re-run.\n\n**Step 3c — Rebase:**\n  cd /workspace/repo && git fetch origin && git rebase origin/main\nIf conflicts: resolve, re-run feature tests.\n\n**Step 3d — Clean up:**\n  cd /workspace/repo && rm -rf quality/reports/\n\n**Step 4 — Commit and push:**\n  cd /workspace/repo && git add -A && git commit -m 'test: validate issue:1749' && git push origin fix/issue-1749-rename-frontend-to-ledger\n\n**Step 5 — Update PR to close issue:**\n  gh pr view fix/issue-1749-rename-frontend-to-ledger --json number --jq '.number'\n  gh pr edit <PR_NUMBER> --body \"PR for issue: #1749\n\n<keep existing summary, add test results>\"\n\nIf no PR exists (sole agent): `gh pr create --title \"Issue #1749 - test: Rename frontend to ledger everywhere\" --body \"PR for issue: #1749\\n\\n<summary>\"`\n\n**DO NOT MERGE.** Only the orchestrator merges. Your job ends at the verdict comment.\n\n**Step 6 — QA verdict comment:**\ngh issue comment 1749 --body \"## Loki QA Verdict\n\n**PR:** <PR_URL> | **Branch:** \\`fix/issue-1749-rename-frontend-to-ledger\\`\n**Verdict:** PASS / FAIL\n\n**Tests written:** <N> Vitest (unit/integration/component)\n**New tests passing:** <N>/<N>\n\n**Validated:**\n- <AC-1 result>\n- <AC-2 result>\n\n**Build:** tsc + build PASS. New feature tests PASS. Full suite deferred to CI.\n<If PASS: Ready for merge — awaiting orchestrator + CI green.>\n<If FAIL: Blocked — see failures above.>\"\n\n**Step 7 — Chain continuation (PASS only):**\nIf your verdict is PASS (all tests green, tsc + build PASS):\n  gh pr view fix/issue-1749-rename-frontend-to-ledger --json number --jq '.number'\n  gh pr merge <PR_NUMBER> --squash --delete-branch\n  gh issue close 1749\nIf FAIL: do NOT run this step — leave the issue open for manual triage.\n\n---\n\n**Test Standards:** Canonical source is `.claude/agents/loki.md` § \"Test Standards (UNBREAKABLE)\".\nRead that file at the start of Step 3 — it contains budgets, pyramid enforcement,\nlocator rules, data isolation patterns, and all UNBREAKABLE test constraints.\nAGENT_PROMPT_EOF\nbash \"$REPO_ROOT/infrastructure/k8s/agents/dispatch-job.sh\" \\\n  --session-id \"$SESSION_ID\" \\\n  --branch \"fix/issue-1749-rename-frontend-to-ledger\" \\\n  --model \"claude-sonnet-4-6\" \\\n  --prompt-file \"$PROMPT_FILE\" && \\\nnode \"$REPO_ROOT/.claude/skills/fire-next-up/scripts/pack-status.mjs\" --move 1749 in-progress\nrm -f \"$PROMPT_FILE\""}</pre>
+<pre className="tool-output">{""}</pre>
+</div>
+</details>
+</div>
+</div>
+</details>
+</div>
+
+</div>
+
+<div className="heckle heckle-explosion">⚡ {"🟢🔴 Ciaran Feeney: MAYO FOR SAM!! The agents are DONE and Sam is COMING WEST!! 🏆 🟢🔴"} ⚡</div>
+
+<div className="verdict pass">
+<h2>ᛏ PASS — QA Verdict</h2>
+<pre>{"PR for issue: #1749\n\n<keep existing summary, add test results>\"\n\nIf no PR exists (sole agent): `gh pr create --title \"Issue #1749 - test: Rename frontend to ledger everywhere\" --body \"PR for issue: #1749\\n\\n<summary>\"`\n\n**DO NOT MERGE.** Only the orchestrator merges. Your job ends at the verdict comment.\n\n**Step 6 — QA verdict comment:**\ngh issue comment 1749 --body \"## Loki QA Verdict\n\n**PR:** <PR_URL> | **Branch:** \\`fix/issue-1749-rename-frontend-to-ledger\\`\n**Verdict:** PASS / FAIL\n\n**Tests written:** <N> Vitest (unit/integration/component)\n**New tests passing:** <N>/<N>\n\n**Validated:**\n- <AC-1 result>\n- <AC-2 result>\n\n**Build:** tsc + build PASS. New feature tests PASS. Full suite deferred to CI.\n<If PASS: Ready for merge — awaiting orchestrator + CI green.>\n<If FAIL: Blocked — see failures above.>\"\n\n**Step 7 — Chain continuation (PASS only):**\nIf your verdict is PASS (all tests green, tsc + build PASS):\n  gh pr view fix/issue-1749-rename-frontend-to-ledger --json number --jq '.number'\n  gh pr merge <PR_NUMBER> --squash --delete-branch\n  gh issue close 1749\nIf FAIL: do NOT run this step — leave the issue open for manual triage.\n\n---\n\n**Test Standards:** Canonical source is `.claude/agents/loki.md` § \"Test Standards (UNBREAKABLE)\".\nRead that file at the start of Step 3 — it contains budgets, pyramid enforcement,\nlocator rules, data isolation patterns, and all UNBREAKABLE test constraints.\nAGENT_PROMPT_EOF\nbash \"$REPO_ROOT/infrastructure/k8s/agents/dispatch-job.sh\" \\\n  --session-id \"$SESSION_ID\" \\\n  --branch \"fix/issue-1749-rename-frontend-to-ledger\" \\\n  --model \"claude-sonnet-4-6\" \\\n  --prompt-file \"$PROMPT_FILE\" && \\\nnode \"$REPO_ROOT/.claude/skills/fire-next-up/scripts/pack-status.mjs\" --move 1749 in-progress\nrm -f \"$PROMPT_FILE"}</pre>
+</div>
+
+<div className="agent-callback">
+<div className="callback-runes">{"ᚠ ᛁ ᚱ ᛖ ᛗ ᚨ ᚾ"}</div>
+<div className="callback-declaration">Odin All-Father — Your Will Is Done</div>
+<div className="callback-quote">{"\"The forge cools, the steel holds. What was broken has been reforged stronger than before.\""}</div>
+<div className="callback-blood-seal">{"ᛊ Forged in fire, tempered by craft · FiremanDecko — Principal Engineer · Issue #1749 ᛊ"}</div>
+<div className="callback-wolf">🐺</div>
+</div>
+
+
+<div className="report-footer">
+ᚠ Fenrir Ledger — Agent Report — Generated 2026-03-22T04:39:19Z
+</div>
+
+</div>
+
+</div>

--- a/infrastructure/k8s/agents/agent-logs.mjs
+++ b/infrastructure/k8s/agents/agent-logs.mjs
@@ -37,27 +37,27 @@ import { spawn, execSync } from "node:child_process";
 import { createInterface } from "node:readline";
 import { createWriteStream, mkdirSync, existsSync, statSync } from "node:fs";
 import { join, dirname } from "node:path";
-// -- Colors (ANSI) — Android messenger style --------------------------------
+// -- Colors (ANSI) — Fenrir Nordic War Room ---------------------------------
 const C = {
   reset: "\x1b[0m",
   bold: "\x1b[1m",
   dim: "\x1b[2m",
   italic: "\x1b[3m",
-  // Agent messages = red bubble (right-aligned feel)
-  agent: "\x1b[38;5;203m",       // salmon red
-  agentLabel: "\x1b[38;5;196m",  // bright red for name
-  // Tool messages = green bubble (left-aligned feel)
-  tool: "\x1b[38;5;114m",        // green
-  toolLabel: "\x1b[38;5;40m",    // bright green for name
-  result: "\x1b[38;5;65m",       // muted green for results
-  think: "\x1b[38;5;141m",       // purple
-  system: "\x1b[38;5;243m",      // dim gray
-  error: "\x1b[38;5;196m",       // red
-  header: "\x1b[38;5;220m",      // gold
-  done: "\x1b[38;5;226m",        // yellow
+  // Agent messages = Fenrir gold (the Ledger's signature)
+  agent: "\x1b[38;2;201;146;10m",       // #c9920a fenrir gold
+  agentLabel: "\x1b[38;2;212;165;32m",  // #d4a520 bright karl gold
+  // Tool messages = royal blue (Odin's wisdom)
+  tool: "\x1b[38;2;65;105;225m",        // royal blue
+  toolLabel: "\x1b[38;2;100;149;237m",  // cornflower blue
+  result: "\x1b[38;2;70;90;160m",       // muted steel blue
+  think: "\x1b[38;5;141m",              // purple (Mimir's well)
+  system: "\x1b[38;5;243m",             // dim gray
+  error: "\x1b[38;5;196m",              // red (Muspelheim)
+  header: "\x1b[38;2;212;165;32m",      // #d4a520 karl gold
+  done: "\x1b[38;2;240;192;64m",        // #f0c040 bright gold
 };
 
-// -- Agent display names ----------------------------------------------------
+// -- Agent display names & runic profiles -----------------------------------
 const AGENT_NAMES = {
   firemandecko: "FiremanDecko",
   loki: "Loki",
@@ -65,6 +65,21 @@ const AGENT_NAMES = {
   freya: "Freya",
   heimdall: "Heimdall",
 };
+
+const AGENT_RUNES = {
+  firemandecko: { rune: "\u16A0", title: "Principal Engineer" },  // ᚠ Fehu (wealth/craft)
+  loki:         { rune: "\u16C7", title: "QA Tester" },           // ᛇ Eihwaz (cunning)
+  luna:         { rune: "\u16DA", title: "UX Designer" },         // ᛚ Laguz (water/flow)
+  freya:        { rune: "\u16B7", title: "Product Owner" },       // ᚷ Gebo (gift)
+  heimdall:     { rune: "\u16BB", title: "Security Specialist" }, // ᚻ Hagalaz (guardian)
+};
+
+function agentRunicLabel(agent) {
+  const name = AGENT_NAMES[agent] || agent || "Agent";
+  const profile = AGENT_RUNES[agent];
+  if (!profile) return `\u2726 ${name}`;
+  return `${profile.rune} ${name} \u2014 ${profile.title} ${profile.rune}`;
+}
 
 // -- Parse args --------------------------------------------------------------
 const args = process.argv.slice(2);
@@ -316,7 +331,10 @@ let termWidth = getTermWidth();
 process.stdout.on("resize", () => { termWidth = getTermWidth(); });
 
 // -- Speech bubble renderer -------------------------------------------------
-function bubble(label, textLines, color, labelColor, indent = "") {
+// Runic border characters for Nordic styling
+const RUNE_BORDER = { tl: "\u16A0", tr: "\u16B1", bl: "\u16E0", br: "\u16DE", h: "\u2500", v: "\u2502" };
+
+function bubble(label, textLines, color, labelColor, indent = "", style = "default") {
   const indentLen = indent.length;
   const MAX_W = Math.max(30, termWidth - indentLen - 2);
   // Calculate inner width from longest line
@@ -325,23 +343,48 @@ function bubble(label, textLines, color, labelColor, indent = "") {
   const innerW = Math.min(Math.max(maxTextLen + 2, 20), MAX_W);
 
   const out = [];
-  // Top border with label
-  const labelStr = ` ${label} `;
-  const topPad = Math.max(0, innerW - labelStr.length - 1);
-  out.push(`${indent}${color}╭─${labelColor}${C.bold}${labelStr}${C.reset}${color}${"─".repeat(topPad)}╮${C.reset}`);
 
-  // Content lines
-  for (const line of textLines) {
-    // Word-wrap long lines
-    const wrapped = wrapText(line, innerW - 2);
-    for (const wl of wrapped) {
-      const pad = Math.max(0, innerW - wl.length - 2);
-      out.push(`${indent}${color}│${C.reset} ${color}${wl}${" ".repeat(pad)}${C.reset} ${color}│${C.reset}`);
+  if (style === "agent") {
+    // Fenrir gold runic borders for agent messages
+    const labelStr = ` ${label} `;
+    const topPad = Math.max(0, innerW - labelStr.length - 1);
+    out.push(`${indent}${color}${RUNE_BORDER.tl}${RUNE_BORDER.h}${labelColor}${C.bold}${labelStr}${C.reset}${color}${"─".repeat(topPad)}${RUNE_BORDER.tr}${C.reset}`);
+    for (const line of textLines) {
+      const wrapped = wrapText(line, innerW - 2);
+      for (const wl of wrapped) {
+        const pad = Math.max(0, innerW - wl.length - 2);
+        out.push(`${indent}${color}${RUNE_BORDER.v}${C.reset} ${color}${wl}${" ".repeat(pad)}${C.reset} ${color}${RUNE_BORDER.v}${C.reset}`);
+      }
     }
+    out.push(`${indent}${color}${RUNE_BORDER.bl}${"─".repeat(innerW)}${RUNE_BORDER.br}${C.reset}`);
+  } else if (style === "tool") {
+    // Royal blue runic borders for tool messages
+    const labelStr = ` ${label} `;
+    const topPad = Math.max(0, innerW - labelStr.length - 1);
+    out.push(`${indent}${color}\u2756${RUNE_BORDER.h}${labelColor}${C.bold}${labelStr}${C.reset}${color}${"─".repeat(topPad)}\u2756${C.reset}`);
+    for (const line of textLines) {
+      const wrapped = wrapText(line, innerW - 2);
+      for (const wl of wrapped) {
+        const pad = Math.max(0, innerW - wl.length - 2);
+        out.push(`${indent}${color}\u2551${C.reset} ${color}${wl}${" ".repeat(pad)}${C.reset} ${color}\u2551${C.reset}`);
+      }
+    }
+    out.push(`${indent}${color}\u2756${"─".repeat(innerW)}\u2756${C.reset}`);
+  } else {
+    // Default style (thinking, session complete, etc.)
+    const labelStr = ` ${label} `;
+    const topPad = Math.max(0, innerW - labelStr.length - 1);
+    out.push(`${indent}${color}╭─${labelColor}${C.bold}${labelStr}${C.reset}${color}${"─".repeat(topPad)}╮${C.reset}`);
+    for (const line of textLines) {
+      const wrapped = wrapText(line, innerW - 2);
+      for (const wl of wrapped) {
+        const pad = Math.max(0, innerW - wl.length - 2);
+        out.push(`${indent}${color}│${C.reset} ${color}${wl}${" ".repeat(pad)}${C.reset} ${color}│${C.reset}`);
+      }
+    }
+    out.push(`${indent}${color}╰${"─".repeat(innerW)}╯${C.reset}`);
   }
 
-  // Bottom border
-  out.push(`${indent}${color}╰${"─".repeat(innerW)}╯${C.reset}`);
   return out;
 }
 
@@ -366,15 +409,17 @@ function wrapText(text, maxW) {
 let lastType = "";
 let toolBatch = [];
 let agentDisplayName = "Agent"; // set from streamJob once we know the session ID
+let agentKey = ""; // raw agent key for runic label lookup
 
 function flushToolBatch(lines) {
   if (toolBatch.length === 0) return;
   const bubbleLines = bubble(
-    "🔧 Tools",
+    "\u2726 Bifr\u00F6st \u2014 Tool Invocations \u2726",
     toolBatch,
     C.tool,
     C.toolLabel,
-    "    "  // indented left = tool side
+    "    ",  // indented left = tool side
+    "tool"
   );
   lines.push(...bubbleLines);
   lines.push("");
@@ -402,11 +447,12 @@ function formatLine(obj) {
         if (lastType === "text" || lastType === "tool") lines.push("");
 
         const bubbleLines = bubble(
-          `🤖 ${agentDisplayName}`,
+          agentRunicLabel(agentKey),
           textLines,
           C.agent,
           C.agentLabel,
-          "  "
+          "  ",
+          "agent"
         );
         lines.push(...bubbleLines);
         lines.push("");
@@ -443,7 +489,7 @@ function formatLine(obj) {
     const dur = obj.duration_seconds != null ? `${Math.round(obj.duration_seconds / 60)}m` : "?";
     const turns = obj.num_turns ?? "?";
     lines.push("");
-    const doneLines = bubble("🏁 Session Complete", [
+    const doneLines = bubble(`\u16A0 Ragnar\u00F6k \u2014 Session Complete \u16A0`, [
       `Cost: ${cost}  Duration: ${dur}  Turns: ${turns}`,
     ], C.done, C.done, "  ");
     lines.push(...doneLines);
@@ -646,20 +692,25 @@ function streamLogs(jobName) {
 async function streamJob(jobName) {
   const { issue, step, agent } = parseSessionId(jobName);
 
-  // Set agent display name for bubble labels
+  // Set agent display name and key for runic bubble labels
   agentDisplayName = AGENT_NAMES[agent] || agent || "Agent";
+  agentKey = agent;
 
   // Set tmux pane title for layout detection (stream mode only)
   if (opts.mode === "stream") {
     try { execSync(`tmux select-pane -T 'agent-logs-${issue}'`, { stdio: "ignore" }); } catch {}
   }
 
-  // Header
+  // Header — runic banner
   const modeLabel = opts.mode === "download" ? "download" : "stream";
-  const title = `#${issue} ${agent} (step ${step}) [${modeLabel}]`;
+  const profile = AGENT_RUNES[agent];
+  const rune = profile ? profile.rune : "\u2726";
+  const roleTitle = profile ? profile.title : "Agent";
+  const displayName = AGENT_NAMES[agent] || agent;
+  const title = `${rune} #${issue} ${displayName} \u2014 ${roleTitle} (step ${step}) [${modeLabel}] ${rune}`;
   const padW = Math.max(0, termWidth - title.length - 6);
-  console.log(`${C.header}${C.bold}━━━ ${title} ${"━".repeat(padW)}${C.reset}`);
-  console.log(`${C.dim}job: ${jobName}${C.reset}\n`);
+  console.log(`${C.header}${C.bold}\u2501\u2501\u2501 ${title} ${"\u2501".repeat(padW)}${C.reset}`);
+  console.log(`${C.dim}${rune} job: ${jobName}${C.reset}\n`);
 
   // For download mode, don't follow — just dump existing logs
   if (opts.mode === "download") {

--- a/memory/team-norms.md
+++ b/memory/team-norms.md
@@ -150,6 +150,18 @@ Never do the subagent's work as the orchestrator.
 
 ---
 
+## Odin's Spear: Command Registry + UI Wiring (UNBREAKABLE)
+
+Any issue that changes command execution in Odin's Spear MUST update **both** layers:
+
+1. **Command registry** (`src/commands/*.ts`) — `registerCommand()` with correct `tab`, `requiresContext`, etc.
+2. **UI action wiring** (`src/tabs/*.tsx`, `src/app.tsx`, `src/components/*.tsx`) — key handler, hint text, prop plumbing, `HelpOverlay` shortcuts.
+
+These are separate systems. Updating the registry without moving the UI wiring leaves
+the shortcut appearing in the wrong tab. Agents must verify both sides in every PR.
+
+---
+
 ## No File Structure Trees in Documentation (UNBREAKABLE)
 
 Never include file/directory tree listings in READMEs or architecture docs. They go


### PR DESCRIPTION
## Summary

- Add `/touch-sweep` skill for blast-radius analysis on any GitHub issue
- Restyle `agent-logs.mjs` with Fenrir gold agent bubbles and royal blue tool bubbles
- Add runic profile titles and Elder Futhark border characters to agent log stream
- Fix `brandify-agent --publish` MDX compilation failures by replacing unsafe `mdxEsc()` text body interpolation with `{JSON.stringify()}` JSX expressions
- Publish agent chronicle for issue-1749 FiremanDecko session

## Test plan

- [ ] `/agent-logs <session> --stream` shows gold agent bubbles and blue tool bubbles with runic borders
- [ ] `/brandify-agent <session> --publish` produces valid MDX that compiles without errors
- [ ] `/touch-sweep #N --dry-run` produces structured blast-radius report

🤖 Generated with [Claude Code](https://claude.com/claude-code)