### PR TITLE
chore: add ADMIN_EMAILS to sync-secrets manifest

### DIFF
--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -94,6 +94,7 @@ const SECRETS = [
   { name: "STRIPE_WEBHOOK_SECRET",     dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_WEBHOOK_SECRET", k8sSecret: "fenrir-app-secrets" },
   { name: "STRIPE_PRICE_ID",           dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_PRICE_ID", k8sSecret: "fenrir-app-secrets" },
   { name: "APP_BASE_URL",             dest: "k8s-app", group: "K8s App Secrets", envVar: "APP_BASE_URL", k8sSecret: "fenrir-app-secrets" },
+  { name: "ADMIN_EMAILS",             dest: "k8s-app", group: "K8s App Secrets", envVar: "ADMIN_EMAILS", k8sSecret: "fenrir-app-secrets" },
 ];
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `ADMIN_EMAILS` to the `k8s-app` destination in `scripts/sync-secrets.mjs`
- Enables `/manage-secrets push ADMIN_EMAILS` to work

## Test plan
- [x] `--push ADMIN_EMAILS` succeeded, deployment restarted

Generated with [Claude Code](https://claude.com/claude-code)