### PR TITLE
fix: source STRIPE_WEBHOOK_SECRET from terraform output

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,8 @@
 #   GCP_PROJECT_ID, GCP_SA_KEY, GCP_REGION, GCP_ZONE, GKE_CLUSTER_NAME
 #   GOOGLE_CLIENT_SECRET, NEXT_PUBLIC_GOOGLE_CLIENT_ID, GOOGLE_PICKER_API_KEY
 #   FENRIR_ANTHROPIC_API_KEY, ENTITLEMENT_ENCRYPTION_KEY
-#   STRIPE_SECRET_KEY, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, STRIPE_WEBHOOK_SECRET, STRIPE_PRICE_ID
+#   STRIPE_SECRET_KEY, NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY, STRIPE_PRICE_ID
+#   (STRIPE_WEBHOOK_SECRET is read from terraform output, not GitHub Secrets)
 #   TF_VAR_BILLING_ACCOUNT_ID, TF_VAR_UPTIME_CHECK_HOST
 #   CLAUDE_CODE_OAUTH_TOKEN, GITHUB_TOKEN_PAT_CLASSIC, GITHUB_TOKEN_PAT_FINE_GRAINED
 #   UMAMI_OAUTH2_PROXY_COOKIE_SECRET  — 32-byte cookie secret for Umami oauth2-proxy
@@ -65,6 +66,8 @@ jobs:
     name: "Terraform: Plan & Apply"
     runs-on: ubuntu-latest
     if: ${{ !inputs.skip_terraform }}
+    outputs:
+      stripe_webhook_secret: ${{ steps.tf-outputs.outputs.stripe_webhook_secret }}
     permissions:
       contents: read
       id-token: write
@@ -101,6 +104,13 @@ jobs:
 
       - name: Terraform Apply
         run: terraform apply -input=false -auto-approve tfplan
+
+      - name: Export Stripe webhook secret
+        id: tf-outputs
+        run: |
+          SECRET=$(terraform output -raw stripe_webhook_signing_secret 2>/dev/null || echo "")
+          echo "::add-mask::${SECRET}"
+          echo "stripe_webhook_secret=${SECRET}" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         run: |
@@ -330,7 +340,7 @@ jobs:
 
   app-deploy:
     name: "App: Deploy to GKE"
-    needs: [app-pre-deploy-tests, build-app-image, detect-changes]
+    needs: [app-pre-deploy-tests, build-app-image, detect-changes, terraform]
     if: >-
       always() && !inputs.skip_deploy &&
       (needs.build-app-image.result == 'success' ||
@@ -391,6 +401,22 @@ jobs:
             --set gcpProjectId=${{ secrets.GCP_PROJECT_ID }} \
             --wait
 
+      - name: Resolve Stripe webhook secret
+        id: stripe-webhook
+        run: |
+          # Prefer terraform output; fall back to existing K8s value when terraform was skipped
+          TF_SECRET="${{ needs.terraform.outputs.stripe_webhook_secret }}"
+          if [ -n "$TF_SECRET" ]; then
+            echo "::add-mask::${TF_SECRET}"
+            echo "secret=${TF_SECRET}" >> "$GITHUB_OUTPUT"
+            echo "Source: terraform output"
+          else
+            EXISTING=$(kubectl get secret fenrir-app-secrets -n fenrir-app -o jsonpath='{.data.STRIPE_WEBHOOK_SECRET}' 2>/dev/null | base64 -d || echo "")
+            echo "::add-mask::${EXISTING}"
+            echo "secret=${EXISTING}" >> "$GITHUB_OUTPUT"
+            echo "Source: existing K8s secret (terraform skipped)"
+          fi
+
       - name: Sync app secrets
         run: |
           kubectl create secret generic fenrir-app-secrets \
@@ -403,7 +429,7 @@ jobs:
             --from-literal=APP_BASE_URL="https://www.fenrirledger.com" \
             --from-literal=STRIPE_SECRET_KEY="${{ secrets.STRIPE_SECRET_KEY }}" \
             --from-literal=NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY="${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}" \
-            --from-literal=STRIPE_WEBHOOK_SECRET="${{ secrets.STRIPE_WEBHOOK_SECRET }}" \
+            --from-literal=STRIPE_WEBHOOK_SECRET="${{ steps.stripe-webhook.outputs.secret }}" \
             --from-literal=STRIPE_PRICE_ID="${{ secrets.STRIPE_PRICE_ID }}" \
             --from-literal=NEXT_PUBLIC_APP_VERSION="${{ github.sha }}" \
             --dry-run=client -o yaml | kubectl apply -f -

--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -62,7 +62,7 @@ const SECRETS = [
   { name: "ENTITLEMENT_ENCRYPTION_KEY",      dest: "github", group: "App Secrets", envVar: "ENTITLEMENT_ENCRYPTION_KEY" },
   { name: "STRIPE_SECRET_KEY",              dest: "github", group: "App Secrets", envVar: "STRIPE_SECRET_KEY" },
   { name: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", dest: "github", group: "App Secrets", envVar: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" },
-  { name: "STRIPE_WEBHOOK_SECRET",          dest: "github", group: "App Secrets", envVar: "STRIPE_WEBHOOK_SECRET" },
+  // STRIPE_WEBHOOK_SECRET — managed by Terraform output → deploy.yml (not GitHub Secrets)
   { name: "STRIPE_PRICE_ID",               dest: "github", group: "App Secrets", envVar: "STRIPE_PRICE_ID" },
 
   // --- GitHub → K8s agent secrets (deploy workflow creates agent-secrets) ---
@@ -91,7 +91,7 @@ const SECRETS = [
   { name: "ENTITLEMENT_ENCRYPTION_KEY", dest: "k8s-app", group: "K8s App Secrets", envVar: "ENTITLEMENT_ENCRYPTION_KEY", k8sSecret: "fenrir-app-secrets" },
   { name: "STRIPE_SECRET_KEY",         dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_SECRET_KEY", k8sSecret: "fenrir-app-secrets" },
   { name: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", dest: "k8s-app", group: "K8s App Secrets", envVar: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", k8sSecret: "fenrir-app-secrets" },
-  { name: "STRIPE_WEBHOOK_SECRET",     dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_WEBHOOK_SECRET", k8sSecret: "fenrir-app-secrets" },
+  // STRIPE_WEBHOOK_SECRET — managed by Terraform output → deploy.yml (not sync-secrets)
   { name: "STRIPE_PRICE_ID",           dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_PRICE_ID", k8sSecret: "fenrir-app-secrets" },
   { name: "APP_BASE_URL",             dest: "k8s-app", group: "K8s App Secrets", envVar: "APP_BASE_URL", k8sSecret: "fenrir-app-secrets" },
   { name: "ADMIN_EMAILS",             dest: "k8s-app", group: "K8s App Secrets", envVar: "ADMIN_EMAILS", k8sSecret: "fenrir-app-secrets" },
@@ -406,17 +406,7 @@ const mode = args[0] || "audit";
 const envVars = parseKeyValueFile(ENV_FILE);
 const secretsVars = parseKeyValueFile(SECRETS_FILE);
 
-// Guard: refuse to sync STRIPE_WEBHOOK_SECRET if stripe listen override is active
-const STRIPE_OVERRIDE = join(REPO_ROOT, "development", "frontend", ".env.stripe-listen");
-if (existsSync(STRIPE_OVERRIDE) && (mode === "--sync" || mode === "--fix-all" || mode === "--push")) {
-  const pushingStripe = mode === "--push" && args[1] === "STRIPE_WEBHOOK_SECRET";
-  if (mode !== "--push" || pushingStripe) {
-    console.error(`${C.red}BLOCKED:${C.r} ${STRIPE_OVERRIDE} exists — stripe listen is active (or was not stopped cleanly).`);
-    console.error(`The STRIPE_WEBHOOK_SECRET in .env.local may be overridden by an ephemeral CLI value.`);
-    console.error(`Run: ${C.bold}rm ${STRIPE_OVERRIDE}${C.r} (or stop stripe via services.sh stop) then retry.`);
-    process.exit(1);
-  }
-}
+// Note: STRIPE_WEBHOOK_SECRET guard removed — that secret is now managed by Terraform output
 
 if (!existsSync(ENV_FILE) && !existsSync(SECRETS_FILE)) {
   console.error(`${C.red}Missing both ${ENV_FILE} and ${SECRETS_FILE}${C.r}`);


### PR DESCRIPTION
## Summary
- `STRIPE_WEBHOOK_SECRET` now flows directly from Terraform output → K8s secret, removing the manual `.secrets` → GitHub Secrets → K8s bridge
- When terraform is skipped (`skip_terraform`), falls back to preserving the existing K8s value
- Removed from `sync-secrets.mjs` manifest, GitHub Secrets, and `.secrets`

## Changes
- `.github/workflows/deploy.yml` — terraform job exports `stripe_webhook_signing_secret`; app-deploy resolves it with K8s fallback
- `scripts/sync-secrets.mjs` — removed STRIPE_WEBHOOK_SECRET entries and stripe-listen guard

## How it works
1. Terraform creates/manages the webhook endpoint
2. `terraform output -raw stripe_webhook_signing_secret` extracts the signing secret
3. Job output passes it to app-deploy
4. `kubectl create secret` uses it directly (masked via `::add-mask::`)
5. If terraform was skipped, reads existing value from K8s (idempotent)

## Test plan
- [ ] CI terraform plan succeeds
- [ ] On merge: terraform apply exports secret → app-deploy uses it in K8s secret sync
- [ ] `skip_terraform` workflow dispatch still works (falls back to existing K8s value)

🤖 Generated with [Claude Code](https://claude.com/claude-code)