### PR TITLE
fix: add ADMIN_EMAILS to deploy.yml secret sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -433,6 +433,7 @@ jobs:
             --from-literal=STRIPE_PRICE_ID="${{ secrets.STRIPE_PRICE_ID }}" \
             --from-literal=NEXT_PUBLIC_APP_VERSION="${{ github.sha }}" \
             --from-literal=GITHUB_TOKEN="${{ secrets.GH_TOKEN_AGENTS }}" \
+            --from-literal=ADMIN_EMAILS="${{ secrets.ADMIN_EMAILS }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync agent secrets

--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -64,6 +64,7 @@ const SECRETS = [
   { name: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY", dest: "github", group: "App Secrets", envVar: "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" },
   // STRIPE_WEBHOOK_SECRET — managed by Terraform output → deploy.yml (not GitHub Secrets)
   { name: "STRIPE_PRICE_ID",               dest: "github", group: "App Secrets", envVar: "STRIPE_PRICE_ID" },
+  { name: "ADMIN_EMAILS",                 dest: "github", group: "App Secrets", envVar: "ADMIN_EMAILS" },
 
   // --- GitHub → K8s agent secrets (deploy workflow creates agent-secrets) ---
   { name: "CLAUDE_CODE_OAUTH_TOKEN", dest: "github", group: "Agent Sandbox", secretsVar: "CLAUDE_CODE_OAUTH_TOKEN" },


### PR DESCRIPTION
## Summary
- `ADMIN_EMAILS` was only pushed via `/manage-secrets` but not in deploy.yml's `kubectl create secret` step
- Every CI deploy recreates the secret from scratch, clobbering manually-pushed keys
- Added to both deploy.yml and sync-secrets.mjs GitHub manifest

## Test plan
- [ ] /admin works after deploy (no more 403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)