### PR TITLE
Issue #1929 - fix: invite mailto link missing https:// prefix

### DIFF
--- a/development/ledger/src/__tests__/household/invite-mailto.test.ts
+++ b/development/ledger/src/__tests__/household/invite-mailto.test.ts
@@ -78,7 +78,7 @@ describe("buildInviteMailtoUrl", () => {
     const url = buildInviteMailtoUrl(code, { random: () => 0 });
     const params = new URLSearchParams(url.replace("mailto:your-friend@example.com?", ""));
     const body = params.get("body") ?? "";
-    expect(body).toContain("fenrirledger.com");
+    expect(body).toContain("https://fenrirledger.com");
     expect(body).toContain("Settings > Household");
     expect(body).toContain("Join a Household");
   });

--- a/development/ledger/src/lib/household/invite-mailto.ts
+++ b/development/ledger/src/lib/household/invite-mailto.ts
@@ -18,7 +18,7 @@ export const INVITE_INTRO_POOL: readonly string[] = [
 
 const JOIN_INSTRUCTIONS = `Here's how to join my household on Fenrir Ledger:
 
-1. Go to fenrirledger.com
+1. Go to https://fenrirledger.com
 2. Sign up or sign in
 3. Go to Settings > Household
 4. Click "Join a Household"


### PR DESCRIPTION
## Summary

- Fixes bare `fenrirledger.com` in the invite email body — most email clients do not auto-link URLs without a protocol prefix
- Changed `1. Go to fenrirledger.com` → `1. Go to https://fenrirledger.com` in `invite-mailto.ts:21`
- Updated the unit test to assert `https://fenrirledger.com`

## Test plan

- [x] tsc — exit 0
- [x] next build — exit 0
- [x] Vitest — 258 test files, 3762 tests, all passed

Closes #1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)