### PR TITLE
fix: visible borders on all form inputs (issue #1902)

### DIFF
--- a/development/ledger/src/app/globals.css
+++ b/development/ledger/src/app/globals.css
@@ -50,7 +50,7 @@
 
     /* ── Structure ──────────────────────────────────────────── */
     --border:               33  36% 48%;    /* #966b3c — warm brown border, visible on parchment (Issue #1874) */
-    --input:                38  25% 91%;    /* #ebdfcb — parchment input */
+    --input:                33  36% 48%;    /* #966b3c — same as --border; ensures input fields have visible borders (Issue #1902) */
     --ring:                 38  80% 28%;    /* dark burnt gold focus ring */
     --radius:               0.25rem;        /* sharp, angular — not pill */
 
@@ -143,7 +143,7 @@
 
   /* ── Structure ──────────────────────────────────────────── */
   --border:               28 22% 40%;     /* lifts to 3.1:1 contrast vs bg */
-  --input:                25 10% 14%;     /* sunken below card for field boundary */
+  --input:                28 22% 40%;     /* matches --border; ensures input fields have visible borders (Issue #1902) */
   --ring:                 42  75% 48%;    /* gold focus ring */
 
   /* ── Card Hover (Issue #298) ──────────────────────────── */


### PR DESCRIPTION
PR for issue: #1902

Makes all form input fields (inputs, selects, date pickers, textareas) show a visible border in both focused and unfocused states across light and dark themes.

## Root Cause

The `--input` CSS custom property (used by Tailwind's `border-input` class on all shadcn form components) was set to near-background colors in both themes:
- Light: `38 25% 91%` (91% lightness parchment — nearly identical to background `38 40% 89%`)
- Dark: `25 10% 14%` (barely above background `28 15% 7%`)

This made `border-input` invisible on all unfocused form fields.

## Fix

Updated `--input` in `globals.css` to match the existing `--border` token value in both themes:
- Light: `33 36% 48%` — warm brown, visible on parchment
- Dark: `28 22% 40%` — provides 3.1:1 contrast vs background

Focused state still shows distinct gold ring via `focus-visible:ring-ring`.

## Affected Components

All shadcn form components that use `border-input`:
- `Input` (input.tsx)
- `Select` trigger (select.tsx)
- `Textarea` (textarea.tsx)
- Any date picker using these primitives

## Verification

- Visit `/ledger/cards/new` — all fields show visible borders
- Visit `/ledger/cards/<id>/edit` — same check
- Toggle light/dark theme — borders visible in both
- Focused field shows distinct gold ring border

## Checks

- tsc: PASS
- build: PASS
- Vitest: 3615/3617 pass (2 pre-existing failures in import-wizard aria-live test, unrelated to this change)