### PR TITLE
Issue #2028 - docs: sync Heimdall security docs

### DIFF
--- a/security/README.md
+++ b/security/README.md
@@ -4,7 +4,7 @@ Owned by **Heimdall** (`.claude/agents/heimdall.md`).
 
 This directory contains all security documentation for the Fenrir Ledger project: audit reports, architecture diagrams, checklists, and advisories.
 
-## Current State (as of 2026-03-23)
+## Current State (as of 2026-04-04)
 
 - **Infrastructure**: GKE Autopilot (not Vercel). See `infrastructure/k8s/app/` for deployment manifests.
 - **Subscription platform**: Stripe Direct only. Patreon has been fully removed.
@@ -12,42 +12,46 @@ This directory contains all security documentation for the Fenrir Ledger project
 - **Stripe webhook**: SHA-256 HMAC via `stripe.webhooks.constructEvent()`.
 - **CSP**: Includes all required Google and Stripe domains.
 - **Entitlement store**: Firestore (migrated from Upstash Redis in issue #1521 — `KV_REST_API_URL` and `KV_REST_API_TOKEN` no longer used or deployed).
-- **Firestore sync (issue #1126)**: ~~2 CRITICAL IDOR vulnerabilities~~ → **RESOLVED**. IDOR in `/api/sync/pull` (PR #1203) and `/api/sync/push` (PR #1207) fixed — both routes now derive `householdId` from the server-side user record, not the client. See report below.
-- **Odin's Throne (issue #1879)**: **1 CRITICAL OPEN** — oauth2-proxy `--skip-auth-regex=.*` bypasses all authentication on `odins-throne.fenrirledger.com`. The full monitor UI and job API are publicly accessible without credentials. Assign to FiremanDecko for immediate fix.
+- **Firestore sync (issue #1126)**: ~~2 CRITICAL IDOR vulnerabilities~~ → **RESOLVED**. IDOR in `/api/sync/pull` (PR #1203) and `/api/sync/push` (PR #1207) fixed — both routes now derive `householdId` from the server-side user record, not the client.
+- **Odin's Throne auth bypass (issue #1879)**: ~~CRITICAL — oauth2-proxy `--skip-auth-regex=.*`~~ → **RESOLVED** in PR #1896. The wildcard skip-auth regex was removed; all Odin's Throne routes now enforce Google OAuth via oauth2-proxy.
+- **Sync state route (issue #2001)**: `/api/sync/state` added (PR #2012) — Karl-only, uses the `requireAuthz()` pattern (authentication + user resolution + household membership + tier check in one call). Household ID derived server-side only; IDOR protection confirmed.
 - **Open findings (Firestore audit)**: 1 HIGH (invite validate PII leakage), 3 MEDIUM (no rate limiting on invite/sync routes, Admin SDK bypasses rules), 3 LOW (error handling, entropy docs, tier disclosure), 3 INFO (emulator-only rules, soft-delete, no collection group).
 - **Open findings (older reports)**: 3 LOW (distributed rate limiting, webhook deduplication, email validation), 3 INFO (trust chain comment, publishable key monitoring), plus external pentest CRITICAL (Next.js CVEs #475 — **RESOLVED**: upgraded to Next.js 16.x) and HIGH (SheetJS #476 — still open).
-- **Report format note**: Pen test reports are now published as self-contained HTML files (e.g., `security/pen-test-report.html`) in addition to Markdown reports in `security/reports/`.
+- **Report format note**: The most recent pen test report is published as a self-contained HTML file at `security/pen-test-report.html`. Older Markdown reports were archived to git history in PR #1880 (commit `164115aa`) — history is preserved but files are not on disk.
 
 ---
 
 ## Reports
 
+The most recent pen test report is on disk. Older Markdown reports were removed from
+the working tree in PR #1880 (commit `164115aa`) — full content is preserved in git history.
+
 | Date | Scope | Risk Summary | Status | Path |
 |------|-------|-------------|--------|------|
-| 2026-03-23 | **External Pen Test — fenrirledger.com + Odin's Throne** (issue #1879) | **1C / 0H / 0M / 2L / 2I** | **[Active] CRITICAL Throne auth bypass open; LOW/INFO new findings; see open tracker** | [pen-test-report.html](pen-test-report.html) |
-| 2026-03-17 | **Firestore Sync & Household Data Access** (issue #1126) | **2C / 1H / 3M / 3L / 3I** | **[Active] CRITICAL IDOR fixed in PRs #1203 + #1207; HIGH + MEDIUM findings open** | [reports/2026-03-17-firestore-sync-audit.md](reports/2026-03-17-firestore-sync-audit.md) |
-| 2026-03-10 | **Comprehensive External Pen Test** — Consolidated from 4 parallel audits (#470–473) | **1C / 1H / 3M / 3L / 5I** | **[Active] CRITICAL Next.js CVEs RESOLVED (Next.js upgraded to 16.x); HIGH SheetJS unpatched — see issues** | [reports/2026-03-09-external-pentest.md](reports/2026-03-09-external-pentest.md) |
-| 2026-03-02 | Google API Integration | 0C / 3H / 3M / 3L / 3I | Active — findings partially open | [reports/2026-03-02-google-api-integration.md](reports/2026-03-02-google-api-integration.md) |
-| 2026-03-04 | Stripe Direct Integration | 0C / 0H / 0M / 3L / 3I | Active — CRITICAL/MEDIUM resolved | [reports/2026-03-04-stripe-direct-integration.md](reports/2026-03-04-stripe-direct-integration.md) |
-| 2026-03-05 | LLM Prompt Injection Remediation (#157) | 0C / 0H / 0M / 0L / 2I | Active | [reports/2026-03-05-llm-prompt-injection-remediation.md](reports/2026-03-05-llm-prompt-injection-remediation.md) |
-| 2026-03-07 | Gmail MCP Deep Audit | N/A (advisory) | Active | [reports/2026-03-07-gmail-mcp-deep-audit.md](reports/2026-03-07-gmail-mcp-deep-audit.md) |
-| 2026-03-07 | Gmail MCP PR #324 Review | 0C / 0H / 0M / 2 new findings | Resolved | [reports/2026-03-07-gmail-mcp-pr324-review.md](reports/2026-03-07-gmail-mcp-pr324-review.md) |
-| 2026-03-08 | Gmail MCP PR #324 Remediation | All findings resolved | Closed | [reports/2026-03-08-gmail-mcp-pr324-remediation.md](reports/2026-03-08-gmail-mcp-pr324-remediation.md) |
+| 2026-03-23 | **External Pen Test — fenrirledger.com + Odin's Throne** (issue #1879) | **1C / 0H / 0M / 2L / 2I** | **[Active] CRITICAL Throne auth bypass RESOLVED (PR #1896); LOW/INFO findings open** | [pen-test-report.html](pen-test-report.html) |
+| 2026-03-17 | **Firestore Sync & Household Data Access** (issue #1126) | **2C / 1H / 3M / 3L / 3I** | **[Active] CRITICAL IDOR fixed in PRs #1203 + #1207; HIGH + MEDIUM findings open** | archived in git (`164115aa`) |
+| 2026-03-10 | **Comprehensive External Pen Test** — Consolidated from 4 parallel audits (#470–473) | **1C / 1H / 3M / 3L / 5I** | **[Active] CRITICAL Next.js CVEs RESOLVED (Next.js upgraded to 16.x); HIGH SheetJS unpatched — see issues** | archived in git (`164115aa`) |
+| 2026-03-02 | Google API Integration | 0C / 3H / 3M / 3L / 3I | Active — findings partially open | archived in git (`164115aa`) |
+| 2026-03-04 | Stripe Direct Integration | 0C / 0H / 0M / 3L / 3I | Active — CRITICAL/MEDIUM resolved | archived in git (`164115aa`) |
+| 2026-03-05 | LLM Prompt Injection Remediation (#157) | 0C / 0H / 0M / 0L / 2I | Active | archived in git (`164115aa`) |
+| 2026-03-07 | Gmail MCP Deep Audit | N/A (advisory) | Active | archived in git (`164115aa`) |
+| 2026-03-07 | Gmail MCP PR #324 Review | 0C / 0H / 0M / 2 new findings | Resolved | archived in git (`164115aa`) |
+| 2026-03-08 | Gmail MCP PR #324 Remediation | All findings resolved | Closed | archived in git (`164115aa`) |
 
-### Penetration Test Sub-Reports (consolidated into 2026-03-09 External Pentest)
+### Penetration Test Sub-Reports (consolidated into 2026-03-09 External Pentest — archived in git)
 
-| Date | Scope | Path |
-|------|-------|------|
-| 2026-03-09 | Client-Side Security & Payment Flow | [reports/2026-03-09-pentest-clientside-payment.md](reports/2026-03-09-pentest-clientside-payment.md) |
-| 2026-03-10 | Authentication & API Authorization | [reports/2026-03-10-pentest-auth.md](reports/2026-03-10-pentest-auth.md) |
-| 2026-03-10 | Reconnaissance & Surface Enumeration | [reports/2026-03-10-pentest-recon.md](reports/2026-03-10-pentest-recon.md) |
-| 2026-03-10 | Injection & SSRF Testing | [reports/2026-03-10-pentest-injection.md](reports/2026-03-10-pentest-injection.md) |
+| Date | Scope | Git archive |
+|------|-------|-------------|
+| 2026-03-09 | Client-Side Security & Payment Flow | `164115aa` |
+| 2026-03-10 | Authentication & API Authorization | `164115aa` |
+| 2026-03-10 | Reconnaissance & Surface Enumeration | `164115aa` |
+| 2026-03-10 | Injection & SSRF Testing | `164115aa` |
 
 ### Archived Reports
 
-| Date | Scope | Notes | Path |
-|------|-------|-------|------|
-| 2026-03-02 | Patreon Integration | Historical — Patreon fully removed | [reports/2026-03-02-patreon-integration.md](reports/2026-03-02-patreon-integration.md) |
+| Date | Scope | Notes | Git archive |
+|------|-------|-------|-------------|
+| 2026-03-02 | Patreon Integration | Historical — Patreon fully removed | `164115aa` |
 
 ### Risk Summary Notes
 
@@ -68,10 +72,10 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Document | Description | Last Reviewed |
 |----------|-------------|---------------|
-| [architecture/auth-architecture.md](architecture/auth-architecture.md) | Full OAuth 2.0 PKCE flow, session storage model, token expiration, incremental Drive consent, trust boundaries, JWKS verification, Stripe subscription auth model, and Firestore sync authorization model | 2026-03-20 |
-| [architecture/data-flow-diagrams.md](architecture/data-flow-diagrams.md) | Security-focused data flow diagrams for OAuth PKCE, URL import (Path A), CSV upload (Path C), Google Picker (Path B), Stripe checkout, and Firestore sync pull/push; marks trust boundaries, SSRF surfaces, and injection points | 2026-03-20 |
-| [architecture/trust-boundaries.md](architecture/trust-boundaries.md) | Five trust zones (browser, GKE server, Google infra, Stripe infra, Firestore); secret locations; what data crosses each boundary; localStorage XSS implications and Firestore householdId constraints | 2026-03-20 |
-| [architecture/threat-model.md](architecture/threat-model.md) | Assets, threat actors, attack surfaces, mitigations in place, and residual risks; includes Firestore sync attack surfaces and IDOR mitigations | 2026-03-20 |
+| [architecture/auth-architecture.md](architecture/auth-architecture.md) | Full OAuth 2.0 PKCE flow, session storage model, token expiration, incremental Drive consent, trust boundaries, JWKS verification, Stripe subscription auth model, Firestore sync authorization model, and `requireAuthz()` pattern for household-scoped routes | 2026-04-04 |
+| [architecture/data-flow-diagrams.md](architecture/data-flow-diagrams.md) | Security-focused data flow diagrams for OAuth PKCE, URL import (Path A), CSV upload (Path C), Google Picker (Path B), Stripe checkout, and Firestore sync pull/push; marks trust boundaries, SSRF surfaces, and injection points | 2026-04-04 |
+| [architecture/trust-boundaries.md](architecture/trust-boundaries.md) | Five trust zones (browser, GKE server, Google infra, Stripe infra, Firestore); secret locations; what data crosses each boundary; localStorage XSS implications and Firestore householdId constraints | 2026-04-04 |
+| [architecture/threat-model.md](architecture/threat-model.md) | Assets, threat actors, attack surfaces, mitigations in place, and residual risks; includes Firestore sync attack surfaces and IDOR mitigations | 2026-04-04 |
 
 ---
 
@@ -79,8 +83,8 @@ This directory contains all security documentation for the Fenrir Ledger project
 
 | Document | Description | Last Reviewed |
 |----------|-------------|---------------|
-| [checklists/api-route-checklist.md](checklists/api-route-checklist.md) | Pre-merge checklist for adding or modifying API routes: requireAuth pattern, Firestore householdId validation, input validation, error handling, secret hygiene, SSRF prevention; includes Stripe webhook exemption | 2026-03-20 |
-| [checklists/deployment-security.md](checklists/deployment-security.md) | Pre-deployment checklist for GKE Autopilot: secret hygiene (including Firestore env vars), CSP verification, OAuth config, Stripe config, dependency audit, build verification, post-deployment checks | 2026-03-20 |
+| [checklists/api-route-checklist.md](checklists/api-route-checklist.md) | Pre-merge checklist for adding or modifying API routes: requireAuth pattern, Firestore householdId validation, input validation, error handling, secret hygiene, SSRF prevention; includes Stripe webhook exemption | 2026-04-04 |
+| [checklists/deployment-security.md](checklists/deployment-security.md) | Pre-deployment checklist for GKE Autopilot: secret hygiene (including Firestore env vars), CSP verification, OAuth config, Stripe config, dependency audit, build verification, post-deployment checks | 2026-04-04 |
 
 ---
 
@@ -98,7 +102,7 @@ The following findings from active reports remain open. Assign to FiremanDecko f
 
 | ID | Report | Severity | Title | Status | Issue |
 |----|--------|----------|-------|--------|-------|
-| **PT2026-CRIT-001** | **pen-test-report.html** | **CRITICAL** | **Odin's Throne: oauth2-proxy auth bypass via `--skip-auth-regex=.*` — all routes unauthenticated** | Open | — |
+| ~~PT2026-CRIT-001~~ | ~~pen-test-report.html~~ | ~~CRITICAL~~ | ~~Odin's Throne: oauth2-proxy auth bypass via `--skip-auth-regex=.*`~~ | **RESOLVED — PR #1896** | #1879 |
 | PT2026-LOW-001 | pen-test-report.html | LOW | Technology disclosure via `x-powered-by: Next.js` header | Open | — |
 | PT2026-LOW-002 | pen-test-report.html | LOW | Build commit SHA exposed in `/api/health` response | Open | — |
 | PT2026-INFO-001 | pen-test-report.html | INFO | No `/.well-known/security.txt` file | Open | — |

--- a/security/architecture/auth-architecture.md
+++ b/security/architecture/auth-architecture.md
@@ -1,7 +1,7 @@
 # Auth Architecture — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-20 (updated entitlement store from Upstash Redis to Firestore — issue #1521)
+**Last reviewed**: 2026-04-04 (fixed remaining Upstash Redis references; added requireAuthz pattern; Odin's Throne CRITICAL resolved PR #1896)
 **References**: ADR-005, ADR-006, ADR-008, ADR-010
 
 ---
@@ -249,8 +249,8 @@ These are the minimum scopes required for Path B. `drive.file` is narrower than
 ### 5.1 Overview
 
 Subscription management uses Stripe Direct exclusively. Users subscribe via Stripe
-Checkout (hosted payment page). Entitlements are stored in Upstash Redis keyed on the
-Google `sub` claim.
+Checkout (hosted payment page). Entitlements are stored in Firestore keyed on the
+Google `sub` claim (migrated from Upstash Redis in issue #1521).
 
 The Stripe integration creates a **layered model**:
 - Google `id_token` in `localStorage` — identity on every API request
@@ -262,7 +262,7 @@ process.env variable used server-to-server only.
 ### 5.2 Checkout Flow
 
 ```
-Browser (authenticated with Google)    /api/stripe/checkout     Stripe / Upstash Redis
+Browser (authenticated with Google)    /api/stripe/checkout     Stripe / Firestore
    |                                        |                           |
    |-- POST /api/stripe/checkout            |                           |
    |   Authorization: Bearer id_token       |                           |
@@ -288,7 +288,7 @@ Browser (authenticated with Google)    /api/stripe/checkout     Stripe / Upstash
    |   Stripe --> POST /api/stripe/webhook  |                           |
    |   checkout.session.completed           |                           |
    |   [SHA-256 HMAC verified]              |                           |
-   |   setStripeEntitlement(googleSub) ---- |-- KV.set ---------------> |
+   |   setStripeEntitlement(googleSub) ---- |-- Firestore.set --------> |
 ```
 
 ### 5.3 Webhook Authentication
@@ -485,8 +485,13 @@ client value and use `user.householdId` exclusively.
 
 ### 10.4 Tier Enforcement
 
-Sync routes check `getStripeEntitlement(googleSub)` from Upstash Redis and return 403 with
+Sync routes check `getStripeEntitlement(googleSub)` from Firestore and return 403 with
 `{ error: "karl_required", current_tier: "thrall" }` for non-Karl users.
+
+The newer `/api/sync/state` route (issue #2001) uses the `requireAuthz()` helper which combines
+authentication, user resolution, household membership verification, and Karl-tier check into a
+single call. New household-scoped routes should prefer `requireAuthz()` over calling `requireAuth()`
+and then separately validating tier and householdId.
 
 ---
 

--- a/security/architecture/data-flow-diagrams.md
+++ b/security/architecture/data-flow-diagrams.md
@@ -1,7 +1,7 @@
 # Security Data Flow Diagrams — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-20 (updated Stripe checkout flow — entitlements now in Firestore, not Upstash Redis; issue #1521)
+**Last reviewed**: 2026-04-04 (verified all flows current; Firestore entitlement references correct; Karl-tier check via getStripeEntitlement now reads from Firestore)
 
 Trust boundary notation:
 - `[TB]` — Trust boundary crossing (browser ↔ server)
@@ -281,7 +281,7 @@ Browser (Karl-tier, authenticated)
   ├─ GET /api/sync/pull?householdId=<IGNORED>  [TB]
   │    Authorization: Bearer <id_token>
   │    requireAuth() → verified Google user { sub }
-  │    Karl tier check via getStripeEntitlement(sub) → Upstash Redis
+  │    Karl tier check via getStripeEntitlement(sub) → Firestore
   │    if not Karl → 403
   │
   │    getUser(sub)           ← Admin SDK, Firestore Zone 6
@@ -307,7 +307,7 @@ Browser (Karl-tier, authenticated)
   │    Authorization: Bearer <id_token>
   │    Body: { cards: Card[] }      ← householdId in body IGNORED
   │    requireAuth() → verified Google user { sub }
-  │    Karl tier check via getStripeEntitlement(sub) → Upstash Redis
+  │    Karl tier check via getStripeEntitlement(sub) → Firestore
   │    if not Karl → 403
   │
   │    getUser(sub)           ← Admin SDK

--- a/security/architecture/threat-model.md
+++ b/security/architecture/threat-model.md
@@ -1,7 +1,7 @@
 # Threat Model — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-20 (updated entitlement store references from Upstash Redis to Firestore — issue #1521)
+**Last reviewed**: 2026-04-04 (removed stale KV/SEV-008 row — Upstash Redis removed; updated deduplication recommendation to Firestore; Odin's Throne CRITICAL resolved PR #1896)
 **Methodology**: STRIDE-lite with OWASP Top 10 mapping
 
 ---
@@ -134,10 +134,9 @@
 | Attack | STRIDE | Mitigation | Residual Risk |
 |--------|--------|-----------|---------------|
 | Webhook forgery | Spoofing | SHA-256 HMAC via `stripe.webhooks.constructEvent()` | Low |
-| Webhook replay | Tampering | Not implemented (open — SEV-005 from 2026-03-04 report) | Low (KV writes idempotent currently) |
+| Webhook replay | Tampering | Not implemented (open — SEV-005 from 2026-03-04 report) | Low (Firestore writes currently idempotent) |
 | Open redirect post-checkout | Tampering | `APP_BASE_URL` only (fixed SEV-002) | Low |
 | Unlimited checkout session creation | DoS | In-memory rate limit (10/min) | Medium — not distributed (SEV-004) |
-| Entitlement tampering via KV error | Tampering | Partial-delete race condition (SEV-008) | Low (non-blocking) |
 | STRIPE_SECRET_KEY exposure | Information Disclosure | Server env only, never logged or serialized | Low |
 
 ---
@@ -208,4 +207,4 @@
 | Anonymous data merge without Zod | LOW | Malformed localStorage data merged without validation | Add `CardsArraySchema.safeParse()` |
 | No refresh token rotation | LOW | Refresh token never rotated; stolen token remains valid | Implement token refresh + rotation via server proxy |
 | LLM singleton caches stale key | LOW | API key rotation may not take effect until cold start | Document; add version check to invalidate singleton |
-| Stripe webhook no deduplication | LOW | At-least-once delivery; currently idempotent but fragile | Event ID deduplication in KV (SEV-005) |
+| Stripe webhook no deduplication | LOW | At-least-once delivery; currently idempotent but fragile | Event ID deduplication in Firestore (SEV-005) |

--- a/security/architecture/trust-boundaries.md
+++ b/security/architecture/trust-boundaries.md
@@ -1,7 +1,7 @@
 # Trust Boundaries — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-20 (removed Zone 5 Upstash Redis — entitlements migrated to Firestore in issue #1521; updated stale vercel.app hostname references)
+**Last reviewed**: 2026-04-04 (removed stale KV_REST_API_TOKEN reference; corrected Upstash Redis mention in XSS section — entitlements are in Firestore since issue #1521)
 
 ---
 
@@ -135,7 +135,6 @@ Every request to an API route crosses this boundary. The following data crosses:
 - `FENRIR_ANTHROPIC_API_KEY`
 - `STRIPE_SECRET_KEY`
 - `STRIPE_WEBHOOK_SECRET`
-- `KV_REST_API_TOKEN`
 - Stack traces
 - Internal error messages
 
@@ -183,7 +182,7 @@ A successful XSS attack on the production GKE hostname could read:
 - `fenrir:pkce` → PKCE verifier if XSS fires during OAuth flow (tab-scoped)
 
 Note: Stripe entitlements are NOT in localStorage. They are stored server-side in
-Upstash Redis and fetched on demand from the API. An XSS payload cannot access entitlement
+Firestore and fetched on demand from the API. An XSS payload cannot access entitlement
 data directly.
 
 ### Mitigations in place
@@ -233,8 +232,8 @@ This means:
 
 ## Stripe Entitlement Data
 
-Subscription entitlements are stored server-side in Firestore (formerly Upstash Redis,
-migrated in issue #1521). The browser fetches the current tier from `/api/stripe/membership`
+Subscription entitlements are stored server-side in Firestore (migrated from Upstash Redis
+in issue #1521). The browser fetches the current tier from `/api/stripe/membership`
 on demand and caches it in React state only (not localStorage). This means:
 
 - An XSS attack cannot read entitlement data from localStorage

--- a/security/checklists/deployment-security.md
+++ b/security/checklists/deployment-security.md
@@ -1,7 +1,7 @@
 # Deployment Security Checklist — Fenrir Ledger
 
 **Owner**: Heimdall
-**Last reviewed**: 2026-03-20 (removed KV_REST_API_URL and KV_REST_API_TOKEN — Upstash Redis removed in issue #1521)
+**Last reviewed**: 2026-04-04 (updated package manager references from npm to pnpm; project uses pnpm-lock.yaml)
 
 Run this checklist before every production deployment. Items marked [AUTOMATED] are
 covered by the Playwright test suite or CI. Items marked [MANUAL] require human review.
@@ -110,13 +110,13 @@ covered by the Playwright test suite or CI. Items marked [MANUAL] require human 
 
 - [ ] [AUTOMATED / CI] **No critical or high CVEs in npm dependencies**
   ```
-  cd development/ledger && npm audit --audit-level=high
+  cd development/ledger && pnpm audit --audit-level=high
   ```
   Expected: 0 vulnerabilities at high or critical severity
 
 - [ ] [MANUAL] **Lock file is committed and up to date**
-  - `package-lock.json` or `yarn.lock` should be committed
-  - `npm ci` should succeed without modifying the lock file
+  - `pnpm-lock.yaml` should be committed at repo root
+  - `pnpm install --frozen-lockfile` should succeed without modifying the lock file
 
 - [ ] [MANUAL] **Review any dependency added or updated in this release**
   - Check for unexpected new transitive dependencies
@@ -128,12 +128,12 @@ covered by the Playwright test suite or CI. Items marked [MANUAL] require human 
 
 - [ ] [AUTOMATED / CI] **Production build succeeds without TypeScript errors**
   ```
-  cd development/ledger && npm run build
+  cd development/ledger && pnpm build
   ```
 
 - [ ] [AUTOMATED / CI] **Full Playwright test suite passes**
   ```
-  cd development/ledger && npx playwright test
+  cd development/ledger && pnpm exec playwright test
   ```
   Expected: 0 failures (baseline count grows with each sprint)
 


### PR DESCRIPTION
## Summary

Doc sync for `security/` directory per issue #2028.

- Fixed all broken `reports/` links (directory removed in PR #1880, history preserved in git `164115aa`)
- Marked Odin's Throne CRITICAL (PT2026-CRIT-001) as RESOLVED (PR #1896 — oauth2-proxy skip-auth-regex removed)
- Fixed remaining Upstash Redis references → Firestore across all architecture docs
- Removed stale `KV_REST_API_TOKEN` from trust-boundaries outbound-never list
- Removed N/A SEV-008 KV row from threat-model
- Added `requireAuthz()` pattern note (new sync/state route, issue #2001)
- Updated deployment-security checklist: npm → pnpm throughout

Fixes #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)