### PR TITLE
fix: odins-spear TUI fills full terminal on launch and resize — issue:1440

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from "react";
+import React, { useState, useCallback, useEffect } from "react";
 import { Box, useApp, useInput, useStdout } from "ink";
 import { log } from "@fenrir/logger";
 import { TopBar } from "./components/TopBar.js";
@@ -142,8 +142,26 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     }
   });
 
-  const termWidth = stdout?.columns ?? 80;
-  const termHeight = stdout?.rows ?? 24;
+  const [termSize, setTermSize] = useState(() => ({
+    width: stdout?.columns ?? process.stdout?.columns ?? 80,
+    height: stdout?.rows ?? process.stdout?.rows ?? 24,
+  }));
+
+  useEffect(() => {
+    const onResize = () => {
+      setTermSize({
+        width: stdout?.columns ?? process.stdout?.columns ?? 80,
+        height: stdout?.rows ?? process.stdout?.rows ?? 24,
+      });
+    };
+    process.stdout?.on("resize", onResize);
+    return () => {
+      process.stdout?.off("resize", onResize);
+    };
+  }, [stdout]);
+
+  const termWidth = termSize.width;
+  const termHeight = termSize.height;
 
   log.debug("SpearInner rendering layout", {
     termWidth,


### PR DESCRIPTION
## Summary

- Added `useEffect` resize listener on `process.stdout` in `SpearInner` (`src/app.tsx`)
- `termSize` state initialised from `stdout?.columns/rows` → `process.stdout?.columns/rows` → 80×24 fallback
- `resize` event updates state live; root `Box` receives new `width`/`height` on every resize
- Cleanup removes the listener on unmount (no memory leak)

## What changed

- `development/odins-spear/src/app.tsx` — replaced static `stdout?.columns/rows` reads with reactive `termSize` state + `useEffect` resize handler

## Test plan

- [ ] Launch TUI — verify it fills the full terminal width and height immediately
- [ ] Resize terminal window — verify UI reflows to new dimensions with no empty padding
- [ ] Quit and relaunch — verify clean teardown
- [ ] Edge: very small terminal (40×10), very large (300×80), rapid consecutive resizes

**Build:** tsc PASS · build PASS. Ready for QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)