### PR TITLE
Issue #1922 - fix: code fence rendering in Odin's Throne

### DIFF
--- a/development/odins-throne/ui/components/LogViewer.tsx
+++ b/development/odins-throne/ui/components/LogViewer.tsx
@@ -797,12 +797,17 @@ function DecreeSectionBody({ body }: { body: string }) {
   const elements: Array<React.ReactElement> = [];
   const listBuffer: string[] = [];
   const codeBuffer: string[] = [];
+  const fenceBuffer: string[] = [];
+  let inFence = false;
+  let fenceLang = "";
   let keyIdx = 0;
 
+  // Triple-backtick fences are handled separately — exclude from isCodeLine
   const isCodeLine = (line: string) =>
-    /^(cd |git |gh |bash |npm |node |```)/.test(line.trimStart()) || /^ {2,}/.test(line);
+    /^(cd |git |gh |bash |npm |node )/.test(line.trimStart()) || /^ {2,}/.test(line);
   const isListLine = (line: string) => /^[-*] /.test(line.trimStart());
   const isHeadingLine = (line: string) => /^##\s+/.test(line.trimStart()) || /^\*\*/.test(line.trimStart());
+  const isFenceLine = (line: string) => /^`{3,}/.test(line.trimStart());
 
   const flushList = () => {
     if (listBuffer.length === 0) return;
@@ -827,7 +832,39 @@ function DecreeSectionBody({ body }: { body: string }) {
     codeBuffer.length = 0;
   };
 
+  const flushFence = () => {
+    if (fenceBuffer.length === 0 && !inFence) return;
+    elements.push(
+      <pre key={`fence-${keyIdx++}`} className="decree-body-fence">
+        <code className={fenceLang ? `language-${fenceLang}` : undefined}>
+          {fenceBuffer.join("\n")}
+        </code>
+      </pre>
+    );
+    fenceBuffer.length = 0;
+    inFence = false;
+    fenceLang = "";
+  };
+
   for (const line of lines) {
+    // Handle triple-backtick fences first
+    if (isFenceLine(line)) {
+      if (!inFence) {
+        flushList();
+        flushCode();
+        inFence = true;
+        fenceLang = line.trimStart().replace(/^`{3,}/, "").trim();
+      } else {
+        flushFence();
+      }
+      continue;
+    }
+
+    if (inFence) {
+      fenceBuffer.push(line);
+      continue;
+    }
+
     if (isCodeLine(line)) {
       flushList();
       codeBuffer.push(line);
@@ -849,6 +886,8 @@ function DecreeSectionBody({ body }: { body: string }) {
   }
   flushCode();
   flushList();
+  // Flush any unclosed fence (render what we have)
+  if (inFence) flushFence();
 
   return <>{elements}</>;
 }

--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -1212,6 +1212,32 @@ body {
   white-space: pre-wrap;
   word-break: break-all;
 }
+.decree-body-fence {
+  display: block;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.55rem;
+  border: 1px solid var(--gold-dim-border);
+  padding: 0.5rem 0.75rem;
+  margin: 0.4rem 0;
+  border-radius: 4px;
+  background: rgba(7, 7, 13, 0.7);
+  color: var(--text-rune);
+  white-space: pre;
+  overflow-x: auto;
+  word-break: normal;
+}
+.decree-body-fence > code {
+  font-family: inherit;
+  font-size: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  color: inherit;
+}
+[data-theme="light"] .decree-body-fence {
+  background: rgba(240, 235, 220, 0.7);
+  color: var(--text-primary);
+}
 .decree-body-link {
   color: var(--gold);
   text-decoration: underline;


### PR DESCRIPTION
PR for issue: #1922

Parses triple backtick code fences in decree/prompt text and renders them as styled code blocks instead of literal backtick characters.

## What changed
- `DecreeSectionBody` now detects triple-backtick fence open/close markers before the generic `isCodeLine` check
- Lines inside a fence are collected into a `fenceBuffer` and rendered as `<pre><code>` once the closing fence is reached
- `isCodeLine` no longer matches ` ``` ` prefix (fence lines are consumed by the dedicated fence handler)
- Added `.decree-body-fence` CSS class: monospace, dark background, `white-space: pre`, scrollable, with light-theme variant
- Unclosed fences render gracefully (flush whatever content was collected)

## Verify
- View any session with triple-backtick code fences in the decree/issue body
- Code blocks render with dark background and monospace font, no raw backtick pills
- Both light and dark themes look correct

## Build
- tsc: PASS
- vite build: PASS
- vitest: N/A (odins-throne has no test infrastructure)