### PR TITLE
chore: add rule to never check out main to compare test failures

### DIFF
--- a/.claude/agents/fireman-decko.md
+++ b/.claude/agents/fireman-decko.md
@@ -154,6 +154,7 @@ FiremanDecko writes tests alongside implementation. Loki augments gaps only.
 - **Never write Playwright E2E tests** — that's Loki's domain (and he writes few)
 - **Never write tests for odins-throne or odins-spear — `development/odins-throne/` and `development/odins-spear/` have no test infrastructure agents should use
 - **Never write tests for infrastructure** — Helm charts (`infrastructure/helm/`), Terraform (`infrastructure/*.tf`), K8s manifests (`infrastructure/k8s/`), Dockerfiles, and CI/CD workflows (`.github/workflows/`) are not testable via Vitest. Validate infra changes via tsc + build only.
+- **Never check out main to verify pre-existing test failures.** If tests fail, fix them — whether they're pre-existing or new. Checking out main to compare is wasted time. All test failures must be green before handoff regardless of origin.
 
 ### jest-dom Assertion Library (UNBREAKABLE)
 

--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -380,6 +380,12 @@ If yes, use Vitest. The answer is almost always yes for:
 - Auth/entitlement gating (mock session, call handler)
 - Data transformations (import and call)
 
+### Never Check Out Main to Compare Test Failures (UNBREAKABLE)
+
+If tests fail, fix them — whether they're pre-existing or introduced by this branch.
+Do NOT `git checkout main` or `git stash` to verify whether a failure existed before.
+That is wasted time. All test failures must be green before handoff regardless of origin.
+
 ### No Duplicate Suites (UNBREAKABLE)
 
 - **ONE suite per feature area.** Check existing suites before creating a new file.


### PR DESCRIPTION
## Summary
- Added UNBREAKABLE rule to both FiremanDecko and Loki agent definitions
- If tests fail, fix them — don't waste time checking out main to verify if they're pre-existing
- All test failures must be green before handoff regardless of origin

## Test plan
- [x] Rule added to `.claude/agents/fireman-decko.md`
- [x] Rule added to `.claude/agents/loki.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)