### PR TITLE
fix: make chain continuation unmissable in agent templates

### DIFF
--- a/.claude/skills/fire-next-up/templates/firemandecko.md
+++ b/.claude/skills/fire-next-up/templates/firemandecko.md
@@ -25,6 +25,7 @@ Then create your todo list via TodoWrite. Every todo below is required:
   - Rebase + final push
   - Create/update PR
   - Post handoff comment
+  - CHAIN CONTINUATION: run /fire-next-up --resume #<NUMBER>
 
 **Issue details:**
 
@@ -90,10 +91,16 @@ gh issue comment <NUMBER> --body "## FiremanDecko → Loki Handoff
 - <Tricky scenarios>
 
 **Build:** tsc + build PASS. Ready for QA."
-**Step 8 — Chain continuation (DONE only):**
-If tsc + build both PASS and handoff comment is posted:
+
+**Step 8 — CHAIN CONTINUATION (MANDATORY — DO NOT SKIP):**
+⚠️ THIS STEP IS NOT OPTIONAL. Your session is NOT complete until this runs.
+⚠️ If you stop after Step 7 without running Step 8, Loki never gets dispatched and the issue stalls.
+
+If tsc + build both PASS and handoff comment is posted, you MUST run this command:
+
   /fire-next-up --resume #<NUMBER>
-This dispatches Loki (QA) on the same branch to validate the implementation.
+
+This dispatches Loki (QA) on the same branch. Without it, the chain is broken.
 If ANY verify step FAILED: do NOT run this step — stop and leave the issue for manual triage.
 
 {{DECREE_TEMPLATE}}

--- a/.claude/skills/fire-next-up/templates/loki.md
+++ b/.claude/skills/fire-next-up/templates/loki.md
@@ -101,8 +101,6 @@ If conflicts: resolve, re-run feature tests.
 
 If no PR exists (sole agent): `gh pr create --title "Issue #<NUMBER> - test: <title>" --body "PR for issue: #<NUMBER>\n\n<summary>"`
 
-**DO NOT MERGE.** Only the orchestrator merges. Your job ends at the verdict comment.
-
 **Step 6 — QA verdict comment:**
 gh issue comment <NUMBER> --body "## Loki QA Verdict
 
@@ -117,14 +115,18 @@ gh issue comment <NUMBER> --body "## Loki QA Verdict
 - <AC-2 result>
 
 **Build:** tsc + build PASS. New feature tests PASS. Full suite deferred to CI.
-<If PASS: Ready for merge — awaiting orchestrator + CI green.>
+<If PASS: Ready for merge.>
 <If FAIL: Blocked — see failures above.>"
 
-**Step 7 — Chain continuation (PASS only):**
-If your verdict is PASS (all tests green, tsc + build PASS):
+**Step 7 — CHAIN CONTINUATION (MANDATORY — DO NOT SKIP):**
+⚠️ THIS STEP IS NOT OPTIONAL. Your session is NOT complete until this runs.
+⚠️ If you stop after Step 6 without running Step 7, the PR never merges and the issue stalls.
+
+If your verdict is PASS (all tests green, tsc + build PASS), you MUST run these commands:
   gh pr view <BRANCH> --json number --jq '.number'
   gh pr merge <PR_NUMBER> --squash --delete-branch
   gh issue close <NUMBER>
+
 If FAIL: do NOT run this step — leave the issue open for manual triage.
 
 ---

--- a/.claude/skills/fire-next-up/templates/sandbox-preamble.md
+++ b/.claude/skills/fire-next-up/templates/sandbox-preamble.md
@@ -57,16 +57,20 @@ Execute ONLY your numbered steps — nothing more. Do NOT close issues, merge PR
 declare things "done", or add commentary beyond your handoff step.
 If something is ambiguous, comment on the issue asking for clarification — don't guess.
 
-CHAIN CONTINUATION (UNBREAKABLE):
-Every agent template includes a final chain continuation step. It is MANDATORY when
-conditions are met (success verdict) and FORBIDDEN when they are not (failure/partial).
+CHAIN CONTINUATION (UNBREAKABLE — YOUR SESSION IS NOT DONE WITHOUT THIS):
+⚠️ The LAST thing you do before your session ends MUST be chain continuation.
+⚠️ If you skip this, the next agent never fires and the issue stalls indefinitely.
+⚠️ Posting the handoff comment is NOT the end — chain continuation IS the end.
 
 - Non-final agents (Luna, FiremanDecko, Heimdall): run `/fire-next-up --resume #<NUMBER>`
-  as the final step ONLY when all verify steps pass and the handoff comment is posted.
+  as the ABSOLUTE LAST step when all verify steps pass and the handoff comment is posted.
   This dispatches the next agent in the chain on the same branch.
 - Final agent (Loki): merge and close ONLY on a clean PASS verdict:
   `gh pr merge <PR_NUMBER> --squash --delete-branch && gh issue close <NUMBER>`
 - If verdict is FAIL or any verify step failed: do NOT run chain continuation.
   Stop immediately and leave the issue open for manual triage.
 - Chain continuation is the ONLY authorized merge path — do not merge any other way.
+
+YOUR TODO LIST MUST INCLUDE CHAIN CONTINUATION AS THE FINAL TODO.
+Mark it in_progress when you start it, completed when done.
 ```


### PR DESCRIPTION
Agents were ending sessions after posting handoff comments without firing chain continuation. Added explicit warnings, todo items, and stronger language to all 3 templates.