### PR TITLE
Issue #1939 - fix: swap tab highlight in Odin's Spear

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -192,6 +192,13 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     );
   } else if (activeTab === 0) {
     mainContent = (
+      <UsersTab
+        cmdStatus={cmdStatus}
+        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(1); }}
+      />
+    );
+  } else {
+    mainContent = (
       <HouseholdsTab
         cmdStatus={cmdStatus}
         initialHouseholdId={jumpHouseholdId}
@@ -202,13 +209,6 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
           const cmd = getCommands().find((c) => c.name === "trial-adjust");
           if (cmd) handleTrialInput(cmd);
         }}
-      />
-    );
-  } else {
-    mainContent = (
-      <UsersTab
-        cmdStatus={cmdStatus}
-        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(0); }}
       />
     );
   }


### PR DESCRIPTION
## Summary
- Fixes swapped tab content in `app.tsx` — `activeTab === 0` now correctly renders `UsersTab` (matching "Users" at index 0 in `TUI_TABS`)
- `else` branch now correctly renders `HouseholdsTab` (matching "Households" at index 1)
- Fixes `onJumpToHousehold` to call `setActiveTab(1)` so jumping to a household activates the Households tab

## Changes
- `development/odins-spear/src/app.tsx`: swapped `UsersTab`/`HouseholdsTab` branches and updated `setActiveTab(0)` → `setActiveTab(1)` in jump handler

## Verification
- [x] `npx tsc --noEmit` passes in `odins-spear`
- [x] `pnpm run build` passes in `odins-spear`
- [x] `pnpm run verify:tsc` passes in `ledger`
- [x] `pnpm run verify:build` passes in `ledger`

Closes #1939

🤖 Generated with [Claude Code](https://claude.com/claude-code)