### PR TITLE
fix: throne profile icons respect light/dark theme — #1841

### DIFF
--- a/development/odins-throne/ui/components/DecreeBlock.tsx
+++ b/development/odins-throne/ui/components/DecreeBlock.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
-import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES } from "../lib/constants";
+import { AGENT_AVATARS, AGENT_LIGHT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES } from "../lib/constants";
+import { useTheme } from "../hooks/useTheme";
 
 // ── Decree detection ──────────────────────────────────────────────────────────
 
@@ -251,13 +252,15 @@ interface DecreeBlockProps {
 }
 
 export function DecreeBlock({ text, agentKey: jobAgentKey, onAvatarClick }: DecreeBlockProps) {
+  const { theme } = useTheme();
   const decree = parseDecree(text);
   const agentKey  = decree.agentKey || jobAgentKey || "";
   const agentName = AGENT_NAMES[agentKey] ?? decree.agentKey ?? "Agent";
   const agentTitle = AGENT_TITLES[agentKey] ?? "";
   const agentRunes = AGENT_RUNE_NAMES[agentKey] ?? "";
   const agentColor = AGENT_COLORS[agentKey] ?? "#c9920a";
-  const avatar     = AGENT_AVATARS[agentKey];
+  const avatarMap  = theme === "light" ? AGENT_LIGHT_AVATARS : AGENT_AVATARS;
+  const avatar     = avatarMap[agentKey];
 
   const [summaryOpen, setSummaryOpen] = useState(true);
   const [checksOpen,  setChecksOpen]  = useState(true);

--- a/development/odins-throne/ui/components/JobCard.tsx
+++ b/development/odins-throne/ui/components/JobCard.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
-import { AGENT_COLORS, AGENT_AVATARS, STATUS_COLORS, STATUS_LABELS } from "../lib/constants";
+import { AGENT_COLORS, AGENT_AVATARS, AGENT_LIGHT_AVATARS, STATUS_COLORS, STATUS_LABELS } from "../lib/constants";
 import { StatusIconSvg } from "./StatusIcon";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 import type { DisplayMode } from "./Sidebar";
 import { downloadLogFile } from "../lib/localStorageLogs";
+import { useTheme } from "../hooks/useTheme";
 
 interface Props {
   job: DisplayJob;
@@ -36,8 +37,10 @@ function formatTimestamp(ts: number | null): string {
 }
 
 export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = false, onTogglePin, onCancelJob, displayMode = "normal", isTerminating = false }: Props) {
+  const { theme } = useTheme();
   const agentColor = AGENT_COLORS[job.agentKey ?? ""] || "#c9920a";
-  const avatar = AGENT_AVATARS[job.agentKey ?? ""];
+  const avatarMap = theme === "light" ? AGENT_LIGHT_AVATARS : AGENT_AVATARS;
+  const avatar = avatarMap[job.agentKey ?? ""];
   const sColor = STATUS_COLORS[job.status] || "#606070";
   const sLabel = STATUS_LABELS[job.status] || job.status;
   const pulse = job.status === "running" ? " pulse" : "";

--- a/development/odins-throne/ui/components/LogViewer.tsx
+++ b/development/odins-throne/ui/components/LogViewer.tsx
@@ -82,9 +82,10 @@ import { ToolBlock } from "./ToolBlock";
 import { NorseErrorTablet } from "./NorseErrorTablet";
 import { NorseVerdictInscription, isVerdictMessage } from "./NorseVerdictInscription";
 import { DecreeBlock, isDecreeBlock } from "./DecreeBlock";
-import { AGENT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
+import { AGENT_AVATARS, AGENT_LIGHT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
 import { StatusIconSvg } from "./StatusIcon";
 import { downloadLogFile } from "../lib/localStorageLogs";
+import { useTheme } from "../hooks/useTheme";
 
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 
@@ -602,9 +603,11 @@ function AgentBubble({
     );
   }
 
+  const { theme } = useTheme();
   const name = agentName ?? AGENT_NAMES[agentKey ?? ""] ?? "Agent";
   const title = AGENT_TITLES[agentKey ?? ""] ?? "";
-  const avatar = AGENT_AVATARS[agentKey ?? ""];
+  const avatarMap = theme === "light" ? AGENT_LIGHT_AVATARS : AGENT_AVATARS;
+  const avatar = avatarMap[agentKey ?? ""];
   const color = AGENT_COLORS[agentKey ?? ""] ?? "var(--gold)";
 
   return (


### PR DESCRIPTION
PR for issue: #1841

## Summary

- JobCard, AgentBubble (LogViewer), and DecreeBlock all hardcoded AGENT_AVATARS (dark variants) without checking active theme
- Each now calls useTheme() and selects AGENT_LIGHT_AVATARS in light mode and AGENT_AVATARS in dark mode
- AgentProfileModal and Sidebar Odin avatar were already correct

## Validated by Loki
- tsc: PASS
- build: PASS
- Code review: all three components correctly implement theme-aware avatar selection