### PR TITLE
security: remove oauth2-proxy skip-auth-regex bypass (Fixes #1888)

### DIFF
--- a/infrastructure/helm/odin-throne/templates/deployment.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment.yaml
@@ -75,7 +75,6 @@ spec:
             - --http-address=0.0.0.0:{{ .Values.oauth2Proxy.port }}
             - --redirect-url={{ .Values.oauth2Proxy.redirectUrl }}
             - --skip-auth-route=GET=^/healthz$
-            - --skip-auth-regex=.*
             - --cookie-secure=true
             - --cookie-samesite=lax
           ports:


### PR DESCRIPTION
PR for issue: #1888

Fixes #1888

## Summary

- Removes `--skip-auth-regex=.*` from oauth2-proxy sidecar args in odin-throne Helm deployment
- This arg bypassed authentication for all routes, exposing GKE job data and internal infrastructure to unauthenticated internet traffic
- Retains `--skip-auth-route=GET=^/healthz$` so K8s liveness/readiness probes continue to work