### PR TITLE
fix: add ValhallaCardTile mock to dashboard tests

### DIFF
--- a/development/ledger/src/__tests__/components/dashboard.test.tsx
+++ b/development/ledger/src/__tests__/components/dashboard.test.tsx
@@ -27,6 +27,13 @@ vi.mock("@/contexts/RagnarokContext", async () => (await import("../mocks/hook-m
 vi.mock("@/hooks/useAuth", async () => (await import("../mocks/hook-mocks")).authMockAuthenticatedHh1);
 vi.mock("@/lib/trial-utils", async () => (await import("../mocks/storage-mocks")).trialUtilsMockLimit);
 vi.mock("@/components/dashboard/CardTile", async () => (await import("../mocks/component-mocks")).cardTileMock);
+vi.mock("@/components/dashboard/ValhallaCardTile", async () => {
+  const React = await import("react");
+  return {
+    ValhallaCardTile: ({ card }: { card: { cardName: string } }) =>
+      React.createElement("div", { "data-testid": `card-tile-${card.cardName}` }, card.cardName),
+  };
+});
 vi.mock("@/components/dashboard/EmptyState", async () => (await import("../mocks/component-mocks")).emptyStateMock);
 vi.mock("@/components/dashboard/AnimatedCardGrid", async () => (await import("../mocks/component-mocks")).animatedCardGridMock);
 vi.mock("@/components/entitlement/KarlUpsellDialog", async () => (await import("../mocks/component-mocks")).karlUpsellDialogMock);


### PR DESCRIPTION
## Summary
- PR #1862 (test consolidation) added tests for "all" and "valhalla" tabs that render closed/graduated cards
- These cards render via `ValhallaCardTile`, but it wasn't mocked — real component triggered happy-dom fetch errors
- Adds async mock for `ValhallaCardTile` matching the existing `cardTileMock` pattern

## Test plan
- [x] All 34 dashboard tests pass
- [x] Full Vitest suite: 3392/3393 pass (1 pre-existing failure in unrelated `valhalla-card-tile-1808.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)