### PR TITLE
fix: use project number for IAP brand to match imported state

### DIFF
--- a/infrastructure/oauth.tf
+++ b/infrastructure/oauth.tf
@@ -51,8 +51,8 @@ resource "google_project_service" "iap_api" {
 # --------------------------------------------------------------------------
 
 resource "google_iap_brand" "fenrir" {
-  project           = var.project_id
-  application_title = "Fenrir Ledger"
+  project           = data.google_project.project.number
+  application_title = "Odin's Throne"  # Must match existing brand — changing forces destroy+recreate which fails
   support_email     = "declanshanaghy@gmail.com"
 
   depends_on = [google_project_service.iap_api]


### PR DESCRIPTION
## Summary
- Use `data.google_project.project.number` instead of `var.project_id` for IAP brand — the API stores project number internally, using the string ID forces replacement
- Match existing brand title "Odin's Throne" to prevent destroy+recreate
- Brand already imported into Terraform state via `terraform import`

## Test plan
- [x] `terraform plan` shows no changes for `google_iap_brand.fenrir`
- [ ] CI terraform plan + apply passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)