### PR TITLE
fix: Karl subscriber no longer sees trial card — issue #1940

### DIFF
--- a/development/ledger/src/__tests__/trial/trial-settings-section-render.test.tsx
+++ b/development/ledger/src/__tests__/trial/trial-settings-section-render.test.tsx
@@ -1,16 +1,18 @@
 /**
- * Component render tests for TrialSettingsSection — Issue #1032
+ * Component render tests for TrialSettingsSection — Issue #1032, #1940
  *
- * Validates that the Subscribe price CTA button is shown/hidden correctly
- * based on trial status, per AC:
- *   - Hidden during active trial
- *   - Shown when trial expired
- *   - Hidden for paid Karl subscribers (converted → section hidden)
- *   - Hidden for Thrall users with no trial (none → section hidden)
- *   - Plain Subscribe button in StripeSettings tier card remains unchanged
+ * Validates that the trial card renders correctly per tier + auth + trial-status:
+ *   - Karl tier → never renders (no flash)
+ *   - Loading → never renders (no flash)
+ *   - Converted → hidden
+ *   - Anonymous + none → sign-in CTA
+ *   - Thrall authenticated + none → "trial over" upsell, no button
+ *   - Thrall authenticated + expired → "trial over" upsell, no button
+ *   - Thrall + active trial → trial progress, no subscribe button
  *
  * @see components/trial/TrialSettingsSection.tsx
  * @see Issue #1032
+ * @see Issue #1940
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -18,8 +20,6 @@ import { render, screen } from "@testing-library/react";
 import { TrialSettingsSection } from "@/components/trial/TrialSettingsSection";
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
-
-const mockSubscribeStripe = vi.hoisted(() => vi.fn());
 
 const mockTrialStatus = {
   remainingDays: 15,
@@ -33,6 +33,16 @@ const mockMetrics = {
   totalAnnualFeesFormatted: "$144.00",
 };
 
+const mockEntitlement = {
+  tier: "thrall" as string,
+  isLoading: false,
+  subscribeStripe: vi.fn(),
+};
+
+const mockAuth = {
+  status: "authenticated" as string,
+};
+
 vi.mock("@/hooks/useTrialStatus", () => ({
   useTrialStatus: () => mockTrialStatus,
 }));
@@ -42,11 +52,11 @@ vi.mock("@/hooks/useTrialMetrics", () => ({
 }));
 
 vi.mock("@/hooks/useEntitlement", () => ({
-  useEntitlement: () => ({
-    tier: "thrall",
-    isLoading: false,
-    subscribeStripe: mockSubscribeStripe,
-  }),
+  useEntitlement: () => mockEntitlement,
+}));
+
+vi.mock("@/contexts/AuthContext", () => ({
+  useAuthContext: () => mockAuth,
 }));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -57,87 +67,99 @@ function setStatus(status: string, remainingDays = 15) {
   mockTrialStatus.isLoading = false;
 }
 
+function setTier(tier: string) {
+  mockEntitlement.tier = tier;
+  mockEntitlement.isLoading = false;
+}
+
+function setAuth(status: string) {
+  mockAuth.status = status;
+}
+
 function renderSection() {
   return render(<TrialSettingsSection />);
 }
 
-/** Price text present in the subscribe CTA button label */
-const PRICE_BUTTON_TEXT = "$3.99/month";
-const PRICE_BUTTON_ARIA = "Upgrade to Karl subscription";
-
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
-describe("TrialSettingsSection — Subscribe price button visibility (Issue #1032)", () => {
-  // AC: Subscribe button with price hidden during active trial
-  it("hides the price CTA button during an active trial", () => {
+describe("TrialSettingsSection — Issue #1940: Karl tier + flash + upsell", () => {
+  beforeEach(() => {
+    mockTrialStatus.status = "active";
+    mockTrialStatus.remainingDays = 15;
+    mockTrialStatus.isLoading = false;
+    mockEntitlement.tier = "thrall";
+    mockEntitlement.isLoading = false;
+    mockAuth.status = "authenticated";
+  });
+
+  // ── Karl tier: never render ────────────────────────────────────────────────
+
+  it("renders nothing for Karl tier (active trial status)", () => {
+    setTier("karl");
     setStatus("active");
-    renderSection();
-
-    // The "Upgrade to Karl subscription" button must NOT exist
-    const priceButton = screen.queryByRole("button", { name: PRICE_BUTTON_ARIA });
-    expect(priceButton).toBeNull();
-  });
-
-  // AC: Subscribe button with price hidden during active trial (text check)
-  it("does not render any button containing '$3.99/month' during active trial", () => {
-    setStatus("active");
     const { container } = renderSection();
-
-    const buttons = container.querySelectorAll("button");
-    const priceButtons = Array.from(buttons).filter((btn) =>
-      btn.textContent?.includes(PRICE_BUTTON_TEXT)
-    );
-    expect(priceButtons).toHaveLength(0);
-  });
-
-  // AC: Subscribe button with price shown when trial expired
-  it("shows the price CTA button when trial has expired", () => {
-    setStatus("expired", 0);
-    renderSection();
-
-    const priceButton = screen.queryByRole("button", { name: PRICE_BUTTON_ARIA });
-    expect(priceButton).not.toBeNull();
-  });
-
-  // AC: Subscribe button with price shown when trial expired (text check)
-  it("renders price button text 'Upgrade to Karl — $3.99/month' when expired", () => {
-    setStatus("expired", 0);
-    const { container } = renderSection();
-
-    const buttons = container.querySelectorAll("button");
-    const priceButtons = Array.from(buttons).filter((btn) =>
-      btn.textContent?.includes(PRICE_BUTTON_TEXT)
-    );
-    expect(priceButtons).toHaveLength(1);
-    expect(priceButtons[0].textContent).toContain("Upgrade to Karl");
-  });
-
-  // AC: Subscribe button with price hidden for paid Karl subscribers (converted)
-  it("renders nothing for converted (paid Karl) users — whole section hidden", () => {
-    setStatus("converted");
-    const { container } = renderSection();
-
-    // TrialSettingsSection returns null for converted
     expect(container.firstChild).toBeNull();
   });
 
-  // AC: Anonymous / no-trial users see the "not started" box (issue #1384)
-  it("renders the anonymous trial-not-started box for status 'none'", () => {
-    setStatus("none");
-    renderSection();
-
-    const section = screen.getByRole("region", { name: "Trial Status" });
-    expect(section).toBeDefined();
+  it("renders nothing for Karl tier (converted status)", () => {
+    setTier("karl");
+    setStatus("converted");
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
   });
 
-  it("shows Norse-themed 'not started' copy for status 'none'", () => {
+  it("renders nothing for Karl tier (none status)", () => {
+    setTier("karl");
     setStatus("none");
     const { container } = renderSection();
-
-    expect(container.textContent).toContain("Thy trial hath not yet begun");
+    expect(container.firstChild).toBeNull();
   });
 
-  it("shows Google sign-in CTA link for status 'none'", () => {
+  it("renders nothing for Karl tier (expired status)", () => {
+    setTier("karl");
+    setStatus("expired", 0);
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
+  });
+
+  // ── Loading states: no flash ───────────────────────────────────────────────
+
+  it("renders nothing while trial is loading", () => {
+    mockTrialStatus.isLoading = true;
+    mockTrialStatus.status = "active";
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
+    mockTrialStatus.isLoading = false;
+  });
+
+  it("renders nothing while entitlement is loading", () => {
+    mockEntitlement.isLoading = true;
+    setStatus("active");
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
+    mockEntitlement.isLoading = false;
+  });
+
+  it("renders nothing while auth is loading", () => {
+    setAuth("loading");
+    setStatus("active");
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
+    setAuth("authenticated");
+  });
+
+  // ── Converted: hide ────────────────────────────────────────────────────────
+
+  it("renders nothing for converted (paid Karl via trial flow) users", () => {
+    setStatus("converted");
+    const { container } = renderSection();
+    expect(container.firstChild).toBeNull();
+  });
+
+  // ── Anonymous + none: sign-in CTA ─────────────────────────────────────────
+
+  it("shows sign-in CTA for anonymous user with no trial", () => {
+    setAuth("anonymous");
     setStatus("none");
     renderSection();
 
@@ -145,51 +167,113 @@ describe("TrialSettingsSection — Subscribe price button visibility (Issue #103
     expect(cta).toBeDefined();
   });
 
-  it("does not render subscribe price button for status 'none'", () => {
+  it("shows 'not yet begun' copy for anonymous user", () => {
+    setAuth("anonymous");
+    setStatus("none");
+    const { container } = renderSection();
+    expect(container.textContent).toContain("Thy trial hath not yet begun");
+  });
+
+  it("does not show subscribe button for anonymous user", () => {
+    setAuth("anonymous");
     setStatus("none");
     renderSection();
-
-    const priceButton = screen.queryByRole("button", { name: PRICE_BUTTON_ARIA });
-    expect(priceButton).toBeNull();
+    const btn = screen.queryByRole("button", { name: /upgrade to karl/i });
+    expect(btn).toBeNull();
   });
 
-  // AC: Section renders during active trial (section itself not hidden)
-  it("renders the Trial Status section during active trial", () => {
-    setStatus("active");
+  // ── Thrall authenticated + none: upsell, no button ────────────────────────
+
+  it("shows 'trial over' upsell for authenticated Thrall with no trial", () => {
+    setAuth("authenticated");
+    setStatus("none");
+    const { container } = renderSection();
+    expect(container.textContent).toContain("Thy trial hath ended");
+  });
+
+  it("shows Karl upsell copy for authenticated Thrall with no trial", () => {
+    setAuth("authenticated");
+    setStatus("none");
+    const { container } = renderSection();
+    expect(container.textContent).toContain("Ascend to Karl");
+  });
+
+  it("does not show sign-in link for authenticated Thrall with no trial", () => {
+    setAuth("authenticated");
+    setStatus("none");
     renderSection();
-
-    const section = screen.getByRole("region", { name: "Trial Status" });
-    expect(section).toBeDefined();
+    const link = screen.queryByRole("link", { name: /sign in/i });
+    expect(link).toBeNull();
   });
 
-  // AC: Section renders during expired trial
-  it("renders the Trial Status section when trial is expired", () => {
+  it("does not show subscribe button for authenticated Thrall with no trial", () => {
+    setAuth("authenticated");
+    setStatus("none");
+    renderSection();
+    const btn = screen.queryByRole("button");
+    expect(btn).toBeNull();
+  });
+
+  // ── Thrall authenticated + expired: upsell, no button ─────────────────────
+
+  it("shows 'trial over' upsell for Thrall with expired trial", () => {
+    setStatus("expired", 0);
+    const { container } = renderSection();
+    expect(container.textContent).toContain("Thy trial hath ended");
+  });
+
+  it("shows Karl upsell copy for Thrall with expired trial", () => {
+    setStatus("expired", 0);
+    const { container } = renderSection();
+    expect(container.textContent).toContain("Ascend to Karl");
+  });
+
+  it("does not show subscribe button for expired trial (Subscription card has one)", () => {
     setStatus("expired", 0);
     renderSection();
+    const btn = screen.queryByRole("button");
+    expect(btn).toBeNull();
+  });
 
+  it("renders Trial Status section heading for expired Thrall", () => {
+    setStatus("expired", 0);
+    renderSection();
     const section = screen.getByRole("region", { name: "Trial Status" });
     expect(section).toBeDefined();
   });
 
-  // Edge: loading state — section hidden
-  it("renders nothing while loading", () => {
-    mockTrialStatus.isLoading = true;
-    mockTrialStatus.status = "active";
-    const { container } = renderSection();
+  // ── Thrall + active trial: progress, no subscribe button ──────────────────
 
-    expect(container.firstChild).toBeNull();
-    // Restore
-    mockTrialStatus.isLoading = false;
-  });
-
-  // AC: Plain Subscribe button in tier card remains unchanged (regression guard)
-  it("active trial section has no button with aria-label 'Upgrade to Karl subscription'", () => {
+  it("renders Trial Status section for active trial", () => {
     setStatus("active");
     renderSection();
+    const section = screen.getByRole("region", { name: "Trial Status" });
+    expect(section).toBeDefined();
+  });
 
-    // Confirm the price button aria-label is absent — plain Subscribe in StripeSettings
-    // is a separate component; this test guards against accidental leakage
-    const btn = screen.queryByRole("button", { name: PRICE_BUTTON_ARIA });
+  it("shows remaining days in plan label for active trial", () => {
+    setStatus("active", 15);
+    const { container } = renderSection();
+    expect(container.textContent).toContain("15 days remaining");
+  });
+
+  it("does not show subscribe button during active trial", () => {
+    setStatus("active");
+    renderSection();
+    const btn = screen.queryByRole("button", { name: /upgrade to karl/i });
     expect(btn).toBeNull();
+  });
+
+  it("shows trial start and end dates during active trial", () => {
+    setStatus("active", 15);
+    const { container } = renderSection();
+    expect(container.textContent).toContain("Trial started");
+    expect(container.textContent).toContain("Trial ends");
+  });
+
+  it("shows cards tracked metric during active trial", () => {
+    setStatus("active");
+    renderSection();
+    expect(screen.getByText("3")).toBeDefined();
   });
 });

--- a/development/ledger/src/components/trial/TrialSettingsSection.tsx
+++ b/development/ledger/src/components/trial/TrialSettingsSection.tsx
@@ -14,14 +14,15 @@
  *
  * @see ux/wireframes/trial/trial-status.html (Scenario 3)
  * @see Issue #622
+ * @see Issue #1940 — Karl tier never renders; no-flash fix; Thrall expired upsell
  *
  * @module trial/TrialSettingsSection
  */
 
-import { useState, useCallback } from "react";
 import { useTrialStatus } from "@/hooks/useTrialStatus";
 import { useTrialMetrics } from "@/hooks/useTrialMetrics";
 import { useEntitlement } from "@/hooks/useEntitlement";
+import { useAuthContext } from "@/contexts/AuthContext";
 import { TRIAL_DURATION_DAYS } from "@/lib/trial-utils";
 
 // ---------------------------------------------------------------------------
@@ -74,27 +75,28 @@ function computeTrialEndDate(remainingDays: number): string {
  * Shows trial details alongside StripeSettings component.
  */
 export function TrialSettingsSection() {
-  const { remainingDays, status, isLoading } = useTrialStatus();
+  const { remainingDays, status, isLoading: trialLoading } = useTrialStatus();
   const metrics = useTrialMetrics();
-  const { subscribeStripe } = useEntitlement();
-  const [isSubscribing, setIsSubscribing] = useState(false);
+  const { tier, isLoading: entitlementLoading } = useEntitlement();
+  const { status: authStatus } = useAuthContext();
 
-  const handleSubscribe = useCallback(async () => {
-    setIsSubscribing(true);
-    try {
-      await subscribeStripe();
-    } catch {
-      setIsSubscribing(false);
-    }
-  }, [subscribeStripe]);
-
-  // Don't render while loading or for paid subscribers (already converted)
-  if (isLoading || status === "converted") {
+  // Karl subscribers — never render this card (no flash, no loading state needed)
+  if (tier === "karl") {
     return null;
   }
 
-  // Anonymous / no-trial state: show Norse-themed "not started" box
-  if (status === "none") {
+  // Suppress until auth + trial data are settled — prevents flash
+  if (authStatus === "loading" || trialLoading || entitlementLoading) {
+    return null;
+  }
+
+  // Already converted to paid Karl via trial flow
+  if (status === "converted") {
+    return null;
+  }
+
+  // Anonymous / no-trial state: show Norse-themed "not started" box with sign-in CTA
+  if (status === "none" && authStatus === "anonymous") {
     return (
       <section
         className="relative border border-border p-5 flex flex-col gap-3"
@@ -131,10 +133,29 @@ export function TrialSettingsSection() {
     );
   }
 
-  const planLabel =
-    status === "expired"
-      ? "Karl Trial (Expired)"
-      : `Karl Trial (${remainingDays} day${remainingDays !== 1 ? "s" : ""} remaining)`;
+  // Thrall authenticated with no trial or expired trial — show Karl upsell (no button)
+  if (status === "none" || status === "expired") {
+    return (
+      <section
+        className="relative border border-border p-5 flex flex-col gap-3"
+        aria-label="Trial Status"
+      >
+        <h2 className="text-sm font-heading font-bold uppercase tracking-[0.08em] text-foreground">
+          Trial Status
+        </h2>
+        <div className="border border-gold/20 bg-gold/5 p-3 flex flex-col gap-1.5">
+          <p className="text-[13px] font-heading font-semibold text-foreground">
+            Thy trial hath ended
+          </p>
+          <p className="text-[12px] text-muted-foreground font-body leading-relaxed">
+            Ascend to Karl to unlock cloud sync, household sharing, and more.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  const planLabel = `Karl Trial (${remainingDays} day${remainingDays !== 1 ? "s" : ""} remaining)`;
 
   return (
     <section
@@ -156,22 +177,18 @@ export function TrialSettingsSection() {
           <span className="font-medium text-foreground font-body">Current plan</span>
           <span className="text-muted-foreground font-body">{planLabel}</span>
         </div>
-        {status === "active" && (
-          <>
-            <div className="flex justify-between items-center py-2 text-[13px]">
-              <span className="font-medium text-foreground font-body">Trial started</span>
-              <span className="text-muted-foreground font-body">
-                {computeTrialStartDate(remainingDays)}
-              </span>
-            </div>
-            <div className="flex justify-between items-center py-2 text-[13px]">
-              <span className="font-medium text-foreground font-body">Trial ends</span>
-              <span className="text-muted-foreground font-body">
-                {computeTrialEndDate(remainingDays)}
-              </span>
-            </div>
-          </>
-        )}
+        <div className="flex justify-between items-center py-2 text-[13px]">
+          <span className="font-medium text-foreground font-body">Trial started</span>
+          <span className="text-muted-foreground font-body">
+            {computeTrialStartDate(remainingDays)}
+          </span>
+        </div>
+        <div className="flex justify-between items-center py-2 text-[13px]">
+          <span className="font-medium text-foreground font-body">Trial ends</span>
+          <span className="text-muted-foreground font-body">
+            {computeTrialEndDate(remainingDays)}
+          </span>
+        </div>
         <div className="flex justify-between items-center py-2 text-[13px]">
           <span className="font-medium text-foreground font-body">Cards tracked</span>
           <span className="text-muted-foreground font-body">{metrics.cardCount}</span>
@@ -183,43 +200,6 @@ export function TrialSettingsSection() {
           </span>
         </div>
       </div>
-
-      {/* Returning user message — shown when trial expired (Issue #623) */}
-      {status === "expired" && (
-        <div className="border border-gold/20 bg-gold/5 p-3 flex flex-col gap-1.5">
-          <p className="text-[13px] font-heading font-semibold text-foreground">
-            Upgrade to Karl
-          </p>
-          <p className="text-[12px] text-muted-foreground font-body leading-relaxed">
-            Your trial ended. Subscribe to Karl to unlock all features including
-            The Howl, Valhalla, and unlimited cards &mdash; $3.99/mo.
-          </p>
-        </div>
-      )}
-
-      {/* Subscribe CTA — only shown when trial has expired (hidden during active trial) */}
-      {status === "expired" && (
-        <button
-          type="button"
-          onClick={handleSubscribe}
-          disabled={isSubscribing}
-          className={[
-            "inline-flex items-center justify-center gap-2",
-            "min-h-[44px] md:min-h-[40px] px-5 py-2",
-            "text-base font-heading font-semibold tracking-wide",
-            "bg-gold text-primary-foreground",
-            "hover:brightness-110 transition-colors",
-            "border border-gold rounded-sm karl-bling-btn",
-            "disabled:opacity-60 disabled:cursor-not-allowed",
-            "self-start",
-          ].join(" ")}
-          aria-label="Upgrade to Karl subscription"
-        >
-          {isSubscribing
-            ? "Redirecting\u2026"
-            : "Upgrade to Karl \u2014 $3.99/month"}
-        </button>
-      )}
     </section>
   );
 }


### PR DESCRIPTION
Fixes #1940

## Summary

- Karl tier check added **first** in `TrialSettingsSection` — `if (tier === "karl") return null` before any loading guard, eliminating flash from cached entitlement
- Three-way loading guard: `authStatus === "loading" || trialLoading || entitlementLoading` → null (no flash)
- Anonymous + `status === "none"` → sign-in CTA preserved
- Authenticated Thrall + `none` or `expired` → "Thy trial hath ended. Ascend to Karl..." upsell, no button
- Active trial → trial progress unchanged
- Removed unused `subscribeStripe`/`isSubscribing` from expired state

## Test results

24 Vitest tests covering Karl × all statuses, loading states, anonymous vs authenticated, expired, active. Full suite: 3773 tests PASS. tsc + build PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)