### PR TITLE
fix: consolidate Gleipnir fragments 1-2 to use shared EasterEggModal (#1817)

### DIFF
--- a/development/ledger/src/__tests__/components/easter-egg-modal-audio-fade-1817.test.tsx
+++ b/development/ledger/src/__tests__/components/easter-egg-modal-audio-fade-1817.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * EasterEggModal — audioFade prop tests (Issue #1817)
+ *
+ * Verifies that:
+ *   - audioFade=true starts audio at volume 0 and fades in to 0.25 over ~500ms
+ *   - audioFade=false plays audio at default volume (no fade)
+ *   - audioFade=true fades audio out over ~600ms when modal closes
+ *   - audio.pause() is called at the end of fade-out
+ *   - Without audioSrc, no Audio instance is created
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, act } from "@testing-library/react";
+import { EasterEggModal } from "@/components/easter-eggs/EasterEggModal";
+import React from "react";
+
+// ── Radix Dialog mock ─────────────────────────────────────────────────────────
+
+vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
+  const React = await import("react");
+  const actual = await importOriginal<typeof import("@radix-ui/react-dialog")>();
+
+  const Overlay = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ className, ...props }, ref) => <div ref={ref} className={className} {...props} />
+  );
+  Overlay.displayName = "Overlay";
+
+  const Content = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+    ({ className, children, ...props }, ref) => (
+      <div ref={ref} role="dialog" className={className} {...props}>
+        {children}
+      </div>
+    )
+  );
+  Content.displayName = "Content";
+
+  const Close = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+    ({ children, ...props }, ref) => (
+      <button ref={ref} aria-label="Close" {...props}>{children}</button>
+    )
+  );
+  Close.displayName = "Close";
+
+  const Title = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+    ({ children, ...props }, ref) => <h2 ref={ref} {...props}>{children}</h2>
+  );
+  Title.displayName = "Title";
+
+  const Description = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+    ({ children, ...props }, ref) => <p ref={ref} {...props}>{children}</p>
+  );
+  Description.displayName = "Description";
+
+  return {
+    ...actual,
+    Root: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+      open !== false ? <>{children}</> : null,
+    Portal: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    Overlay,
+    Content,
+    Close,
+    Title,
+    Description,
+  };
+});
+
+// ── Audio mock ────────────────────────────────────────────────────────────────
+//
+// vi.fn() produces a non-constructable spy, so we use a real class stub and
+// track constructor calls manually.
+
+let audioCtorCallCount = 0;
+let mockPlay: ReturnType<typeof vi.fn>;
+let mockPause: ReturnType<typeof vi.fn>;
+let mockVolume = 1;
+let mockPaused = true;
+let mockCurrentTime = 0;
+
+// We expose a plain object so tests can read / write audio state after render.
+const audioProxy = {
+  get play() { return mockPlay; },
+  get pause() { return mockPause; },
+  get volume() { return mockVolume; },
+  set volume(v: number) { mockVolume = v; },
+  get paused() { return mockPaused; },
+  set paused(v: boolean) { mockPaused = v; },
+  get currentTime() { return mockCurrentTime; },
+  set currentTime(v: number) { mockCurrentTime = v; },
+};
+
+// Real class constructor — usable with `new Audio(src)`.
+class FakeAudio {
+  get play() { return mockPlay; }
+  get pause() { return mockPause; }
+  get volume() { return mockVolume; }
+  set volume(v: number) { mockVolume = v; }
+  get paused() { return mockPaused; }
+  set paused(v: boolean) { mockPaused = v; }
+  get currentTime() { return mockCurrentTime; }
+  set currentTime(v: number) { mockCurrentTime = v; }
+
+  constructor(_src: string) {
+    audioCtorCallCount++;
+    // Reassign mock fns so each construct gets fresh call tracking
+    mockPlay = vi.fn().mockResolvedValue(undefined);
+    mockPause = vi.fn();
+    mockVolume = 1;
+    mockPaused = true;
+    mockCurrentTime = 0;
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function modalJsx(props: Partial<Parameters<typeof EasterEggModal>[0]> = {}) {
+  return (
+    <EasterEggModal
+      open={props.open ?? false}
+      onClose={props.onClose ?? (() => {})}
+      title={props.title ?? "Test Egg"}
+      audioSrc={props.audioSrc}
+      audioFade={props.audioFade}
+    >
+      <p>lore text</p>
+    </EasterEggModal>
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("EasterEggModal — audioFade prop", () => {
+  beforeEach(() => {
+    audioCtorCallCount = 0;
+    mockPlay = vi.fn().mockResolvedValue(undefined);
+    mockPause = vi.fn();
+    mockVolume = 1;
+    mockPaused = true;
+    mockCurrentTime = 0;
+    vi.useFakeTimers();
+    vi.stubGlobal("Audio", FakeAudio);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  // Suppress the proxy variable lint warning — it's used for type-checking readability
+  void audioProxy;
+
+  // ── No audio ────────────────────────────────────────────────────────────────
+
+  it("does not create an Audio instance when audioSrc is not provided", () => {
+    render(modalJsx({ open: true }));
+    expect(audioCtorCallCount).toBe(0);
+  });
+
+  // ── audioFade=false (default) ────────────────────────────────────────────────
+
+  it("audioFade=false: plays audio immediately when modal opens (no fade)", () => {
+    render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: false }));
+    expect(mockPlay).toHaveBeenCalledOnce();
+    // volume is NOT set to 0 — stays at initial value of 1
+    expect(mockVolume).toBe(1);
+  });
+
+  it("audioFade=false: pauses audio immediately when modal closes", () => {
+    const { rerender } = render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: false }));
+
+    // Simulate the audio actually playing (play() mock doesn't flip paused)
+    mockPaused = false;
+
+    act(() => {
+      rerender(modalJsx({ open: false, audioSrc: "/sounds/test.mp3", audioFade: false }));
+    });
+
+    expect(mockPause).toHaveBeenCalled();
+  });
+
+  // ── audioFade=true — fade-in ────────────────────────────────────────────────
+
+  it("audioFade=true: sets volume to 0 before calling play() on open", () => {
+    render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+
+    // Effect sets volume=0 then calls play(); no timers have advanced yet
+    expect(mockPlay).toHaveBeenCalledOnce();
+    expect(mockVolume).toBe(0);
+  });
+
+  it("audioFade=true: volume increases after one fade step (~40ms)", () => {
+    render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+    expect(mockVolume).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(40);
+    });
+
+    expect(mockVolume).toBeGreaterThan(0);
+    expect(mockVolume).toBeLessThan(0.25);
+  });
+
+  it("audioFade=true: volume reaches 0.25 after full 500ms fade-in", () => {
+    render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+    expect(mockVolume).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(600); // overshoot to ensure completion
+    });
+
+    expect(mockVolume).toBeCloseTo(0.25, 5);
+  });
+
+  // ── audioFade=true — fade-out ───────────────────────────────────────────────
+
+  it("audioFade=true: fade-out decreases volume when modal closes", () => {
+    const { rerender } = render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+
+    // Simulate audio is playing at target volume
+    mockPaused = false;
+    mockVolume = 0.25;
+
+    act(() => {
+      rerender(modalJsx({ open: false, audioSrc: "/sounds/test.mp3", audioFade: true }));
+    });
+
+    // Advance one step — volume should drop
+    act(() => {
+      vi.advanceTimersByTime(40);
+    });
+
+    expect(mockVolume).toBeLessThan(0.25);
+  });
+
+  it("audioFade=true: pause() is called after full 600ms fade-out", () => {
+    const { rerender } = render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+
+    mockPaused = false;
+    mockVolume = 0.25;
+
+    act(() => {
+      rerender(modalJsx({ open: false, audioSrc: "/sounds/test.mp3", audioFade: true }));
+    });
+
+    act(() => {
+      vi.advanceTimersByTime(800); // overshoot to ensure completion
+    });
+
+    expect(mockPause).toHaveBeenCalled();
+    expect(mockVolume).toBeCloseTo(0, 5);
+  });
+
+  it("audioFade=true: re-opening mid-fade-out restarts fade-in from volume 0", () => {
+    const { rerender } = render(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+
+    mockPaused = false;
+    mockVolume = 0.25;
+
+    // Close → partial fade-out
+    act(() => {
+      rerender(modalJsx({ open: false, audioSrc: "/sounds/test.mp3", audioFade: true }));
+    });
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    const volDuringFadeOut = mockVolume;
+    expect(volDuringFadeOut).toBeGreaterThan(0);
+    expect(volDuringFadeOut).toBeLessThan(0.25);
+
+    // Re-open — should cancel fade-out and restart fade-in at volume 0
+    act(() => {
+      rerender(modalJsx({ open: true, audioSrc: "/sounds/test.mp3", audioFade: true }));
+    });
+
+    expect(mockVolume).toBe(0);
+    expect(mockPlay).toHaveBeenCalledTimes(2);
+  });
+});

--- a/development/ledger/src/__tests__/components/gleipnir-cat-footfall-1817.test.tsx
+++ b/development/ledger/src/__tests__/components/gleipnir-cat-footfall-1817.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * GleipnirCatFootfall — Hook + Component tests (Issue #1817)
+ *
+ * Tests the useGleipnirFragment1 hook and GleipnirCatFootfall component:
+ *   - trigger() sets egg:gleipnir-1 in localStorage and opens the modal
+ *   - trigger() is a no-op when already found
+ *   - dismiss() closes the modal
+ *   - track() is called with correct metadata on first discovery
+ *   - Component renders modal content when open=true
+ *   - Component counts found fragments from localStorage
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, render, screen } from "@testing-library/react";
+import {
+  useGleipnirFragment1,
+  GleipnirCatFootfall,
+} from "@/components/cards/GleipnirCatFootfall";
+import { track } from "@/lib/analytics/track";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/analytics/track", () => ({
+  track: vi.fn(),
+}));
+
+// Stub EasterEggModal — expose open state via data-testid
+vi.mock("@/components/easter-eggs/EasterEggModal", () => ({
+  EasterEggModal: ({
+    open,
+    onClose,
+    title,
+    children,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <div role="dialog" data-testid="easter-egg-modal">
+        <span data-testid="modal-title">{title}</span>
+        <button onClick={onClose}>close</button>
+        {children}
+      </div>
+    ) : null,
+}));
+
+import React from "react";
+
+const mockTrack = vi.mocked(track);
+
+// ── useGleipnirFragment1 ──────────────────────────────────────────────────────
+
+describe("useGleipnirFragment1", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("starts with open=false", () => {
+    const { result } = renderHook(() => useGleipnirFragment1());
+    expect(result.current.open).toBe(false);
+  });
+
+  it("trigger() sets egg:gleipnir-1 in localStorage", () => {
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(localStorage.getItem("egg:gleipnir-1")).toBe("1");
+  });
+
+  it("trigger() opens the modal on first call", () => {
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  it("trigger() is a no-op when egg:gleipnir-1 is already set", () => {
+    localStorage.setItem("egg:gleipnir-1", "1");
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("dismiss() closes the modal after trigger", () => {
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(true);
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("calling trigger() twice: second call is no-op (key already in storage)", () => {
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("trigger() fires track('easter-egg') with fragment 1 metadata on first discovery", () => {
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith("easter-egg", {
+      fragment: 1,
+      name: "cats-footfall",
+    });
+  });
+
+  it("trigger() does NOT fire track() when fragment is already found", () => {
+    localStorage.setItem("egg:gleipnir-1", "1");
+    const { result } = renderHook(() => useGleipnirFragment1());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+});
+
+// ── GleipnirCatFootfall component ─────────────────────────────────────────────
+
+describe("GleipnirCatFootfall", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when open=false", () => {
+    render(<GleipnirCatFootfall open={false} onClose={() => {}} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders modal when open=true", () => {
+    render(<GleipnirCatFootfall open={true} onClose={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("passes correct title to EasterEggModal", () => {
+    render(<GleipnirCatFootfall open={true} onClose={() => {}} />);
+    expect(screen.getByTestId("modal-title").textContent).toBe(
+      "The Sound of a Cat's Footfall"
+    );
+  });
+
+  it("renders lore text about Gleipnir", () => {
+    render(<GleipnirCatFootfall open={true} onClose={() => {}} />);
+    expect(screen.getByText(/woven into/i)).toBeInTheDocument();
+  });
+
+  it("shows fragment count when open=true (1 of 6 when only fragment 1 found)", () => {
+    localStorage.setItem("egg:gleipnir-1", "1");
+    render(<GleipnirCatFootfall open={true} onClose={() => {}} />);
+    expect(screen.getByText(/Fragment 1 of 6/)).toBeInTheDocument();
+  });
+
+  it("shows 'Gleipnir is complete' when all 6 fragments found", () => {
+    for (let i = 1; i <= 6; i++) {
+      localStorage.setItem(`egg:gleipnir-${i}`, "1");
+    }
+    render(<GleipnirCatFootfall open={true} onClose={() => {}} />);
+    expect(screen.getByText(/Gleipnir is complete/)).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is pressed", () => {
+    const onClose = vi.fn();
+    render(<GleipnirCatFootfall open={true} onClose={onClose} />);
+    screen.getByRole("button", { name: /close/i }).click();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/development/ledger/src/__tests__/components/gleipnir-womans-beard-1817.test.tsx
+++ b/development/ledger/src/__tests__/components/gleipnir-womans-beard-1817.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * GleipnirWomansBeard — Hook + Component tests (Issue #1817)
+ *
+ * Tests the useGleipnirFragment2 hook and GleipnirWomansBeard component:
+ *   - trigger() sets egg:gleipnir-2 in localStorage and opens the modal
+ *   - trigger() is a no-op when already found
+ *   - dismiss() closes the modal
+ *   - track() is called with correct metadata on first discovery
+ *   - Component renders modal content when open=true
+ *   - Component counts found fragments from localStorage
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { renderHook, act, render, screen } from "@testing-library/react";
+import {
+  useGleipnirFragment2,
+  GleipnirWomansBeard,
+} from "@/components/cards/GleipnirWomansBeard";
+import { track } from "@/lib/analytics/track";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock("@/lib/analytics/track", () => ({
+  track: vi.fn(),
+}));
+
+// Stub EasterEggModal — expose open state via data-testid
+vi.mock("@/components/easter-eggs/EasterEggModal", () => ({
+  EasterEggModal: ({
+    open,
+    onClose,
+    title,
+    children,
+  }: {
+    open: boolean;
+    onClose: () => void;
+    title: string;
+    children: React.ReactNode;
+  }) =>
+    open ? (
+      <div role="dialog" data-testid="easter-egg-modal">
+        <span data-testid="modal-title">{title}</span>
+        <button onClick={onClose}>close</button>
+        {children}
+      </div>
+    ) : null,
+}));
+
+import React from "react";
+
+const mockTrack = vi.mocked(track);
+
+// ── useGleipnirFragment2 ──────────────────────────────────────────────────────
+
+describe("useGleipnirFragment2", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("starts with open=false", () => {
+    const { result } = renderHook(() => useGleipnirFragment2());
+    expect(result.current.open).toBe(false);
+  });
+
+  it("trigger() sets egg:gleipnir-2 in localStorage", () => {
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(localStorage.getItem("egg:gleipnir-2")).toBe("1");
+  });
+
+  it("trigger() opens the modal on first call", () => {
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(true);
+  });
+
+  it("trigger() is a no-op when egg:gleipnir-2 is already set", () => {
+    localStorage.setItem("egg:gleipnir-2", "1");
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("dismiss() closes the modal after trigger", () => {
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(true);
+    act(() => {
+      result.current.dismiss();
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("calling trigger() twice: second call is no-op (key already in storage)", () => {
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    act(() => {
+      result.current.dismiss();
+    });
+    act(() => {
+      result.current.trigger();
+    });
+    expect(result.current.open).toBe(false);
+  });
+
+  it("trigger() fires track('easter-egg') with fragment 2 metadata on first discovery", () => {
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(mockTrack).toHaveBeenCalledOnce();
+    expect(mockTrack).toHaveBeenCalledWith("easter-egg", {
+      fragment: 2,
+      name: "womans-beard",
+    });
+  });
+
+  it("trigger() does NOT fire track() when fragment is already found", () => {
+    localStorage.setItem("egg:gleipnir-2", "1");
+    const { result } = renderHook(() => useGleipnirFragment2());
+    act(() => {
+      result.current.trigger();
+    });
+    expect(mockTrack).not.toHaveBeenCalled();
+  });
+});
+
+// ── GleipnirWomansBeard component ─────────────────────────────────────────────
+
+describe("GleipnirWomansBeard", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing when open=false", () => {
+    render(<GleipnirWomansBeard open={false} onClose={() => {}} />);
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("renders modal when open=true", () => {
+    render(<GleipnirWomansBeard open={true} onClose={() => {}} />);
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("passes correct title to EasterEggModal", () => {
+    render(<GleipnirWomansBeard open={true} onClose={() => {}} />);
+    expect(screen.getByTestId("modal-title").textContent).toBe(
+      "The Beard of a Woman"
+    );
+  });
+
+  it("renders lore text about Gleipnir", () => {
+    render(<GleipnirWomansBeard open={true} onClose={() => {}} />);
+    expect(screen.getByText(/woven into/i)).toBeInTheDocument();
+  });
+
+  it("shows fragment count when open=true (1 of 6 when only fragment 2 found)", () => {
+    localStorage.setItem("egg:gleipnir-2", "1");
+    render(<GleipnirWomansBeard open={true} onClose={() => {}} />);
+    expect(screen.getByText(/Fragment 1 of 6/)).toBeInTheDocument();
+  });
+
+  it("shows 'Gleipnir is complete' when all 6 fragments found", () => {
+    for (let i = 1; i <= 6; i++) {
+      localStorage.setItem(`egg:gleipnir-${i}`, "1");
+    }
+    render(<GleipnirWomansBeard open={true} onClose={() => {}} />);
+    expect(screen.getByText(/Gleipnir is complete/)).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is pressed", () => {
+    const onClose = vi.fn();
+    render(<GleipnirWomansBeard open={true} onClose={onClose} />);
+    screen.getByRole("button", { name: /close/i }).click();
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/development/ledger/src/components/cards/GleipnirCatFootfall.tsx
+++ b/development/ledger/src/components/cards/GleipnirCatFootfall.tsx
@@ -12,16 +12,9 @@
  * z-index:  9653 (W-O-L-F on a phone keypad)
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { track } from "@/lib/analytics/track";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import { EasterEggModal } from "@/components/easter-eggs/EasterEggModal";
 
 const STORAGE_KEY = "egg:gleipnir-1";
 const TOTAL_FRAGMENTS = 6;
@@ -37,10 +30,7 @@ export function GleipnirCatFootfall({ open, onClose }: GleipnirCatFootfallProps)
 
   useEffect(() => {
     if (open) {
-      // Mark this fragment found
-      localStorage.setItem(STORAGE_KEY, "1");
-
-      // Count total found
+      // Count total found (this fragment was already written by the hook's trigger()).
       const count = Array.from({ length: TOTAL_FRAGMENTS }, (_, i) =>
         localStorage.getItem(`egg:gleipnir-${i + 1}`)
       ).filter(Boolean).length;
@@ -49,109 +39,46 @@ export function GleipnirCatFootfall({ open, onClose }: GleipnirCatFootfallProps)
   }, [open]);
 
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      {/*
-       * Overrides: w-[92vw] max-w-[680px] override Dialog defaults.
-       * p-0 gap-0 override p-6 gap-4.
-       * z-index 9653 = W-O-L-F on a phone keypad (see copywriting.md Magic Numbers).
-       */}
-      <DialogContent
-        className="w-[92vw] max-w-[680px] p-0 gap-0 flex flex-col
-                   bg-[hsl(var(--egg-bg))] border border-[hsl(var(--egg-border))]
-                   [&>button]:text-[hsl(var(--egg-text-muted))] [&>button]:hover:text-[hsl(var(--egg-text))]"
-        style={{ zIndex: 9653 }}
-      >
-        {/* ── Header ──────────────────────────────────────────────────── */}
-        {/* pr-10 clears the built-in X button */}
-        <div className="px-6 pt-5 pb-4 pr-10 text-center border-b border-[hsl(var(--egg-border))]">
-          <p className="font-mono text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-[hsl(var(--egg-accent))] mb-2">
-            <span aria-hidden="true">ᚠ ᛖ ᚾ ᚱ</span>
-            {" · "}Easter Egg Discovered{" · "}
-            <span aria-hidden="true">ᛁ ᚱ ᛊ</span>
+    <EasterEggModal
+      open={open}
+      onClose={onClose}
+      title="The Sound of a Cat's Footfall"
+      description="You have found Gleipnir fragment 1 of 6: The Sound of a Cat's Footfall. One of the six impossible things woven into the ribbon that bound the great wolf."
+      image={
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src="/easter-eggs/gleipnir-1.svg"
+          alt="The Sound of a Cat's Footfall — Gleipnir artifact"
+          className="w-full max-w-[200px] md:max-w-[240px] aspect-square object-contain"
+        />
+      }
+      audioSrc="/sounds/fenrir-growl.mp3"
+      audioFade
+    >
+      <p className="font-body text-base text-[hsl(var(--egg-text))] leading-relaxed">
+        One of the six impossible things woven into{" "}
+        <span className="text-[hsl(var(--egg-title))] italic">Gleipnir</span> — the only
+        chain strong enough to bind the great wolf. Though it looks like silk
+        ribbon, no chain is stronger.
+      </p>
+
+      <p className="font-body text-sm italic text-[hsl(var(--egg-text-muted))] leading-relaxed">
+        &ldquo;The dwarves of Svartálfaheimr gathered six things that do not
+        exist. From these they wove Gleipnir. When Fenrir felt its touch, he
+        knew at last what true binding was.&rdquo;
+      </p>
+
+      <div className="border-t border-[hsl(var(--egg-border))] pt-3 mt-1">
+        <p className="font-mono text-[0.7rem] text-[hsl(var(--egg-accent))]">
+          Fragment {found} of {TOTAL_FRAGMENTS} found
+        </p>
+        {found === TOTAL_FRAGMENTS && (
+          <p className="font-mono text-[0.65rem] text-[hsl(var(--egg-title))] mt-1 animate-pulse">
+            ✦ Gleipnir is complete. The wolf stirs.
           </p>
-
-          <DialogTitle className="font-display text-[clamp(1.1rem,3.5vw,1.6rem)] font-bold text-[hsl(var(--egg-title))] leading-tight">
-            The Sound of a Cat&apos;s Footfall
-          </DialogTitle>
-        </div>
-
-        {/* Accessible description */}
-        <DialogDescription className="sr-only">
-          You have found Gleipnir fragment 1 of 6: The Sound of a Cat&apos;s Footfall.
-          One of the six impossible things woven into the ribbon that bound the great wolf.
-        </DialogDescription>
-
-        {/* ── Two-column body ─────────────────────────────────────────── */}
-        {/*
-         * Desktop: image left | divider | text right
-         * Mobile:  stacked (image top, text bottom)
-         */}
-        <div className="flex flex-col md:grid md:grid-cols-[1fr_1px_1fr] bg-[hsl(var(--egg-bg-body))]">
-
-          {/* Left — artifact image (SVG served from /public/easter-eggs/) */}
-          <div className="flex items-center justify-center p-6 md:p-8">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="/easter-eggs/gleipnir-1.svg"
-              alt="The Sound of a Cat's Footfall — Gleipnir artifact"
-              className="w-full max-w-[200px] md:max-w-[240px] aspect-square object-contain"
-            />
-          </div>
-
-          {/* Vertical divider — desktop only */}
-          <div
-            className="hidden md:block"
-            style={{
-              background:
-                "linear-gradient(to bottom, transparent, hsl(var(--egg-border)) 20%, hsl(var(--egg-border)) 80%, transparent)",
-            }}
-            aria-hidden="true"
-          />
-
-          {/* Right — discovery text */}
-          <div className="flex flex-col justify-center gap-3 px-6 py-6 md:px-8">
-            <p className="font-body text-base text-[hsl(var(--egg-text))] leading-relaxed">
-              One of the six impossible things woven into{" "}
-              <span className="text-[hsl(var(--egg-title))] italic">Gleipnir</span> — the only
-              chain strong enough to bind the great wolf. Though it looks like silk
-              ribbon, no chain is stronger.
-            </p>
-
-            <p className="font-body text-sm italic text-[hsl(var(--egg-text-muted))] leading-relaxed">
-              &ldquo;The dwarves of Svartálfaheimr gathered six things that do not
-              exist. From these they wove Gleipnir. When Fenrir felt its touch, he
-              knew at last what true binding was.&rdquo;
-            </p>
-
-            <div className="border-t border-[hsl(var(--egg-border))] pt-3 mt-1">
-              <p className="font-mono text-[0.7rem] text-[hsl(var(--egg-accent))]">
-                Fragment {found} of {TOTAL_FRAGMENTS} found
-              </p>
-              {found === TOTAL_FRAGMENTS && (
-                <p className="font-mono text-[0.65rem] text-[hsl(var(--egg-title))] mt-1 animate-pulse">
-                  ✦ Gleipnir is complete. The wolf stirs.
-                </p>
-              )}
-            </div>
-          </div>
-
-        </div>
-
-        {/* ── Footer ──────────────────────────────────────────────────── */}
-        <div className="flex justify-center px-6 py-4 border-t border-[hsl(var(--egg-border))]">
-          <DialogClose asChild>
-            <Button
-              className="px-10 font-heading text-base font-semibold tracking-widest uppercase
-                         bg-[hsl(var(--egg-btn-bg))] text-[hsl(var(--egg-btn-text))] hover:bg-[hsl(var(--egg-btn-hover))]
-                         rounded-none min-h-[44px]"
-            >
-              OK
-            </Button>
-          </DialogClose>
-        </div>
-
-      </DialogContent>
-    </Dialog>
+        )}
+      </div>
+    </EasterEggModal>
   );
 }
 
@@ -163,68 +90,22 @@ export function GleipnirCatFootfall({ open, onClose }: GleipnirCatFootfallProps)
  *   // Call trigger() when the hidden ingredient text is discovered.
  *   // Render: <GleipnirCatFootfall open={open} onClose={dismiss} />
  *
- * Audio: plays /sounds/fenrir-growl.mp3 with fade-in on discovery and fade-out
- * on dismiss. The Audio constructor is called inside trigger() — the direct
- * user-gesture handler — so browsers permit playback without an autoplay
- * policy violation.
+ * Audio fade-in (500ms) on open and fade-out (600ms) on close are handled
+ * by EasterEggModal via the audioFade prop — do not add them here.
+ * The trigger() call is the user-gesture entry point; browsers allow audio from there.
  */
-
-const HOWL_TARGET_VOLUME = 0.25; // max volume during playback
-const FADE_STEP_MS = 40;         // interval between volume steps
-
-function fadeIn(audio: HTMLAudioElement) {
-  audio.volume = 0;
-  const step = HOWL_TARGET_VOLUME / (500 / FADE_STEP_MS); // reach target in ~500ms
-  const id = setInterval(() => {
-    const next = Math.min(audio.volume + step, HOWL_TARGET_VOLUME);
-    audio.volume = next;
-    if (next >= HOWL_TARGET_VOLUME) clearInterval(id);
-  }, FADE_STEP_MS);
-}
-
-function fadeOut(audio: HTMLAudioElement, onDone: () => void) {
-  const step = audio.volume / (600 / FADE_STEP_MS); // reach 0 in ~600ms
-  const id = setInterval(() => {
-    const next = Math.max(audio.volume - step, 0);
-    audio.volume = next;
-    if (next <= 0) {
-      clearInterval(id);
-      audio.pause();
-      audio.currentTime = 0;
-      onDone();
-    }
-  }, FADE_STEP_MS);
-}
-
 export function useGleipnirFragment1() {
   const [open, setOpen] = useState(false);
-  const howlRef = useRef<HTMLAudioElement | null>(null);
 
   function trigger() {
     if (!localStorage.getItem(STORAGE_KEY)) {
       localStorage.setItem(STORAGE_KEY, "1");
       track("easter-egg", { fragment: 1, name: "cats-footfall" });
       setOpen(true);
-
-      // Play within the user-gesture call stack so browsers allow it.
-      try {
-        const howl = new Audio("/sounds/fenrir-growl.mp3");
-        howl.volume = 0;
-        howl.play().catch(() => {/* silently ignore if still blocked */});
-        fadeIn(howl);
-        howlRef.current = howl;
-      } catch {
-        // Audio API unavailable (SSR guard, headless env, etc.)
-      }
     }
   }
 
   function dismiss() {
-    const howl = howlRef.current;
-    if (howl) {
-      howlRef.current = null;
-      fadeOut(howl, () => {}); // fade then stop; setOpen runs immediately
-    }
     setOpen(false);
   }
 

--- a/development/ledger/src/components/cards/GleipnirWomansBeard.tsx
+++ b/development/ledger/src/components/cards/GleipnirWomansBeard.tsx
@@ -12,16 +12,9 @@
  * z-index:  9653 (W-O-L-F on a phone keypad)
  */
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { track } from "@/lib/analytics/track";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
+import { EasterEggModal } from "@/components/easter-eggs/EasterEggModal";
 
 const STORAGE_KEY = "egg:gleipnir-2";
 const TOTAL_FRAGMENTS = 6;
@@ -37,10 +30,7 @@ export function GleipnirWomansBeard({ open, onClose }: GleipnirWomansBeardProps)
 
   useEffect(() => {
     if (open) {
-      // Mark this fragment found
-      localStorage.setItem(STORAGE_KEY, "1");
-
-      // Count total found
+      // Count total found (this fragment was already written by the hook's trigger()).
       const count = Array.from({ length: TOTAL_FRAGMENTS }, (_, i) =>
         localStorage.getItem(`egg:gleipnir-${i + 1}`)
       ).filter(Boolean).length;
@@ -49,109 +39,46 @@ export function GleipnirWomansBeard({ open, onClose }: GleipnirWomansBeardProps)
   }, [open]);
 
   return (
-    <Dialog open={open} onOpenChange={(v) => !v && onClose()}>
-      {/*
-       * Overrides: w-[92vw] max-w-[680px] override Dialog defaults.
-       * p-0 gap-0 override p-6 gap-4.
-       * z-index 9653 = W-O-L-F on a phone keypad (see copywriting.md Magic Numbers).
-       */}
-      <DialogContent
-        className="w-[92vw] max-w-[680px] p-0 gap-0 flex flex-col
-                   bg-[hsl(var(--egg-bg))] border border-[hsl(var(--egg-border))]
-                   [&>button]:text-[hsl(var(--egg-text-muted))] [&>button]:hover:text-[hsl(var(--egg-text))]"
-        style={{ zIndex: 9653 }}
-      >
-        {/* ── Header ──────────────────────────────────────────────────── */}
-        {/* pr-10 clears the built-in X button */}
-        <div className="px-6 pt-5 pb-4 pr-10 text-center border-b border-[hsl(var(--egg-border))]">
-          <p className="font-mono text-[0.65rem] font-semibold uppercase tracking-[0.22em] text-[hsl(var(--egg-accent))] mb-2">
-            <span aria-hidden="true">ᚠ ᛖ ᚾ ᚱ</span>
-            {" · "}Easter Egg Discovered{" · "}
-            <span aria-hidden="true">ᛁ ᚱ ᛊ</span>
+    <EasterEggModal
+      open={open}
+      onClose={onClose}
+      title="The Beard of a Woman"
+      description="You have found Gleipnir fragment 2 of 6: The Beard of a Woman. One of the six impossible things woven into the ribbon that bound the great wolf."
+      image={
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src="/easter-eggs/gleipnir-2.svg"
+          alt="The Beard of a Woman — Gleipnir artifact"
+          className="w-full max-w-[200px] md:max-w-[240px] aspect-square object-contain"
+        />
+      }
+      audioSrc="/sounds/fenrir-growl.mp3"
+      audioFade
+    >
+      <p className="font-body text-base text-[hsl(var(--egg-text))] leading-relaxed">
+        One of the six impossible things woven into{" "}
+        <span className="text-[hsl(var(--egg-title))] italic">Gleipnir</span> — the only
+        chain strong enough to bind the great wolf. Though it looks like silk
+        ribbon, no chain is stronger.
+      </p>
+
+      <p className="font-body text-sm italic text-[hsl(var(--egg-text-muted))] leading-relaxed">
+        &ldquo;The dwarves of Svartálfaheimr gathered six things that do not
+        exist. From these they wove Gleipnir. When Fenrir felt its touch, he
+        knew at last what true binding was.&rdquo;
+      </p>
+
+      <div className="border-t border-[hsl(var(--egg-border))] pt-3 mt-1">
+        <p className="font-mono text-[0.7rem] text-[hsl(var(--egg-accent))]">
+          Fragment {found} of {TOTAL_FRAGMENTS} found
+        </p>
+        {found === TOTAL_FRAGMENTS && (
+          <p className="font-mono text-[0.65rem] text-[hsl(var(--egg-title))] mt-1 animate-pulse">
+            ✦ Gleipnir is complete. The wolf stirs.
           </p>
-
-          <DialogTitle className="font-display text-[clamp(1.1rem,3.5vw,1.6rem)] font-bold text-[hsl(var(--egg-title))] leading-tight">
-            The Beard of a Woman
-          </DialogTitle>
-        </div>
-
-        {/* Accessible description */}
-        <DialogDescription className="sr-only">
-          You have found Gleipnir fragment 2 of 6: The Beard of a Woman.
-          One of the six impossible things woven into the ribbon that bound the great wolf.
-        </DialogDescription>
-
-        {/* ── Two-column body ─────────────────────────────────────────── */}
-        {/*
-         * Desktop: image left | divider | text right
-         * Mobile:  stacked (image top, text bottom)
-         */}
-        <div className="flex flex-col md:grid md:grid-cols-[1fr_1px_1fr] bg-[hsl(var(--egg-bg-body))]">
-
-          {/* Left — artifact image (SVG served from /public/easter-eggs/) */}
-          <div className="flex items-center justify-center p-6 md:p-8">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src="/easter-eggs/gleipnir-2.svg"
-              alt="The Beard of a Woman — Gleipnir artifact"
-              className="w-full max-w-[200px] md:max-w-[240px] aspect-square object-contain"
-            />
-          </div>
-
-          {/* Vertical divider — desktop only */}
-          <div
-            className="hidden md:block"
-            style={{
-              background:
-                "linear-gradient(to bottom, transparent, hsl(var(--egg-border)) 20%, hsl(var(--egg-border)) 80%, transparent)",
-            }}
-            aria-hidden="true"
-          />
-
-          {/* Right — discovery text */}
-          <div className="flex flex-col justify-center gap-3 px-6 py-6 md:px-8">
-            <p className="font-body text-base text-[hsl(var(--egg-text))] leading-relaxed">
-              One of the six impossible things woven into{" "}
-              <span className="text-[hsl(var(--egg-title))] italic">Gleipnir</span> — the only
-              chain strong enough to bind the great wolf. Though it looks like silk
-              ribbon, no chain is stronger.
-            </p>
-
-            <p className="font-body text-sm italic text-[hsl(var(--egg-text-muted))] leading-relaxed">
-              &ldquo;The dwarves of Svartálfaheimr gathered six things that do not
-              exist. From these they wove Gleipnir. When Fenrir felt its touch, he
-              knew at last what true binding was.&rdquo;
-            </p>
-
-            <div className="border-t border-[hsl(var(--egg-border))] pt-3 mt-1">
-              <p className="font-mono text-[0.7rem] text-[hsl(var(--egg-accent))]">
-                Fragment {found} of {TOTAL_FRAGMENTS} found
-              </p>
-              {found === TOTAL_FRAGMENTS && (
-                <p className="font-mono text-[0.65rem] text-[hsl(var(--egg-title))] mt-1 animate-pulse">
-                  ✦ Gleipnir is complete. The wolf stirs.
-                </p>
-              )}
-            </div>
-          </div>
-
-        </div>
-
-        {/* ── Footer ──────────────────────────────────────────────────── */}
-        <div className="flex justify-center px-6 py-4 border-t border-[hsl(var(--egg-border))]">
-          <DialogClose asChild>
-            <Button
-              className="px-10 font-heading text-base font-semibold tracking-widest uppercase
-                         bg-[hsl(var(--egg-btn-bg))] text-[hsl(var(--egg-btn-text))] hover:bg-[hsl(var(--egg-btn-hover))]
-                         rounded-none min-h-[44px]"
-            >
-              OK
-            </Button>
-          </DialogClose>
-        </div>
-
-      </DialogContent>
-    </Dialog>
+        )}
+      </div>
+    </EasterEggModal>
   );
 }
 
@@ -162,63 +89,23 @@ export function GleipnirWomansBeard({ open, onClose }: GleipnirWomansBeardProps)
  *   const { open, trigger, dismiss } = useGleipnirFragment2();
  *   // Call trigger() when the hidden ingredient text is discovered.
  *   // Render: <GleipnirWomansBeard open={open} onClose={dismiss} />
+ *
+ * Audio fade-in (500ms) on open and fade-out (600ms) on close are handled
+ * by EasterEggModal via the audioFade prop — do not add them here.
+ * The trigger() call is the user-gesture entry point; browsers allow audio from there.
  */
-const HOWL_TARGET_VOLUME = 0.25; // max volume during playback
-const FADE_STEP_MS = 40;         // interval between volume steps
-
-function fadeIn(audio: HTMLAudioElement) {
-  audio.volume = 0;
-  const step = HOWL_TARGET_VOLUME / (500 / FADE_STEP_MS); // reach target in ~500ms
-  const id = setInterval(() => {
-    const next = Math.min(audio.volume + step, HOWL_TARGET_VOLUME);
-    audio.volume = next;
-    if (next >= HOWL_TARGET_VOLUME) clearInterval(id);
-  }, FADE_STEP_MS);
-}
-
-function fadeOut(audio: HTMLAudioElement, onDone: () => void) {
-  const step = audio.volume / (600 / FADE_STEP_MS); // reach 0 in ~600ms
-  const id = setInterval(() => {
-    const next = Math.max(audio.volume - step, 0);
-    audio.volume = next;
-    if (next <= 0) {
-      clearInterval(id);
-      audio.pause();
-      audio.currentTime = 0;
-      onDone();
-    }
-  }, FADE_STEP_MS);
-}
-
 export function useGleipnirFragment2() {
   const [open, setOpen] = useState(false);
-  const howlRef = useRef<HTMLAudioElement | null>(null);
 
   function trigger() {
     if (!localStorage.getItem(STORAGE_KEY)) {
       localStorage.setItem(STORAGE_KEY, "1");
       track("easter-egg", { fragment: 2, name: "womans-beard" });
       setOpen(true);
-
-      // Play within the user-gesture call stack so browsers allow it.
-      try {
-        const howl = new Audio("/sounds/fenrir-growl.mp3");
-        howl.volume = 0;
-        howl.play().catch(() => {/* silently ignore if still blocked */});
-        fadeIn(howl);
-        howlRef.current = howl;
-      } catch {
-        // Audio API unavailable (SSR guard, headless env, etc.)
-      }
     }
   }
 
   function dismiss() {
-    const howl = howlRef.current;
-    if (howl) {
-      howlRef.current = null;
-      fadeOut(howl, () => {}); // fade then stop; setOpen runs immediately
-    }
     setOpen(false);
   }
 

--- a/development/ledger/src/components/easter-eggs/EasterEggModal.tsx
+++ b/development/ledger/src/components/easter-eggs/EasterEggModal.tsx
@@ -9,6 +9,7 @@
  *   - Two-column body: image left | divider | children right
  *   - Footer "So it is written" dismiss button
  *   - Optional howl: pass audioSrc="/sounds/fenrir-growl.mp3" to play on open
+ *   - Optional audioFade: fade-in 500ms on open, fade-out 600ms on close
  *
  * Accessibility:
  *   - DialogTitle maps to the supplied `title` prop (screen-reader visible).
@@ -30,6 +31,11 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+
+// -- Constants --
+
+const HOWL_TARGET_VOLUME = 0.25;
+const FADE_STEP_MS = 40;
 
 // -- Types --
 
@@ -53,6 +59,11 @@ export interface EasterEggModalProps {
    * restrictions. Pass undefined to suppress audio.
    */
   audioSrc?: string;
+  /**
+   * When true, audio fades in over ~500ms on open and fades out over ~600ms
+   * on close. Requires audioSrc to have any effect.
+   */
+  audioFade?: boolean;
   /** Discovery text, lore, and reward details -- rendered in the right column. */
   children: ReactNode;
 }
@@ -66,33 +77,88 @@ export function EasterEggModal({
   description = "You have found a hidden easter egg.",
   image,
   audioSrc,
+  audioFade = false,
   children,
 }: EasterEggModalProps) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
+  const fadeTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Play the howl whenever the modal opens.
+  // Handle audio play/stop with optional fade on open/close transitions.
+  // No cleanup return — we don't interrupt fade timers on re-render.
   useEffect(() => {
-    if (!open || !audioSrc) return;
+    if (!audioSrc) return;
 
     if (!audioRef.current) {
       audioRef.current = new Audio(audioSrc);
     }
-
     const audio = audioRef.current;
-    audio.currentTime = 0;
 
-    audio.play().catch((err: unknown) => {
-      if (!(err instanceof DOMException)) return;
-      // Silently ignore autoplay policy blocks and abort signals — both are expected
-      // in headless / background contexts and require no user-facing action.
-      if (err.name === "NotAllowedError" || err.name === "AbortError") return;
-      console.warn("[EasterEggModal] audio playback error:", err);
-    });
+    // Cancel any in-flight fade before starting a new one.
+    if (fadeTimerRef.current) {
+      clearInterval(fadeTimerRef.current);
+      fadeTimerRef.current = null;
+    }
 
+    if (open) {
+      audio.currentTime = 0;
+
+      if (audioFade) {
+        audio.volume = 0;
+        audio.play().catch((err: unknown) => {
+          if (!(err instanceof DOMException)) return;
+          if (err.name === "NotAllowedError" || err.name === "AbortError") return;
+          console.warn("[EasterEggModal] audio playback error:", err);
+        });
+        const step = HOWL_TARGET_VOLUME / (500 / FADE_STEP_MS);
+        fadeTimerRef.current = setInterval(() => {
+          const next = Math.min(audio.volume + step, HOWL_TARGET_VOLUME);
+          audio.volume = next;
+          if (next >= HOWL_TARGET_VOLUME) {
+            clearInterval(fadeTimerRef.current!);
+            fadeTimerRef.current = null;
+          }
+        }, FADE_STEP_MS);
+      } else {
+        audio.play().catch((err: unknown) => {
+          if (!(err instanceof DOMException)) return;
+          if (err.name === "NotAllowedError" || err.name === "AbortError") return;
+          console.warn("[EasterEggModal] audio playback error:", err);
+        });
+      }
+    } else if (!audio.paused) {
+      // Modal just closed while audio is still playing.
+      if (audioFade) {
+        const startVol = audio.volume;
+        const step = startVol > 0 ? startVol / (600 / FADE_STEP_MS) : 0;
+        if (step > 0) {
+          fadeTimerRef.current = setInterval(() => {
+            const next = Math.max(audio.volume - step, 0);
+            audio.volume = next;
+            if (next <= 0) {
+              clearInterval(fadeTimerRef.current!);
+              fadeTimerRef.current = null;
+              audio.pause();
+              audio.currentTime = 0;
+            }
+          }, FADE_STEP_MS);
+        } else {
+          audio.pause();
+        }
+      } else {
+        audio.pause();
+      }
+    }
+  }, [open, audioSrc, audioFade]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Unmount cleanup only — cancel intervals and silence audio.
+  useEffect(() => {
     return () => {
-      audio.pause();
+      if (fadeTimerRef.current) {
+        clearInterval(fadeTimerRef.current);
+      }
+      audioRef.current?.pause();
     };
-  }, [open, audioSrc]);
+  }, []);
 
   return (
     <Dialog open={open} onOpenChange={(v) => !v && onClose()}>


### PR DESCRIPTION
PR for issue: #1817

## Summary

- Refactored `GleipnirCatFootfall` (fragment 1) and `GleipnirWomansBeard` (fragment 2) to use the shared `EasterEggModal` shell
- Added `audioFade` boolean prop to `EasterEggModal`: fades audio in to 0.25 over ~500ms on open, fades out over ~600ms on close, cancels any in-flight fade on transition
- Removed all hand-rolled `Dialog` + `fadeIn`/`fadeOut` logic from fragments 1–2
- Button text "OK" → "So it is written" (matches all 6 fragments)

## Test Results

- 39 new Vitest tests added (15 + 15 + 9)
- 3193/3193 total Vitest tests passing
- tsc: PASS
- next build: PASS

Fixes #1817