### PR TITLE
docs: ADR audit — update stale and add missing (issue #2023)

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -13,10 +13,10 @@ Technical architecture documents. These translate product vision into technical 
 
 These are the Sprint 1-3 ADRs:
 
-- [adrs/ADR-001-tech-stack.md](adrs/ADR-001-tech-stack.md) -- Next.js + TypeScript + Tailwind CSS + shadcn/ui stack choice. **Accepted.**
+- [adrs/ADR-001-tech-stack.md](adrs/ADR-001-tech-stack.md) -- Next.js + TypeScript + Tailwind CSS + shadcn/ui stack choice. **Accepted** (hosting intent superseded by ADR-016).
 - [adrs/ADR-002-data-model.md](adrs/ADR-002-data-model.md) -- Household-scoped data model. **Accepted.**
 - [adrs/ADR-003-local-storage.md](adrs/ADR-003-local-storage.md) -- localStorage persistence with documented migration path. **Accepted.**
-- [adrs/ADR-004-oidc-auth-localStorage.md](adrs/ADR-004-oidc-auth-localStorage.md) -- OIDC auth with per-household localStorage namespacing. **Accepted, superseded by ADR-005.**
+- [adrs/ADR-004-oidc-auth-localStorage.md](adrs/ADR-004-oidc-auth-localStorage.md) -- OIDC auth with Auth.js v5 (never shipped). **Superseded by ADR-005.**
 - [adrs/ADR-005-auth-pkce-public-client.md](adrs/ADR-005-auth-pkce-public-client.md) -- Authorization Code + PKCE flow with server token proxy. **Accepted.**
 - [adrs/ADR-006-anonymous-first-auth.md](adrs/ADR-006-anonymous-first-auth.md) -- Anonymous-first auth model with optional Google sign-in. **Accepted, current.**
 - [adrs/ADR-007-remote-builder-platforms.md](adrs/ADR-007-remote-builder-platforms.md) -- Remote builder platform evaluation: Depot was initially selected but **superseded by infrastructure ADR-004** (GKE Autopilot Jobs chosen for agent execution). **Accepted, superseded.**
@@ -30,6 +30,9 @@ These are the Sprint 1-3 ADRs:
 - [adrs/ADR-013-agent-monitor-spa.md](adrs/ADR-013-agent-monitor-spa.md) -- ADR-013: Agent Monitor single-file SPA for real-time GKE agent log streaming. **Accepted, current.**
 - [adrs/ADR-014-firestore-cloud-sync.md](adrs/ADR-014-firestore-cloud-sync.md) -- ADR-014: Firestore for Karl-tier cloud sync of card data. **Accepted, current.**
 - [adrs/ADR-015-authz-layer.md](adrs/ADR-015-authz-layer.md) -- ADR-015: Centralized `requireAuthz()` authorization layer for household-scoped routes. **Accepted, current.**
+- [adrs/ADR-016-gke-autopilot-migration.md](adrs/ADR-016-gke-autopilot-migration.md) -- ADR-016: GKE Autopilot migration — app moves from Vercel to GKE; standalone Next.js build, Helm deploy, in-cluster Redis. **Accepted, current.**
+- [adrs/ADR-017-trial-tier-system.md](adrs/ADR-017-trial-tier-system.md) -- ADR-017: 30-day free trial with Karl-level features except cloud sync; server-authoritative Firestore state; Stripe for Karl paid tier ($3.99/mo). **Accepted, current.**
+- [adrs/ADR-018-import-pipeline.md](adrs/ADR-018-import-pipeline.md) -- ADR-018: Three-path import pipeline (URL / CSV / file) with LLM-powered card extraction via Anthropic Claude. **Accepted, current.**
 
 ## Other Architecture Documents
 

--- a/architecture/adrs/ADR-001-tech-stack.md
+++ b/architecture/adrs/ADR-001-tech-stack.md
@@ -1,10 +1,10 @@
 # ADR-001: Tech Stack — Next.js + TypeScript + Tailwind CSS + shadcn/ui
 
-## Status: Accepted
+## Status: Accepted (hosting intent superseded by infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md)
 
 ## Context
 
-Fenrir Ledger is a personal finance web app for credit card churners. Sprint 1 targets local-only use (no backend, no auth), with Vercel hosting coming in a future sprint. We need a frontend stack that:
+Fenrir Ledger is a personal finance web app for credit card churners. Sprint 1 targets local-only use (no backend, no auth), with hosting to be added in a future sprint. We need a frontend stack that:
 
 - Enables fast iteration on UI-heavy features (cards, dashboards, forms)
 - Produces a production-quality codebase from day one
@@ -13,7 +13,7 @@ Fenrir Ledger is a personal finance web app for credit card churners. Sprint 1 t
 - Is mobile-responsive (churners check this on the go)
 - Has strong TypeScript support for data model correctness
 
-The team has also decided that the Next.js project root will live at `development/ledger/` so the monorepo can host architecture docs, team SKILLs, and source code alongside each other without collision. Vercel will be configured with Root Directory set to `development/ledger/`.
+The team has also decided that the Next.js project root will live at `development/ledger/` so the monorepo can host architecture docs, team SKILLs, and source code alongside each other without collision.
 
 ## Options Considered
 
@@ -24,7 +24,7 @@ The team has also decided that the Next.js project root will live at `developmen
 - TypeScript eliminates a class of runtime bugs in data model handling (critical when tracking financial dates and amounts)
 - Tailwind CSS enables rapid, consistent styling without a large CSS surface to maintain
 - shadcn/ui provides accessible, unstyled-but-beautiful components (cards, dialogs, forms, badges) that map directly to our UI needs; components are copy-owned, not library-locked
-- Vercel is the natural deploy target for Next.js — zero additional config when we add hosting
+- Next.js standalone output (`output: 'standalone'`) enables containerized deployment on GKE Autopilot
 - Strong community support and long-term viability
 
 **Cons**:
@@ -48,7 +48,7 @@ The team has also decided that the Next.js project root will live at `developmen
 
 **Pros**: Excellent data loading model, good TypeScript support.
 
-**Cons**: Less familiar to most frontend developers. Smaller shadcn/ui integration story. Vercel support is good but Next.js is the primary Vercel-optimized framework.
+**Cons**: Less familiar to most frontend developers. Smaller shadcn/ui integration story. Next.js has broader ecosystem support and better standalone container build story for GKE.
 
 ## Decision
 
@@ -68,7 +68,7 @@ shadcn/ui is initialized after scaffolding with `npx shadcn@latest init`.
 - Consistent type safety across the data model from Sprint 1 onward
 - Tailwind + shadcn/ui enables rapid, accessible UI development
 - App Router provides the foundation for API routes and server components in future sprints
-- Vercel deploy in a future sprint requires zero additional framework configuration
+- Next.js `output: 'standalone'` produces a minimal Node.js bundle suitable for GKE container deployment (see infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md)
 - shadcn/ui components are copy-owned — no dependency drift, no breaking upgrades
 
 **Negative**:
@@ -79,4 +79,4 @@ shadcn/ui is initialized after scaffolding with `npx shadcn@latest init`.
 **Constraints introduced**:
 - All components that use React hooks or browser APIs must include `"use client"` at the top
 - The `development/ledger/` directory is the Next.js project root — all `npm` commands run from there
-- Vercel Root Directory must be set to `development/ledger/` when hosting is configured
+- `output: 'standalone'` in `next.config.js` is required for GKE container builds

--- a/architecture/adrs/ADR-004-oidc-auth-localStorage.md
+++ b/architecture/adrs/ADR-004-oidc-auth-localStorage.md
@@ -1,6 +1,11 @@
 # ADR-004: OIDC Authentication with Auth.js v5 + Per-Household localStorage Namespacing
 
-## Status: Accepted
+## Status: Superseded by ADR-005
+
+> **Note:** ADR-004 was never used in production. The Auth.js v5 approach was replaced before
+> shipping by ADR-005 (Authorization Code + PKCE with server token proxy). This document is
+> retained for historical context only. See [ADR-005](ADR-005-auth-pkce-public-client.md) for
+> the current auth architecture.
 
 ## Context
 

--- a/architecture/adrs/ADR-016-gke-autopilot-migration.md
+++ b/architecture/adrs/ADR-016-gke-autopilot-migration.md
@@ -1,0 +1,105 @@
+# ADR-016: GKE Autopilot Migration
+
+**Status:** Accepted
+**Date:** 2026-03-14
+**Authors:** FiremanDecko (Principal Engineer)
+**Supersedes:** ADR-001 (hosting intent — Vercel references)
+**Full decision record:** [infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md](../../infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md)
+
+---
+
+## Context
+
+Fenrir Ledger was originally planned to deploy on Vercel (referenced in ADR-001 tech stack).
+As product requirements grew — server-side secrets, persistent KV storage, agent execution
+workloads, and unified GCP observability — Vercel's frontend PaaS model became insufficient.
+
+The full decision record lives in the infrastructure ADR layer
+(`infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md`). This entry records the
+architectural decision from the application layer's perspective.
+
+---
+
+## Decision
+
+Deploy Fenrir Ledger on **GKE Autopilot** (`fenrir-autopilot`, `us-central1`) in the
+`fenrir-ledger-prod` GCP project. All workloads — app, Redis, analytics, and agent Jobs —
+run in the same cluster.
+
+### Key application-layer changes
+
+| Concern | Before (Vercel) | After (GKE) |
+|---------|----------------|-------------|
+| Next.js output mode | Default server (Vercel-managed) | `output: 'standalone'` in `next.config.js` |
+| Base URL env var | `VERCEL_URL` | `APP_BASE_URL=https://fenrirledger.com` (static) |
+| KV store | Vercel KV (Upstash, external) | Redis StatefulSet (in-cluster, ~0 ms latency) |
+| Secrets | Vercel dashboard env vars | K8s Secret `fenrir-app-secrets`, injected via `envFrom.secretRef` |
+| Deploy trigger | Vercel GitHub integration | `.github/workflows/deploy.yml` — Docker + Helm on push to `main` |
+| Preview deployments | Automatic per-PR | Not available (manual workarounds not planned) |
+
+### Deployment architecture summary
+
+```
+Internet
+  │
+  ▼
+GKE Ingress (GCE L7 Load Balancer)
+  │  Google-managed SSL cert (fenrirledger.com)
+  │
+  └── fenrir-app namespace
+        ├── Deployment: fenrir-app (2 replicas, 0.5 vCPU / 512 Mi)
+        └── StatefulSet: redis (AOF persistence, ClusterIP only)
+```
+
+### Infrastructure files
+
+| File | Purpose |
+|------|---------|
+| `infrastructure/gke.tf` | GKE Autopilot cluster (Terraform) |
+| `infrastructure/k8s/app/deployment.yaml` | App Deployment, Service, Ingress |
+| `infrastructure/k8s/app/redis.yaml` | Redis StatefulSet |
+| `.github/workflows/deploy.yml` | CI/CD pipeline (Docker → Artifact Registry → Helm) |
+| `infrastructure/SMOKE-TEST.md` | Post-deploy verification steps |
+
+---
+
+## Alternatives Considered
+
+See `infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md` for the full evaluation of
+Vercel (status quo), Google Cloud Run, and GKE Autopilot.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Unified GCP perimeter** — all secrets, compute, logging, and IAM in `fenrir-ledger-prod`
+- **Stateful workloads** — Redis runs in-cluster; ~0 ms latency vs. Vercel KV's 10–50 ms
+- **Agent dispatch** — GKE Jobs in `fenrir-agents` namespace, no external sandbox vendor
+- **Predictable cost** — per-pod resource billing with a `$150/month` budget alert
+- **Zero-downtime deploys** — rolling update with `maxUnavailable: 0`
+
+### Negative
+
+- **No automatic preview deployments** — Vercel's per-PR preview URLs are gone
+- **Operational surface** — Kubernetes YAML, Helm, Terraform, Artifact Registry require maintenance
+- **SSL provisioning lag** — Google-managed certs take 15–60 min after DNS cutover
+
+### Neutral
+
+- **Next.js features unchanged** — App Router, API routes, and Server Components behave
+  identically; only `output: 'standalone'` was added to `next.config.js`
+- **No Vercel-specific APIs remain** — `@vercel/kv`, `@vercel/analytics`, and `VERCEL_URL`
+  were removed in Issue #682
+
+---
+
+## Related
+
+- [infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md](../../infrastructure/adrs/ADR-001-vercel-to-gke-autopilot.md) — full decision record
+- [infrastructure/adrs/ADR-004-gke-jobs-agent-execution.md](../../infrastructure/adrs/ADR-004-gke-jobs-agent-execution.md) — agent sandboxes on the same cluster
+- [infrastructure/adrs/ADR-005-redis-over-vercel-kv.md](../../infrastructure/adrs/ADR-005-redis-over-vercel-kv.md) — in-cluster Redis
+- [ADR-001-tech-stack.md](ADR-001-tech-stack.md) — original tech stack decision (hosting intent superseded here)
+- GitHub Issue #854 — GKE migration tracking issue
+- GitHub Issue #682 — Vercel/Depot reference cleanup

--- a/architecture/adrs/ADR-017-trial-tier-system.md
+++ b/architecture/adrs/ADR-017-trial-tier-system.md
@@ -1,0 +1,152 @@
+# ADR-017: Trial Tier System
+
+**Status:** Accepted
+**Date:** 2026-03-01
+**Authors:** FiremanDecko (Principal Engineer)
+**Related issues:** #1122, #1648
+
+---
+
+## Context
+
+Fenrir Ledger has two paid tiers (Thrall and Karl) with Stripe as the billing platform
+(ADR-010). To lower the conversion barrier, a **free trial** was introduced that gives
+new users full Karl-level features for a limited period — with one deliberate exception:
+cloud sync remains Karl-only to preserve a concrete paid-tier differentiator.
+
+The trial state is server-authoritative (Firestore) to prevent client-side manipulation,
+and is permanent (never deleted) to block restart attempts after expiry.
+
+---
+
+## Decision
+
+Implement a **30-day free trial** triggered on first card creation. The trial:
+
+- Grants Karl-level feature access **except cloud sync**
+- Is tracked server-side in Firestore at `/households/{userId}/trial`
+- Cannot be restarted after expiry
+- Converts automatically when the user subscribes to Karl
+
+### Tier model
+
+| Tier | How granted | Cloud sync | Import pipeline | Card limit |
+|------|-------------|------------|-----------------|------------|
+| Thrall (unauthenticated) | Default | No | No | 3 cards |
+| Thrall (authenticated, post-trial) | Default | No | No | Configurable |
+| Trial | Auto on first card creation | **No** | Yes | Unlimited |
+| Karl | Active Stripe subscription | Yes | Yes | Unlimited |
+
+### Trial gating in code
+
+Cloud sync is explicitly excluded from trial access. The gate is in
+`development/ledger/src/hooks/useCloudSync.ts`:
+
+```typescript
+// Karl-only: no sync for Thrall or free-trial users (#1122 acceptance criterion)
+const isKarl = isAuthenticated && tier === "karl" && isActive;
+```
+
+All other Karl-gated features use `tier: "karl-or-trial"` in `requireAuthz()`:
+
+```typescript
+// ADR-015 authz layer — grants access to Karl subscribers AND active trial users
+const authz = await requireAuthz(request, { tier: "karl-or-trial" });
+```
+
+### Trial Firestore schema
+
+Stored at `/households/{userId}/trial` (via `development/ledger/src/lib/kv/trial-store.ts`):
+
+```typescript
+interface StoredTrial {
+  startDate: string;     // ISO — when trial started (first card creation)
+  expiresAt: string;     // ISO — startDate + 30 days
+  convertedDate?: string; // ISO — when user subscribed to Karl (if ever)
+}
+```
+
+The document is permanent. `TrialRestartError` is thrown if a user attempts to start a
+second trial after the first has expired.
+
+### Trial duration
+
+`TRIAL_DURATION_DAYS = 30` (defined in `development/ledger/src/lib/trial-utils.ts`).
+
+### Stripe pricing (Karl tier)
+
+- Price: **$3.99/month** (recurring)
+- Platform: Stripe Checkout + Customer Portal (ADR-010)
+- Entitlements written to Firestore by Stripe webhook handler; read by `requireAuthz()`
+
+---
+
+## Alternatives Considered
+
+### 1. No trial — Karl paywall from day one
+
+**Pros**: Simpler entitlement logic; no trial/Karl distinction to maintain.
+
+**Cons**: High conversion friction for new users with no card data yet. Trial lowers the
+barrier to evaluating import, dashboards, and budget tools before committing to a subscription.
+
+### 2. Trial with cloud sync included
+
+**Pros**: Users experience the full Karl feature set before deciding.
+
+**Cons**: Cloud sync requires Firestore reads/writes per sync operation. Offering it during
+trial creates infrastructure cost with no revenue offset and removes a key paid-tier differentiator.
+
+### 3. Trial stored client-side (localStorage)
+
+**Pros**: Zero server round-trip to check trial status.
+
+**Cons**: Trivially bypassable — clearing localStorage or using DevTools resets the trial.
+Server-authoritative Firestore is the only tamper-resistant option.
+
+### 4. 14-day trial
+
+**Pros**: Shorter trial reduces the window of free Karl access.
+
+**Cons**: 30 days gives users enough time to import real card data, evaluate reminders, and
+see a billing cycle — sufficient for a genuine conversion decision. 14 days was considered
+too short for the import-heavy onboarding flow.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Lower conversion friction** — users experience Karl features before committing
+- **Tamper-resistant** — trial state is server-side; client cannot extend or restart it
+- **Clean differentiator** — cloud sync remains exclusively Karl-tier; trial is not "free Karl"
+- **Automatic conversion** — Stripe webhook sets `convertedDate` when subscription activates
+
+### Negative
+
+- **Extra Firestore read per request** — `requireAuthz()` reads trial state on every
+  `karl-or-trial` gated route; mitigated by short-lived in-process caching
+- **UI complexity** — trial expiry modals, mid-trial nudges, and post-trial banners require
+  localStorage flags (`fenrir:trial-start-toast-shown`, etc.) to avoid repeated display
+- **Support surface** — users expect trial restart; the hard block requires clear UX messaging
+
+### Constraints introduced
+
+- Trial state MUST be read from Firestore, never from client-supplied data
+- Cloud sync routes (`/api/sync/*`) MUST use `tier: "karl"` (not `"karl-or-trial"`) in `requireAuthz()`
+- All other Karl-gated routes use `tier: "karl-or-trial"`
+- `TRIAL_DURATION_DAYS` is the single source of truth — do not hardcode `30` elsewhere
+
+---
+
+## Related
+
+- [ADR-010-stripe-direct.md](ADR-010-stripe-direct.md) — Stripe Checkout and webhook-driven entitlements
+- [ADR-014-firestore-cloud-sync.md](ADR-014-firestore-cloud-sync.md) — Firestore cloud sync (Karl-only)
+- [ADR-015-authz-layer.md](ADR-015-authz-layer.md) — `requireAuthz()` tier gating implementation
+- `development/ledger/src/hooks/useCloudSync.ts` — cloud sync Karl gate (line ~177)
+- `development/ledger/src/lib/kv/trial-store.ts` — Firestore trial read/write
+- `development/ledger/src/lib/trial-utils.ts` — `TRIAL_DURATION_DAYS` constant
+- `development/ledger/src/lib/auth/authz.ts` — `requireAuthz()` with `karl-or-trial` tier
+- GitHub Issue #1122 — trial tier acceptance criteria (cloud sync exclusion)

--- a/architecture/adrs/ADR-018-import-pipeline.md
+++ b/architecture/adrs/ADR-018-import-pipeline.md
@@ -1,0 +1,179 @@
+# ADR-018: Import Pipeline
+
+**Status:** Accepted
+**Date:** 2026-03-15
+**Authors:** FiremanDecko (Principal Engineer)
+
+---
+
+## Context
+
+Users need to import their existing credit card data into Fenrir Ledger. Card data lives in
+a variety of formats: public Google Sheets, CSV exports from spreadsheet tools, and Excel
+files (`.xls`/`.xlsx`). Manually entering every card is a high-friction onboarding barrier.
+
+The import feature must:
+
+1. Support multiple source formats without requiring users to standardise their data first
+2. Handle messy, freeform spreadsheet layouts (non-standard column names, extra rows, etc.)
+3. Be gated behind Karl-or-trial tier (import is a premium feature per ADR-017)
+4. Run entirely server-side to keep the Anthropic API key out of the browser bundle
+5. Apply SSRF protection when fetching external URLs
+
+---
+
+## Decision
+
+Implement a **three-path import pipeline** behind a single API route
+(`POST /api/sheets/import`), with LLM-powered card extraction for all paths.
+
+### Path A — URL (Google Sheets / CSV URL)
+
+1. Client POSTs `{ url: "https://docs.google.com/spreadsheets/..." }`
+2. Server validates the URL against an SSRF allowlist (`validateImportUrl`)
+3. Server fetches the public Google Sheets export URL (`/export?format=csv`) or raw CSV URL
+4. Raw CSV is passed to `extractCardsFromCsv()`
+
+### Path B — CSV text upload
+
+1. Client POSTs `{ csv: "<raw CSV text>" }`
+2. Raw CSV is passed directly to `extractCardsFromCsv()`
+
+### Path C — Binary file upload (XLS / XLSX)
+
+1. Client POSTs `{ file: "<base64>", filename: "cards.xlsx", format: "xlsx" }`
+2. Server decodes base64, parses the binary spreadsheet via a server-side XLSX parser
+3. First sheet is serialised to CSV, then passed to `extractCardsFromCsv()`
+
+Accepted formats: `xls`, `xlsx`. Other formats (`.ods`, `.csv` with wrong field) are rejected
+with `INVALID_CSV` before reaching the LLM.
+
+### LLM card extraction (`extractCardsFromCsv`)
+
+All three paths converge at `extractCardsFromCsv()` in
+`development/ledger/src/lib/sheets/extract-cards.ts`:
+
+1. **Sanitise** — strip prompt-injection patterns from CSV text (`sanitizeCsvForPrompt`)
+2. **Prompt** — build a structured extraction prompt (`buildExtractionPrompt`)
+3. **LLM call** — call the configured LLM provider (Anthropic Claude via `FENRIR_ANTHROPIC_API_KEY`);
+   provider is resolved at runtime by `getLlmProvider()`
+4. **Parse** — strip markdown code fences if present; JSON-parse the response
+5. **Validate** — validate against `CardsArraySchema` (Zod); reject malformed responses
+6. **UUID assignment** — assign stable UUIDs to each extracted card before returning
+
+The LLM handles non-standard column names, extra header rows, and freeform layouts that
+rule-based parsing cannot handle reliably.
+
+### Auth and rate limiting
+
+```typescript
+// Tier gate: Karl subscribers and active trial users only
+const authz = await requireAuthz(request, { tier: "karl-or-trial" });
+
+// 5 imports per user per hour (GHSA-4r6h, GHSA-5pgg)
+const { success } = rateLimit(`sheets:import:${authz.user.sub}`, { limit: 5, windowMs: 3_600_000 });
+```
+
+### SSRF prevention (URL path only)
+
+`validateImportUrl()` rejects:
+- Non-HTTP(S) schemes
+- Private IP ranges (RFC 1918, loopback, link-local)
+- Non-allowlisted hostnames for Google Sheets (`docs.google.com`, `sheets.googleapis.com`)
+
+### Route configuration
+
+```typescript
+// development/ledger/src/app/api/sheets/import/route.ts
+export const maxDuration = 60; // LLM calls may take 10–30 s
+```
+
+---
+
+## Alternatives Considered
+
+### 1. Rule-based column mapping (no LLM)
+
+Parse CSV by detecting known column headers (`Card Name`, `Annual Fee`, `Signup Bonus`, etc.)
+and mapping them to the Card schema.
+
+**Pros**: Fast, deterministic, zero API cost.
+
+**Cons**: Users' spreadsheets use wildly different column names (`card`, `cc name`, `bonus`,
+`SUB`, etc.). A rule-based matcher would require an ever-growing synonym list and still fails
+on unusual layouts. The LLM handles arbitrary layouts reliably with a single prompt.
+
+### 2. Client-side LLM call (browser → Anthropic API directly)
+
+Call the Anthropic API directly from the browser with a public API key.
+
+**Pros**: Simpler — no server round-trip.
+
+**Cons**: `FENRIR_ANTHROPIC_API_KEY` would be exposed in the client bundle (visible in DevTools
+network tab). Unacceptable — this key has billing implications and no request-level auth.
+
+### 3. Separate endpoints per import mode (URL / CSV / file)
+
+Three distinct API routes: `/api/sheets/import/url`, `/api/sheets/import/csv`,
+`/api/sheets/import/file`.
+
+**Pros**: Cleaner route separation.
+
+**Cons**: Duplicates auth, rate limiting, and error handling across three handlers. A single
+route with mode dispatch at the top keeps the shared logic (auth, rate limit, SSRF check,
+LLM extraction) in one place.
+
+### 4. Synchronous response (no timeout extension)
+
+Return the LLM result synchronously within the default Next.js route timeout (10 s on Vercel).
+
+**Pros**: No configuration needed.
+
+**Cons**: LLM calls for large spreadsheets can take 15–30 s. On GKE the pod timeout is
+effectively unlimited, but `maxDuration = 60` is set explicitly as a safety bound and for
+forward compatibility if routes are ever extracted.
+
+---
+
+## Consequences
+
+### Positive
+
+- **Handles arbitrary layouts** — LLM extraction works on freeform spreadsheets without user
+  pre-processing
+- **Single route** — auth, rate limiting, SSRF, and extraction logic are centralised
+- **API key stays server-side** — `FENRIR_ANTHROPIC_API_KEY` never reaches the browser
+- **SSRF protection** — URL imports validate against an allowlist before any network call
+
+### Negative
+
+- **LLM cost** — each import call invokes the Anthropic API; large spreadsheets consume more
+  tokens; rate limit (5/hour/user) bounds worst-case spend
+- **Non-deterministic output** — LLM extraction may occasionally misparse edge cases; the
+  Zod schema validation catches structural errors but not semantic mismatches
+- **60 s timeout** — large imports block the connection for up to a minute; the UI shows a
+  progress indicator during this window
+- **Binary file size** — XLS/XLSX files are base64-encoded in the POST body; large files
+  may hit Next.js body size limits (currently 4 MB default, configurable)
+
+### Constraints introduced
+
+- `FENRIR_ANTHROPIC_API_KEY` is a server-only env var — never use `NEXT_PUBLIC_` prefix
+- All import paths MUST go through `requireAuthz(request, { tier: "karl-or-trial" })`
+- URL imports MUST call `validateImportUrl()` before any fetch (SSRF prevention)
+- Rate limit key is `sheets:import:{user.sub}` — 5 requests per hour per user
+
+---
+
+## Related
+
+- [ADR-015-authz-layer.md](ADR-015-authz-layer.md) — `requireAuthz()` tier gating
+- [ADR-017-trial-tier-system.md](ADR-017-trial-tier-system.md) — import is a Karl-or-trial feature
+- `development/ledger/src/app/api/sheets/import/route.ts` — route handler
+- `development/ledger/src/lib/sheets/extract-cards.ts` — LLM extraction shared logic
+- `development/ledger/src/lib/sheets/import-pipeline.ts` — Path A (URL) pipeline
+- `development/ledger/src/lib/sheets/csv-import-pipeline.ts` — Path B (CSV) pipeline
+- `development/ledger/src/lib/sheets/file-import-pipeline.ts` — Path C (file) pipeline
+- `development/ledger/src/lib/sheets/url-validation.ts` — SSRF allowlist
+- `development/ledger/src/lib/sheets/prompt.ts` — extraction prompt builder
+- `development/ledger/src/lib/llm/extract.ts` — LLM provider abstraction


### PR DESCRIPTION
PR for issue: #2023

Updates stale ADRs and adds missing architectural decision records.

**Changes:**
- ADR-001 updated: removed Vercel hosting intent; references GKE standalone build and infrastructure ADR-001
- ADR-004 marked superseded: adds header noting Auth.js v5 was never shipped; superseded by ADR-005
- ADR-016 created: GKE Autopilot migration — app-layer perspective, cross-references infrastructure/adrs/ADR-001
- ADR-017 created: 30-day trial tier system — Karl features minus cloud sync, Firestore-authoritative state
- ADR-018 created: three-path import pipeline (URL/CSV/file) with LLM-powered card extraction
- architecture/README.md: index updated with all new and amended ADRs

Closes #2023