### PR TITLE
fix: replace vacuous assertion in premature-household-1670 test (#1845)

### DIFF
--- a/development/ledger/src/__tests__/auth/premature-household-1670.test.ts
+++ b/development/ledger/src/__tests__/auth/premature-household-1670.test.ts
@@ -114,11 +114,21 @@ describe("Issue #1670/#1671 — no premature household creation", () => {
       expect(hh1.createdAt).toBe(hh2.createdAt);
     });
 
-    it("anonymous pages do NOT call initializeHousehold (householdId is null)", () => {
+    it("anonymous pages do NOT call initializeHousehold (householdId is null)", async () => {
       // With #1671, anonymous pages use ANON_HOUSEHOLD_ID = "anon" for storage.
       // initializeHousehold is never called for anonymous users.
       // This test documents the contract: anon users have no household record.
-      expect(true).toBe(true); // Contract documented above
+      const { ANON_HOUSEHOLD_ID } = await import("@/lib/constants");
+      const storageModule = await import("@/lib/storage");
+      const initSpy = vi.spyOn(storageModule, "initializeHousehold");
+
+      // Simulate what anonymous pages do: read the legacy anon id (no-op for new users)
+      const { getAnonHouseholdId } = await import("@/lib/auth/household");
+      getAnonHouseholdId();
+
+      // Anonymous users use the fixed "anon" key — initializeHousehold is never invoked
+      expect(ANON_HOUSEHOLD_ID).toBe("anon");
+      expect(initSpy).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replaces `expect(true).toBe(true)` at line 121 of `premature-household-1670.test.ts` with real assertions
- Spies on `initializeHousehold` and asserts it is **never called** during an anonymous page simulation
- Asserts `ANON_HOUSEHOLD_ID === "anon"` to validate the fixed-key contract introduced in #1671

## Test plan
- [x] `pnpm run verify:tsc` — passes (0 errors)
- [x] `pnpm run verify:build` — passes
- [x] `npx vitest run` — 223 test files, 3154 tests, all pass
- [x] Target test now exercises a real spy-based assertion instead of a hollow `expect(true).toBe(true)`

Closes #1845

🤖 Generated with [Claude Code](https://claude.com/claude-code)