### PR TITLE
Issue #2027 - docs: sync Loki QA docs

### DIFF
--- a/quality/README.md
+++ b/quality/README.md
@@ -12,7 +12,7 @@
 |-------|--------|-------|-------|---------|
 | **Unit** | Vitest | ~500+ | ~2s | Pure logic, utilities, helpers |
 | **Integration** | Vitest + happy-dom | ~300+ | ~3s | API routes, component render, hooks |
-| **E2E** | Playwright | ~20 | ~1min | User journeys, critical integrations, multi-page flows |
+| **E2E** | Playwright | ~10 | ~1min | User journeys, critical integrations, multi-page flows |
 
 Run `bash quality/scripts/loki-critique.sh` to generate the latest bloat critique and per-suite details.
 
@@ -51,8 +51,8 @@ Run `bash quality/scripts/loki-critique.sh` to generate the latest bloat critiqu
 **Generated on demand:** Run `bash quality/scripts/loki-critique.sh` to produce a fresh quality report. The report is not committed — it is regenerated each session.
 
 Key metrics:
-- **E2E suites:** 3 directories, 8 spec files
-- **E2E tests:** ~20 (Playwright)
+- **E2E suites:** 3 directories, 4 spec files
+- **E2E tests:** ~10 (Playwright)
 - **Unit/Integration:** ~802 tests (Vitest)
 - **Overall health:** Run `bash quality/scripts/loki-critique.sh` for a real-time verdict
 

--- a/quality/test-guidelines.md
+++ b/quality/test-guidelines.md
@@ -16,7 +16,7 @@ What belongs where. Loki must follow this when writing or reviewing tests.
 |-------|--------|-------|---------|
 | Unit | Vitest | ~500+ | ~2s |
 | Integration | Vitest + happy-dom | ~300+ | ~3s |
-| E2E | Playwright | ~20 | ~1min |
+| E2E | Playwright | ~10 | ~1min |
 
 ### Global E2E Cap (UNBREAKABLE)
 
@@ -196,12 +196,12 @@ mockRequireAuth.mockResolvedValueOnce({
 8. **No structural DOM assertions.** Landmark presence, aria-label existence, and tag structure belong in integration tests. E2E tests should focus on user interactions and navigation.
 9. **Critical integrations are non-negotiable.** Always keep E2E coverage for: OAuth flows (sign-in, callback, returnto), Stripe integration (checkout, webhook, portal), card CRUD (add, edit, delete), data persistence (localStorage), dashboard navigation, and a11y gates (dialog, landmarks). Delete or trim low-value suites first (static content, CSS measurements, regression suites) before cutting critical path tests.
 
-### Current E2E suites (8 files, ~20 tests)
+### Current E2E suites (4 files, ~10 tests)
 
 | Category | Suites | Tests |
 |----------|--------|-------|
-| Auth | auth/ (auth-callback, sign-in), auth-returnto/ | ~8 |
-| Cards | card-lifecycle/ (add, edit, close, delete, wizard-save) | ~12 |
+| Auth | auth/ (sign-in), auth-returnto/ | ~6 |
+| Cards | card-lifecycle/ (add-card, wizard-save) | ~4 |
 
 > **Removed (Issue #610 audit + Issue #929):** Extensive cleanup of bloated/static/duplicated suites. Removed: `accessibility/`, `dashboard/`, `layout/`, `settings-*/`, `trial-*/`, `gke-migration/`, `issue-682/`, `trust-safety/`, `admin-console/`, `features/`, `theme-toggle/`, `dialog-a11y/`, `stale-auth-nudge/`, and more. Static content checks migrated to Vitest component tests; logic tests migrated to Vitest unit/integration.
 


### PR DESCRIPTION
## Summary
- Corrected stale E2E spec file count: 8 → 4
- Corrected stale E2E test count: ~20 → ~10
- Removed references to non-existent spec files (auth-callback, card edit/close/delete)

Doc sync for `quality/` directory.

Fixes #2027

🤖 Generated with [Claude Code](https://claude.com/claude-code)