### PR TITLE
fix(ci): pass TF_VAR_stripe_api_key to terraform workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -97,6 +97,7 @@ jobs:
           TF_VAR_zone: ${{ secrets.GCP_ZONE }}
           TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
           TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
+          TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}
 
       - name: Terraform Apply
         run: terraform apply -input=false -auto-approve tfplan

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -68,6 +68,7 @@ jobs:
           TF_VAR_zone: ${{ secrets.GCP_ZONE }}
           TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
           TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
+          TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}
 
       - name: Post plan to PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## Summary
- Add `TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}` to both `deploy.yml` and `terraform-plan.yml`
- Fixes terraform plan failure: "No value for required variable stripe_api_key"
- The variable was added by the #1778 agent but the CI env var was not wired up

## Test plan
- [ ] Terraform plan succeeds in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)