### PR TITLE
fix: f5bot workflow Reddit-compliant User-Agent

### DIFF
--- a/infrastructure/n8n/workflows/gmail-f5bot-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-f5bot-monitor.json
@@ -141,7 +141,7 @@
           "parameters": [
             {
               "name": "User-Agent",
-              "value": "fenrir-ledger-n8n/1.0"
+              "value": "fenrir-ledger:f5bot-monitor:v1.0 (by /u/Wide-Pass369)"
             }
           ]
         },


### PR DESCRIPTION
## Summary

Reddit API returns 403 for generic User-Agent headers. Updated to Reddit-compliant format: `fenrir-ledger:f5bot-monitor:v1.0 (by /u/Wide-Pass369)`

## Test plan

- [x] Re-imported to n8n
- [ ] Execute workflow — HTTP node should return 200 instead of 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)