### PR TITLE
fix: WSS tooltip overflow in Odin's Throne sidebar (#1675)

### DIFF
--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -225,8 +225,9 @@ body {
 .wss-tooltip {
   position: absolute;
   top: calc(100% + 6px);
-  left: 50%;
-  transform: translateX(-50%);
+  right: 0;
+  left: auto;
+  transform: none;
   z-index: 200;
   padding: 0.3rem 0.5rem;
   font-size: 0.7rem;
@@ -251,8 +252,9 @@ body {
   content: "";
   position: absolute;
   top: -5px;
-  left: 50%;
-  transform: translateX(-50%);
+  right: 17px;
+  left: auto;
+  transform: none;
   border-left: 5px solid transparent;
   border-right: 5px solid transparent;
   border-bottom: 5px solid var(--rune-border, #334155);


### PR DESCRIPTION
Fixes #1675

## Summary
- Fixed `.wss-tooltip` CSS positioning: changed from `left: 50%; transform: translateX(-50%)` to `right: 0; left: auto; transform: none` — tooltip now anchors to the icon's right edge and expands leftward, staying fully within the sidebar
- Updated `.wss-tooltip::before` caret arrow from `left: 50%` to `right: 17px` to correctly point at the 16px WSS icon within its 44px touch target

## Test plan
- [x] odins-throne tsc PASS
- [x] odins-throne build PASS
- [x] ledger tsc PASS
- [x] ledger build PASS
- [x] CSS-only change — Vitest skipped per rules (odins-throne has no test infra)

Generated with Claude Code