### PR TITLE
fix: shared bonus aggregation lib; Valhalla separates pts/mi/cashback (#1954)

### DIFF
--- a/development/ledger/src/__tests__/lib/bonus-utils-1954.test.ts
+++ b/development/ledger/src/__tests__/lib/bonus-utils-1954.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for lib/bonus-utils.ts
+ *
+ * Verifies aggregateBonuses correctly separates points, miles, and cashback,
+ * skips unmet bonuses, and converts cashback cents → dollars.
+ *
+ * Issue #1954 — shared bonus aggregation lib
+ */
+
+import { describe, it, expect } from "vitest";
+import { aggregateBonuses } from "@/lib/bonus-utils";
+import { makeCard } from "@/__tests__/fixtures/cards";
+
+describe("aggregateBonuses", () => {
+  it("returns zero totals when no cards provided", () => {
+    expect(aggregateBonuses([])).toEqual({ points: 0, miles: 0, cashback: 0 });
+  });
+
+  it("returns zero totals when no card has a signUpBonus", () => {
+    const cards = [makeCard(), makeCard()];
+    expect(aggregateBonuses(cards)).toEqual({ points: 0, miles: 0, cashback: 0 });
+  });
+
+  it("skips bonuses where met is false", () => {
+    const card = makeCard({
+      signUpBonus: {
+        type: "points",
+        amount: 50000,
+        met: false,
+        spendRequirement: 500000,
+        deadline: null,
+      },
+    });
+    expect(aggregateBonuses([card])).toEqual({ points: 0, miles: 0, cashback: 0 });
+  });
+
+  it("accumulates points from met bonuses", () => {
+    const cards = [
+      makeCard({
+        signUpBonus: { type: "points", amount: 60000, met: true, spendRequirement: 400000, deadline: null },
+      }),
+      makeCard({
+        signUpBonus: { type: "points", amount: 80000, met: true, spendRequirement: 500000, deadline: null },
+      }),
+    ];
+    expect(aggregateBonuses(cards)).toEqual({ points: 140000, miles: 0, cashback: 0 });
+  });
+
+  it("accumulates miles from met bonuses separately from points", () => {
+    const cards = [
+      makeCard({
+        signUpBonus: { type: "points", amount: 50000, met: true, spendRequirement: 300000, deadline: null },
+      }),
+      makeCard({
+        signUpBonus: { type: "miles", amount: 40000, met: true, spendRequirement: 300000, deadline: null },
+      }),
+    ];
+    expect(aggregateBonuses(cards)).toEqual({ points: 50000, miles: 40000, cashback: 0 });
+  });
+
+  it("converts cashback cents to dollars", () => {
+    const card = makeCard({
+      signUpBonus: { type: "cashback", amount: 50000, met: true, spendRequirement: 300000, deadline: null },
+    });
+    // 50000 cents = $500
+    expect(aggregateBonuses([card])).toEqual({ points: 0, miles: 0, cashback: 500 });
+  });
+
+  it("sums mixed types correctly, skipping unmet bonuses", () => {
+    const cards = [
+      makeCard({
+        signUpBonus: { type: "points", amount: 75000, met: true, spendRequirement: 400000, deadline: null },
+      }),
+      makeCard({
+        signUpBonus: { type: "miles", amount: 60000, met: true, spendRequirement: 300000, deadline: null },
+      }),
+      makeCard({
+        signUpBonus: { type: "cashback", amount: 30000, met: true, spendRequirement: 200000, deadline: null },
+      }),
+      // unmet — should be ignored
+      makeCard({
+        signUpBonus: { type: "points", amount: 100000, met: false, spendRequirement: 500000, deadline: null },
+      }),
+      // no bonus
+      makeCard(),
+    ];
+    expect(aggregateBonuses(cards)).toEqual({ points: 75000, miles: 60000, cashback: 300 });
+  });
+
+  it("handles multiple cashback cards and accumulates in dollars", () => {
+    const cards = [
+      makeCard({
+        signUpBonus: { type: "cashback", amount: 20000, met: true, spendRequirement: 200000, deadline: null },
+      }),
+      makeCard({
+        signUpBonus: { type: "cashback", amount: 30000, met: true, spendRequirement: 300000, deadline: null },
+      }),
+    ];
+    // 20000 + 30000 = 50000 cents = $500
+    expect(aggregateBonuses(cards)).toEqual({ points: 0, miles: 0, cashback: 500 });
+  });
+});

--- a/development/ledger/src/components/dashboard/TabSummary.tsx
+++ b/development/ledger/src/components/dashboard/TabSummary.tsx
@@ -17,6 +17,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { DashboardTab } from "@/lib/constants";
 import type { Card } from "@/lib/types";
 import { daysUntil, formatCurrency } from "@/lib/card-utils";
+import { aggregateBonuses } from "@/lib/bonus-utils";
 
 /** localStorage key pattern for summary dismissal */
 function getSummaryStorageKey(tabId: DashboardTab): string {
@@ -69,20 +70,7 @@ function allSummary(cards: Card[]): React.ReactNode[] {
  * Issue #1808 — show total rewards reaped instead of generic closed/graduated counts.
  */
 function valhallaSummary(cards: Card[]): React.ReactNode[] {
-  const totalPoints = cards.reduce((sum, c) => {
-    if (c.signUpBonus?.met && c.signUpBonus.type !== "cashback") {
-      return sum + c.signUpBonus.amount;
-    }
-    return sum;
-  }, 0);
-
-  const totalCashback = cards.reduce((sum, c) => {
-    if (c.signUpBonus?.met && c.signUpBonus.type === "cashback") {
-      return sum + c.signUpBonus.amount;
-    }
-    return sum;
-  }, 0);
-
+  const { points, miles, cashback } = aggregateBonuses(cards);
   const totalFeesPaid = cards.reduce((sum, c) => sum + c.annualFee, 0);
 
   const parts: React.ReactNode[] = [];
@@ -92,21 +80,37 @@ function valhallaSummary(cards: Card[]): React.ReactNode[] {
     </span>
   );
 
-  if (totalPoints > 0) {
+  if (points > 0) {
     parts.push(" · ");
     parts.push(
       <span key="pts" className="font-bold">
-        {totalPoints.toLocaleString()} pts
+        {points.toLocaleString()} pts
       </span>
-      );
+    );
+  }
+
+  if (miles > 0) {
+    parts.push(" · ");
+    parts.push(
+      <span key="mi" className="font-bold">
+        {miles.toLocaleString()} mi
+      </span>
+    );
+    parts.push(" reaped");
+  } else if (points > 0) {
     parts.push(" reaped");
   }
 
-  if (totalCashback > 0) {
+  if (cashback > 0) {
     parts.push(" · ");
     parts.push(
       <span key="cash" className="font-bold">
-        {formatCurrency(totalCashback)}
+        {new Intl.NumberFormat("en-US", {
+          style: "currency",
+          currency: "USD",
+          minimumFractionDigits: 0,
+          maximumFractionDigits: 0,
+        }).format(cashback)}
       </span>
     );
     parts.push(" cashback");

--- a/development/ledger/src/components/shared/WolfHungerMeter.tsx
+++ b/development/ledger/src/components/shared/WolfHungerMeter.tsx
@@ -12,34 +12,18 @@ import { useEffect, useState } from "react";
 import { useAuth } from "@/hooks/useAuth";
 import { getCards, getClosedCards } from "@/lib/storage";
 import { ANON_HOUSEHOLD_ID } from "@/lib/constants";
-import type { Card, BonusType } from "@/lib/types";
-
-interface BonusTotals {
-  points: number;
-  miles: number;
-  cashback: number; // in cents
-}
-
-function aggregateBonuses(cards: Card[]): BonusTotals {
-  const totals: BonusTotals = { points: 0, miles: 0, cashback: 0 };
-  for (const card of cards) {
-    if (card.signUpBonus && card.signUpBonus.met) {
-      const { type, amount } = card.signUpBonus;
-      totals[type] += amount;
-    }
-  }
-  return totals;
-}
+import type { BonusType } from "@/lib/types";
+import { aggregateBonuses, type BonusTotals } from "@/lib/bonus-utils";
 
 function formatBonusLine(type: BonusType, amount: number): string {
   if (type === "cashback") {
-    // amount is in cents
+    // amount is in dollars (shared lib converts cents → dollars)
     return new Intl.NumberFormat("en-US", {
       style: "currency",
       currency: "USD",
       minimumFractionDigits: 0,
       maximumFractionDigits: 0,
-    }).format(amount / 100) + " cashback";
+    }).format(amount) + " cashback";
   }
   const label = type === "miles" ? "miles" : "points";
   return new Intl.NumberFormat("en-US").format(amount) + " " + label;

--- a/development/ledger/src/lib/bonus-utils.ts
+++ b/development/ledger/src/lib/bonus-utils.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared bonus aggregation utilities.
+ *
+ * Used by TabSummary (Valhalla tab) and WolfHungerMeter to compute identical
+ * reward totals from a list of cards.
+ *
+ * Issue #1954 — separate points/miles/cashback; eliminate duplicated logic.
+ */
+
+import type { Card } from "@/lib/types";
+
+export interface BonusTotals {
+  points: number;
+  miles: number;
+  cashback: number; // in dollars (not cents — see issue #1915)
+}
+
+/**
+ * Aggregate sign-up bonus amounts across cards where bonus was met.
+ *
+ * Cashback stored as cents in Card.signUpBonus.amount is converted to dollars
+ * so all three fields use the same unit as their display label implies.
+ */
+export function aggregateBonuses(cards: Card[]): BonusTotals {
+  const totals: BonusTotals = { points: 0, miles: 0, cashback: 0 };
+  for (const card of cards) {
+    if (card.signUpBonus && card.signUpBonus.met) {
+      const { type, amount } = card.signUpBonus;
+      if (type === "cashback") {
+        totals.cashback += amount / 100;
+      } else {
+        totals[type] += amount;
+      }
+    }
+  }
+  return totals;
+}


### PR DESCRIPTION
## Summary

- **New `lib/bonus-utils.ts`** — exports `BonusTotals` interface and `aggregateBonuses(cards)` function. Cashback stored in cents on `Card.signUpBonus.amount` is converted to dollars in the returned totals (see issue #1915).
- **`TabSummary.tsx` `valhallaSummary()`** — replaced duplicated inline reductions with `aggregateBonuses()` from shared lib. Points and miles now render as separate segments (`215,000 pts · 20,000 mi reaped`) instead of being lumped together as "pts".
- **`WolfHungerMeter.tsx`** — removed local `BonusTotals` interface and `aggregateBonuses` function; imports both from shared lib. Updated `formatBonusLine` for cashback to use dollars (not cents) since the shared lib already converts.
- **`__tests__/lib/bonus-utils-1954.test.ts`** — 7 Vitest tests covering all bonus types, unmet-bonus skipping, and cents→dollars cashback conversion.

## Test plan
- [x] `pnpm run verify:tsc` — clean
- [x] `pnpm run verify:build` — clean
- [x] `npx vitest run` — 264 files / 3841 tests all pass (includes 7 new bonus-utils tests)
- [ ] Manual: open Valhalla tab with mixed points/miles/cashback cards — verify separate segments render correctly
- [ ] Manual: open Easter Egg modal (Fenrir's Plunder / WolfHungerMeter) — verify totals match Valhalla tab summary

Closes #1954

🤖 Generated with [Claude Code](https://claude.com/claude-code)