### PR TITLE
fix: add GITHUB_TOKEN to app secrets for /admin

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -432,6 +432,7 @@ jobs:
             --from-literal=STRIPE_WEBHOOK_SECRET="${{ steps.stripe-webhook.outputs.secret }}" \
             --from-literal=STRIPE_PRICE_ID="${{ secrets.STRIPE_PRICE_ID }}" \
             --from-literal=NEXT_PUBLIC_APP_VERSION="${{ github.sha }}" \
+            --from-literal=GITHUB_TOKEN="${{ secrets.GH_TOKEN_AGENTS }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync agent secrets

--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -95,6 +95,7 @@ const SECRETS = [
   { name: "STRIPE_PRICE_ID",           dest: "k8s-app", group: "K8s App Secrets", envVar: "STRIPE_PRICE_ID", k8sSecret: "fenrir-app-secrets" },
   { name: "APP_BASE_URL",             dest: "k8s-app", group: "K8s App Secrets", envVar: "APP_BASE_URL", k8sSecret: "fenrir-app-secrets" },
   { name: "ADMIN_EMAILS",             dest: "k8s-app", group: "K8s App Secrets", envVar: "ADMIN_EMAILS", k8sSecret: "fenrir-app-secrets" },
+  { name: "GITHUB_TOKEN",            dest: "k8s-app", group: "K8s App Secrets", secretsVar: "GITHUB_TOKEN_PAT_CLASSIC", k8sSecret: "fenrir-app-secrets" },
 ];
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `/admin` was returning 500 — pack-status API needs `GITHUB_TOKEN` to query GitHub Projects board
- Added `GITHUB_TOKEN` (from `GH_TOKEN_AGENTS`) to `deploy.yml` app secret sync and `sync-secrets.mjs` manifest
- Already hotfixed in K8s (secret + pod restart) — this PR persists the fix in CI

## Test plan
- [ ] Visit https://www.fenrirledger.com/admin — should load Pack Status dashboard
- [ ] CI deploy syncs GITHUB_TOKEN into fenrir-app-secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)