### PR TITLE
fix(odins-throne): build:api must emit dist/ for static serving

### DIFF
--- a/development/odins-throne/Dockerfile
+++ b/development/odins-throne/Dockerfile
@@ -36,9 +36,8 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/dist-ui ./dist-ui
 COPY --from=builder /app/public ./public
+COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/package.json ./
-COPY --from=builder /app/src ./src
-COPY --from=builder /app/tsconfig.json ./
 
 # Non-root user for security
 RUN addgroup -S appgroup && adduser -S appuser -G appgroup
@@ -49,4 +48,4 @@ EXPOSE 3001
 HEALTHCHECK --interval=15s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:3001/healthz || exit 1
 
-CMD ["node", "--import", "tsx/esm", "src/index.ts"]
+CMD ["node", "dist/index.js"]

--- a/development/odins-throne/package.json
+++ b/development/odins-throne/package.json
@@ -10,7 +10,7 @@
     "dev:ui": "vite",
     "build": "pnpm run build:ui && pnpm run build:api",
     "build:ui": "tsc -b tsconfig.ui.json && vite build",
-    "build:api": "tsc --noEmit",
+    "build:api": "tsc",
     "start": "node dist/index.js",
     "compile": "tsc",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- `build:api` was `tsc --noEmit` so `dist/index.js` never included `serveStatic` middleware
- Root `/` returned 404 because the SPA catch-all was missing from compiled output
- Dockerfile copied `src/` and used `tsx` which gets pruned as dev dep, falling back to stale `dist/`

## Changes
- `build:api`: `tsc --noEmit` → `tsc` (actually emits to `dist/`)
- Dockerfile: copy `dist/` not `src/`, run `node dist/index.js` directly

## Test plan
- [x] `pnpm run build` produces `dist/index.js` with `serveStatic` lines
- [ ] Deploy new image → `https://odins-throne.fenrirledger.com/` serves SPA

🤖 Generated with [Claude Code](https://claude.com/claude-code)