### PR TITLE
feat: migration script runner in Odin's Spear TUI — issue:1801

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -6,6 +6,9 @@ import { StatusBar } from "./components/StatusBar.js";
 import { HelpOverlay } from "./components/HelpOverlay.js";
 import { ResultsOverlay } from "./components/ResultsOverlay.js";
 import { TrialInputDialog } from "./components/TrialInputDialog.js";
+import { ScriptBrowserOverlay } from "./components/ScriptBrowserOverlay.js";
+import { ScriptConfirmOverlay } from "./components/ScriptConfirmOverlay.js";
+import { ScriptRunnerOverlay } from "./components/ScriptRunnerOverlay.js";
 import { UsersTab } from "./tabs/UsersTab.js";
 import { HouseholdsTab } from "./tabs/HouseholdsTab.js";
 import { CardDrilldownView } from "./tabs/CardDrilldownView.js";
@@ -13,6 +16,8 @@ import { SelectionProvider, useSelection } from "./context/SelectionContext.js";
 import type { PaletteCommand, CommandContext } from "./commands/registry.js";
 import { getCommands } from "./commands/registry.js";
 import type { ConnStatus, Counts } from "./components/StatusBar.js";
+import type { MigrationScript } from "./lib/migrations.js";
+import { listMigrations, runMigration } from "./lib/migrations.js";
 
 const TUI_TABS = ["Households", "Users"] as const;
 
@@ -27,7 +32,10 @@ type OverlayMode =
   | { kind: "none" }
   | { kind: "help" }
   | { kind: "results"; title: string; lines: string[] }
-  | { kind: "trial-input"; cmd: PaletteCommand };
+  | { kind: "trial-input"; cmd: PaletteCommand }
+  | { kind: "script-browser" }
+  | { kind: "script-confirm"; script: MigrationScript }
+  | { kind: "script-running"; script: MigrationScript };
 
 function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): React.JSX.Element {
   log.debug("SpearInner render");
@@ -54,6 +62,11 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
   // Suppress unused-variable warnings for setters wired in later stories
   void setConnState;
   void setCountState;
+
+  // ─── Script runner state ───────────────────────────────────────────────────
+  const [scriptLines, setScriptLines] = useState<string[]>([]);
+  const [scriptRunning, setScriptRunning] = useState(false);
+  const [scriptExitCode, setScriptExitCode] = useState<number | null>(null);
 
   // Build CommandContext from SelectionContext
   const cmdCtx: CommandContext = {
@@ -100,6 +113,33 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     }
   }, [cmdCtx, closeOverlay]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  // ─── Script runner callbacks ───────────────────────────────────────────────
+
+  const handleScriptSelect = useCallback((script: MigrationScript) => {
+    log.debug("SpearInner: script selected", { name: script.name });
+    setOverlay({ kind: "script-confirm", script });
+  }, []);
+
+  const handleScriptConfirm = useCallback((script: MigrationScript) => {
+    log.debug("SpearInner: script confirmed, starting", { name: script.name });
+    setScriptLines([]);
+    setScriptRunning(true);
+    setScriptExitCode(null);
+    setOverlay({ kind: "script-running", script });
+
+    runMigration(
+      script,
+      (line) => {
+        setScriptLines((prev) => [...prev, line]);
+      },
+      (code) => {
+        log.debug("SpearInner: script finished", { name: script.name, code });
+        setScriptRunning(false);
+        setScriptExitCode(code);
+      },
+    );
+  }, []);
+
   // ─── Global key handler (inactive when an overlay owns input) ─────────────
 
   useInput((input, key) => {
@@ -125,6 +165,12 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
 
     if (input === "?") {
       openHelp();
+      return;
+    }
+
+    if (input === "s") {
+      log.debug("SpearInner: opening script browser");
+      setOverlay({ kind: "script-browser" });
       return;
     }
 
@@ -180,6 +226,32 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
       <ResultsOverlay
         title={overlay.title}
         lines={overlay.lines}
+        onClose={closeOverlay}
+      />
+    );
+  } else if (overlay.kind === "script-browser") {
+    mainContent = (
+      <ScriptBrowserOverlay
+        scripts={listMigrations()}
+        onSelect={handleScriptSelect}
+        onClose={closeOverlay}
+      />
+    );
+  } else if (overlay.kind === "script-confirm") {
+    mainContent = (
+      <ScriptConfirmOverlay
+        script={overlay.script}
+        onConfirm={() => { handleScriptConfirm(overlay.script); }}
+        onCancel={() => { setOverlay({ kind: "script-browser" }); }}
+      />
+    );
+  } else if (overlay.kind === "script-running") {
+    mainContent = (
+      <ScriptRunnerOverlay
+        script={overlay.script}
+        lines={scriptLines}
+        running={scriptRunning}
+        exitCode={scriptExitCode}
         onClose={closeOverlay}
       />
     );

--- a/development/odins-spear/src/components/HelpOverlay.tsx
+++ b/development/odins-spear/src/components/HelpOverlay.tsx
@@ -62,6 +62,7 @@ const SECTIONS: Section[] = [
     title: "System Commands",
     tabs: "all",
     shortcuts: [
+      { key: "s",       desc: "Open migration script browser" },
       { key: "Ctrl+R",  desc: "Reload current view" },
     ],
   },

--- a/development/odins-spear/src/components/ScriptBrowserOverlay.tsx
+++ b/development/odins-spear/src/components/ScriptBrowserOverlay.tsx
@@ -1,0 +1,124 @@
+import React, { useState } from "react";
+import { Box, Text, useInput, useStdout } from "ink";
+import { log } from "@fenrir/logger";
+import type { MigrationScript } from "../lib/migrations.js";
+
+// ─── Colors ──────────────────────────────────────────────────────────────────
+
+const GOLD = "#c9920a";
+const GRAY = "#6b6b80";
+const DIM = "#3b3b4f";
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+export interface ScriptBrowserOverlayProps {
+  scripts: MigrationScript[];
+  onSelect: (script: MigrationScript) => void;
+  onClose: () => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ScriptBrowserOverlay({
+  scripts,
+  onSelect,
+  onClose,
+}: ScriptBrowserOverlayProps): React.JSX.Element {
+  log.debug("ScriptBrowserOverlay render", { count: scripts.length });
+
+  const { stdout } = useStdout();
+  const termHeight = stdout?.rows ?? 24;
+  const PAGE_SIZE = Math.max(4, termHeight - 10);
+
+  const [cursor, setCursor] = useState(0);
+
+  useInput((_input, key) => {
+    log.debug("ScriptBrowserOverlay useInput", {
+      keyEscape: key.escape,
+      keyReturn: key.return,
+      keyUpArrow: key.upArrow,
+      keyDownArrow: key.downArrow,
+    });
+
+    if (key.escape) {
+      log.debug("ScriptBrowserOverlay: escape, closing");
+      onClose();
+      return;
+    }
+
+    if (key.upArrow) {
+      setCursor((c) => Math.max(0, c - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setCursor((c) => Math.min(scripts.length - 1, c + 1));
+      return;
+    }
+
+    if (key.return) {
+      const selected = scripts[cursor];
+      if (selected) {
+        log.debug("ScriptBrowserOverlay: selected", { name: selected.name });
+        onSelect(selected);
+      }
+      return;
+    }
+  });
+
+  const offset = Math.max(0, cursor - PAGE_SIZE + 1);
+  const visible = scripts.slice(offset, offset + PAGE_SIZE);
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={GOLD}
+      paddingX={3}
+      paddingY={1}
+      marginX={4}
+      marginY={1}
+    >
+      {/* Header */}
+      <Text bold color={GOLD}>
+        Migration Scripts
+      </Text>
+
+      <Box height={1} />
+
+      {scripts.length === 0 ? (
+        <Text color={GRAY} dimColor>
+          No migration scripts found in migrations/
+        </Text>
+      ) : (
+        visible.map((script, i) => {
+          const idx = offset + i;
+          const isActive = idx === cursor;
+          return (
+            <Box key={script.filename} flexDirection="row" gap={1}>
+              <Text color={isActive ? GOLD : DIM}>{isActive ? "▶" : " "}</Text>
+              <Box flexDirection="column">
+                <Text bold={isActive} color={isActive ? GOLD : "#e5e5f0"}>
+                  {script.name}
+                </Text>
+                <Text color={GRAY} dimColor>
+                  {"  "}
+                  {script.desc}
+                </Text>
+              </Box>
+            </Box>
+          );
+        })
+      )}
+
+      <Box height={1} />
+
+      {/* Footer */}
+      <Box flexDirection="row" gap={3}>
+        <Text color={GRAY} dimColor>↑↓ navigate</Text>
+        <Text color={GRAY} dimColor>Enter select</Text>
+        <Text color={GRAY} dimColor>Esc close</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/development/odins-spear/src/components/ScriptConfirmOverlay.tsx
+++ b/development/odins-spear/src/components/ScriptConfirmOverlay.tsx
@@ -1,0 +1,93 @@
+import React from "react";
+import { Box, Text, useInput } from "ink";
+import { log } from "@fenrir/logger";
+import type { MigrationScript } from "../lib/migrations.js";
+
+// ─── Colors ──────────────────────────────────────────────────────────────────
+
+const GOLD = "#c9920a";
+const GRAY = "#6b6b80";
+const GREEN = "#22c55e";
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+export interface ScriptConfirmOverlayProps {
+  script: MigrationScript;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ScriptConfirmOverlay({
+  script,
+  onConfirm,
+  onCancel,
+}: ScriptConfirmOverlayProps): React.JSX.Element {
+  log.debug("ScriptConfirmOverlay render", { name: script.name });
+
+  useInput((_input, key) => {
+    log.debug("ScriptConfirmOverlay useInput", {
+      keyEscape: key.escape,
+      keyReturn: key.return,
+    });
+
+    if (key.escape) {
+      log.debug("ScriptConfirmOverlay: cancelled");
+      onCancel();
+      return;
+    }
+
+    if (key.return) {
+      log.debug("ScriptConfirmOverlay: confirmed");
+      onConfirm();
+      return;
+    }
+  });
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={GOLD}
+      paddingX={3}
+      paddingY={1}
+      marginX={4}
+      marginY={1}
+    >
+      {/* Header */}
+      <Text bold color={GOLD}>
+        Run Migration Script
+      </Text>
+
+      <Box height={1} />
+
+      {/* Script info */}
+      <Box flexDirection="row" gap={1}>
+        <Text color={GRAY}>Script:</Text>
+        <Text color="#e5e5f0" bold>{script.filename}</Text>
+      </Box>
+      <Box flexDirection="row" gap={1}>
+        <Text color={GRAY}>{"      "}</Text>
+        <Text color={GRAY} dimColor>{script.desc}</Text>
+      </Box>
+
+      <Box height={1} />
+
+      <Text color="#9b9baa">
+        This will execute the migration against the configured Firestore database.
+      </Text>
+      <Text color={GRAY} dimColor>
+        Scripts are trusted local code. Ensure you know what this script does before running.
+      </Text>
+
+      <Box height={1} />
+
+      {/* Footer */}
+      <Box flexDirection="row" gap={3}>
+        <Text color={GREEN} bold>Enter to run</Text>
+        <Text color={GOLD}>Esc to cancel</Text>
+      </Box>
+    </Box>
+  );
+}

--- a/development/odins-spear/src/components/ScriptRunnerOverlay.tsx
+++ b/development/odins-spear/src/components/ScriptRunnerOverlay.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from "react";
+import { Box, Text, useInput, useStdout } from "ink";
+import { log } from "@fenrir/logger";
+import type { MigrationScript } from "../lib/migrations.js";
+
+// ─── Colors ──────────────────────────────────────────────────────────────────
+
+const GOLD = "#c9920a";
+const GRAY = "#6b6b80";
+const GREEN = "#22c55e";
+const RED = "#ef4444";
+
+// ─── Props ───────────────────────────────────────────────────────────────────
+
+export interface ScriptRunnerOverlayProps {
+  script: MigrationScript;
+  lines: string[];
+  running: boolean;
+  exitCode: number | null;
+  onClose: () => void;
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function ScriptRunnerOverlay({
+  script,
+  lines,
+  running,
+  exitCode,
+  onClose,
+}: ScriptRunnerOverlayProps): React.JSX.Element {
+  log.debug("ScriptRunnerOverlay render", {
+    name: script.name,
+    lineCount: lines.length,
+    running,
+    exitCode,
+  });
+
+  const { stdout } = useStdout();
+  const termHeight = stdout?.rows ?? 24;
+  // Reserve rows: 2 border + 1 title + 1 status + 2 gaps + 1 footer + 2 margin = 9
+  const PAGE_SIZE = Math.max(4, termHeight - 9);
+
+  const [offset, setOffset] = useState(0);
+  const maxOffset = Math.max(0, lines.length - PAGE_SIZE);
+
+  useInput((_input, key) => {
+    log.debug("ScriptRunnerOverlay useInput", {
+      keyEscape: key.escape,
+      running,
+    });
+
+    if (key.escape && !running) {
+      log.debug("ScriptRunnerOverlay: escape, closing");
+      onClose();
+      return;
+    }
+
+    if (key.upArrow) {
+      setOffset((o) => Math.max(0, o - 1));
+      return;
+    }
+
+    if (key.downArrow) {
+      setOffset((o) => Math.min(maxOffset, o + 1));
+      return;
+    }
+
+    if (key.pageUp) {
+      setOffset((o) => Math.max(0, o - PAGE_SIZE));
+      return;
+    }
+
+    if (key.pageDown) {
+      setOffset((o) => Math.min(maxOffset, o + PAGE_SIZE));
+      return;
+    }
+  });
+
+  // Auto-follow tail while running
+  const viewOffset = running ? maxOffset : offset;
+  const visibleLines = lines.slice(viewOffset, viewOffset + PAGE_SIZE);
+  const scrollInfo =
+    lines.length > PAGE_SIZE
+      ? ` [${viewOffset + 1}–${Math.min(viewOffset + PAGE_SIZE, lines.length)}/${lines.length}]`
+      : "";
+
+  const statusColor = running ? GOLD : exitCode === 0 ? GREEN : RED;
+  const statusText = running
+    ? "Running…"
+    : exitCode === 0
+      ? "Done — exit 0 (success)"
+      : `Failed — exit ${exitCode ?? "?"}`;
+
+  return (
+    <Box
+      flexDirection="column"
+      borderStyle="round"
+      borderColor={statusColor}
+      paddingX={2}
+      paddingY={1}
+      marginX={4}
+      marginY={1}
+    >
+      {/* Title */}
+      <Box flexDirection="row" gap={1}>
+        <Text bold color={GOLD}>{script.name}</Text>
+        {scrollInfo ? <Text color={GRAY} dimColor>{scrollInfo}</Text> : null}
+        <Box flexGrow={1} />
+        <Text color={statusColor} bold>{statusText}</Text>
+      </Box>
+
+      <Box height={1} />
+
+      {/* Output */}
+      {visibleLines.length === 0 ? (
+        <Text color={GRAY} dimColor>{running ? "Waiting for output…" : "(no output)"}</Text>
+      ) : (
+        visibleLines.map((line, i) => (
+          <Text key={viewOffset + i} color="#9b9baa">{line}</Text>
+        ))
+      )}
+
+      <Box height={1} />
+
+      {/* Footer */}
+      {running ? (
+        <Text color={GRAY} dimColor>Running… please wait</Text>
+      ) : (
+        <Box flexDirection="row" gap={2}>
+          <Text color={GRAY} dimColor>↑↓ scroll</Text>
+          {lines.length > PAGE_SIZE && <Text color={GRAY} dimColor>PgUp/PgDn page</Text>}
+          <Text color={GRAY} dimColor>Esc close</Text>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/development/odins-spear/src/components/TopBar.tsx
+++ b/development/odins-spear/src/components/TopBar.tsx
@@ -52,6 +52,8 @@ export function TopBar({ activeTab, onTabSwitch: _onTabSwitch }: TopBarProps): R
       {/* Right: shortcut hints */}
       <Box flexDirection="row" gap={3}>
         <Text color={GRAY}>{"["}</Text>
+        <Text color={GOLD}>{"s"}</Text>
+        <Text color={GRAY}>{"] Scripts  ["}</Text>
         <Text color={GOLD}>{"^R"}</Text>
         <Text color={GRAY}>{"] Reload  ["}</Text>
         <Text color={GOLD}>{"?"}</Text>

--- a/development/odins-spear/src/lib/migrations.ts
+++ b/development/odins-spear/src/lib/migrations.ts
@@ -1,0 +1,122 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn, type ChildProcess } from "node:child_process";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface MigrationScript {
+  name: string;
+  filename: string;
+  path: string;
+  desc: string;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function getMigrationsDir(): string {
+  const thisFile = fileURLToPath(import.meta.url);
+  // src/lib/migrations.ts → ../../migrations/
+  return join(dirname(thisFile), "..", "..", "migrations");
+}
+
+// ─── List ─────────────────────────────────────────────────────────────────────
+
+export function listMigrations(): MigrationScript[] {
+  const migrationsDir = getMigrationsDir();
+  let files: string[];
+  try {
+    files = readdirSync(migrationsDir)
+      .filter((f) => f.endsWith(".mjs") && !f.startsWith("_"))
+      .sort();
+  } catch {
+    return [];
+  }
+
+  return files.map((filename) => {
+    const scriptPath = join(migrationsDir, filename);
+    let desc = filename;
+    try {
+      const content = readFileSync(scriptPath, "utf-8");
+      const firstLine = content.split("\n")[0] ?? "";
+      if (firstLine.startsWith("//")) {
+        desc = firstLine.slice(2).trim();
+      }
+    } catch {
+      // ignore — use filename as fallback
+    }
+    return { name: filename.replace(".mjs", ""), filename, path: scriptPath, desc };
+  });
+}
+
+// ─── Run ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Spawns the migration script as a child process.
+ *
+ * Detection heuristic: if the last 10 lines of the script contain a bare
+ * `main(` call, the script is self-invoking and we spawn it directly.
+ * Otherwise we wrap it with an inline ES-module runner so `main()` is called.
+ *
+ * onLine receives each line of stdout/stderr as it arrives.
+ * onDone receives the exit code (0 = success).
+ */
+export function runMigration(
+  script: MigrationScript,
+  onLine: (line: string, stream: "stdout" | "stderr") => void,
+  onDone: (exitCode: number) => void,
+): void {
+  let content = "";
+  try {
+    content = readFileSync(script.path, "utf-8");
+  } catch (err) {
+    onLine(`Error reading script: ${String(err)}`, "stderr");
+    onDone(1);
+    return;
+  }
+
+  const tail = content.split("\n").slice(-10).join("\n");
+  const selfInvokes = /\bmain\s*\(/.test(tail);
+
+  let proc: ChildProcess;
+
+  if (selfInvokes) {
+    proc = spawn("node", [script.path], {
+      stdio: ["ignore", "pipe", "pipe"],
+      env: process.env,
+    });
+  } else {
+    // Wrap: import module and call main()
+    const fileUrl = "file://" + script.path;
+    const wrapper = `import { main } from ${JSON.stringify(fileUrl)};\nawait main();\n`;
+    proc = spawn("node", ["--input-type=module"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+    if (proc.stdin) {
+      proc.stdin.write(wrapper);
+      proc.stdin.end();
+    }
+  }
+
+  const handleChunk =
+    (stream: "stdout" | "stderr") =>
+    (chunk: Buffer): void => {
+      const text = chunk.toString("utf-8");
+      for (const line of text.split("\n")) {
+        if (line.length > 0) onLine(line, stream);
+      }
+    };
+
+  proc.stdout?.on("data", handleChunk("stdout"));
+  proc.stderr?.on("data", handleChunk("stderr"));
+
+  proc.on("close", (code) => {
+    onDone(code ?? 1);
+  });
+
+  proc.on("error", (err) => {
+    onLine(`Process error: ${String(err)}`, "stderr");
+    onDone(1);
+  });
+}


### PR DESCRIPTION
Fixes #1801

## Summary

- Added `[s] Scripts` top-level command to Odin's Spear TUI for running one-off Firestore migration scripts
- New `ScriptBrowserOverlay` lists `.mjs` files from `migrations/` with filename + first-line comment as description
- New `ScriptConfirmOverlay` presents a confirmation prompt before execution
- New `ScriptRunnerOverlay` streams stdout/stderr live with tail-follow while running, reports exit code on completion
- New `src/lib/migrations.ts` with `listMigrations()` + `runMigration()` — handles both self-invoking and export-only script styles

## QA Validation

- tsc: PASS
- build: PASS
- vitest: N/A (odins-spear has no test infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)