### PR TITLE
feat(spear): make Households the default tab — issue #1781

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -14,7 +14,7 @@ import type { PaletteCommand, CommandContext } from "./commands/registry.js";
 import { getCommands } from "./commands/registry.js";
 import type { ConnStatus, Counts } from "./components/StatusBar.js";
 
-const TUI_TABS = ["Users", "Households"] as const;
+const TUI_TABS = ["Households", "Users"] as const;
 
 // ─── Inner component (needs SelectionProvider in tree) ───────────────────────
 
@@ -192,13 +192,6 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     );
   } else if (activeTab === 0) {
     mainContent = (
-      <UsersTab
-        cmdStatus={cmdStatus}
-        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(1); }}
-      />
-    );
-  } else {
-    mainContent = (
       <HouseholdsTab
         cmdStatus={cmdStatus}
         initialHouseholdId={jumpHouseholdId}
@@ -209,6 +202,13 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
           const cmd = getCommands().find((c) => c.name === "trial-adjust");
           if (cmd) handleTrialInput(cmd);
         }}
+      />
+    );
+  } else {
+    mainContent = (
+      <UsersTab
+        cmdStatus={cmdStatus}
+        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(0); }}
       />
     );
   }

--- a/development/odins-spear/src/components/HelpOverlay.tsx
+++ b/development/odins-spear/src/components/HelpOverlay.tsx
@@ -92,7 +92,7 @@ export function HelpOverlay({ activeTab, onClose }: HelpOverlayProps): React.JSX
     onClose();
   });
 
-  const tabLabel = activeTab === 0 ? "Users" : "Households";
+  const tabLabel = activeTab === 0 ? "Households" : "Users";
   const sections = getSectionsForTab(activeTab);
 
   return (

--- a/development/odins-spear/src/components/StatusBar.tsx
+++ b/development/odins-spear/src/components/StatusBar.tsx
@@ -44,8 +44,8 @@ export function StatusBar({ connStatus, counts, activeTab }: StatusBarProps): Re
   log.debug("StatusBar render", { activeTab });
   const countLabel =
     activeTab === 0
-      ? `${counts.users} user${counts.users !== 1 ? "s" : ""}`
-      : `${counts.households} household${counts.households !== 1 ? "s" : ""}`;
+      ? `${counts.households} household${counts.households !== 1 ? "s" : ""}`
+      : `${counts.users} user${counts.users !== 1 ? "s" : ""}`;
 
   return (
     <Box

--- a/development/odins-spear/src/index.ts
+++ b/development/odins-spear/src/index.ts
@@ -5,7 +5,7 @@
  * Design reference: development/odins-spear/odins-spear.html
  *
  * Layout:
- *   TopBar  │ ODIN'S SPEAR ⚡  [Users]  [Households]  │  [/] Command  [^R] Reload  [?] Help
+ *   TopBar  │ ODIN'S SPEAR ⚡  [Households]  [Users]  │  [/] Command  [^R] Reload  [?] Help
  *   Main    │ Left list (34 cols) │ Right detail (flex-grow)
  *   StatusBar│ ● Firestore  ● Stripe    │  <count>
  *


### PR DESCRIPTION
## Summary
- Swaps `TUI_TABS` from `["Users", "Households"]` to `["Households", "Users"]` so index 0 = Households
- Updates `app.tsx` tab render logic: index 0 now renders `HouseholdsTab`, else `UsersTab`
- Fixes `onJumpToHousehold` callback: `setActiveTab(0)` (was `1`) since Households is now index 0
- Fixes `StatusBar` count label: index 0 now shows households count
- Fixes `HelpOverlay` tab label: index 0 now reports "Households"
- Updates layout comment in `index.ts`

## Test plan
- [x] `tsc --noEmit` in `development/odins-spear` — clean
- [x] `pnpm run verify:tsc` in `development/ledger` — clean
- [x] `pnpm run verify:build` in `development/ledger` — clean
- [ ] Manual: launch Odin's Spear, confirm Households tab is shown on startup
- [ ] Manual: press `[Tab]` to cycle to Users tab — still accessible
- [ ] Manual: jump-to-household from Users tab lands on correct Households tab

Closes #1781

🤖 Generated with [Claude Code](https://claude.com/claude-code)