### PR TITLE
fix: align stripe webhook TF state with live mode

### DIFF
--- a/infrastructure/stripe.tf
+++ b/infrastructure/stripe.tf
@@ -14,9 +14,10 @@ resource "stripe_webhook_endpoint" "main" {
 
   enabled_events = [
     "checkout.session.completed",
-    "customer.subscription.updated",
+    "customer.subscription.created",
     "customer.subscription.deleted",
-    "billing_portal.session.created",
+    "customer.subscription.paused",
+    "customer.subscription.updated",
   ]
 
   description = "Fenrir Ledger production webhook — managed by Terraform"


### PR DESCRIPTION
## Summary
- Terraform plan was failing with 404 because state tracked a test-mode webhook (`we_1TDvbF...`) while CI uses a live-mode Stripe key
- Removed stale state, imported existing live-mode webhook (`we_1TI0G8...`), updated `enabled_events` to match live config
- Deleted both orphaned test-mode webhooks from Stripe

## What changes
- `infrastructure/stripe.tf`: events now match live webhook — adds `customer.subscription.created` + `customer.subscription.paused`, removes `billing_portal.session.created`

## Post-merge action
After CI apply recreates the webhook, run `/manage-secrets` to sync the new `STRIPE_WEBHOOK_SECRET` to K8s

## Test plan
- [ ] CI terraform plan succeeds (no more 404)
- [ ] After merge: terraform apply creates webhook, `/manage-secrets` syncs signing secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)