### PR TITLE
Issue #1885 - fix: Odin's Throne cache button label and height

### DIFF
--- a/development/odins-throne/ui/components/LogViewer.tsx
+++ b/development/odins-throne/ui/components/LogViewer.tsx
@@ -160,11 +160,11 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
         )}
         {replayedFromCache && (
           <span
-            className="ws-badge replayed-cache"
+            className="header-action-btn replayed-cache"
             title="Pod cleaned up — showing cached logs"
             aria-label="Replayed from cache"
           >
-            ᛗ replayed from cache
+            ᛗ Cached
           </span>
         )}
         <CopySessionIdButton sessionId={job.sessionId} />

--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -799,7 +799,8 @@ body {
 .ws-badge.open            { color: var(--teal-asgard); border-color: var(--teal-asgard); }
 .ws-badge.closed          { color: var(--text-void); border-color: var(--rune-border); }
 .ws-badge.error           { color: var(--error-strong); border-color: var(--error-strong); }
-.ws-badge.replayed-cache  { color: var(--gold); border-color: var(--gold); opacity: 0.85; }
+.ws-badge.replayed-cache,
+.header-action-btn.replayed-cache { color: var(--gold); border-color: var(--gold); opacity: 0.85; cursor: default; }
 /* icon variant: higher specificity wins over state-based border-color overrides above */
 .ws-badge.ws-badge-icon   { border: none; padding: 0; border-radius: 0; }
 


### PR DESCRIPTION
PR for issue: #1885

Changes 'replayed from cache' button to 'Cached' and fixes height to match adjacent header buttons.

**Changes:**
- Button label: 'ᛗ replayed from cache' -> 'ᛗ Cached'
- Element class: `ws-badge replayed-cache` -> `header-action-btn replayed-cache` (matches Cancel/Copy/Pinned height: 1.6rem)
- CSS: added `.header-action-btn.replayed-cache` rule to preserve gold color and set `cursor: default`

**Verification:**
- tsc: PASS
- vite build: PASS
- Visual check: button height aligns with all other session header buttons in both light and dark themes