### PR TITLE
fix(spear): update path aliases after frontend→ledger rename

### DIFF
--- a/development/odins-spear/loader.mjs
+++ b/development/odins-spear/loader.mjs
@@ -9,9 +9,9 @@ const baseDir = new URL(".", import.meta.url);
 
 const aliases = [
   // Order matters: exact matches before prefix matches
-  { prefix: "@fenrir/logger-base", target: "../frontend/src/lib/logger.ts", exact: true },
+  { prefix: "@fenrir/logger-base", target: "../ledger/src/lib/logger.ts", exact: true },
   { prefix: "@fenrir/logger",      target: "./src/log.ts",                  exact: true },
-  { prefix: "@fenrir/",            target: "../frontend/src/" },
+  { prefix: "@fenrir/",            target: "../ledger/src/" },
 ];
 
 export function resolve(specifier, context, nextResolve) {

--- a/development/odins-spear/tsconfig.json
+++ b/development/odins-spear/tsconfig.json
@@ -21,8 +21,8 @@
     "allowUnusedLabels": false,
     "paths": {
       "@fenrir/logger":      ["./src/log.ts"],
-      "@fenrir/logger-base": ["../frontend/src/lib/logger.ts"],
-      "@fenrir/*":           ["../frontend/src/*"]
+      "@fenrir/logger-base": ["../ledger/src/lib/logger.ts"],
+      "@fenrir/*":           ["../ledger/src/*"]
     },
     "outDir": "dist"
   },


### PR DESCRIPTION
## Summary

- Odin's Spear `tsconfig.json` and `loader.mjs` still referenced `../frontend/src` — the old path before #1749 renamed it to `../ledger/src`
- Fixes `ENOENT: no such file or directory` crash on `just spear run`

## Test plan

- [ ] `just spear run` starts without ENOENT

🤖 Generated with [Claude Code](https://claude.com/claude-code)