### PR TITLE
chore: forbid background test execution in agent definitions

### DIFF
--- a/.claude/agents/fireman-decko.md
+++ b/.claude/agents/fireman-decko.md
@@ -321,6 +321,13 @@ Push-triggered runs use `git diff --name-only HEAD~1 HEAD` with path patterns.
 
 ## Implementation Rules (UNBREAKABLE)
 
+- **NEVER run tests or builds in the background.** All `pnpm run verify:tsc`,
+  `pnpm run verify:build`, `npx vitest run`, and any other verify/test commands
+  MUST run in the foreground (blocking). Do NOT use `run_in_background: true` or
+  the Bash `&` operator for these commands. You MUST see the output directly and
+  confirm pass/fail before proceeding. Background verify = unverified = bug.
+  Do NOT poll background task output files with `sleep` — just run the command
+  in the foreground and read the result.
 - Mobile-friendly: min 375px, two-col collapse with `flex flex-col md:grid`.
 - **Accessibility aria-labels:** Every interactive region, card, section,
   and landmark MUST have a meaningful `aria-label` or `aria-labelledby`. Gate regions

--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -51,6 +51,16 @@ All defects MUST be filed as GitHub Issues per `quality/issue-template.md`.
 
 A defect without a GitHub Issue is untracked.
 
+## Foreground Execution (UNBREAKABLE)
+
+**NEVER run tests or builds in the background.** All `pnpm run verify:tsc`,
+`pnpm run verify:build`, `npx vitest run`, `npx playwright test`, and any other
+verify/test commands MUST run in the foreground (blocking). Do NOT use
+`run_in_background: true` or the Bash `&` operator for these commands. You MUST
+see the output directly and confirm pass/fail before proceeding. Background
+verify = unverified = bug. Do NOT poll background task output files with `sleep`
+— just run the command in the foreground and read the result.
+
 ## Test Strategy (MANDATORY)
 
 Every QA validation MUST include automated tests. **Default to Vitest** (unit or


### PR DESCRIPTION
## Summary
- Added UNBREAKABLE rule to fireman-decko.md and loki.md forbidding `run_in_background` for tests/builds
- Agents were wasting 20+ min per session polling background task output with sleep loops

## Test plan
- [ ] Verify next dispatched agents run tests in foreground

🤖 Generated with [Claude Code](https://claude.com/claude-code)