### PR TITLE
feat: rewrite brandify chronicle generator to match Odin's Throne style

### DIFF
--- a/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
+++ b/.claude/skills/brandify-agent/scripts/generate-agent-report.mjs
@@ -19,8 +19,20 @@ import {
   AGENT_SIGNOFFS,
   AGENT_CALLBACK_QUOTES,
   AGENT_CALLBACK_RUNES,
+  AGENT_RUNE_NAMES,
+  AGENT_TITLES as AGENT_ROLE_TITLES,
   parseDecreeBlock,
 } from "./agent-identity.mjs";
+
+// Agent accent colors — matches Odin's Throne constants.ts
+const AGENT_COLORS = {
+  firemandecko: "#4ecdc4",
+  loki: "#a78bfa",
+  luna: "#6b8afd",
+  freya: "#f0b429",
+  heimdall: "#8B5E3C",
+  odin: "#c9920a",
+};
 
 // Agent display names — inline since we no longer import from mayo-heckler
 const AGENT_NAMES = {
@@ -475,6 +487,45 @@ function toolBadgeClass(name) {
   return "";
 }
 
+// ---------------------------------------------------------------------------
+// Tool categorisation — ported from Odin's Throne constants.ts
+// ---------------------------------------------------------------------------
+function toolCategory(name, input) {
+  const cmd = String(input?.command ?? "");
+  if (name === "TodoWrite" || name === "TodoUpdate") return "tracking";
+  if (name === "Read" || name === "Grep" || name === "Glob") return "reading";
+  if (name === "Edit" || name === "MultiEdit") return "editing";
+  if (name === "Write") return "writing";
+  if (name === "Agent") return "delegating";
+  if (name === "Bash") {
+    if (/git\s+(add|commit|push)/.test(cmd)) return "committing";
+    if (/git\s+(fetch|rebase|pull|merge)/.test(cmd)) return "syncing";
+    if (/git\s+(log|diff|status|branch)/.test(cmd)) return "inspecting";
+    if (/verify\.sh|tsc|--noEmit/.test(cmd)) return "verifying";
+    if (/vitest|playwright|jest/.test(cmd)) return "testing";
+    if (/next\s+build|npm\s+run\s+build/.test(cmd)) return "building";
+    if (/gh\s+issue/.test(cmd)) return "issue ops";
+    if (/gh\s+pr/.test(cmd)) return "PR ops";
+    if (/npm\s+(ci|install)|npx/.test(cmd)) return "installing";
+    if (/curl|wget/.test(cmd)) return "fetching";
+    if (/kubectl|helm/.test(cmd)) return "k8s ops";
+    if (/rm\s+-rf|mkdir/.test(cmd)) return "cleanup";
+  }
+  return name.toLowerCase();
+}
+
+function batchSummary(tools) {
+  const categories = {};
+  for (const t of tools) {
+    const cat = toolCategory(t.name, t.input);
+    categories[cat] = (categories[cat] || 0) + 1;
+  }
+  const parts = Object.entries(categories)
+    .sort((a, b) => b[1] - a[1])
+    .map(([cat, count]) => count > 1 ? `${count} ${cat}` : cat);
+  return parts.join(", ");
+}
+
 function toolInputPreview(tool) {
   function singleLine(s) { return s.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim(); }
   if (tool.name === "Bash" && tool.input?.command) return esc(singleLine(tool.input.description || tool.input.command.slice(0, 100)));
@@ -505,19 +556,45 @@ function renderToolOutput(tool) {
   return sanitizeToolOutput(raw, 800);
 }
 
+function renderEntrypointLine(line) {
+  if (/^===.*===$/.test(line)) {
+    const text = line.replace(/^=+\s*|\s*=+$/g, "");
+    return `<div class="ep-header">${esc(text)}</div>`;
+  }
+  if (/^---.*---$/.test(line)) {
+    const text = line.replace(/^-+\s*|\s*-+$/g, "");
+    return `<div class="ep-header">${esc(text)}</div>`;
+  }
+  if (line.startsWith("[FATAL]")) {
+    return `<div class="ep-fatal">${esc(line.slice(7).trim())}</div>`;
+  }
+  if (line.startsWith("[WARN]")) {
+    return `<div class="ep-warn">${esc(line.slice(6).trim())}</div>`;
+  }
+  if (line.startsWith("[ok]")) {
+    return `<div class="ep-ok"><span class="ep-ok-marker">[ok]</span> ${esc(line.slice(4).trim())}</div>`;
+  }
+  const kvMatch = /^(Session|Branch|Model|Working directory):\s*(.+)$/.exec(line);
+  if (kvMatch) {
+    return `<div class="ep-kv"><span class="ep-kv-key">${esc(kvMatch[1])}</span><span class="ep-kv-val">${esc(kvMatch[2])}</span></div>`;
+  }
+  return `<div class="ep-raw">${esc(line)}</div>`;
+}
+
 function renderEntrypoint() {
   // Split into sandbox setup (before --- TASK PROMPT ---) and decree (after)
   const promptIdx = entrypointLines.findIndex(l => /TASK PROMPT/.test(l));
   const setupLines = promptIdx >= 0 ? entrypointLines.slice(0, promptIdx) : entrypointLines;
   const promptLines = promptIdx >= 0 ? entrypointLines.slice(promptIdx + 1) : [];
 
-  const setupText = setupLines
+  const setupBody = setupLines
     .filter(l => l.trim())
+    .map(l => renderEntrypointLine(l))
     .join("\n");
   const setupMarkup = `
 <details class="entrypoint">
 <summary>&#5765; Sandbox Forging</summary>
-<pre>${esc(setupText)}</pre>
+<div class="ep-body">${setupBody}</div>
 </details>`;
 
   if (promptLines.length === 0) return setupMarkup;
@@ -743,7 +820,7 @@ while (mi < turns.length) {
 <details class="agent-turn${hasError ? " agent-turn-error" : ""}">
 <summary>
 <span class="agent-turn-num">${numLabel}</span>
-<span class="agent-turn-summary">${mergedTools.length} tool calls</span>
+<span class="agent-turn-summary">${esc(batchSummary(mergedTools))}</span>
 <span class="agent-turn-badges">${toolBadges}</span>
 </summary>
 <div class="agent-turn-body">
@@ -840,41 +917,74 @@ if (verdict) {
 
 const decreeMarkup = renderEntrypoint();
 
-// Build decree-complete block if present
+// Build decree-complete block — Odin's Throne DecreeBlock style
 let decreeCompleteMarkup = "";
 if (decree) {
-  const dVerdictColor = decree.verdict === "PASS" ? "var(--teal-asgard)" : decree.verdict === "FAIL" ? "var(--fire-muspel)" : "var(--amber-hati)";
+  const dAgentColor = AGENT_COLORS[agentNameKey] || "#c9920a";
+  const dAgentRunes = AGENT_RUNE_NAMES[agentNameKey] || AGENT_RUNE_NAMES._fallback || "";
+  const dAgentRole = AGENT_ROLE_TITLES[agentNameKey] || "";
+
+  const isPass = /^(PASS|DONE|DELIVERED|APPROVED|SECURED)$/i.test(decree.verdict || "");
+  const isFail = /^FAIL$/i.test(decree.verdict || "");
+  const verdictColor = isFail ? "#ef4444" : isPass ? "#f0b429" : "#9ca3af";
+  const verdictGlow = isFail ? "0 0 12px rgba(239,68,68,0.6)" : isPass ? "0 0 12px rgba(240,180,41,0.5)" : "none";
+  const borderColor = isFail ? "#ef4444" : dAgentColor;
+  const verdictBg = isFail ? "rgba(239,68,68,0.06)" : "rgba(201,146,10,0.04)";
+  const verdictBorder = isFail ? "rgba(239,68,68,0.25)" : "rgba(201,146,10,0.20)";
+
   const dChecks = decree.checks.length > 0
     ? decree.checks.map(c => {
-        const ok = /pass|ok|complete|delivered|approved|secured|done/i.test(c.result);
-        const fail = /fail|error|missing/i.test(c.result);
-        const cc = ok ? "var(--teal-asgard)" : fail ? "var(--fire-muspel)" : "var(--text-rune)";
-        return `<div class="decree-check"><span class="decree-check-name">${esc(c.name)}</span><span class="decree-check-result" style="color: ${cc}">${esc(c.result)}</span></div>`;
+        const ok = /^(pass|ok|complete|delivered|approved|secured|done)/i.test(c.result);
+        const fail = /^(fail|error|missing|findings)/i.test(c.result);
+        const cc = fail ? "#ef4444" : ok ? "#22c55e" : "#9ca3af";
+        const bg = fail ? "rgba(239,68,68,0.15)" : ok ? "rgba(34,197,94,0.12)" : "rgba(96,96,112,0.15)";
+        return `<div class="dc-check-item"><span class="dc-check-name">${esc(c.name)}</span><span class="dc-check-value" style="color: ${cc}; background: ${bg}">${esc(c.result)}</span></div>`;
       }).join("\n")
     : "";
+
   const dSummary = decree.summary.length > 0
-    ? `<ul class="decree-summary">${decree.summary.map(s => `<li>${esc(s)}</li>`).join("")}</ul>`
+    ? decree.summary.map(s => `<li class="dc-list-item">${esc(s)}</li>`).join("\n")
     : "";
-  const dPr = decree.pr ? `<div class="decree-field"><span class="decree-label">PR:</span> <a href="${esc(decree.pr)}" target="_blank" rel="noopener">${esc(decree.pr)}</a></div>` : "";
+
+  const dPr = decree.pr
+    ? `<a class="dc-pr-link" href="${esc(decree.pr)}" target="_blank" rel="noopener noreferrer" aria-label="Pull request: ${esc(decree.pr)}">PR &nearr;</a>`
+    : "";
+
   decreeCompleteMarkup = `
-<div class="decree-complete">
-<div class="decree-complete-header">
-<div class="decree-complete-runes">&#5869;&#5869;&#5869; DECREE COMPLETE &#5869;&#5869;&#5869;</div>
-<div class="decree-complete-verdict" style="color: ${dVerdictColor}">${esc(decree.verdict ?? "COMPLETE")}</div>
+<div class="dc-card" style="border-left: 3px solid ${borderColor}" aria-label="Decree from ${esc(agentName)}: verdict ${esc(decree.verdict || 'COMPLETE')}">
+<div class="dc-header">
+<div class="dc-identity">
+<div class="dc-avatar" style="border-color: ${dAgentColor}"><img src="${agentAvatarPath}" alt="${esc(agentName)}" loading="lazy"></div>
+<div class="dc-agent-info">
+<span class="dc-agent-name" style="color: ${dAgentColor}">${esc(agentName)}</span>
+${dAgentRole ? `<span class="dc-agent-title">${esc(dAgentRole)}</span>` : ""}
+${dAgentRunes ? `<span class="dc-agent-runes" style="color: ${dAgentColor}" aria-hidden="true">${esc(dAgentRunes)}</span>` : ""}
 </div>
-<div class="decree-complete-body">
-<div class="decree-field"><span class="decree-label">Issue:</span> #${esc(decree.issue ?? issueNum)}</div>
+</div>
+<div class="dc-meta">
+<div class="dc-title"><span class="dc-rune-delim" aria-hidden="true">&#5869;&#5869;&#5869;</span> DECREE COMPLETE <span class="dc-rune-delim" aria-hidden="true">&#5869;&#5869;&#5869;</span></div>
+${decree.issue ? `<span class="dc-issue" aria-label="Issue #${esc(decree.issue)}">Issue #${esc(decree.issue)}</span>` : ""}
+</div>
+</div>
+<div class="dc-verdict-row" style="border-top: 1px solid ${verdictBorder}; border-bottom: 1px solid ${verdictBorder}; background: ${verdictBg}" aria-label="Verdict: ${esc(decree.verdict || 'COMPLETE')}">
+<span class="dc-verdict-label">VERDICT</span>
+<span class="dc-verdict-value" style="color: ${verdictColor}; text-shadow: ${verdictGlow}">${esc(decree.verdict || "COMPLETE")}</span>
 ${dPr}
-${dSummary}
-${dChecks}
-<div class="decree-seal-line">
-<span class="decree-seal-runes">${esc(decree.sealRunes ?? agentCallback.runes)}</span>
-<span class="decree-seal-agent">${esc(decree.sealAgent ?? agentName)}</span>
-<span class="decree-seal-title">${esc(decree.sealTitle ?? agentTitle)}</span>
 </div>
-<div class="decree-signoff">${esc(decree.signoff ?? agentCallback.signoff)}</div>
+${dSummary ? `<div class="dc-section">
+<div class="dc-section-header"><span class="dc-section-glyph" aria-hidden="true">&#5765;</span> <span class="dc-section-title">SUMMARY</span></div>
+<ul class="dc-list" aria-label="Decree summary">${dSummary}</ul>
+</div>` : ""}
+${dChecks ? `<div class="dc-section">
+<div class="dc-section-header"><span class="dc-section-glyph" aria-hidden="true">&#5775;</span> <span class="dc-section-title">CHECKS</span></div>
+<div class="dc-checks" aria-label="Decree checks">${dChecks}</div>
+</div>` : ""}
+<div class="dc-footer" style="border-top: 1px solid rgba(201,146,10,0.20)">
+<div class="dc-seal-band" style="color: ${dAgentColor}" aria-hidden="true">&#5869; &middot; &#5869; &middot; &#5869;</div>
+${decree.sealAgent || decree.sealRunes || decree.sealTitle ? `<div class="dc-seal">${esc(decree.sealAgent || agentName)} &middot; ${esc(decree.sealRunes || dAgentRunes)} &middot; ${esc(decree.sealTitle || dAgentRole)}</div>` : ""}
+${decree.signoff ? `<div class="dc-signoff">&ldquo;${esc(decree.signoff)}&rdquo;</div>` : ""}
+<div class="dc-seal-band" style="color: ${dAgentColor}" aria-hidden="true">&#5869; &middot; &#5869; &middot; &#5869;</div>
 </div>
-<div class="decree-complete-footer">&#5869;&#5869;&#5869; END DECREE &#5869;&#5869;&#5869;</div>
 </div>`;
 }
 

--- a/development/ledger/src/app/(marketing)/chronicles/chronicle-norse.css
+++ b/development/ledger/src/app/(marketing)/chronicles/chronicle-norse.css
@@ -1012,7 +1012,357 @@
 
 .chronicle-page .commit-item:last-child { border-bottom: none; }
 
-/* ── Decree Complete ── */
+/* ══════════════════════════════════════════════════════════════════
+   DECREE CARD — Odin's Throne style (.dc-*)
+   ══════════════════════════════════════════════════════════════════ */
+
+.chronicle-page .dc-card {
+  position: relative;
+  border: 1px solid var(--c-border);
+  border-left-width: 3px;
+  margin: 24px 0;
+  background: var(--c-bg-card);
+  padding: 0;
+}
+
+/* ── Header: agent profile + decree title ── */
+
+.chronicle-page .dc-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 14px 16px 10px;
+  gap: 12px;
+}
+
+.chronicle-page .dc-identity {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.chronicle-page .dc-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  border: 2px solid;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.chronicle-page .dc-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.chronicle-page .dc-agent-info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.chronicle-page .dc-agent-name {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.chronicle-page .dc-agent-title {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.65rem;
+  color: var(--c-fg-muted);
+}
+
+.chronicle-page .dc-agent-runes {
+  font-size: 0.68rem;
+  opacity: 0.75;
+  letter-spacing: 2px;
+}
+
+.chronicle-page .dc-meta {
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.chronicle-page .dc-title {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.72rem;
+  letter-spacing: 0.15em;
+  color: var(--c-gold);
+}
+
+.chronicle-page .dc-rune-delim {
+  opacity: 0.6;
+}
+
+.chronicle-page .dc-issue {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.68rem;
+  color: var(--c-fg-muted);
+}
+
+/* ── Verdict row ── */
+
+.chronicle-page .dc-verdict-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 16px;
+}
+
+.chronicle-page .dc-verdict-label {
+  font-size: 0.62rem;
+  letter-spacing: 1.5px;
+  color: var(--c-fg-muted);
+  text-transform: uppercase;
+  font-family: var(--font-mono), monospace;
+}
+
+.chronicle-page .dc-verdict-value {
+  font-size: 1.3rem;
+  font-weight: 700;
+  letter-spacing: 2px;
+  font-family: var(--font-cinzel-decorative), 'Cinzel Decorative', serif;
+}
+
+.chronicle-page .dc-pr-link {
+  margin-left: auto;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-teal);
+  text-decoration: none;
+}
+
+.chronicle-page .dc-pr-link:hover {
+  text-decoration: underline;
+}
+
+/* ── Collapsible sections (Summary / Checks) ── */
+
+.chronicle-page .dc-section {
+  padding: 0 16px;
+  margin: 8px 0;
+}
+
+.chronicle-page .dc-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 0;
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: var(--c-fg);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.chronicle-page .dc-section-glyph {
+  font-size: 0.85rem;
+  color: var(--c-gold);
+  opacity: 0.8;
+}
+
+.chronicle-page .dc-section-title {
+  color: var(--c-fg);
+}
+
+/* Summary list */
+
+.chronicle-page .dc-list {
+  list-style: none;
+  padding: 0 0 0 4px;
+  margin: 4px 0 8px;
+}
+
+.chronicle-page .dc-list-item {
+  font-size: 0.82rem;
+  line-height: 1.6;
+  color: var(--c-fg);
+  padding: 2px 0;
+  padding-left: 12px;
+  position: relative;
+}
+
+.chronicle-page .dc-list-item::before {
+  content: '\2022';
+  position: absolute;
+  left: 0;
+  color: var(--c-gold);
+  opacity: 0.6;
+}
+
+/* Checks grid */
+
+.chronicle-page .dc-checks {
+  margin: 4px 0 8px;
+}
+
+.chronicle-page .dc-check-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--c-border);
+}
+
+.chronicle-page .dc-check-item:last-child {
+  border-bottom: none;
+}
+
+.chronicle-page .dc-check-name {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-fg-muted);
+}
+
+.chronicle-page .dc-check-value {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.8px;
+  padding: 1px 7px;
+  border-radius: 4px;
+}
+
+/* ── Footer: seal + signoff ── */
+
+.chronicle-page .dc-footer {
+  margin-top: 4px;
+  padding: 10px 16px;
+}
+
+.chronicle-page .dc-seal-band {
+  opacity: 0.5;
+  letter-spacing: 4px;
+  font-size: 0.75rem;
+  text-align: center;
+}
+
+.chronicle-page .dc-seal {
+  font-style: italic;
+  font-size: 0.72rem;
+  color: var(--c-gold);
+  text-align: center;
+  padding: 4px 0;
+  letter-spacing: 0.5px;
+}
+
+.chronicle-page .dc-signoff {
+  font-style: italic;
+  font-size: 0.68rem;
+  color: var(--c-fg-muted);
+  text-align: center;
+  padding: 2px 0 4px;
+}
+
+/* Mobile */
+@media (max-width: 480px) {
+  .chronicle-page .dc-header {
+    flex-direction: column;
+    gap: 8px;
+  }
+  .chronicle-page .dc-meta {
+    text-align: left;
+  }
+  .chronicle-page .dc-verdict-value {
+    font-size: 1.1rem;
+  }
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   ENTRYPOINT STRUCTURED LINES — Odin's Throne style (.ep-*)
+   ══════════════════════════════════════════════════════════════════ */
+
+.chronicle-page .ep-body {
+  padding: 12px;
+  margin: 8px 0 0;
+  background: var(--c-bg-card);
+  border: 1px solid var(--c-border);
+}
+
+.chronicle-page .ep-header {
+  font-family: var(--font-cinzel), 'Cinzel', serif;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--c-gold);
+  letter-spacing: 0.1em;
+  padding: 4px 0;
+  border-bottom: 1px solid var(--c-border);
+  margin-bottom: 4px;
+}
+
+.chronicle-page .ep-ok {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-teal);
+  padding: 2px 0;
+}
+
+.chronicle-page .ep-ok-marker {
+  font-weight: 700;
+  margin-right: 4px;
+}
+
+.chronicle-page .ep-warn {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-amber);
+  padding: 2px 0;
+}
+
+.chronicle-page .ep-warn::before {
+  content: '[WARN] ';
+  font-weight: 700;
+}
+
+.chronicle-page .ep-fatal {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+  color: var(--c-fire);
+  font-weight: 700;
+  padding: 2px 0;
+  background: rgba(239, 68, 68, 0.06);
+  padding-left: 8px;
+  border-left: 2px solid var(--c-fire);
+}
+
+.chronicle-page .ep-fatal::before {
+  content: '[FATAL] ';
+}
+
+.chronicle-page .ep-kv {
+  display: flex;
+  gap: 8px;
+  padding: 2px 0;
+  font-family: var(--font-mono), monospace;
+  font-size: 0.72rem;
+}
+
+.chronicle-page .ep-kv-key {
+  color: var(--c-fg-muted);
+  min-width: 100px;
+}
+
+.chronicle-page .ep-kv-key::after {
+  content: ':';
+}
+
+.chronicle-page .ep-kv-val {
+  color: var(--c-gold);
+}
+
+.chronicle-page .ep-raw {
+  font-family: var(--font-mono), monospace;
+  font-size: 0.68rem;
+  color: var(--c-fg-muted);
+  opacity: 0.6;
+  padding: 1px 0;
+  white-space: pre-wrap;
+}
+
+/* Legacy decree-complete kept for backward compat with existing chronicles */
 
 .chronicle-page .decree-complete {
   border: 2px solid var(--c-teal);


### PR DESCRIPTION
## Summary
- Ports the decree-complete block to Odin's Throne DecreeBlock layout with agent profile header (avatar, name, role, runes), large colored verdict, collapsible summary/checks sections, and seal/signoff footer
- Adds smart tool batch summaries ported from Odin's Throne (`toolCategory()` + `batchSummary()`) — e.g. "2 reading, 3 committing" instead of "5 tool calls"
- Rewrites entrypoint renderer to parse `[ok]`, `[WARN]`, `[FATAL]` with color coding and structured Key: Value rows matching Odin's Throne `useLogStream.ts`
- Adds `.dc-*` CSS classes for decree card and `.ep-*` CSS for structured entrypoint lines
- Preserves legacy `.decree-complete` CSS for backward compatibility with existing chronicles

## Test plan
- [x] Run generator against sample log: `node .claude/skills/brandify-agent/scripts/generate-agent-report.mjs --input <log>`
- [x] Verify MDX compile validation passes
- [x] Verify decree card renders with agent color, avatar, verdict, checks, seal
- [x] Verify tool batch summaries show categories instead of "N tool calls"
- [x] Verify entrypoint lines are structured with [ok]/[WARN]/Key:Value styling

Generated with [Claude Code](https://claude.com/claude-code)