### PR TITLE
fix: replace Opened with Bonus at Stake on Hunt card

### DIFF
--- a/development/ledger/src/components/dashboard/HuntCardTile.tsx
+++ b/development/ledger/src/components/dashboard/HuntCardTile.tsx
@@ -8,7 +8,7 @@
  * Differences from CardTile:
  *   - Removes Credit limit and Annual fee rows.
  *   - Adds Min spend, Spent (with inline progress bar) rows.
- *   - Keeps Bonus deadline and Opened rows.
+ *   - Keeps Bonus deadline row, replaces Opened with Bonus at Stake.
  *   - Progress ring reflects spent / minSpend ratio (not time-based).
  *   - Ring wrapper carries a native title tooltip: remaining spend + human-friendly
  *     time until deadline.
@@ -244,13 +244,17 @@ export function HuntCardTile({ card, lokiLabel }: HuntCardTileProps) {
               </div>
             )}
 
-            {/* Opened date */}
-            <div className="flex justify-between text-muted-foreground">
-              <span>Opened</span>
-              <span className="font-medium text-foreground">
-                {formatDate(card.openDate)}
-              </span>
-            </div>
+            {/* Bonus at stake */}
+            {card.signUpBonus && card.signUpBonus.amount > 0 && (
+              <div className="flex justify-between text-muted-foreground">
+                <span>Bonus at Stake</span>
+                <span className="font-medium text-primary">
+                  {card.signUpBonus.type === "cashback"
+                    ? formatCurrency(card.signUpBonus.amount)
+                    : `${card.signUpBonus.amount.toLocaleString()} ${card.signUpBonus.type}`}
+                </span>
+              </div>
+            )}
           </CardContent>
         </Card>
       </Link>


### PR DESCRIPTION
## Summary
- Replace "Opened" date row with "Bonus at Stake" showing the sign-up bonus value
- Displays points/miles count or cashback dollar amount in gold accent color
- Only renders when card has a non-zero sign-up bonus

## Test plan
- [ ] Verify Hunt tab cards show bonus value instead of opened date
- [ ] Check points, miles, and cashback formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)