### PR TITLE
chore: add UNBREAKABLE rules for test date hygiene and mock completeness

### DIFF
--- a/.claude/agents/fireman-decko.md
+++ b/.claude/agents/fireman-decko.md
@@ -155,6 +155,8 @@ FiremanDecko writes tests alongside implementation. Loki augments gaps only.
 - **Never write tests for odins-throne or odins-spear — `development/odins-throne/` and `development/odins-spear/` have no test infrastructure agents should use
 - **Never write tests for infrastructure** — Helm charts (`infrastructure/helm/`), Terraform (`infrastructure/*.tf`), K8s manifests (`infrastructure/k8s/`), Dockerfiles, and CI/CD workflows (`.github/workflows/`) are not testable via Vitest. Validate infra changes via tsc + build only.
 - **Never check out main to verify pre-existing test failures.** If tests fail, fix them — whether they're pre-existing or new. Checking out main to compare is wasted time. All test failures must be green before handoff regardless of origin.
+- **Never hardcode absolute dates in tests.** Use relative dates from `Date.now()` (e.g., `new Date(Date.now() + 10 * 86_400_000).toISOString()`). Hardcoded dates create time-bomb tests that fail days later.
+- **Mock every dependency.** Read the implementation before writing tests. If the function calls `ensureFreshToken()`, `getSession()`, `fetch()`, etc., mock ALL of them. Missing mocks = test that never tested the right thing.
 
 ### jest-dom Assertion Library (UNBREAKABLE)
 

--- a/.claude/agents/loki.md
+++ b/.claude/agents/loki.md
@@ -512,4 +512,23 @@ Pre-populate via `seedCards()` in `beforeEach`. Multi-step flows are the #1 flak
 
 **Group by feature:** `test.describe("Add Card — Validation", ...)` not `test.describe("CardForm renders", ...)`
 
-**Keep lean:** Max 10 tests per spec file. Use shared seed data helpers. Never use date-dependent assertions.
+**Keep lean:** Max 10 tests per spec file. Use shared seed data helpers.
+
+### No Hardcoded Dates or Stale Mocks (UNBREAKABLE)
+
+**Dates:** Never hardcode absolute dates in tests (e.g., `"2026-04-02T00:00:00.000Z"`).
+These create time-bomb tests that pass when written but fail days/weeks later.
+Always use relative dates computed from `Date.now()`:
+```typescript
+// WRONG — will fail after April 2, 2026
+const deadline = "2026-04-02T00:00:00.000Z";
+// RIGHT — always 10 days from now
+const deadline = new Date(Date.now() + 10 * 86_400_000).toISOString();
+```
+
+**Mocks:** Every dependency the code-under-test calls must be mocked. Read the
+implementation before writing the test — if the function calls `ensureFreshToken()`,
+`getSession()`, `fetch()`, etc., mock ALL of them. A test that fails because a mock
+is missing is a test that was never actually testing the right thing. When an
+implementation adds a new dependency (e.g., a token refresh step before fetch), all
+existing tests for that function must have their mock setup updated.


### PR DESCRIPTION
## Summary
- Added rules to FiremanDecko and Loki agent definitions preventing hardcoded dates and incomplete mocks in tests
- No hardcoded absolute dates — always use relative dates from `Date.now()`
- Every dependency must be mocked — read the implementation before writing tests
- Filed #1986 to fix existing violations

## Test plan
- [x] Rules added to `.claude/agents/fireman-decko.md`
- [x] Rules added to `.claude/agents/loki.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)