### PR TITLE
chore: add freyafenrir78@gmail.com to OAuth2 proxy allowlists

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -607,7 +607,8 @@ jobs:
             --from-literal=GOOGLE_CLIENT_ID="${{ secrets.ODINS_THRONE_CLIENT_ID }}" \
             --from-literal=GOOGLE_CLIENT_SECRET="${{ secrets.ODINS_THRONE_CLIENT_SECRET }}" \
             --from-literal=OAUTH2_PROXY_COOKIE_SECRET="${{ secrets.MONITOR_OAUTH2_PROXY_COOKIE_SECRET }}" \
-            --from-literal=emails.txt="declanshanaghy@gmail.com" \
+            --from-literal=emails.txt="declanshanaghy@gmail.com
+freyafenrir78@gmail.com" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Resolve odins-throne image tag
@@ -701,7 +702,8 @@ jobs:
             --from-literal=GOOGLE_CLIENT_ID="${{ secrets.ODINS_THRONE_CLIENT_ID }}" \
             --from-literal=GOOGLE_CLIENT_SECRET="${{ secrets.ODINS_THRONE_CLIENT_SECRET }}" \
             --from-literal=OAUTH2_PROXY_COOKIE_SECRET="${{ secrets.UMAMI_OAUTH2_PROXY_COOKIE_SECRET }}" \
-            --from-literal=emails.txt="declanshanaghy@gmail.com" \
+            --from-literal=emails.txt="declanshanaghy@gmail.com
+freyafenrir78@gmail.com" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Setup Helm
@@ -812,7 +814,8 @@ jobs:
             --dry-run=client -o yaml | kubectl apply -f -
           kubectl create secret generic n8n-oauth2-proxy-emails \
             --namespace=fenrir-marketing \
-            --from-literal=emails.txt="declanshanaghy@gmail.com" \
+            --from-literal=emails.txt="declanshanaghy@gmail.com
+freyafenrir78@gmail.com" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Setup Helm


### PR DESCRIPTION
## Summary
- Adds `freyafenrir78@gmail.com` to all 3 OAuth2 proxy email allowlists in deploy.yml
- Odin's Throne, Umami, and n8n proxies all get both emails
- Prevents deploys from overwriting the K8s secret back to single-email

## Test plan
- [x] K8s secret already updated manually for n8n (immediate fix)
- [ ] Next deploy propagates to all 3 proxies

Generated with [Claude Code](https://claude.com/claude-code)