### PR TITLE
fix: re-seed job map on K8s watch reconnect — issue #1982

### DIFF
--- a/development/odins-throne/src/k8s.ts
+++ b/development/odins-throne/src/k8s.ts
@@ -278,7 +278,14 @@ export function watchAgentJobs(
           currentJobReq = null;
           if (!stopped) {
             if (err) onError(err);
-            setTimeout(() => void doJobWatch(), 5000);
+            // Re-seed on reconnect to catch jobs missed during disconnect gap.
+            // seedFromList() has internal error handling — failure is non-fatal.
+            setTimeout(async () => {
+              if (!stopped) {
+                await seedFromList();
+                void doJobWatch();
+              }
+            }, 5000);
           }
         }
       );
@@ -352,7 +359,14 @@ export function watchAgentJobs(
           currentPodReq = null;
           if (!stopped) {
             if (err) onError(err);
-            setTimeout(() => void doPodWatch(), 5000);
+            // Re-seed on reconnect to catch jobs missed during disconnect gap.
+            // seedFromList() has internal error handling — failure is non-fatal.
+            setTimeout(async () => {
+              if (!stopped) {
+                await seedFromList();
+                void doPodWatch();
+              }
+            }, 5000);
           }
         }
       );
@@ -371,8 +385,8 @@ export function watchAgentJobs(
 
   const doWatch = async (): Promise<void> => {
     if (stopped) return;
-    // Seed on first connect with accurate job + pod status
-    if (jobMap.size === 0) await seedFromList();
+    // Always seed on startup with accurate job + pod status
+    await seedFromList();
     void doJobWatch();
     void doPodWatch();
   };


### PR DESCRIPTION
PR for issue: #1982

Fix Odin's Throne missing short-lived agent jobs when K8s watch stream disconnects and reconnects.

**Changes:**
- `development/odins-throne/src/k8s.ts` — call `seedFromList()` on every watch reconnect, not just initial startup

**Root cause:** The job watch reconnect handler only called `seedFromList()` when `jobMap.size === 0` (first connect). Jobs that completed during a disconnect gap were never discovered.

**Fix details:**
- `doJobWatch()` reconnect handler: now calls `await seedFromList()` before restarting the watch
- `doPodWatch()` reconnect handler: same — re-seeds before restarting pod watch
- `doWatch()` bootstrap: removed `jobMap.size === 0` guard — always seeds on startup
- `stopped` guard added inside the `setTimeout` callbacks to avoid restarting after cancel

**Safety:** `seedFromList()` has its own internal try/catch — a failed seed logs but never throws, so watch restart always proceeds regardless.

**Verification:**
- tsc + build pass
- Watch reconnect logic still auto-reconnects on `Premature close`
- Jobs created during disconnect gaps are discovered on reconnect
- No duplicate entries: `jobMap.set()` is idempotent — re-seeding an existing key updates in place