### PR TITLE
fix: use markAsRead operation in f5bot Gmail node

### DIFF
--- a/infrastructure/n8n/workflows/gmail-f5bot-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-f5bot-monitor.json
@@ -236,13 +236,8 @@
     {
       "parameters": {
         "resource": "message",
-        "operation": "update",
-        "messageId": "={{ $('Extract — Reddit Links').first().json.emailId }}",
-        "updateFields": {
-          "removeLabelIds": [
-            "UNREAD"
-          ]
-        }
+        "operation": "markAsRead",
+        "messageId": "={{ $('Extract — Reddit Links').first().json.emailId }}"
       },
       "id": "f5b0-0013-4000-8000-000000000013",
       "name": "Gmail — Mark as Read",


### PR DESCRIPTION
## Summary
- Change Gmail node operation from `update` (unsupported) to `markAsRead`
- Remove `updateFields.removeLabelIds` (not needed with markAsRead)

Generated with [Claude Code](https://claude.com/claude-code)