### PR TITLE
Issue #1763 - fix: download button for all successful sessions

### DIFF
--- a/development/odins-throne-ui/src/components/JobCard.tsx
+++ b/development/odins-throne-ui/src/components/JobCard.tsx
@@ -4,7 +4,7 @@ import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_LABELS } from "../li
 import { StatusIconSvg } from "./StatusIcon";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 import type { DisplayMode } from "./Sidebar";
-import { downloadLog } from "../lib/localStorageLogs";
+import { downloadLogFile } from "../lib/localStorageLogs";
 
 interface Props {
   job: DisplayJob;
@@ -150,7 +150,7 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
             {onTogglePin && (
               <CardPinButtonLabeled isPinned={isPinned} onTogglePin={onTogglePin} />
             )}
-            {isPinned && job.status === "succeeded" && (
+            {job.status === "succeeded" && (
               <CardDownloadButtonLabeled sessionId={job.sessionId} />
             )}
           </>
@@ -182,7 +182,7 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
             {onTogglePin && (
               <CardPinButton isPinned={isPinned} onTogglePin={onTogglePin} />
             )}
-            {isPinned && job.status === "succeeded" && (
+            {job.status === "succeeded" && (
               <CardDownloadButton sessionId={job.sessionId} />
             )}
             <CardCopySessionIdButton sessionId={job.sessionId} />
@@ -390,7 +390,7 @@ function CardDownloadButton({ sessionId }: { sessionId: string }) {
       className="card-pin-btn"
       onClick={(e) => {
         e.stopPropagation();
-        downloadLog(sessionId);
+        void downloadLogFile(sessionId);
       }}
       title="Download session log"
       aria-label="Download session log"
@@ -406,7 +406,7 @@ function CardDownloadButtonLabeled({ sessionId }: { sessionId: string }) {
       className="card-extended-action-btn"
       onClick={(e) => {
         e.stopPropagation();
-        downloadLog(sessionId);
+        void downloadLogFile(sessionId);
       }}
       title="Download session log"
       aria-label="Download session log"

--- a/development/odins-throne-ui/src/components/LogViewer.tsx
+++ b/development/odins-throne-ui/src/components/LogViewer.tsx
@@ -84,7 +84,7 @@ import { NorseVerdictInscription, isVerdictMessage } from "./NorseVerdictInscrip
 import { DecreeBlock, isDecreeBlock } from "./DecreeBlock";
 import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
 import { StatusIconSvg } from "./StatusIcon";
-import { downloadLog } from "../lib/localStorageLogs";
+import { downloadLogFile } from "../lib/localStorageLogs";
 
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 
@@ -198,7 +198,7 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
             </button>
           )
         )}
-        {isPinned && job.status === "succeeded" && (
+        {job.status === "succeeded" && (
           <DownloadSessionButton sessionId={job.sessionId} />
         )}
       </span>
@@ -1053,7 +1053,7 @@ function DownloadSessionButton({ sessionId }: { sessionId: string }) {
   return (
     <button
       className="copy-session-btn"
-      onClick={() => downloadLog(sessionId)}
+      onClick={() => void downloadLogFile(sessionId)}
       title="Download session log"
       aria-label="Download session log"
     >

--- a/development/odins-throne-ui/src/lib/localStorageLogs.ts
+++ b/development/odins-throne-ui/src/lib/localStorageLogs.ts
@@ -114,6 +114,43 @@ export function downloadLog(sessionId: string): void {
   URL.revokeObjectURL(url);
 }
 
+function triggerBlobDownload(content: string, filename: string): void {
+  const blob = new Blob([content], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * Download a session log by fetching the latest from the K8s pod via the
+ * monitor API. Falls back to localStorage (temp log or pinned cache) if the
+ * pod is no longer available.
+ */
+export async function downloadLogFile(sessionId: string): Promise<void> {
+  try {
+    const res = await fetch(`/api/logs/${encodeURIComponent(sessionId)}`);
+    if (res.ok) {
+      const content = await res.text();
+      if (content) {
+        triggerBlobDownload(content, `${sessionId}.log`);
+        return;
+      }
+    }
+  } catch {
+    // Network error — fall through to localStorage
+  }
+  // Fallback: localStorage (pinned cache or temp log)
+  const content = getLog(sessionId) ?? getCachedLog(sessionId);
+  if (content) {
+    triggerBlobDownload(content, `${sessionId}.log`);
+  }
+}
+
 // ── Pin cache API ────────────────────────────────────────────────────────────
 
 /** Returns true if this session has a cache entry (is pinned). */

--- a/development/odins-throne/src/index.ts
+++ b/development/odins-throne/src/index.ts
@@ -1,6 +1,6 @@
 import { Hono } from "hono";
 import { serve } from "@hono/node-server";
-import { listAgentJobs, deleteAgentJob } from "./k8s.js";
+import { listAgentJobs, deleteAgentJob, findPodForSession, streamPodLogs } from "./k8s.js";
 import { attachWebSocketServer } from "./ws.js";
 
 const app = new Hono();
@@ -25,6 +25,39 @@ app.get("/api/jobs", async (c) => {
     const message = err instanceof Error ? err.message : "Unknown error";
     console.warn("[k8s] Could not list jobs:", message);
     return c.json({ jobs: [], count: 0, error: message });
+  }
+});
+
+// Download full agent session log from K8s pod
+app.get("/api/logs/:sessionId", async (c) => {
+  const sessionId = c.req.param("sessionId");
+  try {
+    const podName = await findPodForSession(sessionId, NAMESPACE);
+    if (!podName) {
+      return c.json({ error: "Pod not found for session" }, 404);
+    }
+    const lines: string[] = [];
+    await new Promise<void>((resolve, reject) => {
+      streamPodLogs(
+        podName,
+        NAMESPACE,
+        (line) => lines.push(line),
+        () => resolve(),
+        (err) => reject(err),
+        { follow: false }
+      );
+    });
+    const content = lines.join("\n");
+    return new Response(content, {
+      headers: {
+        "Content-Type": "text/plain; charset=utf-8",
+        "Content-Disposition": `attachment; filename="${sessionId}.log"`,
+      },
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Unknown error";
+    console.warn(`[k8s] Could not fetch logs for session ${sessionId}:`, message);
+    return c.json({ error: message }, 500);
   }
 });
 


### PR DESCRIPTION
PR for issue: #1763

Show download button for any successful session, not just pinned ones. Implements K8s log retrieval on click.

**Changes:**
- Removed `isPinned` requirement from download button visibility in `JobCard.tsx` (2 locations) and `LogViewer.tsx` (1 location)
- Added `GET /api/logs/:sessionId` REST endpoint to the monitor backend (`development/monitor/src/index.ts`) that fetches the full pod log via `findPodForSession` + `streamPodLogs`
- Added `downloadLogFile()` async helper to `localStorageLogs.ts` that calls the K8s API first, falls back to localStorage (temp log or pinned cache) if the pod is no longer available
- Updated all three download button `onClick` handlers to use `downloadLogFile()`

**Verification:**
- Open Odin's Throne — download button appears on any `succeeded` session, not just pinned ones
- Clicking download fetches the latest log from the K8s pod and triggers file download
- If pod is reaped (purged), falls back to cached localStorage content
- Non-successful sessions (running, pending, failed) still have no download button