### PR TITLE
feat: sync UI needs-upload/needs-download indicators + auto-sync on tab entry

### DIFF
--- a/development/ledger/src/__tests__/components/sync-indicator.test.tsx
+++ b/development/ledger/src/__tests__/components/sync-indicator.test.tsx
@@ -36,7 +36,7 @@ vi.mock("@/hooks/useIsKarlOrTrial", () => ({
 }));
 
 const mockCloudSync = {
-  status: "idle" as "idle" | "syncing" | "synced" | "offline" | "error",
+  status: "idle" as "idle" | "needs-upload" | "needs-download" | "syncing" | "synced" | "offline" | "error",
   lastSyncedAt: null as Date | null,
   cardCount: null as number | null,
   errorMessage: null as string | null,
@@ -63,6 +63,7 @@ function setThrall() {
 function setKarl(status: typeof mockCloudSync.status = "idle") {
   mockIsKarlOrTrial.value = true;
   mockCloudSync.status = status;
+  mockCloudSync.lastSyncedAt = null;
 }
 
 // ── aria-label per state ───────────────────────────────────────────────────────
@@ -310,5 +311,85 @@ describe("SyncIndicator — dot CSS state classes", () => {
     const { container } = render(<SyncIndicator />);
     const dot = container.querySelector(".sync-dot");
     expect(dot?.className).toContain("motion-reduce:transition-none");
+  });
+
+  it("needs-upload state: dot has amber class (gold)", () => {
+    setKarl("needs-upload");
+    const { container } = render(<SyncIndicator />);
+    const dot = container.querySelector(".sync-dot");
+    expect(dot?.className).toContain("bg-amber-400");
+  });
+
+  it("needs-download state: dot has cyan class (contrasting blue)", () => {
+    setKarl("needs-download");
+    const { container } = render(<SyncIndicator />);
+    const dot = container.querySelector(".sync-dot");
+    expect(dot?.className).toContain("bg-cyan-500");
+  });
+});
+
+// ── needs-upload / needs-download states ───────────────────────────────────────
+
+describe("SyncIndicator — needs-upload state", () => {
+  it("aria-label is 'Local changes waiting to sync'", () => {
+    setKarl("needs-upload");
+    render(<SyncIndicator />);
+    expect(
+      screen.getByRole("button", { name: "Local changes waiting to sync" })
+    ).toBeDefined();
+  });
+
+  it("SR live region announces 'Local changes waiting to sync'", () => {
+    setKarl("needs-upload");
+    const { container } = render(<SyncIndicator />);
+    const sr = container.querySelector('[aria-live="polite"]');
+    expect(sr?.textContent).toBe("Local changes waiting to sync");
+  });
+
+  it("no ping ring in needs-upload state", () => {
+    setKarl("needs-upload");
+    const { container } = render(<SyncIndicator />);
+    expect(container.querySelector(".sync-ping-ring")).toBeNull();
+  });
+
+  it("Gleipnir Fragment 1 trigger fires on needs-upload click", () => {
+    setKarl("needs-upload");
+    render(<SyncIndicator />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "Local changes waiting to sync" })
+    );
+    expect(mockTrigger).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SyncIndicator — needs-download state", () => {
+  it("aria-label is 'New changes from household available'", () => {
+    setKarl("needs-download");
+    render(<SyncIndicator />);
+    expect(
+      screen.getByRole("button", { name: "New changes from household available" })
+    ).toBeDefined();
+  });
+
+  it("SR live region announces 'New changes from household available'", () => {
+    setKarl("needs-download");
+    const { container } = render(<SyncIndicator />);
+    const sr = container.querySelector('[aria-live="polite"]');
+    expect(sr?.textContent).toBe("New changes from household available");
+  });
+
+  it("no ping ring in needs-download state", () => {
+    setKarl("needs-download");
+    const { container } = render(<SyncIndicator />);
+    expect(container.querySelector(".sync-ping-ring")).toBeNull();
+  });
+
+  it("Gleipnir Fragment 1 trigger fires on needs-download click", () => {
+    setKarl("needs-download");
+    render(<SyncIndicator />);
+    fireEvent.click(
+      screen.getByRole("button", { name: "New changes from household available" })
+    );
+    expect(mockTrigger).toHaveBeenCalledTimes(1);
   });
 });

--- a/development/ledger/src/__tests__/components/sync-settings-section.test.tsx
+++ b/development/ledger/src/__tests__/components/sync-settings-section.test.tsx
@@ -36,7 +36,7 @@ const mockTrialStatus = {
 };
 
 const mockCloudSync = {
-  status: "idle" as "idle" | "syncing" | "synced" | "offline" | "error",
+  status: "idle" as "idle" | "needs-upload" | "needs-download" | "syncing" | "synced" | "offline" | "error",
   lastSyncedAt: null as Date | null,
   cardCount: null as number | null,
   errorMessage: null as string | null,
@@ -81,6 +81,7 @@ function setKarl() {
 
 function setStatus(s: typeof mockCloudSync.status) {
   mockCloudSync.status = s;
+  mockCloudSync.syncNow.mockClear();
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────
@@ -262,6 +263,8 @@ describe("getSyncStatusDotClass", () => {
     ["synced", "bg-emerald-500"],
     ["offline", "opacity-40"],
     ["error", "bg-destructive"],
+    ["needs-upload", "bg-amber-400"],
+    ["needs-download", "bg-cyan-500"],
   ] as const)("returns correct class for status=%s", (status, expected) => {
     expect(getSyncStatusDotClass(status)).toContain(expected);
   });
@@ -309,5 +312,84 @@ describe("SyncSettingsSection — Karl: error state", () => {
     const btn = screen.getByRole("button", { name: "Dismiss sync error" });
     act(() => fireEvent.click(btn));
     expect(mockCloudSync.dismissError).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("SyncSettingsSection — Karl: needs-upload state", () => {
+  beforeEach(() => {
+    setKarl();
+    setStatus("needs-upload");
+  });
+
+  it("renders 'Local changes waiting to sync' message", () => {
+    render(<SyncSettingsSection />);
+    expect(screen.getByText(/Local changes waiting to sync/)).toBeDefined();
+  });
+
+  it("renders enabled Sync Now button", () => {
+    render(<SyncSettingsSection />);
+    const btn = screen.getByRole("button", { name: "Sync cards to cloud now" });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("auto-triggers syncNow on mount", () => {
+    act(() => {
+      render(<SyncSettingsSection />);
+    });
+    expect(mockCloudSync.syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("dot has amber class (gold accent)", () => {
+    expect(getSyncStatusDotClass("needs-upload")).toContain("bg-amber-400");
+  });
+});
+
+describe("SyncSettingsSection — Karl: needs-download state", () => {
+  beforeEach(() => {
+    setKarl();
+    setStatus("needs-download");
+  });
+
+  it("renders 'New changes from household available' message", () => {
+    render(<SyncSettingsSection />);
+    expect(screen.getByText(/New changes from household available/)).toBeDefined();
+  });
+
+  it("renders enabled Sync Now button", () => {
+    render(<SyncSettingsSection />);
+    const btn = screen.getByRole("button", { name: "Sync cards to cloud now" });
+    expect((btn as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it("auto-triggers syncNow on mount", () => {
+    act(() => {
+      render(<SyncSettingsSection />);
+    });
+    expect(mockCloudSync.syncNow).toHaveBeenCalledTimes(1);
+  });
+
+  it("dot has cyan class (contrasting blue)", () => {
+    expect(getSyncStatusDotClass("needs-download")).toContain("bg-cyan-500");
+  });
+});
+
+describe("SyncSettingsSection — Karl: no auto-sync for non-dirty states", () => {
+  it("does NOT call syncNow on mount when status is idle", () => {
+    setKarl();
+    setStatus("idle");
+    act(() => {
+      render(<SyncSettingsSection />);
+    });
+    expect(mockCloudSync.syncNow).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call syncNow on mount when status is synced", () => {
+    setKarl();
+    setStatus("synced");
+    mockCloudSync.lastSyncedAt = new Date();
+    act(() => {
+      render(<SyncSettingsSection />);
+    });
+    expect(mockCloudSync.syncNow).not.toHaveBeenCalled();
   });
 });

--- a/development/ledger/src/components/layout/SyncIndicator.tsx
+++ b/development/ledger/src/components/layout/SyncIndicator.tsx
@@ -62,16 +62,16 @@ function getStateConfig(
   switch (status) {
     case "needs-upload":
       return {
-        ariaLabel: "Upload pending",
-        tooltip: "Changes pending upload\u2026",
-        dotClass: "bg-[hsl(var(--egg-accent))] opacity-70",
+        ariaLabel: "Local changes waiting to sync",
+        tooltip: "Local changes waiting to sync\u2026",
+        dotClass: "bg-amber-400 dark:bg-amber-300",
         showPing: false,
       };
     case "needs-download":
       return {
-        ariaLabel: "Download pending",
-        tooltip: "New changes available\u2026",
-        dotClass: "bg-[hsl(var(--egg-accent))] opacity-70",
+        ariaLabel: "New changes from household available",
+        tooltip: "New changes from household available\u2026",
+        dotClass: "bg-cyan-500 dark:bg-cyan-400",
         showPing: false,
       };
     case "syncing":

--- a/development/ledger/src/components/sync/SyncSettingsSection.tsx
+++ b/development/ledger/src/components/sync/SyncSettingsSection.tsx
@@ -13,6 +13,7 @@
  * Issue #1125
  */
 
+import { useEffect } from "react";
 import type { CloudSyncStatus } from "@/hooks/useCloudSync";
 import { useCloudSync } from "@/hooks/useCloudSync";
 import { useEntitlement } from "@/hooks/useEntitlement";
@@ -44,8 +45,8 @@ export function formatTimestamp(date: Date): string {
 const STATUS_DOT_BASE = "inline-flex h-2 w-2 rounded-full flex-shrink-0";
 
 const STATUS_DOT_CLASSES: Record<CloudSyncStatus, string> = {
-  "needs-upload": `${STATUS_DOT_BASE} bg-[hsl(var(--egg-accent))] opacity-70`,
-  "needs-download": `${STATUS_DOT_BASE} bg-[hsl(var(--egg-accent))] opacity-70`,
+  "needs-upload": `${STATUS_DOT_BASE} bg-amber-400 dark:bg-amber-300`,
+  "needs-download": `${STATUS_DOT_BASE} bg-cyan-500 dark:bg-cyan-400`,
   syncing: `${STATUS_DOT_BASE} bg-[hsl(var(--egg-accent))]`,
   synced: `${STATUS_DOT_BASE} bg-emerald-500 dark:bg-emerald-400`,
   offline: `${STATUS_DOT_BASE} bg-[hsl(var(--egg-border))] opacity-40`,
@@ -60,6 +61,22 @@ export function getSyncStatusDotClass(status: CloudSyncStatus): string {
 // ---------------------------------------------------------------------------
 // Sub-components for SyncStatusCard
 // ---------------------------------------------------------------------------
+
+function SyncNeedsUploadMessage() {
+  return (
+    <p className="text-[13px] text-foreground/90 font-body leading-relaxed">
+      Local changes waiting to sync.
+    </p>
+  );
+}
+
+function SyncNeedsDownloadMessage() {
+  return (
+    <p className="text-[13px] text-foreground/90 font-body leading-relaxed">
+      New changes from household available.
+    </p>
+  );
+}
 
 function SyncProgressBar() {
   return (
@@ -361,9 +378,19 @@ function SyncStatusCard({ isTrial }: { isTrial: boolean }) {
   const isError = status === "error";
   const isSyncing = status === "syncing";
   const isOffline = status === "offline";
+  const isNeedsUpload = status === "needs-upload";
+  const isNeedsDownload = status === "needs-download";
   const syncNowDisabled = isSyncing || isOffline;
   const showLastSynced = lastSyncedAt !== null && !isSyncing;
   const showCardCount = cardCount !== null && !isSyncing && !isError;
+
+  // Auto-sync on mount when there is pending work to do
+  useEffect(() => {
+    if (status === "needs-upload" || status === "needs-download") {
+      void syncNow();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <section
@@ -406,6 +433,8 @@ function SyncStatusCard({ isTrial }: { isTrial: boolean }) {
         </p>
       )}
 
+      {isNeedsUpload && <SyncNeedsUploadMessage />}
+      {isNeedsDownload && <SyncNeedsDownloadMessage />}
       {isSyncing && <SyncProgressBar />}
       {isOffline && <SyncOfflineMessage />}
       {isError && (


### PR DESCRIPTION
Fixes #2007

## Summary
- Added \`needs-upload\` (amber/gold dot) and \`needs-download\` (cyan/blue dot) status configs to \`SyncIndicator\`
- Added corresponding status dot classes and status text messages to \`SyncSettingsSection\`
- \`useEffect\` in \`SyncSettingsSection\` auto-calls \`syncNow()\` on mount when status is \`needs-upload\` or \`needs-download\`
- SR \`aria-live="polite"\` live region announces both new states

## Test Results
- 81 Vitest assertions across \`sync-settings-section.test.tsx\` + \`sync-indicator.test.tsx\`
- Full suite: 3400/3400 tests passing (229 files)
- \`verify:tsc\`: PASS
- \`verify:build\`: PASS

Generated with Claude Code