### PR TITLE
chore: add APP_BASE_URL to sync-secrets manifest

### DIFF
--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -93,6 +93,7 @@ const SECRETS = [
   { name: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", dest: "k8s-app", group: "K8s App Secrets", envVar: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", k8sSecret: "fenrir-app-secrets" },
   { name: "STRIPE_WEBHOOK_SECRET",     dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_WEBHOOK_SECRET", k8sSecret: "fenrir-app-secrets" },
   { name: "STRIPE_PRICE_ID",           dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_PRICE_ID", k8sSecret: "fenrir-app-secrets" },
+  { name: "APP_BASE_URL",             dest: "k8s-app", group: "K8s App Secrets", envVar: "APP_BASE_URL", k8sSecret: "fenrir-app-secrets" },
 ];
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Added `APP_BASE_URL` to sync-secrets SECRETS array so `--fix-all` includes it in K8s app secrets
- Without it, Stripe checkout redirected to localhost instead of www.fenrirledger.com

## Test plan
- [x] `--push APP_BASE_URL` works
- [x] Stripe checkout redirects to production URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)