### PR TITLE
fix: mark ignored-subreddit f5bot emails as read

### DIFF
--- a/infrastructure/n8n/workflows/gmail-f5bot-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-f5bot-monitor.json
@@ -86,7 +86,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Subreddits to ignore - read from env var (K8s configmap n8n-workflow-config)\n// Update via: kubectl edit configmap n8n-workflow-config -n fenrir-marketing\n// Format: comma-separated, e.g. \"r/sportscards,r/othersub\"\nconst IGNORED_SUBREDDITS = new Set(\n  ($env.IGNORED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst items = $input.all();\nconst results = [];\n\nfor (const item of items) {\n  const emailId = item.json.id || '';\n  const subject = item.json.Subject || item.json.subject || '';\n\n  const keywordMatch = subject.match(/F5Bot found something:\\s*(.+)/i);\n  const keyword = keywordMatch ? keywordMatch[1].trim() : 'unknown';\n\n  let bodyText = '';\n  if (item.json.payload) {\n    const getParts = (part) => {\n      if (!part) return [];\n      const out = [];\n      if (part.body && part.body.data) {\n        out.push({ mimeType: part.mimeType || '', data: part.body.data });\n      }\n      if (part.parts) {\n        for (const p of part.parts) out.push(...getParts(p));\n      }\n      return out;\n    };\n    const parts = getParts(item.json.payload);\n    const htmlPart = parts.find(p => p.mimeType === 'text/html')\n      || parts.find(p => p.mimeType === 'text/plain')\n      || parts[0];\n    if (htmlPart && htmlPart.data) {\n      try {\n        bodyText = Buffer.from(htmlPart.data, 'base64url').toString('utf-8');\n      } catch (e) {\n        bodyText = Buffer.from(htmlPart.data, 'base64').toString('utf-8');\n      }\n    }\n  }\n  if (!bodyText) {\n    bodyText = item.json.html || item.json.textAsHtml || item.json.text || item.json.snippet || '';\n  }\n\n  const seen = new Set();\n\n  // F5Bot HTML structure per mention:\n  //   <p style='margin-left:10px'>\n  //     Reddit Posts (/r/SUBREDDIT/): <a href='https://f5bot.com/url?u=ENCODED_URL'>POST TITLE</a> by USERNAME<br>\n  //     <span style='...'>SNIPPET with <strong>keyword</strong> highlighted</span>\n  //   </p>\n  //\n  // Parse each <p> block to extract: subreddit, URL, title, author, snippet, type (Posts vs Comments)\n\n  const blockRegex = /Reddit\\s+(Posts|Comments)\\s+\\(\\/r\\/([^/]+)\\/\\):\\s*<a\\s+href='[^']*f5bot\\.com\\/url\\?u=([^&']+)[^']*'>([^<]+)<\\/a>\\s*by\\s+(\\S+)\\s*<br>\\s*\\n?\\s*<span[^>]*>([\\s\\S]*?)<\\/span>/gi;\n\n  let match;\n  while ((match = blockRegex.exec(bodyText)) !== null) {\n    const type = match[1].toLowerCase();  // \"posts\" or \"comments\"\n    const subreddit = 'r/' + match[2];\n    let redditUrl;\n    try {\n      redditUrl = decodeURIComponent(match[3]);\n    } catch (e) {\n      continue;\n    }\n    const postTitle = match[4].trim();\n    const author = match[5].trim();\n    const rawSnippet = match[6]\n      .replace(/<strong>/gi, '')\n      .replace(/<\\/strong>/gi, '')\n      .replace(/<[^>]+>/g, '')\n      .trim();\n\n    const cleanUrl = redditUrl.split('?')[0].split('#')[0].replace(/\\/+$/, '');\n    const normalKey = cleanUrl.toLowerCase();\n    if (seen.has(normalKey)) continue;\n    seen.add(normalKey);\n\n    // Skip ignored subreddits\n    if (IGNORED_SUBREDDITS.has(subreddit.toLowerCase())) continue;\n\n    const isComment = type === 'comments';\n\n    results.push({\n      json: {\n        emailId,\n        subject,\n        keyword,\n        redditUrl: cleanUrl,\n        isComment,\n        subreddit,\n        postTitle,\n        author,\n        snippet: rawSnippet.substring(0, 1500)\n      }\n    });\n  }\n\n  // Fallback: if HTML parsing found nothing, try extracting from plain text\n  if (results.length === 0) {\n    const textBody = item.json.text || item.json.snippet || '';\n    const textRegex = /Reddit\\s+(Posts|Comments)\\s+\\(\\/r\\/([^/]+)\\/\\):\\s*'([^']+)'\\s+by\\s+(\\S+)\\s*\\n\\s*(https?:\\/\\/f5bot\\.com\\/url\\?u=(\\S+))/gi;\n    let tm;\n    while ((tm = textRegex.exec(textBody)) !== null) {\n      const type = tm[1].toLowerCase();\n      const subreddit = 'r/' + tm[2];\n      const postTitle = tm[3].trim();\n      const author = tm[4].trim();\n      let redditUrl;\n      try {\n        redditUrl = decodeURIComponent(tm[6].split('&')[0]);\n      } catch (e) {\n        continue;\n      }\n      const cleanUrl = redditUrl.split('?')[0].split('#')[0].replace(/\\/+$/, '');\n      const normalKey = cleanUrl.toLowerCase();\n      if (seen.has(normalKey)) continue;\n      seen.add(normalKey);\n\n      // Skip ignored subreddits\n      if (IGNORED_SUBREDDITS.has(subreddit.toLowerCase())) continue;\n\n      results.push({\n        json: {\n          emailId,\n          subject,\n          keyword,\n          redditUrl: cleanUrl,\n          isComment: type === 'comments',\n          subreddit,\n          postTitle,\n          author,\n          snippet: ''\n        }\n      });\n    }\n  }\n}\n\nreturn results;\n"
+        "jsCode": "// Subreddits to ignore - read from env var (K8s configmap n8n-workflow-config)\n// Update via: kubectl edit configmap n8n-workflow-config -n fenrir-marketing\n// Format: comma-separated, e.g. \"r/sportscards,r/othersub\"\nconst IGNORED_SUBREDDITS = new Set(\n  ($env.IGNORED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst items = $input.all();\nconst results = [];\n\nfor (const item of items) {\n  const emailId = item.json.id || '';\n  const subject = item.json.Subject || item.json.subject || '';\n\n  const keywordMatch = subject.match(/F5Bot found something:\\s*(.+)/i);\n  const keyword = keywordMatch ? keywordMatch[1].trim() : 'unknown';\n\n  let bodyText = '';\n  if (item.json.payload) {\n    const getParts = (part) => {\n      if (!part) return [];\n      const out = [];\n      if (part.body && part.body.data) {\n        out.push({ mimeType: part.mimeType || '', data: part.body.data });\n      }\n      if (part.parts) {\n        for (const p of part.parts) out.push(...getParts(p));\n      }\n      return out;\n    };\n    const parts = getParts(item.json.payload);\n    const htmlPart = parts.find(p => p.mimeType === 'text/html')\n      || parts.find(p => p.mimeType === 'text/plain')\n      || parts[0];\n    if (htmlPart && htmlPart.data) {\n      try {\n        bodyText = Buffer.from(htmlPart.data, 'base64url').toString('utf-8');\n      } catch (e) {\n        bodyText = Buffer.from(htmlPart.data, 'base64').toString('utf-8');\n      }\n    }\n  }\n  if (!bodyText) {\n    bodyText = item.json.html || item.json.textAsHtml || item.json.text || item.json.snippet || '';\n  }\n\n  const seen = new Set();\n\n  // F5Bot HTML structure per mention:\n  //   <p style='margin-left:10px'>\n  //     Reddit Posts (/r/SUBREDDIT/): <a href='https://f5bot.com/url?u=ENCODED_URL'>POST TITLE</a> by USERNAME<br>\n  //     <span style='...'>SNIPPET with <strong>keyword</strong> highlighted</span>\n  //   </p>\n  //\n  // Parse each <p> block to extract: subreddit, URL, title, author, snippet, type (Posts vs Comments)\n\n  const blockRegex = /Reddit\\s+(Posts|Comments)\\s+\\(\\/r\\/([^/]+)\\/\\):\\s*<a\\s+href='[^']*f5bot\\.com\\/url\\?u=([^&']+)[^']*'>([^<]+)<\\/a>\\s*by\\s+(\\S+)\\s*<br>\\s*\\n?\\s*<span[^>]*>([\\s\\S]*?)<\\/span>/gi;\n\n  let match;\n  while ((match = blockRegex.exec(bodyText)) !== null) {\n    const type = match[1].toLowerCase();  // \"posts\" or \"comments\"\n    const subreddit = 'r/' + match[2];\n    let redditUrl;\n    try {\n      redditUrl = decodeURIComponent(match[3]);\n    } catch (e) {\n      continue;\n    }\n    const postTitle = match[4].trim();\n    const author = match[5].trim();\n    const rawSnippet = match[6]\n      .replace(/<strong>/gi, '')\n      .replace(/<\\/strong>/gi, '')\n      .replace(/<[^>]+>/g, '')\n      .trim();\n\n    const cleanUrl = redditUrl.split('?')[0].split('#')[0].replace(/\\/+$/, '');\n    const normalKey = cleanUrl.toLowerCase();\n    if (seen.has(normalKey)) continue;\n    seen.add(normalKey);\n\n    const isIgnored = IGNORED_SUBREDDITS.has(subreddit.toLowerCase());\n\n    const isComment = type === 'comments';\n\n    results.push({\n      json: {\n        emailId,\n        subject,\n        keyword,\n        redditUrl: cleanUrl,\n        isComment,\n        isIgnored,\n        subreddit,\n        postTitle,\n        author,\n        snippet: rawSnippet.substring(0, 1500)\n      }\n    });\n  }\n\n  // Fallback: if HTML parsing found nothing, try extracting from plain text\n  if (results.length === 0) {\n    const textBody = item.json.text || item.json.snippet || '';\n    const textRegex = /Reddit\\s+(Posts|Comments)\\s+\\(\\/r\\/([^/]+)\\/\\):\\s*'([^']+)'\\s+by\\s+(\\S+)\\s*\\n\\s*(https?:\\/\\/f5bot\\.com\\/url\\?u=(\\S+))/gi;\n    let tm;\n    while ((tm = textRegex.exec(textBody)) !== null) {\n      const type = tm[1].toLowerCase();\n      const subreddit = 'r/' + tm[2];\n      const postTitle = tm[3].trim();\n      const author = tm[4].trim();\n      let redditUrl;\n      try {\n        redditUrl = decodeURIComponent(tm[6].split('&')[0]);\n      } catch (e) {\n        continue;\n      }\n      const cleanUrl = redditUrl.split('?')[0].split('#')[0].replace(/\\/+$/, '');\n      const normalKey = cleanUrl.toLowerCase();\n      if (seen.has(normalKey)) continue;\n      seen.add(normalKey);\n\n      // Skip ignored subreddits\n      if (IGNORED_SUBREDDITS.has(subreddit.toLowerCase())) continue;\n\n      results.push({\n        json: {\n          emailId,\n          subject,\n          keyword,\n          redditUrl: cleanUrl,\n          isComment: type === 'comments',\n          isIgnored,\n          subreddit,\n          postTitle,\n          author,\n          snippet: ''\n        }\n      });\n    }\n  }\n}\n\nreturn results;\n"
       },
       "id": "f5b0-0004-4000-8000-000000000004",
       "name": "Extract — Reddit Links",
@@ -130,6 +130,39 @@
         220
       ],
       "notes": "Safety guard: only process items with a valid Reddit URL (starts with http). Handles edge cases where Extract — Reddit Links might emit a malformed item."
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": {
+            "caseSensitive": false,
+            "leftValue": "",
+            "typeValidation": "strict"
+          },
+          "conditions": [
+            {
+              "id": "cond-not-ignored",
+              "leftValue": "={{ $json.isIgnored }}",
+              "rightValue": true,
+              "operator": {
+                "type": "boolean",
+                "operation": "notEqual"
+              }
+            }
+          ],
+          "combinator": "and"
+        },
+        "options": {}
+      },
+      "id": "f5b0-0014-4000-8000-000000000014",
+      "name": "Filter — Not Ignored",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [
+        1340,
+        220
+      ],
+      "notes": "Splits items by isIgnored flag. True branch (not ignored) goes to Claude for draft reply. False branch (ignored subreddit) goes directly to Mark as Read."
     },
     {
       "parameters": {
@@ -312,7 +345,7 @@
       "main": [
         [
           {
-            "node": "Claude API — Draft Reply",
+            "node": "Filter — Not Ignored",
             "type": "main",
             "index": 0
           }
@@ -320,6 +353,24 @@
         [
           {
             "node": "No Reddit Links",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Filter — Not Ignored": {
+      "main": [
+        [
+          {
+            "node": "Claude API — Draft Reply",
+            "type": "main",
+            "index": 0
+          }
+        ],
+        [
+          {
+            "node": "Gmail — Mark as Read",
             "type": "main",
             "index": 0
           }


### PR DESCRIPTION
## Summary
- Extract node now emits `isIgnored` flag instead of skipping items
- New "Filter - Not Ignored" IF node splits the flow
- Ignored items route directly to Gmail Mark as Read
- Non-ignored items continue to Claude draft reply as before

Generated with [Claude Code](https://claude.com/claude-code)