### PR TITLE
fix: time-bomb dates and stale mocks in tests — issue #1986

### DIFF
--- a/development/ledger/src/__tests__/components/tab-summary-hunt.test.tsx
+++ b/development/ledger/src/__tests__/components/tab-summary-hunt.test.tsx
@@ -115,7 +115,7 @@ describe("TabSummary hunt — aggregate spend logic", () => {
   it("shows approaching deadline count for cards within 30 days", async () => {
     // Deadline 10 days from now (dynamic — avoids staleness as time passes)
     const urgentDeadline = new Date(Date.now() + 10 * 24 * 60 * 60 * 1000).toISOString();
-    const farDeadline = "2030-12-31T00:00:00.000Z";
+    const farDeadline = new Date(Date.now() + 365 * 86_400_000).toISOString();
 
     const cards: Card[] = [
       makeHuntCard({ id: "c1", spendRequirement: 100000, deadline: urgentDeadline }),


### PR DESCRIPTION
PR for issue: #1986

Fix two test hygiene violations causing failures on main:
1. tab-summary-hunt — hardcoded `2026-04-02` deadline replaced with relative `Date.now()` computation
2. trial-1971-karl-guard — added missing `getCards` mock to `@/lib/storage` stub; `validateCode` calls `getCards()` (added in #1970) which was undefined → TypeError → catch → `network_error`, blocking all 5 join-flow tests

**Changes:**
- `src/__tests__/components/tab-summary-hunt.test.tsx` — relative dates (urgentDeadline + farDeadline)
- `src/__tests__/trial/trial-1971-karl-guard.test.tsx` — `getCards: vi.fn().mockReturnValue([])` added to storage mock

**Verification:**
- All 222 test files pass (3271 tests, 0 failures)
- tsc: clean
- build: clean
- No hardcoded time-bomb dates remain in the affected test files