### PR TITLE
chore: enable env var access in n8n Code nodes

### DIFF
--- a/infrastructure/helm/n8n/n8n-app-values.yaml
+++ b/infrastructure/helm/n8n/n8n-app-values.yaml
@@ -38,6 +38,8 @@ config:
   extraEnv:
     - name: N8N_PUBLIC_API_DISABLED
       value: "false"
+    - name: N8N_BLOCK_ENV_ACCESS_IN_NODE
+      value: "false"
     - name: N8N_EDITOR_BASE_URL
       value: "https://marketing.fenrirledger.com/"
     - name: WEBHOOK_URL


### PR DESCRIPTION
## Summary
- Set `N8N_BLOCK_ENV_ACCESS_IN_NODE=false` in n8n Helm values
- Allows Code nodes to access env vars via `$env.*`
- Required for IGNORED_SUBREDDITS configmap and future workflow config

Generated with [Claude Code](https://claude.com/claude-code)