### PR TITLE
fix(helm): update component selectors after monitor rename

### DIFF
--- a/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment-ui.yaml
@@ -16,7 +16,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: odin-throne
-      app.kubernetes.io/component: monitor-ui
+      app.kubernetes.io/component: odins-throne-ui
   template:
     metadata:
       labels:
@@ -30,7 +30,7 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: odin-throne
-              app.kubernetes.io/component: monitor-ui
+              app.kubernetes.io/component: odins-throne-ui
       {{- if .Values.oauth2Proxy.enabled }}
       volumes:
         - name: oauth2-proxy-emails

--- a/infrastructure/helm/odin-throne/templates/deployment.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
           labelSelector:
             matchLabels:
               app.kubernetes.io/name: odin-throne
-              app.kubernetes.io/component: monitor
+              app.kubernetes.io/component: odins-throne
       volumes:
         - name: oauth2-proxy-emails
           secret:

--- a/infrastructure/helm/odin-throne/templates/pdb.yaml
+++ b/infrastructure/helm/odin-throne/templates/pdb.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: odin-throne
-      app.kubernetes.io/component: monitor
+      app.kubernetes.io/component: odins-throne
 ---
 {{- end }}
 {{- if ge (int .Values.ui.replicaCount) 2 }}
@@ -27,5 +27,5 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: odin-throne
-      app.kubernetes.io/component: monitor-ui
+      app.kubernetes.io/component: odins-throne-ui
 {{- end }}

--- a/infrastructure/helm/odin-throne/templates/service-ui.yaml
+++ b/infrastructure/helm/odin-throne/templates/service-ui.yaml
@@ -12,7 +12,7 @@ spec:
   type: ClusterIP
   selector:
     app.kubernetes.io/name: odin-throne
-    app.kubernetes.io/component: monitor-ui
+    app.kubernetes.io/component: odins-throne-ui
   ports:
     - name: http
       port: 80

--- a/infrastructure/helm/odin-throne/templates/service.yaml
+++ b/infrastructure/helm/odin-throne/templates/service.yaml
@@ -9,7 +9,7 @@ spec:
   type: {{ .Values.service.type }}
   selector:
     {{- include "odin-throne.selectorLabels" . | nindent 4 }}
-    app.kubernetes.io/component: monitor
+    app.kubernetes.io/component: odins-throne
   ports:
     - name: http
       port: {{ .Values.service.port }}


### PR DESCRIPTION
## Summary

The #1679 rename agent updated Helm template *labels* from `monitor`/`monitor-ui` to `odins-throne`/`odins-throne-ui` but missed the hardcoded *selectors* in services, deployments, and PDBs. This caused a label mismatch where:

- Pod labels: `component=odins-throne` (new)
- Service selectors: `component=monitor` (old)

Result: services couldn't route to pods, breaking WebSocket connections on monitor.fenrirledger.com.

**Files fixed:**
- `service.yaml` — selector `monitor` → `odins-throne`
- `service-ui.yaml` — selector `monitor-ui` → `odins-throne-ui`
- `deployment.yaml` — topologySpread selector
- `deployment-ui.yaml` — matchLabels + topologySpread (2 instances)
- `pdb.yaml` — both PDB selectors

## Test plan

- [ ] Helm deploy succeeds
- [ ] `kubectl get endpoints odin-throne -n fenrir-monitor` shows pod IPs
- [ ] WebSocket connects at `wss://monitor.fenrirledger.com/ws`

🤖 Generated with [Claude Code](https://claude.com/claude-code)