### PR TITLE
fix(settings): hide Manage Subscription for household members — #1795

### DIFF
--- a/development/ledger/src/__tests__/components/stripe-settings-1795-member-hide.test.tsx
+++ b/development/ledger/src/__tests__/components/stripe-settings-1795-member-hide.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * StripeSettings — issue #1795: hide Manage Subscription for household members
+ *
+ * Verifies that:
+ *   - Household members (isOwner=false) do NOT see "Manage Subscription" button
+ *   - Household members see "Contact your household owner..." message instead
+ *   - Owners (isOwner=true) still see "Manage Subscription"
+ *   - Solo/loading state (isOwner=null) still sees "Manage Subscription" (safe default)
+ *
+ * Covers karl-active and canceled subscription states.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { StripeSettings } from "@/components/entitlement/StripeSettings";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockSubscribeStripe = vi.fn().mockResolvedValue(undefined);
+const mockOpenPortal = vi.fn().mockResolvedValue(undefined);
+
+const KARL_ACTIVE_ENTITLEMENT = {
+  tier: "karl" as string,
+  isActive: true,
+  isLinked: true,
+  isLoading: false,
+  platform: "stripe" as string | null,
+  cancelAtPeriodEnd: false,
+  currentPeriodEnd: "2026-05-01T00:00:00Z",
+  subscribeStripe: mockSubscribeStripe,
+  openPortal: mockOpenPortal,
+  hasFeature: vi.fn().mockReturnValue(true),
+  refresh: vi.fn(),
+};
+
+const CANCELED_ENTITLEMENT = {
+  ...KARL_ACTIVE_ENTITLEMENT,
+  isActive: false,
+  cancelAtPeriodEnd: false,
+};
+
+let mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+let mockIsOwner: boolean | null = null;
+let mockToken: string | null = "tok_test";
+
+vi.mock("@/hooks/useEntitlement", () => ({
+  useEntitlement: () => mockEntitlement,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock("@/lib/auth/refresh-session", () => ({
+  ensureFreshToken: () => Promise.resolve(mockToken),
+}));
+
+// Stub fetch so useHouseholdRole resolves with the current mockIsOwner
+const originalFetch = global.fetch;
+beforeEach(() => {
+  mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+  mockIsOwner = null;
+  mockToken = "tok_test";
+  vi.clearAllMocks();
+
+  global.fetch = vi.fn((url: RequestInfo | URL) => {
+    if (String(url).includes("/api/household/members")) {
+      if (mockToken === null) {
+        return Promise.resolve(new Response(null, { status: 401 }));
+      }
+      return Promise.resolve(
+        new Response(JSON.stringify({ isOwner: mockIsOwner }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+    }
+    return originalFetch(url as RequestInfo);
+  }) as typeof global.fetch;
+});
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderStripeSettings() {
+  return render(<StripeSettings />);
+}
+
+// ── Karl-active state ─────────────────────────────────────────────────────────
+
+describe("StripeSettings — karl-active — household member (isOwner=false)", () => {
+  it("hides Manage Subscription button for members", async () => {
+    mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+    mockIsOwner = false;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /manage subscription/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows contact owner message for members", async () => {
+    mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+    mockIsOwner = false;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/contact your household owner to manage the subscription/i)
+      ).toBeInTheDocument();
+    });
+  });
+});
+
+describe("StripeSettings — karl-active — owner (isOwner=true)", () => {
+  it("shows Manage Subscription button for owners", async () => {
+    mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+    mockIsOwner = true;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /manage subscription/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("does not show contact owner message for owners", async () => {
+    mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+    mockIsOwner = true;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(/contact your household owner/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("StripeSettings — karl-active — isOwner null (loading/solo)", () => {
+  it("shows Manage Subscription button when isOwner is null (safe default)", async () => {
+    mockEntitlement = { ...KARL_ACTIVE_ENTITLEMENT };
+    mockIsOwner = null;
+    renderStripeSettings();
+    // isOwner=null means the fetch hasn't resolved or user is solo
+    // The component renders with null initially — button should be visible
+    // (null is not false, so isMember=false)
+    expect(
+      screen.getByRole("button", { name: /manage subscription/i })
+    ).toBeInTheDocument();
+  });
+});
+
+// ── Canceled state ────────────────────────────────────────────────────────────
+
+describe("StripeSettings — canceled — household member (isOwner=false)", () => {
+  it("hides Manage Subscription button for members", async () => {
+    mockEntitlement = { ...CANCELED_ENTITLEMENT };
+    mockIsOwner = false;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /manage subscription/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows contact owner message for members", async () => {
+    mockEntitlement = { ...CANCELED_ENTITLEMENT };
+    mockIsOwner = false;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.getByText(/contact your household owner to manage the subscription/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("hides Resubscribe button for members in canceled state", async () => {
+    mockEntitlement = { ...CANCELED_ENTITLEMENT };
+    mockIsOwner = false;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.queryByRole("button", { name: /resubscribe/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe("StripeSettings — canceled — owner (isOwner=true)", () => {
+  it("shows both Resubscribe and Manage Subscription for owners", async () => {
+    mockEntitlement = { ...CANCELED_ENTITLEMENT };
+    mockIsOwner = true;
+    renderStripeSettings();
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /resubscribe/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /manage subscription/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/development/ledger/src/components/entitlement/StripeSettings.tsx
+++ b/development/ledger/src/components/entitlement/StripeSettings.tsx
@@ -20,10 +20,11 @@
  * @module entitlement/StripeSettings
  */
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { useEntitlement } from "@/hooks/useEntitlement";
+import { ensureFreshToken } from "@/lib/auth/refresh-session";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -72,6 +73,43 @@ function deriveSubscriptionState(
   const isCanceled = isStripeLinked && tier === "karl" && !isActive;
   if (isCanceled) return "canceled";
   return "thrall";
+}
+
+// ---------------------------------------------------------------------------
+// Household role hook
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetches the current user's household role.
+ * Returns null while loading or when unauthenticated.
+ * Used to gate the "Manage Subscription" button for non-owner members.
+ *
+ * Issue #1795
+ */
+function useHouseholdRole(): { isOwner: boolean | null } {
+  const [isOwner, setIsOwner] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetch_() {
+      const token = await ensureFreshToken();
+      if (!token || cancelled) return;
+      try {
+        const res = await fetch("/api/household/members", {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok || cancelled) return;
+        const json = (await res.json()) as { isOwner: boolean };
+        if (!cancelled) setIsOwner(json.isOwner);
+      } catch {
+        // Network error — leave isOwner as null (safe default: show button)
+      }
+    }
+    fetch_();
+    return () => { cancelled = true; };
+  }, []);
+
+  return { isOwner };
 }
 
 // ---------------------------------------------------------------------------
@@ -249,6 +287,8 @@ interface ManageActionProps {
   isAnyLoading: boolean;
   isManaging: boolean;
   handleManage: () => Promise<void>;
+  /** null while loading or unauthenticated; false for household members */
+  isOwner: boolean | null;
 }
 
 /**
@@ -309,7 +349,9 @@ function KarlActivePanel({
   isAnyLoading,
   isManaging,
   handleManage,
+  isOwner,
 }: { formattedPeriodEnd: string | null } & ManageActionProps) {
+  const isMember = isOwner === false;
   return (
     <>
       <p
@@ -328,17 +370,23 @@ function KarlActivePanel({
 
       <div className="border-t border-border" />
 
-      <div className="flex flex-row flex-wrap gap-3">
-        <Button
-          onClick={handleManage}
-          disabled={isAnyLoading}
-          isLoading={isManaging}
-          loadingText="Redirecting..."
-          className="min-h-[44px] w-full sm:w-auto font-heading font-bold bg-gold text-primary-foreground border-2 border-gold karl-bling-btn"
-        >
-          Manage Subscription
-        </Button>
-      </div>
+      {isMember ? (
+        <p className="text-sm text-muted-foreground font-body">
+          Contact your household owner to manage the subscription.
+        </p>
+      ) : (
+        <div className="flex flex-row flex-wrap gap-3">
+          <Button
+            onClick={handleManage}
+            disabled={isAnyLoading}
+            isLoading={isManaging}
+            loadingText="Redirecting..."
+            className="min-h-[44px] w-full sm:w-auto font-heading font-bold bg-gold text-primary-foreground border-2 border-gold karl-bling-btn"
+          >
+            Manage Subscription
+          </Button>
+        </div>
+      )}
     </>
   );
 }
@@ -411,8 +459,10 @@ function CanceledPanel({
   isManaging,
   handleSubscribe,
   handleManage,
+  isOwner,
 }: { formattedPeriodEnd: string | null } & SubscribeActionProps &
   ManageActionProps) {
+  const isMember = isOwner === false;
   return (
     <>
       <p
@@ -437,27 +487,33 @@ function CanceledPanel({
 
       <div className="border-t border-border" />
 
-      <div className="flex flex-row flex-wrap gap-3">
-        <Button
-          onClick={handleSubscribe}
-          disabled={isAnyLoading}
-          isLoading={isSubscribing}
-          loadingText="Redirecting..."
-          className="min-h-[44px] w-full sm:w-auto font-heading font-bold bg-gold text-primary-foreground border-2 border-gold karl-bling-btn"
-        >
-          Resubscribe
-        </Button>
-        <Button
-          variant="outline"
-          onClick={handleManage}
-          disabled={isAnyLoading}
-          isLoading={isManaging}
-          loadingText="Redirecting..."
-          className="min-h-[44px] w-full sm:w-auto font-heading text-[13px]"
-        >
-          Manage Subscription
-        </Button>
-      </div>
+      {isMember ? (
+        <p className="text-sm text-muted-foreground font-body">
+          Contact your household owner to manage the subscription.
+        </p>
+      ) : (
+        <div className="flex flex-row flex-wrap gap-3">
+          <Button
+            onClick={handleSubscribe}
+            disabled={isAnyLoading}
+            isLoading={isSubscribing}
+            loadingText="Redirecting..."
+            className="min-h-[44px] w-full sm:w-auto font-heading font-bold bg-gold text-primary-foreground border-2 border-gold karl-bling-btn"
+          >
+            Resubscribe
+          </Button>
+          <Button
+            variant="outline"
+            onClick={handleManage}
+            disabled={isAnyLoading}
+            isLoading={isManaging}
+            loadingText="Redirecting..."
+            className="min-h-[44px] w-full sm:w-auto font-heading text-[13px]"
+          >
+            Manage Subscription
+          </Button>
+        </div>
+      )}
     </>
   );
 }
@@ -484,6 +540,8 @@ export function StripeSettings() {
     handleSubscribe,
     handleManage,
   } = useStripeSettings();
+
+  const { isOwner } = useHouseholdRole();
 
   if (isLoading && !isLinked) {
     return <StripeSettingsSkeleton />;
@@ -523,6 +581,7 @@ export function StripeSettings() {
             isAnyLoading={isAnyLoading}
             isManaging={isManaging}
             handleManage={handleManage}
+            isOwner={isOwner}
           />
         )}
 
@@ -542,6 +601,7 @@ export function StripeSettings() {
             isManaging={isManaging}
             handleSubscribe={handleSubscribe}
             handleManage={handleManage}
+            isOwner={isOwner}
           />
         )}
       </section>


### PR DESCRIPTION
Fixes #1795

## Summary
- Added \`useHouseholdRole\` hook in \`StripeSettings.tsx\` that fetches \`/api/household/members\` to determine if the current user is a household owner
- \`isMember = isOwner === false\` — only exact \`false\` hides the button (null = loading/solo = safe default, shows button)
- \`KarlActivePanel\`: members see "Contact your household owner to manage the subscription." instead of Manage Subscription button
- \`CanceledPanel\`: same treatment — members see the message, owners see Resubscribe + Manage Subscription

## Tests
9 Vitest component tests in \`stripe-settings-1795-member-hide.test.tsx\`:
- Member (isOwner=false): hides button, shows contact owner message (karl-active + canceled states)
- Owner (isOwner=true): shows Manage Subscription button, no contact message
- Solo/loading (isOwner=null): shows Manage Subscription (safe default)
- Canceled + member: hides both Resubscribe and Manage Subscription buttons
- Canceled + owner: shows both Resubscribe and Manage Subscription

Full Vitest suite: 2991 tests passing. tsc: clean. Build: clean.