### PR TITLE
feat(odins-spear): xterm mouse click support for user list — issue #1773

### DIFF
--- a/development/odins-spear/src/lib/useMouse.ts
+++ b/development/odins-spear/src/lib/useMouse.ts
@@ -1,0 +1,86 @@
+import { useEffect, useRef } from "react";
+import { useStdout } from "ink";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MousePressEvent {
+  /** 1-based terminal column */
+  x: number;
+  /** 1-based terminal row */
+  y: number;
+  /** 0 = left, 1 = middle, 2 = right */
+  button: number;
+}
+
+export type MousePressHandler = (event: MousePressEvent) => void;
+
+// ─── Hook ─────────────────────────────────────────────────────────────────────
+
+/**
+ * useMouseClick — enables xterm X10 mouse tracking and fires onPress on each
+ * mouse-button-press event.
+ *
+ * Protocol: sends ESC [ ? 1 0 0 0 h to stdout to enable tracking; reads raw
+ * ESC [ M <b> <x> <y> sequences from process.stdin.  Works in iTerm2,
+ * Terminal.app, Alacritty, tmux, and most xterm-compatible emulators.
+ *
+ * Coordinates are 1-based: (x=1, y=1) is the top-left terminal cell.
+ *
+ * Only one component should call this hook at a time to avoid duplicate
+ * listeners.
+ *
+ * The hook is a no-op when process.stdin is not a TTY (CI, pipes, tests).
+ */
+export function useMouseClick(onPress: MousePressHandler): void {
+  const { stdout } = useStdout();
+
+  // Use a ref so we always call the latest handler without restarting the
+  // effect every render.
+  const handlerRef = useRef<MousePressHandler>(onPress);
+  handlerRef.current = onPress;
+
+  useEffect(() => {
+    if (!stdout || !process.stdin.isTTY) return;
+
+    // Enable X10 mouse tracking (press events only — no drag/release noise).
+    stdout.write("\x1b[?1000h");
+
+    const handleData = (chunk: Buffer | string): void => {
+      const buf = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string);
+
+      // X10 encoding: ESC [ M <b+32> <x+32> <y+32>  (exactly 6 bytes per event)
+      // Scan the whole chunk — multiple events can arrive in one read.
+      let i = 0;
+      while (i + 5 < buf.length) {
+        if (
+          buf[i] === 0x1b &&      // ESC
+          buf[i + 1] === 0x5b &&  // [
+          buf[i + 2] === 0x4d    // M
+        ) {
+          const rawButton = (buf[i + 3] ?? 32) - 32;
+          const x = (buf[i + 4] ?? 32) - 32;
+          const y = (buf[i + 5] ?? 32) - 32;
+
+          // rawButton bits 0-1 encode the button number (0=left, 1=middle,
+          // 2=right, 3=release in some terminals).  We only care about presses.
+          const button = rawButton & 0x03;
+          if (button !== 3) {
+            // button === 3 signals a release in some terminals; skip it.
+            handlerRef.current({ x, y, button });
+          }
+          i += 6;
+          continue;
+        }
+        i++;
+      }
+    };
+
+    process.stdin.on("data", handleData);
+
+    return () => {
+      // Disable X10 mouse tracking on cleanup.
+      stdout.write("\x1b[?1000l");
+      process.stdin.off("data", handleData);
+    };
+  }, [stdout]); // stdout is stable; handlerRef avoids re-registering on render
+}

--- a/development/odins-spear/src/tabs/UsersTab.tsx
+++ b/development/odins-spear/src/tabs/UsersTab.tsx
@@ -3,6 +3,7 @@ import { Box, Text, useInput } from "ink";
 import { log } from "@fenrir/logger";
 import { firestoreClient } from "../lib/firestore.js";
 import { useSelection } from "../context/SelectionContext.js";
+import { useMouseClick } from "../lib/useMouse.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -481,6 +482,44 @@ export function UsersTab({
     },
     [] // setters are stable
   );
+
+  // ─── Mouse click handler ──────────────────────────────────────────────────
+  //
+  // Terminal layout (1-based rows):
+  //   Row 1  TopBar content
+  //   Row 2  TopBar bottom border
+  //   Row 3  Left-panel header "Users (N)"
+  //   Row 4  Left-panel header bottom border
+  //   Row 5+ List items (one per row)
+  //
+  // Left panel spans columns 1–36.
+  // paddingX={1} inside the list means usable content is cols 2–35, but we
+  // accept clicks across the full panel width for a forgiving hit target.
+
+  useMouseClick(({ x, y, button }) => {
+    log.debug("UsersTab mouseClick", { x, y, button });
+
+    // Only respond to left-click (button=0) in the left list panel.
+    if (button !== 0) return;
+    if (x < 1 || x > 36) return;
+
+    const LIST_START_Y = 5;
+    if (y < LIST_START_Y) return;
+
+    const clickedIdx = scrollOffset + (y - LIST_START_Y);
+    if (clickedIdx < 0 || clickedIdx >= users.length) return;
+
+    // Clicking the already-selected row deselects it (toggle).
+    if (clickedIdx === selectedIdx) {
+      log.debug("UsersTab: mouse deselect", { idx: clickedIdx });
+      setSelectedIdx(-1);
+      setActionMode("none");
+    } else {
+      log.debug("UsersTab: mouse select", { idx: clickedIdx });
+      setSelectedIdx(clickedIdx);
+      setActionMode("none");
+    }
+  });
 
   useInput((input, key) => {
     // Delete confirmation


### PR DESCRIPTION
## Summary

- Researched Ink mouse support: Ink has no native mouse API; raw xterm X10 protocol is the viable approach
- Added `src/lib/useMouse.ts` — a reusable `useMouseClick` hook that enables X10 mouse tracking (`\x1b[?1000h`) and parses `ESC [ M <b> <x> <y>` sequences from `process.stdin`
- Wired into `UsersTab`: left-clicking a row selects it; clicking the selected row toggles deselection
- No-op in non-TTY environments (CI, pipes) — safe everywhere

## How it works

Terminal layout for coordinate mapping:
```
Row 1  TopBar content
Row 2  TopBar bottom border
Row 3  Left-panel header "Users (N)"
Row 4  Header bottom border
Row 5+ List items  (cols 1–36 = left panel)
```

Click at `(x, y)` → `selectedIdx = scrollOffset + (y - 5)` when `x ≤ 36`.

## Files changed

| File | Change |
|------|--------|
| `src/lib/useMouse.ts` | New: `useMouseClick` hook with xterm X10 parsing |
| `src/tabs/UsersTab.tsx` | Wire in `useMouseClick` for row selection |

## Test plan

- [x] `tsc --noEmit` passes
- [x] `pnpm run build` passes
- [ ] Manual: run `pnpm dev`, click rows in Users tab to verify selection/deselect toggle
- [ ] Manual: works in iTerm2, Terminal.app, Alacritty, tmux

Closes #1773

🤖 Generated with [Claude Code](https://claude.com/claude-code)