### PR TITLE
fix: align brandify CSS with chronicle stylesheet

### DIFF
--- a/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
+++ b/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
@@ -467,11 +467,11 @@ function esc(s) {
 
 function toolBadgeClass(name) {
   const n = name.toLowerCase();
-  if (n === "bash") return "bash";
-  if (n === "read" || n === "grep" || n === "glob") return "read";
-  if (n === "edit" || n === "multiedit") return "edit";
-  if (n === "write") return "write";
-  if (n === "todowrite" || n === "todoupdate") return "todo";
+  if (n === "bash") return "badge-bash";
+  if (n === "read" || n === "grep" || n === "glob") return "badge-read";
+  if (n === "edit" || n === "multiedit") return "badge-edit";
+  if (n === "write") return "badge-write";
+  if (n === "todowrite" || n === "todoupdate") return "badge-todo";
   return "";
 }
 
@@ -690,14 +690,14 @@ const mdxExcerpt = `Agent execution report — ${agentName} on Issue #${issueNum
 // Tool block renderer — plain HTML for MDX
 // ---------------------------------------------------------------------------
 function renderToolBlock(tool) {
-  return `<details class="tool-block${tool.is_error ? " has-error" : ""}">
-<summary class="tool-block-header">
-<span class="tool-name">${esc(tool.name)}</span>
-<span class="tool-input-preview">${toolInputPreview(tool)}</span>
+  return `<details class="agent-tool-block">
+<summary>
+<span class="agent-tool-name">${esc(tool.name)}</span>
+<span class="agent-tool-preview">${toolInputPreview(tool)}</span>
 </summary>
-<div class="tool-block-body">
-<pre class="tool-input">${esc(renderToolInput(tool))}</pre>
-<pre class="tool-output${tool.is_error ? " error" : ""}">${esc(renderToolOutput(tool))}</pre>
+<div class="agent-tool-body">
+<pre class="agent-tool-input">${esc(renderToolInput(tool))}</pre>
+<pre class="${tool.is_error ? "agent-tool-error" : "agent-tool-output"}">${esc(renderToolOutput(tool))}</pre>
 </div>
 </details>
 `;
@@ -732,28 +732,25 @@ while (mi < turns.length) {
       ? `#${turnNums[0]}`
       : `#${turnNums[0]}&ndash;${turnNums[turnNums.length - 1]}`;
     const toolBadges = mergedTools
-      .map(t => `<span class="tool-badge ${toolBadgeClass(t.name)}">${esc(t.name)}</span>`)
+      .map(t => `<span class="agent-tool-badge ${toolBadgeClass(t.name)}">${esc(t.name)}</span>`)
       .join(" ");
 
     turnsMarkup += `
-<div class="turn${hasError ? " has-error" : ""}">
 <div class="turn-agent-profile">
-<img class="turn-agent-avatar" src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy">
-<span class="turn-agent-title">${agentTitle}</span>
+<div class="agent-profile-avatar"><img src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy"></div>
+<span class="agent-profile-name">${agentTitle}</span>
 </div>
-<details class="turn-box">
-<summary class="turn-header">
-<span class="turn-num">${numLabel}</span>
-<span class="turn-summary">${mergedTools.length} tool calls</span>
-<span class="turn-tools">${toolBadges}</span>
-<span class="chevron">&#9654;</span>
+<details class="agent-turn${hasError ? " agent-turn-error" : ""}">
+<summary>
+<span class="agent-turn-num">${numLabel}</span>
+<span class="agent-turn-summary">${mergedTools.length} tool calls</span>
+<span class="agent-turn-badges">${toolBadges}</span>
 </summary>
-<div class="turn-body">
-<div class="toolbox">
+<div class="agent-turn-body">
+<div class="agent-toolbox">
 ${mergedTools.map(t => renderToolBlock(t)).join("")}</div>
 </div>
 </details>
-</div>
 `;
     continue;
   }
@@ -764,38 +761,35 @@ ${mergedTools.map(t => renderToolBlock(t)).join("")}</div>
     ? esc(turn.texts[0].slice(0, 120))
     : turn.tools.map(t => esc(t.name)).join(", ");
   const toolBadges = turn.tools
-    .map(t => `<span class="tool-badge ${toolBadgeClass(t.name)}">${esc(t.name)}</span>`)
+    .map(t => `<span class="agent-tool-badge ${toolBadgeClass(t.name)}">${esc(t.name)}</span>`)
     .join(" ");
 
   turnsMarkup += `
-<div class="turn${hasError ? " has-error" : ""}">
 <div class="turn-agent-profile">
-<img class="turn-agent-avatar" src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy">
-<span class="turn-agent-title">${agentTitle}</span>
+<div class="agent-profile-avatar"><img src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy"></div>
+<span class="agent-profile-name">${agentTitle}</span>
 </div>
-<details class="turn-box">
-<summary class="turn-header">
-<span class="turn-num">#${mi + 1}</span>
-<span class="turn-summary">${summary}</span>
-<span class="turn-tools">${toolBadges}</span>
-<span class="chevron">&#9654;</span>
+<details class="agent-turn${hasError ? " agent-turn-error" : ""}">
+<summary>
+<span class="agent-turn-num">#${mi + 1}</span>
+<span class="agent-turn-summary">${summary}</span>
+<span class="agent-turn-badges">${toolBadges}</span>
 </summary>
-<div class="turn-body">
+<div class="agent-turn-body">
 `;
 
   for (const thinking of turn.thinking) {
-    turnsMarkup += `<div class="thinking">${esc(thinking.slice(0, 1000))}</div>\n`;
+    turnsMarkup += `<div class="agent-thinking">${esc(thinking.slice(0, 1000))}</div>\n`;
   }
   for (const text of turn.texts) {
-    turnsMarkup += `<div class="text-block">${esc(text)}</div>\n`;
+    turnsMarkup += `<div class="agent-text-block">${esc(text)}</div>\n`;
   }
   if (turn.tools.length > 0) {
-    turnsMarkup += `<div class="toolbox">\n${turn.tools.map(t => renderToolBlock(t)).join("")}</div>\n`;
+    turnsMarkup += `<div class="agent-toolbox">\n${turn.tools.map(t => renderToolBlock(t)).join("")}</div>\n`;
   }
 
   turnsMarkup += `</div>
 </details>
-</div>
 `;
 
   mi++;
@@ -838,9 +832,9 @@ ${commits.map(c => `<div class="commit-item"><span class="msg">${esc(c)}</span><
 let verdictMarkup = "";
 if (verdict) {
   verdictMarkup = `
-<div class="verdict ${verdict.pass ? "pass" : "fail"}">
-<h2>&#5839; ${verdict.pass ? "PASS" : "FAIL"} &mdash; QA Verdict</h2>
-<pre>${esc(verdict.text)}</pre>
+<div class="agent-verdict ${verdict.pass ? "verdict-pass" : "verdict-fail"}">
+<div class="agent-verdict-label">ᛏ ${verdict.pass ? "PASS" : "FAIL"} — QA Verdict</div>
+<div class="agent-verdict-text"><pre>${esc(verdict.text)}</pre></div>
 </div>`;
 }
 
@@ -886,7 +880,7 @@ ${dChecks}
 
 const callbackMarkup = `
 <div class="agent-callback">
-<div class="callback-runes">${esc(agentCallback.runes)}</div>
+<div class="callback-rune-row">${esc(agentCallback.runes)}</div>
 <div class="callback-declaration">Odin All-Father &mdash; Your Will Is Done</div>
 <div class="callback-quote">&ldquo;${esc(agentCallback.quote)}&rdquo;</div>
 <div class="callback-blood-seal">&#5765; ${esc(agentCallback.signoff)} &middot; ${agentTitle} &middot; Issue #${esc(issueNum)} &#5765;</div>
@@ -897,7 +891,7 @@ ${decreeCompleteMarkup}`;
 const mdx = `---
 title: "${mdxTitle.replace(/"/g, '\\"')}"
 date: "${dateStr}"
-rune: "&#5810;"
+rune: "ᚲ"
 excerpt: "${mdxExcerpt.replace(/"/g, '\\"')}"
 slug: "${mdxSlug}"
 category: "agent"
@@ -905,46 +899,27 @@ category: "agent"
 
 <div class="chronicle-page">
 
-<div class="report">
-
-<div class="report-header">
-<div class="odin-header">
-<img class="odin-avatar" src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy">
-<div class="odin-title">
-<h1>&#5810; ${esc(agentName)} &mdash; Issue #${esc(issueNum)} (Step ${esc(stepNum)})</h1>
+<div class="agent-report-header">
+<div class="agent-report-avatar-row">
+<div class="agent-profile-avatar"><img src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy"></div>
+<div class="agent-report-title">ᚲ ${esc(agentName)} — Issue #${esc(issueNum)} (Step ${esc(stepNum)})</div>
 </div>
-</div>
-<div class="meta">
-<span><span class="label">Session:</span> ${esc(meta.session || "unknown")}</span>
-<span><span class="label">Branch:</span> ${esc(meta.branch || "unknown")}</span>
-<span><span class="label">Model:</span> ${esc(meta.model || "unknown")}</span>
+<div class="session-meta">
+<span>Session: <span class="val">${esc(meta.session || "unknown")}</span></span>
+<span>Branch: <span class="val">${esc(meta.branch || "unknown")}</span></span>
+<span>Model: <span class="val">${esc(meta.model || "unknown")}</span></span>
 </div>
 </div>
 
-<div class="stats-grid">
-<div class="stats-card">
-<div class="stats-card-label">&#5765; Session</div>
-<div class="stats-row">
-<div class="stat"><span class="num">${turns.length}</span><span class="lbl">turns</span></div>
-<div class="stat"><span class="num">${totalTools}</span><span class="lbl">tools</span></div>
-<div class="stat"><span class="num" style="color: ${errors ? 'var(--fire-muspel)' : 'var(--teal-asgard)'}">${errors}</span><span class="lbl">errors</span></div>
-</div>
-</div>
-<div class="stats-card">
-<div class="stats-card-label">&#5846; Git</div>
-<div class="stats-row">
-<div class="stat"><span class="num">${commits.length}</span><span class="lbl">commits</span></div>
-<div class="stat"><span class="num">${pushCount}</span><span class="lbl">pushes</span></div>
-</div>
-</div>
-<div class="stats-card">
-<div class="stats-card-label">&#5792; Tokens</div>
-<div class="stats-row">
-<div class="stat"><span class="num sm">${fmtNum(totalInputTokens)}</span><span class="lbl">in</span></div>
-<div class="stat"><span class="num sm">${fmtNum(totalOutputTokens)}</span><span class="lbl">out</span></div>
-<div class="stat"><span class="num sm">${fmtNum(totalCacheRead)}</span><span class="lbl">cache</span></div>
-</div>
-</div>
+<div class="stat-grid">
+<div class="stat-card"><div class="stat-label">Turns</div><div class="stat-val">${turns.length}</div></div>
+<div class="stat-card"><div class="stat-label">Tools</div><div class="stat-val">${totalTools}</div></div>
+<div class="stat-card"><div class="stat-label">Errors</div><div class="stat-val${errors ? ' stat-fire' : ' stat-teal'}">${errors}</div></div>
+<div class="stat-card"><div class="stat-label">Commits</div><div class="stat-val">${commits.length}</div></div>
+<div class="stat-card"><div class="stat-label">Pushes</div><div class="stat-val">${pushCount}</div></div>
+<div class="stat-card"><div class="stat-label">Tokens In</div><div class="stat-val">${fmtNum(totalInputTokens)}</div></div>
+<div class="stat-card"><div class="stat-label">Tokens Out</div><div class="stat-val">${fmtNum(totalOutputTokens)}</div></div>
+<div class="stat-card"><div class="stat-label">Cache</div><div class="stat-val">${fmtNum(totalCacheRead)}</div></div>
 </div>
 
 ${changesMarkup}
@@ -953,17 +928,14 @@ ${commitsMarkup}
 ${decreeMarkup}
 
 <div class="agent-turns-section">
-<div class="agent-turns-title">Execution Turns</div>
 ${turnsMarkup}
 </div>
 
 ${verdictMarkup}
 ${callbackMarkup}
 
-<div class="report-footer">
-&#5792; Fenrir Ledger &mdash; Agent Report &mdash; Generated ${new Date().toISOString().slice(0, 19)}Z
-</div>
-
+<div class="agent-report-footer">
+ᚠ Fenrir Ledger — Agent Report — Generated ${new Date().toISOString().slice(0, 19)}Z
 </div>
 
 </div>

--- a/development/ledger/src/app/(marketing)/chronicles/chronicle-norse.css
+++ b/development/ledger/src/app/(marketing)/chronicles/chronicle-norse.css
@@ -884,3 +884,284 @@
   line-height: 1.6;
   color: var(--c-fg);
 }
+
+.chronicle-page .agent-verdict-text pre {
+  white-space: pre-wrap;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+
+/* ═══════════════════════════════════════════════════════════════════
+   COMPONENT 6: AGENT REPORT LAYOUT
+   (.agent-report-header, .agent-turns-section, .agent-report-footer,
+    .changes-summary, .decree-complete)
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Agent Report Header ── */
+
+.chronicle-page .agent-report-header {
+  margin-bottom: 32px;
+}
+
+.chronicle-page .agent-report-avatar-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.chronicle-page .agent-report-avatar-row .agent-profile-avatar {
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  border: 2px solid var(--c-gold);
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.chronicle-page .agent-report-avatar-row .agent-profile-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chronicle-page .agent-report-title {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--c-fg);
+}
+
+/* ── Turns Section ── */
+
+.chronicle-page .agent-turns-section {
+  margin: 32px 0;
+}
+
+/* ── Changes Summary ── */
+
+.chronicle-page .changes-summary {
+  background: var(--c-bg-card);
+  border: 1px solid var(--c-border);
+  padding: 16px 20px;
+  margin: 20px 0;
+}
+
+.chronicle-page .changes-summary h2 {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: var(--c-gold);
+  margin: 0 0 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.chronicle-page .changes-summary h3 {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: var(--c-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin: 0 0 8px;
+}
+
+.chronicle-page .changes-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 480px) {
+  .chronicle-page .changes-cols {
+    grid-template-columns: 1fr;
+  }
+}
+
+.chronicle-page .changes-summary ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.chronicle-page .changes-summary li {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-fg);
+  padding: 2px 0;
+}
+
+.chronicle-page .changes-summary li .icon {
+  color: var(--c-teal);
+  margin-right: 6px;
+  font-weight: 700;
+}
+
+.chronicle-page .file-mod .icon { color: var(--c-amber) !important; }
+
+.chronicle-page .commit-item {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-fg);
+  padding: 4px 0;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.chronicle-page .commit-item:last-child { border-bottom: none; }
+
+/* ── Decree Complete ── */
+
+.chronicle-page .decree-complete {
+  border: 2px solid var(--c-teal);
+  padding: 20px 24px;
+  margin: 20px 0;
+}
+
+.chronicle-page .decree-complete-header {
+  text-align: center;
+  margin-bottom: 16px;
+}
+
+.chronicle-page .decree-complete-runes {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.3em;
+  color: var(--c-teal);
+  margin-bottom: 4px;
+}
+
+.chronicle-page .decree-complete-verdict {
+  font-family: var(--font-cinzel-decorative), 'Cinzel Decorative', serif;
+  font-size: 1.3rem;
+  font-weight: 700;
+}
+
+.chronicle-page .decree-complete-body {
+  font-size: 0.85rem;
+  line-height: 1.7;
+  color: var(--c-fg);
+}
+
+.chronicle-page .decree-field {
+  margin: 4px 0;
+}
+
+.chronicle-page .decree-label {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--c-fg-muted);
+  text-transform: uppercase;
+}
+
+.chronicle-page .decree-summary {
+  padding-left: 20px;
+  margin: 8px 0;
+}
+
+.chronicle-page .decree-summary li {
+  font-size: 0.82rem;
+  margin: 4px 0;
+}
+
+.chronicle-page .decree-check {
+  display: flex;
+  justify-content: space-between;
+  padding: 4px 0;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.chronicle-page .decree-check:last-child { border-bottom: none; }
+
+.chronicle-page .decree-check-name { color: var(--c-fg-muted); }
+.chronicle-page .decree-check-result { font-weight: 700; }
+
+.chronicle-page .decree-seal-line {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--c-border);
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.7rem;
+  color: var(--c-fg-muted);
+}
+
+.chronicle-page .decree-signoff {
+  text-align: center;
+  font-style: italic;
+  font-size: 0.8rem;
+  color: var(--c-fg-muted);
+  margin-top: 8px;
+}
+
+.chronicle-page .decree-complete-footer {
+  text-align: center;
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.8rem;
+  letter-spacing: 0.3em;
+  color: var(--c-teal);
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--c-border);
+}
+
+/* ── Agent Report Footer ── */
+
+.chronicle-page .agent-report-footer {
+  margin-top: 48px;
+  padding-top: 24px;
+  border-top: 1px solid var(--c-border);
+  text-align: center;
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.68rem;
+  color: var(--c-fg-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+
+/* ── Entrypoint (sandbox forging) ── */
+
+.chronicle-page .entrypoint {
+  margin: 20px 0;
+}
+
+.chronicle-page .entrypoint summary {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  color: var(--c-gold);
+  cursor: pointer;
+  list-style: none;
+}
+
+.chronicle-page .entrypoint summary::-webkit-details-marker { display: none; }
+
+.chronicle-page .entrypoint summary::before {
+  content: '\25B6 ';
+  font-size: 0.6rem;
+  color: var(--c-fg-muted);
+  transition: transform 0.15s ease;
+}
+
+.chronicle-page .entrypoint[open] summary::before {
+  content: '\25BC ';
+}
+
+.chronicle-page .entrypoint pre {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.7rem;
+  line-height: 1.5;
+  color: var(--c-fg-muted);
+  white-space: pre-wrap;
+  padding: 12px;
+  margin: 8px 0 0;
+  background: var(--c-bg-card);
+  border: 1px solid var(--c-border);
+}


### PR DESCRIPTION
## Summary
- Fixes all CSS class mismatches between brandify-agent output and chronicle.css/chronicle-norse.css
- Frontmatter rune uses actual Unicode ᚲ instead of HTML entity &#5810;
- Stats grid, turns, tool badges, verdict, callback all now use the correct CSS vocabulary
- Added missing CSS for agent-report-specific elements (header, changes, decree-complete, footer, entrypoint)

## Test plan
- [x] Generated Luna issue-1833 chronicle — MDX compiles
- [x] Stats grid renders as styled cards with gold values
- [x] Turns render with agent profile, collapsible details, tool badges
- [x] Tool badges color-coded (Bash=teal, Read=blue, Edit=amber, TodoWrite=purple)
- [x] Rune ᚲ renders properly in page header

🤖 Generated with [Claude Code](https://claude.com/claude-code)