### PR TITLE
feat: warm beige light mode background for Odin's Throne (#1826)

### DIFF
--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -69,9 +69,9 @@
 /* Derived from globals.css light palette (Lightning Norse / Stone Marble).
  * Applied when <html data-theme="light"> is set by useTheme hook. */
 [data-theme="light"] {
-  --void:              #f7fafc;   /* body bg     — globals.css --background: 210 40% 98% */
-  --forge:             #ffffff;   /* sidebar bg  — globals.css --card: 0 0% 100% */
-  --chain:             #f1f7fa;   /* card hover  — globals.css --input: 210 40% 96% */
+  --void:              #f5f0e8;   /* body bg     — warm beige/cream (hsl 40 30% 95.5%) */
+  --forge:             #faf7f1;   /* sidebar bg  — slightly lighter warm panel surface */
+  --chain:             #ede8dc;   /* card hover  — warm hover/active surface */
   --gold:              #8f6e0e;   /* accent gold — globals.css --primary: 38 80% 28% */
   --gold-bright:       #d97706;   /* bright gold — globals.css --realm-hati: 38 92% 42% */
   --text-saga:         #0f1419;   /* primary txt — globals.css --foreground: 220 40% 8% */


### PR DESCRIPTION
## Summary

- Shifts Odin's Throne light mode background from stark white (`#f7fafc`) to warm beige (`#f5f0e8`) matching the Ledger's Norse aesthetic
- Panel/sidebar surfaces use `#faf7f1` (slightly lighter warm variant) for visual contrast
- Card hover state uses `#ede8dc` (warm, slightly darker) for interaction feedback
- Dark mode is untouched

## Changes

| Variable | Before | After |
|---|---|---|
| `--void` (body bg) | `#f7fafc` (cool ice-white) | `#f5f0e8` (warm beige, hsl 40 30% 95.5%) |
| `--forge` (sidebar/panel bg) | `#ffffff` (pure white) | `#faf7f1` (warm panel surface) |
| `--chain` (card hover) | `#f1f7fa` (cool tint) | `#ede8dc` (warm hover) |

## Verification

- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — ✓ built in 1.99s
- [x] WCAG AA contrast maintained (text `#0f1419` on `#f5f0e8` ≫ 7:1)
- [x] Dark mode unchanged
- [x] All views affected (sidebar uses `--forge`, body uses `--void`, cards use `--chain`)

Closes #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)