### PR TITLE
fix: decree section gray background in light theme (#1884)

### DIFF
--- a/development/odins-throne/ui/components/DecreeBlock.tsx
+++ b/development/odins-throne/ui/components/DecreeBlock.tsx
@@ -310,7 +310,7 @@ export function DecreeBlock({ text, agentKey: jobAgentKey, onAvatarClick }: Decr
               right: "8px",
               fontSize: "9px",
               color: "var(--text-void)",
-              background: "rgba(42,42,62,0.6)",
+              background: theme === "light" ? "rgba(100, 80, 45, 0.12)" : "rgba(42,42,62,0.6)",
               padding: "1px 5px",
               borderRadius: "3px",
               fontFamily: "monospace",

--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -1110,7 +1110,7 @@ body {
   font-size: 0.6rem; font-weight: 600;
   color: var(--gold);
   letter-spacing: 0.04em;
-  background: linear-gradient(135deg, rgba(201, 146, 10, 0.06) 0%, transparent 100%);
+  background: linear-gradient(135deg, rgba(201, 146, 10, 0.06) 0%, rgba(201, 146, 10, 0) 100%);
 }
 .decree-section-header:hover { background: rgba(201, 146, 10, 0.1); }
 .decree-section-glyph {
@@ -1135,6 +1135,9 @@ body {
   position: relative;
   background: linear-gradient(180deg, rgba(7, 7, 13, 0.4) 0%, rgba(201, 146, 10, 0.02) 100%);
 }
+[data-theme="light"] .decree-section-body {
+  background: linear-gradient(180deg, rgba(143, 110, 14, 0.04) 0%, rgba(143, 110, 14, 0.01) 100%);
+}
 .decree-section-body p {
   margin: 0 0 0.25rem 0;
 }
@@ -1156,7 +1159,7 @@ body {
   position: absolute;
   bottom: 0; left: 0; right: 0;
   height: 2rem;
-  background: linear-gradient(transparent, var(--void));
+  background: linear-gradient(rgba(7, 7, 13, 0), var(--void));
   pointer-events: none;
 }
 /* When expanded, remove height limit and fade */
@@ -1166,6 +1169,9 @@ body {
 }
 .decree-section.open .decree-section-body::after {
   display: none;
+}
+[data-theme="light"] .decree-section-body::after {
+  background: linear-gradient(rgba(238, 230, 216, 0), var(--void));
 }
 /* Full-width sections (identity + issue details) span the grid */
 .decree-section.decree-wide {
@@ -1211,7 +1217,7 @@ body {
   margin: 0.75rem 0 0.25rem;
   padding: 0.75rem 1rem;
   text-align: center;
-  background: linear-gradient(135deg, rgba(201, 146, 10, 0.04) 0%, transparent 50%, rgba(201, 146, 10, 0.04) 100%);
+  background: linear-gradient(135deg, rgba(201, 146, 10, 0.04) 0%, rgba(201, 146, 10, 0) 50%, rgba(201, 146, 10, 0.04) 100%);
 }
 .decree-seal-runic-band {
   font-size: 0.65rem;
@@ -1446,7 +1452,7 @@ body {
 .decree-card-footer {
   padding: 0.5rem 0.8rem 0.4rem;
   text-align: center;
-  background: linear-gradient(135deg, rgba(201, 146, 10, 0.04) 0%, transparent 50%, rgba(201, 146, 10, 0.04) 100%);
+  background: linear-gradient(135deg, rgba(201, 146, 10, 0.04) 0%, rgba(201, 146, 10, 0) 50%, rgba(201, 146, 10, 0.04) 100%);
 }
 .decree-card-seal-band {
   font-size: 0.6rem;


### PR DESCRIPTION
## Summary

- **Root cause**: `.decree-section-body` used `rgba(7, 7, 13, 0.4)` — a hardcoded dark color at 40% opacity — which renders as visible gray on the parchment (`--void`) background in light theme
- **Secondary**: CSS `transparent` keyword in gradients resolves to `rgba(0,0,0,0)`, causing dark color-stop banding on light backgrounds (`.decree-section-header`, `.decree-section-body::after`, `.decree-seal`, `.decree-card-footer`)
- **Component**: Format fallback badge in `DecreeBlock.tsx` used hardcoded `rgba(42,42,62,0.6)` — dark on parchment

## Changes

- `index.css`: Add `[data-theme="light"] .decree-section-body` override with gold-tinted transparent gradient instead of dark overlay
- `index.css`: Add `[data-theme="light"] .decree-section-body::after` override with parchment-matched fade (`rgba(238,230,216,0)` → `var(--void)`)
- `index.css`: Replace all `transparent` gradient color-stops with explicit `rgba(color, 0)` to prevent black-channel interpolation — applies to `.decree-section-header`, `.decree-seal`, `.decree-card-footer`
- `DecreeBlock.tsx`: Format badge background is now theme-aware (`rgba(100,80,45,0.12)` in light, existing dark value in dark)

Dark theme: **unchanged** — all fixes are additive light-theme overrides or neutral `transparent`→`rgba(x,x,x,0)` substitutions.

## Test plan

- [ ] tsc: PASS ✅
- [ ] build: PASS ✅
- [ ] Visual: decree section matches parchment background in light theme
- [ ] Visual: dark theme appearance unchanged

Closes #1884

🤖 Generated with [Claude Code](https://claude.com/claude-code)