### PR TITLE
fix: pull-first migration on new device (empty localStorage) — issue:2003

### DIFF
--- a/development/ledger/src/__tests__/lib/migration.test.ts
+++ b/development/ledger/src/__tests__/lib/migration.test.ts
@@ -95,6 +95,14 @@ function makePushResponse(cards: Card[]): Response {
   } as Response;
 }
 
+function makePullResponse(cards: Card[]): Response {
+  const activeCount = cards.filter((c) => !c.deletedAt).length;
+  return {
+    ok: true,
+    json: async () => ({ cards, activeCount }),
+  } as Response;
+}
+
 function makeErrorResponse(status: number, error: string, description: string): Response {
   return {
     ok: false,
@@ -146,9 +154,36 @@ describe("runMigration — already migrated guard", () => {
   });
 });
 
-describe("runMigration — download direction", () => {
+describe("runMigration — download direction (pull-first)", () => {
   beforeEach(() => {
     localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it("calls GET /api/sync/pull when local cards are empty", async () => {
+    mockGetRawAllCards.mockReturnValue([]);
+    const cloudCards = [
+      makeCard("c1", "2026-01-01T10:00:00Z"),
+      makeCard("c2", "2026-01-02T10:00:00Z"),
+    ];
+    mockFetch.mockResolvedValue(makePullResponse(cloudCards));
+
+    await runMigration("hh-test", "tok-pull");
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "/api/sync/pull?householdId=hh-test",
+      expect.objectContaining({
+        method: "GET",
+        headers: expect.objectContaining({
+          Authorization: "Bearer tok-pull",
+        }),
+      })
+    );
+    // Must NOT call push when local is empty
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      "/api/sync/push",
+      expect.anything()
+    );
   });
 
   it("direction=download when local is empty and cloud has cards", async () => {
@@ -161,7 +196,7 @@ describe("runMigration — download direction", () => {
       makeCard("c2", "2026-01-02T10:00:00Z"),
       makeCard("c3", "2026-01-03T10:00:00Z"),
     ];
-    mockFetch.mockResolvedValue(makePushResponse(cloudCards));
+    mockFetch.mockResolvedValue(makePullResponse(cloudCards));
 
     const result = await runMigration("hh-test", "id-token-123");
 
@@ -169,7 +204,7 @@ describe("runMigration — download direction", () => {
     expect(result.cardCount).toBe(3);
     expect(result.direction).toBe("download");
 
-    // Should apply merged result to localStorage
+    // Should write pulled cards to localStorage
     expect(mockSetAllCards).toHaveBeenCalledWith("hh-test", cloudCards);
 
     // Should mark migrated
@@ -177,6 +212,31 @@ describe("runMigration — download direction", () => {
       "fenrir:migrated",
       "true"
     );
+  });
+
+  it("direction=empty when local is empty and cloud is also empty", async () => {
+    mockGetRawAllCards.mockReturnValue([]);
+    mockFetch.mockResolvedValue(makePullResponse([]));
+
+    const result = await runMigration("hh-test", "id-token-123");
+
+    expect(result.ran).toBe(true);
+    expect(result.cardCount).toBe(0);
+    expect(result.direction).toBe("empty");
+    expect(localStorageMock.setItem).toHaveBeenCalledWith("fenrir:migrated", "true");
+  });
+
+  it("includes tombstones from pull in setAllCards", async () => {
+    mockGetRawAllCards.mockReturnValue([]);
+    const active = makeCard("c1", "2026-01-01T10:00:00Z");
+    const tombstone = makeCard("c2", "2026-01-01T09:00:00Z", "2026-01-02T08:00:00Z");
+    mockFetch.mockResolvedValue(makePullResponse([active, tombstone]));
+
+    const result = await runMigration("hh-test", "id-token-123");
+
+    // activeCount is 1 (tombstone excluded), but setAllCards receives all cards
+    expect(result.cardCount).toBe(1);
+    expect(mockSetAllCards).toHaveBeenCalledWith("hh-test", [active, tombstone]);
   });
 });
 
@@ -256,31 +316,14 @@ describe("runMigration — merge direction", () => {
   });
 });
 
-describe("runMigration — empty direction", () => {
+
+describe("runMigration — API error handling (pull path, empty local)", () => {
   beforeEach(() => {
     localStorageMock.clear();
+    vi.clearAllMocks();
   });
 
-  it("direction=empty when both local and cloud are empty", async () => {
-    mockGetRawAllCards.mockReturnValue([]);
-    mockFetch.mockResolvedValue(makePushResponse([]));
-
-    const result = await runMigration("hh-test", "id-token-123");
-
-    expect(result.ran).toBe(true);
-    expect(result.cardCount).toBe(0);
-    expect(result.direction).toBe("empty");
-    // Should still mark migrated even if empty
-    expect(localStorageMock.setItem).toHaveBeenCalledWith("fenrir:migrated", "true");
-  });
-});
-
-describe("runMigration — API error handling", () => {
-  beforeEach(() => {
-    localStorageMock.clear();
-  });
-
-  it("throws and does NOT set migration flag when API returns non-OK", async () => {
+  it("throws and does NOT set migration flag when pull API returns non-OK", async () => {
     mockGetRawAllCards.mockReturnValue([]);
     mockFetch.mockResolvedValue(
       makeErrorResponse(403, "forbidden", "Cloud sync is a Karl-tier feature.")
@@ -295,7 +338,7 @@ describe("runMigration — API error handling", () => {
     expect(mockSetAllCards).not.toHaveBeenCalled();
   });
 
-  it("throws with error code attached to the error", async () => {
+  it("throws with error code attached when pull API errors", async () => {
     mockGetRawAllCards.mockReturnValue([]);
     mockFetch.mockResolvedValue(
       makeErrorResponse(500, "internal_error", "Server blew up.")
@@ -313,7 +356,7 @@ describe("runMigration — API error handling", () => {
     expect(thrown?.message).toBe("Server blew up.");
   });
 
-  it("throws with generic message when error body is not parseable JSON", async () => {
+  it("throws with generic message when pull error body is not parseable JSON", async () => {
     mockGetRawAllCards.mockReturnValue([]);
     mockFetch.mockResolvedValue({
       ok: false,
@@ -327,22 +370,61 @@ describe("runMigration — API error handling", () => {
   });
 });
 
+describe("runMigration — API error handling (push path, local has cards)", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    vi.clearAllMocks();
+  });
+
+  it("throws and does NOT set migration flag when push API returns non-OK", async () => {
+    mockGetRawAllCards.mockReturnValue([makeCard("c1", "2026-01-01T10:00:00Z")]);
+    mockFetch.mockResolvedValue(
+      makeErrorResponse(403, "forbidden", "Cloud sync is a Karl-tier feature.")
+    );
+
+    await expect(runMigration("hh-test", "id-token-123")).rejects.toThrow(
+      "Cloud sync is a Karl-tier feature."
+    );
+
+    expect(hasMigrated()).toBe(false);
+    expect(mockSetAllCards).not.toHaveBeenCalled();
+  });
+});
+
 describe("runMigration — idempotency", () => {
   beforeEach(() => {
     localStorageMock.clear();
+    vi.clearAllMocks();
   });
 
-  it("second call returns ran=false without fetching", async () => {
+  it("second call returns ran=false without fetching (pull path)", async () => {
     mockGetRawAllCards.mockReturnValue([]);
     const cards = [makeCard("c1", "2026-01-01T10:00:00Z")];
-    mockFetch.mockResolvedValue(makePushResponse(cards));
+    mockFetch.mockResolvedValue(makePullResponse(cards));
 
-    // First call
+    // First call — local empty → pull
     const first = await runMigration("hh-test", "id-token-123");
     expect(first.ran).toBe(true);
     expect(mockFetch).toHaveBeenCalledTimes(1);
 
-    // Second call — should be skipped
+    // Second call — should be skipped (flag set)
+    vi.clearAllMocks();
+    const second = await runMigration("hh-test", "id-token-123");
+    expect(second.ran).toBe(false);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("second call returns ran=false without fetching (push path)", async () => {
+    const localCards = [makeCard("c1", "2026-01-01T10:00:00Z")];
+    mockGetRawAllCards.mockReturnValue(localCards);
+    mockFetch.mockResolvedValue(makePushResponse(localCards));
+
+    // First call — local has cards → push
+    const first = await runMigration("hh-test", "id-token-123");
+    expect(first.ran).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second call — should be skipped (flag set)
     vi.clearAllMocks();
     const second = await runMigration("hh-test", "id-token-123");
     expect(second.ran).toBe(false);

--- a/development/ledger/src/lib/sync/migration.ts
+++ b/development/ledger/src/lib/sync/migration.ts
@@ -94,8 +94,9 @@ export function markMigrated(): void {
  * Steps:
  *   1. Guard — return early if already migrated (idempotent)
  *   2. Read local cards (including tombstones)
- *   3. POST to /api/sync/push — server merges local + remote (LWW) and returns merged
- *   4. Apply merged result back to localStorage via setAllCards
+ *   3a. If local is empty → GET /api/sync/pull (new device: download cloud data)
+ *   3b. If local has cards → POST /api/sync/push (existing data: merge with cloud)
+ *   4. Apply result to localStorage via setAllCards
  *   5. Mark migrated
  *   6. Return MigrationResult for caller to show appropriate toast
  *
@@ -113,51 +114,94 @@ export async function runMigration(
     return { ran: false, cardCount: 0, direction: "empty" };
   }
 
-  // Snapshot local state before the push so we can infer direction
+  // Snapshot local state before the API call so we can infer direction
   const localCards = getRawAllCards(householdId);
   const localActiveCount = localCards.filter((c) => !c.deletedAt).length;
 
-  // Push local cards → server fetches remote, merges (LWW), writes Firestore, returns merged
-  const response = await fetch("/api/sync/push", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${idToken}`,
-    },
-    body: JSON.stringify({ householdId, cards: localCards }),
-  });
+  let resultCards: Card[];
+  let resultActiveCount: number;
 
-  if (!response.ok) {
-    let errCode = "migration_error";
-    let errMsg = "Migration failed.";
-    try {
-      const errBody = (await response.json()) as {
-        error?: string;
-        error_description?: string;
-      };
-      errCode = errBody.error ?? errCode;
-      errMsg = errBody.error_description ?? errMsg;
-    } catch {
-      // ignore JSON parse failure on error body
+  if (localCards.length === 0) {
+    // New device with no local data — pull cloud cards down rather than pushing nothing
+    const response = await fetch(
+      `/api/sync/pull?householdId=${encodeURIComponent(householdId)}`,
+      {
+        method: "GET",
+        headers: {
+          Authorization: `Bearer ${idToken}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      let errCode = "migration_error";
+      let errMsg = "Migration failed.";
+      try {
+        const errBody = (await response.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        errCode = errBody.error ?? errCode;
+        errMsg = errBody.error_description ?? errMsg;
+      } catch {
+        // ignore JSON parse failure on error body
+      }
+      throw Object.assign(new Error(errMsg), { code: errCode });
     }
-    throw Object.assign(new Error(errMsg), { code: errCode });
+
+    const { cards: pulledCards, activeCount } = (await response.json()) as {
+      cards: Card[];
+      activeCount: number;
+    };
+
+    resultCards = pulledCards;
+    resultActiveCount = activeCount;
+  } else {
+    // Local has cards — push to cloud; server merges (LWW), writes Firestore, returns merged
+    const response = await fetch("/api/sync/push", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${idToken}`,
+      },
+      body: JSON.stringify({ householdId, cards: localCards }),
+    });
+
+    if (!response.ok) {
+      let errCode = "migration_error";
+      let errMsg = "Migration failed.";
+      try {
+        const errBody = (await response.json()) as {
+          error?: string;
+          error_description?: string;
+        };
+        errCode = errBody.error ?? errCode;
+        errMsg = errBody.error_description ?? errMsg;
+      } catch {
+        // ignore JSON parse failure on error body
+      }
+      throw Object.assign(new Error(errMsg), { code: errCode });
+    }
+
+    const { cards: mergedCards, syncedCount } = (await response.json()) as {
+      cards: Card[];
+      syncedCount: number;
+    };
+
+    resultCards = mergedCards;
+    resultActiveCount = syncedCount;
   }
 
-  const { cards: mergedCards, syncedCount } = (await response.json()) as {
-    cards: Card[];
-    syncedCount: number;
-  };
-
-  // Apply merged result back to localStorage — same semantics as regular sync
-  setAllCards(householdId, mergedCards);
+  // Apply result to localStorage — same semantics as regular sync
+  setAllCards(householdId, resultCards);
 
   // Infer data flow direction for the caller's toast message
-  const direction = inferDirection(localActiveCount, syncedCount);
+  const direction = inferDirection(localActiveCount, resultActiveCount);
 
   // Mark as migrated — prevents re-running on subsequent sign-ins
   markMigrated();
 
-  return { ran: true, cardCount: syncedCount, direction };
+  return { ran: true, cardCount: resultActiveCount, direction };
 }
 
 // ─── Internal helpers ─────────────────────────────────────────────────────────


### PR DESCRIPTION
PR for issue: #2003

## Summary

- Fixed runMigration() in src/lib/sync/migration.ts to call GET /api/sync/pull when local cards are empty (new device path)
- When localCards.length === 0 → GET /api/sync/pull?householdId=... (download path)
- When localCards.length > 0 → POST /api/sync/push (existing merge path, unchanged)
- MigrationDirection returns 'download' / 'empty' correctly for pull path
- markMigrated() called after successful pull

## Test Results

18 Vitest unit tests covering pull-first path, push path, error handling, and idempotency. tsc + build PASS.

Fixes #2003