### PR TITLE
fix: settings cards stretch to full height — issue #1878

### DIFF
--- a/development/ledger/src/app/ledger/settings/page.tsx
+++ b/development/ledger/src/app/ledger/settings/page.tsx
@@ -334,7 +334,7 @@ export default function SettingsPage() {
         hidden={activeTab !== "account"}
         className="pt-6"
       >
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
           <StripeSettings />
           <TrialSettingsSection />
         </div>
@@ -348,7 +348,7 @@ export default function SettingsPage() {
         hidden={activeTab !== "household"}
         className="pt-6"
       >
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
           <HouseholdSettingsSection />
           <SyncSettingsSection />
         </div>


### PR DESCRIPTION
Fixes #1878

## Summary
- Added `items-start` to both two-column grid containers on the Settings page (Account and Household tabs)
- CSS grid `align-items` defaults to `stretch`, which caused shorter cards (e.g. Cloud Sync) to stretch to match the tallest sibling
- `items-start` pins each card to the top of its grid cell and collapses it to fit content height only

## Test plan
- [x] tsc --noEmit — PASS
- [x] next build — PASS
- [x] vitest run — 240 files, 3513 tests PASS
- [x] CSS-only change — no new Vitest tests added (class name assertions are banned per loki.md; no behavioral logic to test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)