### PR TITLE
fix: button icon contrast in light mode — issue #1881

### DIFF
--- a/development/odins-throne/ui/components/JobCard.tsx
+++ b/development/odins-throne/ui/components/JobCard.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
-import { AGENT_COLORS, AGENT_AVATARS, AGENT_LIGHT_AVATARS, STATUS_COLORS, STATUS_LABELS } from "../lib/constants";
+import { AGENT_COLORS, AGENT_AVATARS, AGENT_LIGHT_AVATARS, STATUS_COLORS, STATUS_COLORS_LIGHT, STATUS_LABELS } from "../lib/constants";
 import { StatusIconSvg } from "./StatusIcon";
 import { resolveSessionTitle } from "../lib/resolveSessionTitle";
 import type { DisplayMode } from "./Sidebar";
@@ -41,7 +41,8 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
   const agentColor = AGENT_COLORS[job.agentKey ?? ""] || "#c9920a";
   const avatarMap = theme === "light" ? AGENT_LIGHT_AVATARS : AGENT_AVATARS;
   const avatar = avatarMap[job.agentKey ?? ""];
-  const sColor = STATUS_COLORS[job.status] || "#606070";
+  const statusColorMap = theme === "light" ? STATUS_COLORS_LIGHT : STATUS_COLORS;
+  const sColor = statusColorMap[job.status] || (theme === "light" ? "#57534e" : "#606070");
   const sLabel = STATUS_LABELS[job.status] || job.status;
   const pulse = job.status === "running" ? " pulse" : "";
   const displayTitle = resolveSessionTitle(job);

--- a/development/odins-throne/ui/components/LogViewer.tsx
+++ b/development/odins-throne/ui/components/LogViewer.tsx
@@ -82,7 +82,7 @@ import { ToolBlock } from "./ToolBlock";
 import { NorseErrorTablet } from "./NorseErrorTablet";
 import { NorseVerdictInscription, isVerdictMessage } from "./NorseVerdictInscription";
 import { DecreeBlock, isDecreeBlock } from "./DecreeBlock";
-import { AGENT_AVATARS, AGENT_LIGHT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
+import { AGENT_AVATARS, AGENT_LIGHT_AVATARS, AGENT_COLORS, AGENT_NAMES, AGENT_RUNE_NAMES, AGENT_TITLES, STATUS_COLORS, STATUS_COLORS_LIGHT, STATUS_LABELS, WIKI_LINKS } from "../lib/constants";
 import { StatusIconSvg } from "./StatusIcon";
 import { downloadLogFile } from "../lib/localStorageLogs";
 import { useTheme } from "../hooks/useTheme";
@@ -101,6 +101,8 @@ interface SessionHeaderProps {
 function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, replayedFromCache = false, onCancelJob }: SessionHeaderProps) {
   const displayTitle = resolveSessionTitle(job);
   const [confirmingUnpin, setConfirmingUnpin] = useState(false);
+  const { theme } = useTheme();
+  const statusColorMap = theme === "light" ? STATUS_COLORS_LIGHT : STATUS_COLORS;
 
   // Reset confirmation state when pin state changes externally
   useEffect(() => {
@@ -151,7 +153,7 @@ function SessionHeader({ job, isPinned = false, onTogglePin, showPin = true, rep
         ) : (
           <span
             className={`job-status-icon-btn${job.status === "running" ? " pulse" : ""}`}
-            style={{ color: STATUS_COLORS[job.status] }}
+            style={{ color: statusColorMap[job.status] }}
             title={`Job status: ${STATUS_LABELS[job.status]}`}
             aria-label={`Job status: ${STATUS_LABELS[job.status]}`}
           >

--- a/development/odins-throne/ui/lib/constants.ts
+++ b/development/odins-throne/ui/lib/constants.ts
@@ -137,6 +137,16 @@ export const STATUS_COLORS: Record<Job["status"], string> = {
   cached: "#c9920a",   // gold — pinned in Odin's memory
 };
 
+/** Darker variants of STATUS_COLORS for light mode — WCAG AA ≥3:1 on parchment bg */
+export const STATUS_COLORS_LIGHT: Record<Job["status"], string> = {
+  running:   "#0e7490",  // dark cyan    — matches --teal-asgard family
+  succeeded: "#16a34a",  // dark green   — same as --success-strong light
+  failed:    "#dc2626",  // dark red     — same as --error-strong light
+  pending:   "#b45309",  // dark amber
+  purged:    "#57534e",  // warm dark gray
+  cached:    "#8f6e0e",  // dark gold    — same as --gold light
+};
+
 export const STATUS_LABELS: Record<Job["status"], string> = {
   running: "running",
   succeeded: "succeeded",

--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -790,6 +790,14 @@ body {
 }
 .copy-session-btn:hover { color: var(--gold); border-color: var(--gold); }
 .copy-session-btn.copied { color: var(--teal-asgard); border-color: var(--teal-asgard); }
+
+/* ── Light mode: button icon contrast ─────────── */
+/* .card-pin-btn and .copy-session-btn default to --text-void which is marginal for
+ * small 11–14 px stroke icons on the parchment bg. Upgrade to --text-rune (~7:1). */
+[data-theme="light"] .card-pin-btn { color: var(--text-rune); }
+[data-theme="light"] .pin-btn { color: var(--text-rune); }
+[data-theme="light"] .copy-session-btn { color: var(--text-rune); }
+
 .ws-badge {
   font-family: 'JetBrains Mono', monospace; font-size: 0.65rem;
   padding: 0.15rem 0.5rem; border-radius: 3px;


### PR DESCRIPTION
PR for issue: #1881

## Summary

- Add `STATUS_COLORS_LIGHT` constant with WCAG AA-compliant dark equivalents for all job status colors (bright teal/green/yellow were ≤1.9:1 contrast on the parchment background)
- Update `JobCard` and `LogViewer/SessionHeader` to select `STATUS_COLORS_LIGHT` when `theme === "light"`, fixing all inline `style={{ color: sColor }}` status icon buttons
- Add `[data-theme="light"]` CSS overrides for `.card-pin-btn`, `.pin-btn`, `.copy-session-btn` upgrading from `--text-void` (~4.4:1) to `--text-rune` (~7.4:1) — needed for 11–14 px thin stroke icons

## Test plan
- [x] tsc: PASS
- [x] build: PASS
- Validated by Loki QA