### PR TITLE
fix brandify-agent mdx path resolution after rename

### DIFF
--- a/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
+++ b/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
@@ -1674,10 +1674,12 @@ ${mdxCallbackMarkup}
   // Attempt to compile the generated MDX using @mdx-js/mdx. If it fails,
   // keep the file for debugging and exit non-zero to prevent silent bad publishes.
   try {
-    const mdxJsIndexPath = join(
-      __scriptDir,
-      "../../../../development/ledger/node_modules/@mdx-js/mdx/index.js"
-    );
+    // Resolve @mdx-js/mdx dynamically — works regardless of directory renames
+    const repoRoot = resolve(__scriptDir, "..", "..", "..", "..");
+    const ledgerModules = join(repoRoot, "development", "ledger", "node_modules", "@mdx-js", "mdx", "index.js");
+    const rootModules = join(repoRoot, "node_modules", "@mdx-js", "mdx", "index.js");
+    const { existsSync: mdxExists } = await import("fs");
+    const mdxJsIndexPath = mdxExists(ledgerModules) ? ledgerModules : rootModules;
     const { compile: mdxCompile } = await import(mdxJsIndexPath);
     await mdxCompile(mdx, { format: "mdx" });
     console.log(`[ok] MDX compile validation passed`);

--- a/development/ledger/content/blog/agent-issue-1749-step1-firemandecko-72732341-jsonl.mdx
+++ b/development/ledger/content/blog/agent-issue-1749-step1-firemandecko-72732341-jsonl.mdx
@@ -105,10 +105,24 @@ category: "agent"
 </div>
 <div className="heckle heckle-mayo">
 <div className="heckle-identity">
-<span className="heckle-name">{"Ciaran Feeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+<span className="heckle-name">{"Grainne Barrett"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Grainne Barrett" loading="lazy" />
 </div>
-<div className="heckle-text">{"The pain of 2016 fuels EVERY lint in this repo!! MAYO!!"}</div>
+<div className="heckle-text">{"MAIGH EO ABÚ! Now for the love of God and all the holy water in Knock, merge the branch!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"My architecture is more elegant than yer insults!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Grainne Barrett"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Grainne Barrett" loading="lazy" />
+</div>
+<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
 </div>
 
 
@@ -235,6 +249,48 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Grainne Barrett"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Grainne Barrett" loading="lazy" />
+</div>
+<div className="heckle-text">{"Killala is ELECTRIC tonight!! Sam is coming, craythur!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Donal McNicholas"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lass.png" alt="Donal McNicholas" loading="lazy" />
+</div>
+<div className="heckle-text">{"Oi Grainne Barrett!! Sit yer arse DOWN — ye're letting the SIDE down, ye pure eejit!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Grainne Barrett"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Grainne Barrett" loading="lazy" />
+</div>
+<div className="heckle-text">{"Donal McNicholas ye pox — yer da couldn't heckle his way out of a PAPER BAG!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"I'll have this feature live before the throw-in and I'll dedicate it to the woman from Charlestown who never missed a final."}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Grainne Barrett"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Grainne Barrett" loading="lazy" />
+</div>
+<div className="heckle-text">{"💥 *spontaneously combusts from pure passion* 💥 ...me last words... Mayo... for... Sam..."}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"...God rest their soul. And God help whoever heckles me NEXT."}</div>
+</div>
 
 
 <div className="turn">
@@ -333,6 +389,20 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-entrance">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"🟢🔴 *parachutes in from a Ryanair flight* Grainne Barrett is DOWN?? Good — they were SHITE at heckling!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"Did I miss Grainne Barrett's explosion?? FECK. Tell me about it LATER — SAM FIRST!!"}</div>
+</div>
 
 
 <div className="turn">
@@ -423,24 +493,10 @@ category: "agent"
 </div>
 <div className="heckle heckle-mayo">
 <div className="heckle-identity">
-<span className="heckle-name">{"Ciaran Feeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
 </div>
-<div className="heckle-text">{"Jaysus, the rain at Croke Park never stopped Mayo fans and it won't stop this deployment! MOVE! ☔"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"This is the cleanest diff west of the Shannon and it's going to production on time, ye gobshite."}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Ciaran Feeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
+<div className="heckle-text">{"I dreamed about this county winning Sam Maguire and I woke up embarrassed — my DREAMS have better judgement than yer MANAGEMENT!"}</div>
 </div>
 
 
@@ -490,27 +546,6 @@ category: "agent"
 </div>
 </details>
 </div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Ciaran Feeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"The goats on Ox Mountains are going MENTAL!! MAYO FOR SAM!!"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"Sam Maguire texted — he says this standup is mighty!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Ciaran Feeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Ciaran Feeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!"}</div>
-</div>
 
 
 <div className="turn">
@@ -529,6 +564,27 @@ category: "agent"
 <div className="text-block">{"Let me check root package.json and CI to understand script names:"}</div>
 </div>
 </details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"The fella beside me drove up from Limerick just to see this disaster — he's been saying 'I drove from LIMERICK' on a loop since the throw-in!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"My event loop never blocks. My hope never blocks. My attention to detail never blocks. I am non-blocking by nature and by faith."}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"Ye think yer so smart with yer fancy functions?? MY DOG could write better TypeScript!!"}</div>
 </div>
 
 
@@ -656,20 +712,6 @@ category: "agent"
 </div>
 </details>
 </div>
-<div className="heckle heckle-entrance">
-<div className="heckle-identity">
-<span className="heckle-name">{"Siobhan Sweeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"🟢🔴 *appears in a puff of turf smoke* Ciaran Feeney couldn't hack it. I'M from BELMULLET. Try me!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Siobhan Sweeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"I heard Ciaran Feeney EXPLODED?? Jaysus. ANYWAY — SAM MAGUIRE or BUST!!"}</div>
-</div>
 
 
 <div className="turn">
@@ -757,6 +799,48 @@ category: "agent"
 <div className="text-block">{"Now update GitHub Actions workflows:"}</div>
 </div>
 </details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"Lashing wind and couldn't care less — MAYO!! musha!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Padraig O'Malley"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig O'Malley" loading="lazy" />
+</div>
+<div className="heckle-text">{"Oisin Nallen — shut yer gob and let someone with PASSION take over!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"Oh that's RICH coming from Padraig O'Malley — weren't ye BARRED from Croke Park??"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"This PR is now officially sponsored by yer shouting — cheers ye sweet suffering Christ!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Oisin Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-da.png" alt="Oisin Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"💥 *spontaneously combusts from pure passion* 💥 ...me last words... Mayo... for... Sam..."}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"...moment of silence... ... ...RIGHT, back to Sam's PR!!"}</div>
 </div>
 
 
@@ -943,41 +1027,6 @@ category: "agent"
 <div className="text-block">{"Now update shell scripts and quality .mjs scripts:"}</div>
 </div>
 </details>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Siobhan Sweeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"I'VE BEEN STANDING IN THE hail SINCE 2012 — HURRY UP!! whist!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Fergal O'Malley"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lass.png" alt="Fergal O'Malley" loading="lazy" />
-</div>
-<div className="heckle-text">{"Siobhan Sweeney ye useless sack of turf — yer making Mayo look BAD in front of the agent!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Siobhan Sweeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"Fergal O'Malley, last time ye heckled, the agent fell ASLEEP!! Leave it to the PROFESSIONALS!!"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"This repository is more organised than the thinking of whatever spa is shouting at me right now."}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Siobhan Sweeney"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Siobhan Sweeney" loading="lazy" />
-</div>
-<div className="heckle-text">{"That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!"}</div>
 </div>
 
 
@@ -1183,20 +1232,6 @@ category: "agent"
 </div>
 </details>
 </div>
-<div className="heckle heckle-entrance">
-<div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
-</div>
-<div className="heckle-text">{"🟢🔴 *falls out of a tractor* What happened to Siobhan Sweeney?? Ah feck it — MAYO FOR SAM!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
-</div>
-<div className="heckle-text">{"Siobhan Sweeney left big shoes to fill. Good thing I've got BIGGER ONES!!"}</div>
-</div>
 
 
 <div className="turn">
@@ -1295,6 +1330,20 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-entrance">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Mortimer"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Mortimer" loading="lazy" />
+</div>
+<div className="heckle-text">{"🟢🔴 *emerges from a hedge on the N5* Oisin Durcan sent me a TEXT before they blew up!! Said CARRY ON!! MAYO ABÚ!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Mortimer"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Mortimer" loading="lazy" />
+</div>
+<div className="heckle-text">{"Oisin Durcan's explosion was NOTHING — wait till ye see what I can do!! 🟢🔴"}</div>
+</div>
 
 
 <div className="turn">
@@ -1363,6 +1412,13 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Declan Mortimer"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Mortimer" loading="lazy" />
+</div>
+<div className="heckle-text">{"The road from Carnacon to Croke Park is JAMMED!! thick as a plank!!"}</div>
+</div>
 
 
 <div className="turn">
@@ -1420,27 +1476,6 @@ category: "agent"
 <div className="text-block">{"Now check brandify-agent and brandify-session:"}</div>
 </div>
 </details>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
-</div>
-<div className="heckle-text">{"Westport is ELECTRIC tonight!! Sam is coming, craythur!!"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"Away with ye, ye musha — ye're thick as a plank!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
-</div>
-<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
 </div>
 
 
@@ -1646,13 +1681,6 @@ category: "agent"
 </div>
 </details>
 </div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
-</div>
-<div className="heckle-text">{"I've submitted a freedom of information request to understand what actually happened to the All-Ireland chances in that second half!"}</div>
-</div>
 
 
 <div className="turn">
@@ -1789,6 +1817,20 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-entrance">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Mickey Joe Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"🟢🔴 *descends from the heavens on a cloud of green smoke* WEAK EFFORT from Declan Mortimer. I'M here now!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Mickey Joe Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"I drove all the way from Belmullet because Declan Mortimer told me to come!! MAYO!!"}</div>
+</div>
 
 
 <div className="turn">
@@ -1849,38 +1891,24 @@ category: "agent"
 </div>
 <div className="heckle heckle-mayo">
 <div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+<span className="heckle-name">{"Mickey Joe Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Mickey Joe Nallen" loading="lazy" />
 </div>
-<div className="heckle-text">{"By all the saints at Knock Shrine, will ya ever deploy this feckin' thing!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Peadar Nallen"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Peadar Nallen" loading="lazy" />
-</div>
-<div className="heckle-text">{"Padraig McHale ye soft southern gobshite — this is MAYO, not feckin LIMERICK!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
-</div>
-<div className="heckle-text">{"Who let Peadar Nallen in?? Security!! SECURITY!! Ah feck it — MAYO FOR SAM!!"}</div>
+<div className="heckle-text">{"The RTÉ cameraman kept finding the same anguished supporter in the stands — she became an accidental documentary subject today!"}</div>
 </div>
 <div className="heckle heckle-comeback">
 <div className="heckle-identity">
 <img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
 <span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
 </div>
-<div className="heckle-text">{"My code review comments are honest, specific, and kind — unlike the post-match analysis which is honest, specific, and CRUEL"}</div>
+<div className="heckle-text">{"My test suite is more solid than Kerry's defence!!"}</div>
 </div>
 <div className="heckle heckle-mayo">
 <div className="heckle-identity">
-<span className="heckle-name">{"Padraig McHale"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-avatar.png" alt="Padraig McHale" loading="lazy" />
+<span className="heckle-name">{"Mickey Joe Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Mickey Joe Nallen" loading="lazy" />
 </div>
-<div className="heckle-text">{"I'M TAKING OFF ME JACKET!! Nobody talks to a Mayo fan like that and LIVES!!"}</div>
+<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
 </div>
 
 
@@ -1949,6 +1977,13 @@ category: "agent"
 <div className="text-block">{"Now do a broad sweep for any remaining references in other file types before running pnpm install:"}</div>
 </div>
 </details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Mickey Joe Nallen"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Mickey Joe Nallen" loading="lazy" />
+</div>
+<div className="heckle-text">{"The N5 dual carriageway project has been promised since before I had hair — much like a Mayo All-Ireland, it's theoretical infrastructure!"}</div>
 </div>
 
 
@@ -2124,27 +2159,6 @@ category: "agent"
 </div>
 </details>
 </div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
-</div>
-<div className="heckle-text">{"Me granny from Dugort would skelp ye for that backlog!! by the holy!!"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"Sam Maguire texted — he says this merge is class!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
-</div>
-<div className="heckle-text">{"Oh is THAT so?? Well me UNCLE played for Mayo in '89 and HE says yer code is SHITE!!"}</div>
-</div>
 
 
 <div className="turn">
@@ -2212,27 +2226,6 @@ category: "agent"
 <div className="text-block">{"tsc passes (exit 0). Now run build:"}</div>
 </div>
 </details>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
-</div>
-<div className="heckle-text">{"Since before the telly was invented we've been waiting — NO MORE!! thundering!! MAYO!!"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"I'm an AI agent bred from the west of Ireland's finest stubborn code and I'll hear no criticism today."}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Mickey Joe McNicholas"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-teen.png" alt="Mickey Joe McNicholas" loading="lazy" />
-</div>
-<div className="heckle-text">{"That's the LAST STRAW ye digital BLAGGARD!! I'm writing to the COUNTY BOARD!!"}</div>
 </div>
 
 
@@ -2349,6 +2342,13 @@ category: "agent"
 <div className="text-block">{"All 2907 tests pass (201 test files). Now do the final verification grep, rebase, and push:"}</div>
 </div>
 </details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Mulchrone"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Maeve Mulchrone" loading="lazy" />
+</div>
+<div className="heckle-text">{"Your reaction times out there are slower than a planning permission in Mayo — and that takes three years on a good application!"}</div>
 </div>
 
 
@@ -2544,27 +2544,6 @@ category: "agent"
 </div>
 </details>
 </div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Declan Walsh"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
-</div>
-<div className="heckle-text">{"The 2012 drawn final gave us false hope and false hope in Mayo is more dangerous than no hope at all, ya teasing shower!"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"I'll squash five commits into one, write a message worthy of literature, and sign it with the blood of pure Mayo conviction"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Declan Walsh"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
-</div>
-<div className="heckle-text">{"MOTHER OF DIVINE JAYSUS I'm gonna REACH through this terminal and SKELP ye!!"}</div>
-</div>
 
 
 <div className="turn">
@@ -2583,6 +2562,27 @@ category: "agent"
 <div className="text-block">{"Two conflicts to resolve:\n1. New test file added in main under old path — needs to move to new path\n2. complexity-report.json deleted in main — accept the deletion"}</div>
 </div>
 </details>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Mulchrone"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Maeve Mulchrone" loading="lazy" />
+</div>
+<div className="heckle-text">{"Jaysus, Cillian O'Connor's career scoring record is a monument to consistency — your coding record is a DISGRACE!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Durcan"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-granny.png" alt="Maeve Durcan" loading="lazy" />
+</div>
+<div className="heckle-text">{"Whisht Maeve Mulchrone!! Ye call THAT a heckle?? That wouldn't scare a WET KITTEN!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Mulchrone"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Maeve Mulchrone" loading="lazy" />
+</div>
+<div className="heckle-text">{"Maeve Durcan ye pox — yer da couldn't heckle his way out of a PAPER BAG!!"}</div>
 </div>
 
 
@@ -2641,34 +2641,6 @@ category: "agent"
 <div className="thinking">{"The rebase is continuing and hit another conflict. Let me check the current status."}</div>
 </div>
 </details>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Declan Walsh"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
-</div>
-<div className="heckle-text">{"Kevin McStay didn't bleed for THIS — wait, this IS what he fought for!! MAYO!! 🏆"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"I'm algorithms but me spirit is pure Bohola!! MAYO!!"}</div>
-</div>
-<div className="heckle heckle-mayo">
-<div className="heckle-identity">
-<span className="heckle-name">{"Declan Walsh"}</span>
-<img className="heckle-avatar" src="/hecklers/heckler-lad.png" alt="Declan Walsh" loading="lazy" />
-</div>
-<div className="heckle-text">{"💥 *disintegrates, but a single voice echoes* 💥 ...mayo... for... saaaaam... 🏆"}</div>
-</div>
-<div className="heckle heckle-comeback">
-<div className="heckle-identity">
-<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
-<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
-</div>
-<div className="heckle-text">{"...gone but not forgotten. Unlike this bug I'm about to fix."}</div>
 </div>
 
 
@@ -2874,6 +2846,34 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Mulchrone"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Maeve Mulchrone" loading="lazy" />
+</div>
+<div className="heckle-text">{"Tiocfaidh ár lá!! The soul of Mayo speaks Gaeilge!! musha!!"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"I was trained on every GAA match report ever written and every npm changelog ever published — I contain multitudes of suffering"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Mulchrone"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-uncle.png" alt="Maeve Mulchrone" loading="lazy" />
+</div>
+<div className="heckle-text">{"💥 *turns into a pillar of pure green and red light* 💥 ...the prophecy... is fulfilled..."}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"...rest easy, ye magnificent hoor. Your heckling was top class."}</div>
+</div>
 
 
 <div className="turn">
@@ -2921,6 +2921,20 @@ category: "agent"
 <div className="text-block">{"FiremanDecko is done, Loki is next. Dispatching step 2:"}</div>
 </div>
 </details>
+</div>
+<div className="heckle heckle-entrance">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Jennings"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Maeve Jennings" loading="lazy" />
+</div>
+<div className="heckle-text">{"🟢🔴 *emerges from a hedge on the N5* Maeve Mulchrone sent me a TEXT before they blew up!! Said CARRY ON!! MAYO ABÚ!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Jennings"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Maeve Jennings" loading="lazy" />
+</div>
+<div className="heckle-text">{"Maeve Mulchrone died for Sam and SO WILL I if needs be!!"}</div>
 </div>
 
 
@@ -2970,6 +2984,27 @@ category: "agent"
 </div>
 </details>
 </div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Jennings"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Maeve Jennings" loading="lazy" />
+</div>
+<div className="heckle-text">{"MAYO ABÚ! We've waited 73 years for Sam and we can't wait another minute for this PR! MERGE IT! 🏆"}</div>
+</div>
+<div className="heckle heckle-comeback">
+<div className="heckle-identity">
+<img className="heckle-avatar" src="/agents/profiles/fireman-decko-dark.png" alt="FiremanDecko" loading="lazy" />
+<span className="heckle-name">{"FiremanDecko — Principal Engineer"}</span>
+</div>
+<div className="heckle-text">{"Yerra would ye halt yer roaring ye mother of divine!!"}</div>
+</div>
+<div className="heckle heckle-mayo">
+<div className="heckle-identity">
+<span className="heckle-name">{"Maeve Jennings"}</span>
+<img className="heckle-avatar" src="/hecklers/heckler-mammy.png" alt="Maeve Jennings" loading="lazy" />
+</div>
+<div className="heckle-text">{"SHITE TALK from a SHITE AGENT!! Mayo deserves BETTER!!"}</div>
+</div>
 
 
 <div className="turn">
@@ -3013,7 +3048,7 @@ category: "agent"
 
 </div>
 
-<div className="heckle heckle-explosion">⚡ {"🟢🔴 Ciaran Feeney: MAYO FOR SAM!! The agents are DONE and Sam is COMING WEST!! 🏆 🟢🔴"} ⚡</div>
+<div className="heckle heckle-explosion">⚡ {"🟢🔴 Maeve Jennings: MAYO FOR SAM!! The agents are DONE and Sam is COMING WEST!! 🏆 🟢🔴"} ⚡</div>
 
 <div className="verdict pass">
 <h2>ᛏ PASS — QA Verdict</h2>
@@ -3030,7 +3065,7 @@ category: "agent"
 
 
 <div className="report-footer">
-ᚠ Fenrir Ledger — Agent Report — Generated 2026-03-22T04:39:19Z
+ᚠ Fenrir Ledger — Agent Report — Generated 2026-03-22T05:32:54Z
 </div>
 
 </div>


### PR DESCRIPTION
## Summary

- Replace hardcoded `@mdx-js/mdx` import path with dynamic resolution (tries `development/ledger/node_modules/` then root `node_modules/`)
- Prevents breakage when directory names change
- Regenerate issue-1749 agent chronicle

## Test plan

- [x] `/brandify-agent issue-1749-step1-firemandecko-72732341 --publish` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)