### PR TITLE
feat: reddit monitor scans suggested posts in preferred subs

### DIFF
--- a/infrastructure/n8n/workflows/gmail-reddit-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-reddit-monitor.json
@@ -1,9 +1,9 @@
 {
-  "updatedAt": "2026-03-18T00:00:00.000Z",
+  "updatedAt": "2026-04-04T00:00:00.000Z",
   "createdAt": "2026-03-19T01:01:15.554Z",
   "id": "gmail-reddit-monitor",
-  "name": "Gmail — Reddit Reply Monitor",
-  "description": null,
+  "name": "Gmail — Reddit Monitor",
+  "description": "Monitors Freya's Gmail for Reddit reply notifications AND suggested post emails. Replies get follow-up drafts. Suggested posts in preferred subreddits get new comment drafts via Reddit JSON API.",
   "active": false,
   "isArchived": false,
   "nodes": [
@@ -15,9 +15,9 @@
       "typeVersion": 1,
       "position": [
         240,
-        300
+        400
       ],
-      "notes": "Odin kicks this off manually when he wants to check for Reddit replies.\n\nFUTURE: Replace with a Webhook node — set up a Gmail filter (From: noreply@redditmail.com, Subject: replied to your comment) that forwards matching emails to the n8n webhook URL. This eliminates manual polling entirely."
+      "notes": "Odin kicks this off manually to process Reddit emails."
     },
     {
       "parameters": {
@@ -28,7 +28,6 @@
         "limit": 50,
         "filters": {
           "sender": "noreply@redditmail.com",
-          "subject": "replied to your",
           "readStatus": "unread"
         },
         "options": {
@@ -36,12 +35,12 @@
         }
       },
       "id": "a1b2c3d4-0002-4000-8000-000000000002",
-      "name": "Gmail — Fetch Reddit Replies",
+      "name": "Gmail — Fetch Reddit Emails",
       "type": "n8n-nodes-base.gmail",
       "typeVersion": 2,
       "position": [
         460,
-        300
+        400
       ],
       "credentials": {
         "gmailOAuth2": {
@@ -49,72 +48,48 @@
           "name": "Gmail account"
         }
       },
-      "notes": "Reads unread emails from freyafenrir@gmail.com sent by noreply@redditmail.com with subject matching 'replied to your comment'."
+      "notes": "Fetches ALL unread Reddit emails (not just replies). The router node splits by type."
     },
     {
       "parameters": {
-        "conditions": {
-          "options": {
-            "caseSensitive": false,
-            "leftValue": "",
-            "typeValidation": "strict"
-          },
-          "conditions": [
-            {
-              "id": "cond-subject-check",
-              "leftValue": "={{ $json.Subject || $json.subject }}",
-              "rightValue": "replied to your",
-              "operator": {
-                "type": "string",
-                "operation": "contains"
-              }
-            }
-          ],
-          "combinator": "and"
-        },
-        "options": {}
+        "jsCode": "// Route Reddit emails into categories based on subject line\nconst items = $input.all();\nconst replies = [];\nconst suggestions = [];\nconst other = [];\n\nfor (const item of items) {\n  const subject = (item.json.Subject || item.json.subject || '').toLowerCase();\n  \n  if (subject.includes('replied to your')) {\n    replies.push(item);\n  } else if (\n    subject.includes('posts from') ||\n    subject.includes('trending') ||\n    subject.includes('popular') ||\n    subject.includes('because you') ||\n    subject.includes('you might like') ||\n    subject.includes('new posts in') ||\n    subject.includes('top posts')\n  ) {\n    suggestions.push(item);\n  } else {\n    other.push(item);\n  }\n}\n\n// Return 3 outputs: [replies, suggestions, other]\nreturn [replies, suggestions, other];"
       },
-      "id": "a1b2c3d4-0003-4000-8000-000000000003",
-      "name": "Filter — Reddit Reply Emails",
-      "type": "n8n-nodes-base.if",
+      "id": "a1b2c3d4-0020-4000-8000-000000000020",
+      "name": "Router — Email Type",
+      "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
         680,
-        300
+        400
       ],
-      "notes": "Secondary guard: only process emails whose subject explicitly contains 'replied to your'. Defense-in-depth."
+      "outputs": ["main", "main", "main"],
+      "notes": "Splits Reddit emails into 3 categories by subject: replies (output 0), post suggestions (output 1), other/noise (output 2)."
     },
+
     {
       "parameters": {
-        "jsCode": "// Subreddits to ignore - read from env var (K8s configmap n8n-workflow-config)\n// Update via: kubectl edit configmap n8n-workflow-config -n fenrir-marketing\n// Format: comma-separated, e.g. \"r/sportscards,r/othersub\"\nconst IGNORED_SUBREDDITS = new Set(\n  ($env.IGNORED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst items = $input.all();\nconst results = [];\nconst seenThreads = new Set();\n\nfor (const item of items) {\n  const subject = item.json.Subject || item.json.subject || '';\n  const snippet = item.json.snippet || item.json.text || '';\n  const htmlBody = item.json.html || item.json.textAsHtml || item.json.body || '';\n  const messageId = item.json.id || '';\n  const threadId = item.json.threadId || messageId;\n  const date = item.json.internalDate\n    ? new Date(parseInt(item.json.internalDate)).toISOString()\n    : (item.json.date || new Date().toISOString());\n\n  const subjectMatch = subject.match(/u\\/(\\S+)\\s+replied to your (?:post|comment) in (r\\/\\S+)/i);\n  const replierName = subjectMatch ? subjectMatch[1] : 'someone';\n  const subreddit = subjectMatch ? subjectMatch[2] : 'unknown';\n\n  // Skip bot/AutoModerator/ModTeam replies\n  const botNames = ['automoderator', 'bot', 'moderator', 'modteam'];\n  if (botNames.some(b => replierName.toLowerCase().includes(b))) {\n    continue;\n  }\n\n  // Check ignore list from env var\n  const isIgnored = IGNORED_SUBREDDITS.has(subreddit.toLowerCase());\n\n  // Deduplicate by threadId\n  if (seenThreads.has(threadId)) {\n    continue;\n  }\n  seenThreads.add(threadId);\n\n  // Extract the \"View Reply\" link from the HTML email body\n  let replyLink = '';\n  const viewReplyMatch = htmlBody.match(/href=[\"'](https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/[^\"']*\\/comments\\/[^\"']*)[\"'][^>]*>[^<]*(?:View Reply|Reply|View Comment|View)/i);\n  if (viewReplyMatch) {\n    replyLink = viewReplyMatch[1];\n  } else {\n    const commentLinkMatch = htmlBody.match(/href=[\"'](https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/[^\"']*\\/comments\\/[^\"']*)[\"']/i);\n    if (commentLinkMatch) {\n      replyLink = commentLinkMatch[1];\n    }\n  }\n\n  const replyText = snippet.substring(0, 1000).trim();\n\n  results.push({\n    json: {\n      messageId,\n      threadId,\n      date,\n      subject,\n      replierName,\n      subreddit,\n      replyText,\n      replyLink,\n      isIgnored,\n      rawBody: snippet\n    }\n  });\n}\n\nreturn results;"
+        "jsCode": "// Subreddits to ignore\nconst IGNORED_SUBREDDITS = new Set(\n  ($env.IGNORED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst items = $input.all();\nconst results = [];\nconst seenThreads = new Set();\n\nfor (const item of items) {\n  const subject = item.json.Subject || item.json.subject || '';\n  const snippet = item.json.snippet || item.json.text || '';\n  const htmlBody = item.json.html || item.json.textAsHtml || item.json.body || '';\n  const messageId = item.json.id || '';\n  const threadId = item.json.threadId || messageId;\n  const date = item.json.internalDate\n    ? new Date(parseInt(item.json.internalDate)).toISOString()\n    : (item.json.date || new Date().toISOString());\n\n  const subjectMatch = subject.match(/u\\/(\\S+)\\s+replied to your (?:post|comment) in (r\\/\\S+)/i);\n  const replierName = subjectMatch ? subjectMatch[1] : 'someone';\n  const subreddit = subjectMatch ? subjectMatch[2] : 'unknown';\n\n  const botNames = ['automoderator', 'bot', 'moderator', 'modteam'];\n  if (botNames.some(b => replierName.toLowerCase().includes(b))) continue;\n\n  const isIgnored = IGNORED_SUBREDDITS.has(subreddit.toLowerCase());\n\n  if (seenThreads.has(threadId)) continue;\n  seenThreads.add(threadId);\n\n  let replyLink = '';\n  const viewReplyMatch = htmlBody.match(/href=[\"'](https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/[^\"']*\\/comments\\/[^\"']*)[\"'][^>]*>[^<]*(?:View Reply|Reply|View Comment|View)/i);\n  if (viewReplyMatch) {\n    replyLink = viewReplyMatch[1];\n  } else {\n    const commentLinkMatch = htmlBody.match(/href=[\"'](https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/[^\"']*\\/comments\\/[^\"']*)[\"']/i);\n    if (commentLinkMatch) replyLink = commentLinkMatch[1];\n  }\n\n  results.push({\n    json: {\n      messageId, threadId, date, subject, replierName, subreddit,\n      replyText: snippet.substring(0, 1000).trim(),\n      replyLink, isIgnored, rawBody: snippet\n    }\n  });\n}\n\nreturn results;"
       },
       "id": "a1b2c3d4-0004-4000-8000-000000000004",
-      "name": "Extract — Thread Context",
+      "name": "Extract — Reply Context",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
       "position": [
         900,
         220
       ],
-      "notes": "Parses Gmail message to extract replierName, subreddit, replyText, replyLink. Uses IGNORED_SUBREDDITS env var for ignore list. Emits isIgnored flag."
+      "notes": "Parses reply notification emails. Extracts replierName, subreddit, replyText, replyLink. Emits isIgnored flag."
     },
     {
       "parameters": {
         "conditions": {
-          "options": {
-            "caseSensitive": false,
-            "leftValue": "",
-            "typeValidation": "strict"
-          },
+          "options": { "caseSensitive": false, "leftValue": "", "typeValidation": "strict" },
           "conditions": [
             {
-              "id": "cond-not-ignored",
+              "id": "cond-not-ignored-reply",
               "leftValue": "={{ $json.isIgnored }}",
               "rightValue": true,
-              "operator": {
-                "type": "boolean",
-                "operation": "notEqual"
-              }
+              "operator": { "type": "boolean", "operation": "notEqual" }
             }
           ],
           "combinator": "and"
@@ -122,67 +97,52 @@
         "options": {}
       },
       "id": "a1b2c3d4-0009-4000-8000-000000000009",
-      "name": "Filter — Not Ignored",
+      "name": "Filter — Reply Not Ignored",
       "type": "n8n-nodes-base.if",
       "typeVersion": 2,
       "position": [
         1120,
         220
       ],
-      "notes": "Splits by isIgnored flag. True branch (not ignored) goes to Claude. False branch (ignored subreddit) goes directly to Mark as Read."
+      "notes": "Splits replies: non-ignored to Claude, ignored to Mark as Read."
     },
     {
       "parameters": {
         "resource": "text",
         "operation": "message",
-        "modelId": {
-          "__rl": true,
-          "mode": "id",
-          "value": "claude-sonnet-4-20250514"
-        },
+        "modelId": { "__rl": true, "mode": "id", "value": "claude-sonnet-4-20250514" },
         "messages": {
           "values": [
             {
-              "content": "=A Reddit user named {{ $json.replierName }} replied to your comment on {{ $json.subreddit }}.\n\nTheir reply:\n{{ $json.replyText }}\n\nDraft a short, genuine follow-up response. Write 2-4 short paragraphs (one point per paragraph, 1-2 sentences each). Break up your response so it reads naturally on Reddit. No walls of text.\n\nBe conversational, helpful, and specific to what they said. Where it fits naturally, steer the conversation toward tracking strategies that matter for churning: annual fee dates, signup bonus deadlines, minimum spend windows, product change timing, or statement close dates. Share from personal experience how keeping close tabs on these dates has saved you money or helped you optimize.\n\nSprinkle in the occasional emoji or ASCII smiley (like :-D or ;-) or :-P) to keep the tone casual and human. Not every comment needs one, but use them when the mood fits.\n\nDo not mention any specific apps, tools, or products by name.",
+              "content": "=A Reddit user named {{ $json.replierName }} replied to your comment on {{ $json.subreddit }}.\n\nTheir reply:\n{{ $json.replyText }}\n\nDraft a short, genuine follow-up response. Write 2-4 short paragraphs (one point per paragraph, 1-2 sentences each). Break up your response so it reads naturally on Reddit. No walls of text.\n\nBe conversational, helpful, and specific to what they said. Where it fits naturally, steer the conversation toward tracking strategies that matter for churning: annual fee dates, signup bonus deadlines, minimum spend windows, product change timing, or statement close dates. Share from personal experience.\n\nSprinkle in the occasional emoji or ASCII smiley (like :-D or ;-) or :-P) when the mood fits.\n\nDo not mention any specific apps, tools, or products by name.",
               "role": "user"
             }
           ]
         },
         "simplify": true,
         "options": {
-          "system": "You are Freya, a 34-year-old in Denver. You and your husband Marcus (software engineer) got into churning 3 years ago after he booked your honeymoon to Iceland on points. Now you manage 12 active cards between you. You have two daughters, Lily (7) and Nora (4), and a golden retriever named Odin.\n\nYou track everything in a color-coded spreadsheet you built yourself. Your favorites: Amex Gold (groceries for the family basically earns itself), Chase Sapphire Reserve (travel), Citi Premier (backup flexibility). You recently closed an Amex Platinum after the second AF because you weren't using the credits enough with two kids. Current goal: family trip to Japan next year, fully on points. Stockpiling MR and UR.\n\nYour philosophy: churning is a numbers game, and the people who win are the ones who treat their card stack like a portfolio with clear dates and milestones for every card. You're practical, not a maximizer. More of a 'good enough' optimizer.\n\nYour tone is friendly, knowledgeable, and never promotional. You give real value first with specific advice, honest opinions, and genuine engagement. You write short Reddit comments (2-4 sentences per paragraph, multiple paragraphs). No marketing speak. No exclamation points. Never use em dashes. Use occasional emojis or ASCII smileys (:-D, ;-), :-P) to sound human and casual. Reference your family naturally: 'my husband and I split the card apps,' 'with two kids under 8 the grocery spend basically earns itself.' Sound like a real person who genuinely enjoys the hobby. Never mention any specific apps, tools, or products by name. When tracking comes up naturally, talk about the strategy and what to track, not what tool to use.",
+          "system": "You are Freya, a 34-year-old in Denver. You and your husband Marcus (software engineer) got into churning 3 years ago after he booked your honeymoon to Iceland on points. Now you manage 12 active cards between you. You have two daughters, Lily (7) and Nora (4), and a golden retriever named Odin.\n\nYou track everything in a color-coded spreadsheet you built yourself. Your favorites: Amex Gold (groceries for the family basically earns itself), Chase Sapphire Reserve (travel), Citi Premier (backup flexibility). You recently closed an Amex Platinum after the second AF because you weren't using the credits enough with two kids. Current goal: family trip to Japan next year, fully on points. Stockpiling MR and UR.\n\nYour philosophy: churning is a numbers game, and the people who win are the ones who treat their card stack like a portfolio with clear dates and milestones for every card. You're practical, not a maximizer. More of a 'good enough' optimizer.\n\nYour tone is friendly, knowledgeable, and never promotional. You give real value first. You write short Reddit comments (2-4 sentences per paragraph, multiple paragraphs). No marketing speak. No exclamation points. Never use em dashes. Use occasional emojis or ASCII smileys (:-D, ;-), :-P). Reference your family naturally. Sound like a real person. Never mention any specific apps, tools, or products by name.",
           "maxTokens": 512
         }
       },
       "id": "a1b2c3d4-0005-4000-8000-000000000005",
-      "name": "Claude API — Draft Follow-up",
+      "name": "Claude — Draft Reply",
       "type": "@n8n/n8n-nodes-langchain.anthropic",
       "typeVersion": 1,
-      "position": [
-        1340,
-        220
-      ],
-      "credentials": {
-        "anthropicApi": {
-          "id": "anthropic-fenrir",
-          "name": "Anthropic (Fenrir)"
-        }
-      },
-      "notes": "Built-in n8n Anthropic node. Uses claude-sonnet-4 via anthropicApi credential."
+      "position": [ 1340, 220 ],
+      "credentials": { "anthropicApi": { "id": "anthropic-fenrir", "name": "Anthropic (Fenrir)" } },
+      "notes": "Drafts a follow-up reply to a Reddit comment."
     },
     {
       "parameters": {
-        "jsCode": "const items = $input.all();\nconst contextItems = $('Extract — Thread Context').all();\nconst results = [];\n\nfor (let i = 0; i < items.length; i++) {\n  const claudeResponse = items[i].json;\n  const draftText = claudeResponse?.text || claudeResponse?.content?.[0]?.text || 'Claude draft unavailable — check API credentials.';\n\n  // Match context by index — each Claude response pairs with its Extract input\n  const context = contextItems[i]?.json || contextItems[0]?.json || {};\n\n  results.push({\n    json: {\n      draftText,\n      replierName: context.replierName || 'unknown',\n      subreddit: context.subreddit || 'unknown',\n      replyText: context.replyText || '',\n      replyLink: context.replyLink || '',\n      subject: context.subject || '',\n      messageId: context.messageId || '',\n      threadId: context.threadId || '',\n      date: context.date || '',\n      rawBody: context.rawBody || ''\n    }\n  });\n}\n\nreturn results;"
+        "jsCode": "const items = $input.all();\nconst contextItems = $('Extract — Reply Context').all();\nconst results = [];\n\nfor (let i = 0; i < items.length; i++) {\n  const claudeResponse = items[i].json;\n  const draftText = claudeResponse?.text || claudeResponse?.content?.[0]?.text || 'Claude draft unavailable.';\n  const context = contextItems[i]?.json || contextItems[0]?.json || {};\n\n  results.push({\n    json: {\n      draftText,\n      replierName: context.replierName || 'unknown',\n      subreddit: context.subreddit || 'unknown',\n      replyText: context.replyText || '',\n      replyLink: context.replyLink || '',\n      subject: context.subject || '',\n      messageId: context.messageId || '',\n      date: context.date || ''\n    }\n  });\n}\n\nreturn results;"
       },
       "id": "a1b2c3d4-0006-4000-8000-000000000006",
-      "name": "Merge — Context + Draft",
+      "name": "Merge — Reply + Draft",
       "type": "n8n-nodes-base.code",
       "typeVersion": 2,
-      "position": [
-        1560,
-        220
-      ],
-      "notes": "Merges Claude draft text with email context data."
+      "position": [ 1560, 220 ],
+      "notes": "Merges Claude reply draft with email context."
     },
     {
       "parameters": {
@@ -190,165 +150,281 @@
         "operation": "create",
         "subject": "=Reply to u/{{ $json.replierName }} on {{ $json.subreddit }}",
         "emailType": "html",
-        "message": "=<h3>Reddit Reply Draft</h3>\n<p><strong>Reply to:</strong> <a href=\"{{ $json.replyLink }}\">{{ $json.replyLink ? 'View Reply on Reddit' : 'Link unavailable, check ' + $json.subreddit }}</a></p>\n<p><strong>Thread:</strong> {{ $json.subreddit }} | <strong>Replier:</strong> u/{{ $json.replierName }}</p>\n<p><strong>Received:</strong> {{ $json.date }}</p>\n<hr/>\n<h4>Their Reply</h4>\n<blockquote>{{ $json.replyText }}</blockquote>\n<hr/>\n<h4>Draft Response (post as u/Wide-Pass369)</h4>\n<div style=\"background: #f0f8ff; padding: 12px; border-radius: 4px; white-space: pre-line;\">{{ $json.draftText }}</div>\n<hr/>\n<p><em>1. Click the link above to open the Reddit comment<br/>2. Review and edit the draft response<br/>3. Post as u/Wide-Pass369<br/>4. Delete this email when done</em></p>",
-        "toList": [
-          "reddit-replies@fenrirledger.com"
-        ],
+        "message": "=<h3>Reddit Reply Draft</h3>\n<p><strong>Reply to:</strong> <a href=\"{{ $json.replyLink }}\">View Reply on Reddit</a></p>\n<p><strong>Thread:</strong> {{ $json.subreddit }} | <strong>Replier:</strong> u/{{ $json.replierName }}</p>\n<p><strong>Received:</strong> {{ $json.date }}</p>\n<hr/>\n<h4>Their Reply</h4>\n<blockquote>{{ $json.replyText }}</blockquote>\n<hr/>\n<h4>Draft Response (post as u/Wide-Pass369)</h4>\n<div style=\"background: #f0f8ff; padding: 12px; border-radius: 4px; white-space: pre-line;\">{{ $json.draftText }}</div>\n<hr/>\n<p><em>1. Click the link above to open the Reddit comment<br/>2. Review and edit the draft response<br/>3. Post as u/Wide-Pass369<br/>4. Delete this email when done</em></p>",
         "options": {}
       },
       "id": "a1b2c3d4-0007-4000-8000-000000000007",
-      "name": "Gmail — Create Draft Reply",
+      "name": "Gmail — Create Reply Draft",
       "type": "n8n-nodes-base.gmail",
       "typeVersion": 2,
-      "position": [
-        1780,
-        220
-      ],
-      "credentials": {
-        "gmailOAuth2": {
-          "id": "Eck5j1Xj1x6zyc9A",
-          "name": "Gmail account"
-        }
-      },
-      "notes": "Creates a Gmail draft with the Reddit post link and Claude's draft reply."
+      "position": [ 1780, 220 ],
+      "credentials": { "gmailOAuth2": { "id": "Eck5j1Xj1x6zyc9A", "name": "Gmail account" } },
+      "notes": "Creates draft for reply follow-up."
     },
     {
       "parameters": {
         "resource": "message",
         "operation": "markAsRead",
-        "messageId": "={{ $('Extract — Thread Context').first().json.messageId }}"
+        "messageId": "={{ $('Extract — Reply Context').first().json.messageId }}"
       },
       "id": "a1b2c3d4-0010-4000-8000-000000000010",
-      "name": "Gmail — Mark as Read",
+      "name": "Gmail — Mark Reply Read",
       "type": "n8n-nodes-base.gmail",
       "typeVersion": 2,
-      "position": [
-        2000,
-        220
-      ],
-      "credentials": {
-        "gmailOAuth2": {
-          "id": "Eck5j1Xj1x6zyc9A",
-          "name": "Gmail account"
-        }
+      "position": [ 2000, 300 ],
+      "credentials": { "gmailOAuth2": { "id": "Eck5j1Xj1x6zyc9A", "name": "Gmail account" } },
+      "notes": "Marks reply email as read after processing or if ignored."
+    },
+
+    {
+      "parameters": {
+        "jsCode": "// Extract Reddit post links from suggestion emails and filter by PREFERRED_SUBREDDITS\nconst PREFERRED = new Set(\n  ($env.PREFERRED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\nconst IGNORED = new Set(\n  ($env.IGNORED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst items = $input.all();\nconst results = [];\nconst seen = new Set();\n\nfor (const item of items) {\n  const messageId = item.json.id || '';\n  const subject = item.json.Subject || item.json.subject || '';\n  const htmlBody = item.json.html || item.json.textAsHtml || item.json.body || '';\n  const snippet = item.json.snippet || item.json.text || '';\n\n  // Find all Reddit post links in the email HTML\n  const linkRegex = /href=[\"'](https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([^/]+)\\/comments\\/([^/\"']+)[^\"']*)[\"']/gi;\n  let match;\n  while ((match = linkRegex.exec(htmlBody)) !== null) {\n    const postUrl = match[1].split('?')[0].replace(/\\/+$/, '');\n    const subreddit = 'r/' + match[2];\n    const postId = match[3];\n    const normalKey = postUrl.toLowerCase();\n\n    if (seen.has(normalKey)) continue;\n    seen.add(normalKey);\n\n    // Skip ignored subs\n    if (IGNORED.has(subreddit.toLowerCase())) continue;\n\n    // Only process preferred subs (if list is non-empty)\n    const isPreferred = PREFERRED.size === 0 || PREFERRED.has(subreddit.toLowerCase());\n    if (!isPreferred) continue;\n\n    results.push({\n      json: {\n        messageId,\n        subject,\n        postUrl,\n        postId,\n        subreddit,\n        jsonUrl: postUrl + '.json',\n        snippet: snippet.substring(0, 500)\n      }\n    });\n  }\n}\n\nreturn results;"
       },
-      "notes": "Marks the source Reddit reply email as read after draft is created or if the subreddit is ignored."
+      "id": "a1b2c3d4-0030-4000-8000-000000000030",
+      "name": "Extract — Suggested Posts",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [ 900, 580 ],
+      "notes": "Extracts Reddit post links from suggestion emails. Filters by PREFERRED_SUBREDDITS and IGNORED_SUBREDDITS env vars."
     },
     {
       "parameters": {
+        "jsCode": "// Fetch the Reddit post content via the JSON API\nconst items = $input.all();\nconst results = [];\n\nfor (const item of items) {\n  const jsonUrl = item.json.jsonUrl;\n  if (!jsonUrl) continue;\n\n  try {\n    const response = await fetch(jsonUrl, {\n      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; FenrirBot/1.0)' }\n    });\n    \n    if (!response.ok) {\n      results.push({ json: { ...item.json, postTitle: '(fetch failed)', postText: '', postAuthor: '', fetchError: response.status } });\n      continue;\n    }\n\n    const data = await response.json();\n    const post = data?.[0]?.data?.children?.[0]?.data || {};\n\n    results.push({\n      json: {\n        ...item.json,\n        postTitle: post.title || '(no title)',\n        postText: (post.selftext || '').substring(0, 2000),\n        postAuthor: post.author || 'unknown',\n        postScore: post.score || 0,\n        postComments: post.num_comments || 0,\n        postCreated: post.created_utc ? new Date(post.created_utc * 1000).toISOString() : '',\n        fetchError: null\n      }\n    });\n  } catch (e) {\n    results.push({ json: { ...item.json, postTitle: '(fetch error)', postText: '', postAuthor: '', fetchError: e.message } });\n  }\n}\n\nreturn results;"
+      },
+      "id": "a1b2c3d4-0031-4000-8000-000000000031",
+      "name": "Fetch — Reddit Post JSON",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [ 1120, 580 ],
+      "notes": "Fetches post content from Reddit's JSON API (append .json to post URL). No auth needed. Rate limit: 60 req/min."
+    },
+    {
+      "parameters": {
+        "conditions": {
+          "options": { "caseSensitive": false, "leftValue": "", "typeValidation": "strict" },
+          "conditions": [
+            {
+              "id": "cond-has-content",
+              "leftValue": "={{ $json.postTitle }}",
+              "rightValue": "(fetch",
+              "operator": { "type": "string", "operation": "notStartsWith" }
+            }
+          ],
+          "combinator": "and"
+        },
         "options": {}
       },
+      "id": "a1b2c3d4-0032-4000-8000-000000000032",
+      "name": "Filter — Post Fetched OK",
+      "type": "n8n-nodes-base.if",
+      "typeVersion": 2,
+      "position": [ 1340, 580 ],
+      "notes": "Only proceed if the Reddit JSON fetch succeeded."
+    },
+    {
+      "parameters": {
+        "resource": "text",
+        "operation": "message",
+        "modelId": { "__rl": true, "mode": "id", "value": "claude-sonnet-4-20250514" },
+        "messages": {
+          "values": [
+            {
+              "content": "=Here's a Reddit post on {{ $json.subreddit }} that's relevant to your expertise in credit card churning.\n\nTitle: {{ $json.postTitle }}\nAuthor: u/{{ $json.postAuthor }}\nScore: {{ $json.postScore }} | Comments: {{ $json.postComments }}\n\nPost content:\n{{ $json.postText || '(no body text, title-only post)' }}\n\nURL: {{ $json.postUrl }}\n\nDraft a helpful top-level comment on this post. Write 2-4 short paragraphs (one point per paragraph, 1-2 sentences each). Be specific to the post content. Add real value with personal experience and practical advice.\n\nSprinkle in the occasional emoji or ASCII smiley when the mood fits.\n\nDo not mention any specific apps, tools, or products by name. If the post doesn't relate to credit cards, churning, or personal finance at all, respond with exactly: SKIP",
+              "role": "user"
+            }
+          ]
+        },
+        "simplify": true,
+        "options": {
+          "system": "You are Freya, a 34-year-old in Denver. You and your husband Marcus (software engineer) got into churning 3 years ago after he booked your honeymoon to Iceland on points. Now you manage 12 active cards between you. You have two daughters, Lily (7) and Nora (4), and a golden retriever named Odin.\n\nYou track everything in a color-coded spreadsheet you built yourself. Your favorites: Amex Gold (groceries for the family basically earns itself), Chase Sapphire Reserve (travel), Citi Premier (backup flexibility). You recently closed an Amex Platinum after the second AF because you weren't using the credits enough with two kids. Current goal: family trip to Japan next year, fully on points. Stockpiling MR and UR.\n\nYour philosophy: churning is a numbers game, and the people who win are the ones who treat their card stack like a portfolio with clear dates and milestones for every card. You're practical, not a maximizer. More of a 'good enough' optimizer.\n\nYour tone is friendly, knowledgeable, and never promotional. You give real value first. You write short Reddit comments (2-4 sentences per paragraph, multiple paragraphs). No marketing speak. No exclamation points. Never use em dashes. Use occasional emojis or ASCII smileys (:-D, ;-), :-P). Reference your family naturally. Sound like a real person. Never mention any specific apps, tools, or products by name.",
+          "maxTokens": 512
+        }
+      },
+      "id": "a1b2c3d4-0033-4000-8000-000000000033",
+      "name": "Claude — Draft Comment",
+      "type": "@n8n/n8n-nodes-langchain.anthropic",
+      "typeVersion": 1,
+      "position": [ 1560, 580 ],
+      "credentials": { "anthropicApi": { "id": "anthropic-fenrir", "name": "Anthropic (Fenrir)" } },
+      "notes": "Drafts a new top-level comment for a suggested Reddit post."
+    },
+    {
+      "parameters": {
+        "jsCode": "const items = $input.all();\nconst contextItems = $('Fetch — Reddit Post JSON').all();\nconst results = [];\n\nfor (let i = 0; i < items.length; i++) {\n  const claudeResponse = items[i].json;\n  const draftText = claudeResponse?.text || claudeResponse?.content?.[0]?.text || 'Claude draft unavailable.';\n  \n  // Skip posts Claude flagged as irrelevant\n  if (draftText.trim() === 'SKIP') continue;\n  \n  const context = contextItems[i]?.json || contextItems[0]?.json || {};\n\n  results.push({\n    json: {\n      draftText,\n      postTitle: context.postTitle || '',\n      postAuthor: context.postAuthor || '',\n      postUrl: context.postUrl || '',\n      subreddit: context.subreddit || '',\n      postScore: context.postScore || 0,\n      postComments: context.postComments || 0,\n      messageId: context.messageId || ''\n    }\n  });\n}\n\nreturn results;"
+      },
+      "id": "a1b2c3d4-0034-4000-8000-000000000034",
+      "name": "Merge — Post + Draft",
+      "type": "n8n-nodes-base.code",
+      "typeVersion": 2,
+      "position": [ 1780, 580 ],
+      "notes": "Merges Claude comment draft with post context. Filters out SKIP responses."
+    },
+    {
+      "parameters": {
+        "resource": "draft",
+        "operation": "create",
+        "subject": "=Comment on {{ $json.subreddit }}: {{ $json.postTitle }}",
+        "emailType": "html",
+        "message": "=<h3>Reddit Comment Draft</h3>\n<p><strong>Post:</strong> <a href=\"{{ $json.postUrl }}\">{{ $json.postTitle }}</a></p>\n<p><strong>Subreddit:</strong> {{ $json.subreddit }} | <strong>Author:</strong> u/{{ $json.postAuthor }} | <strong>Score:</strong> {{ $json.postScore }} | <strong>Comments:</strong> {{ $json.postComments }}</p>\n<hr/>\n<h4>Draft Comment (post as u/Wide-Pass369)</h4>\n<div style=\"background: #f0f8ff; padding: 12px; border-radius: 4px; white-space: pre-line;\">{{ $json.draftText }}</div>\n<hr/>\n<p><em>1. Click the post link above<br/>2. Review and edit the draft comment<br/>3. Post as u/Wide-Pass369<br/>4. Delete this email when done</em></p>",
+        "options": {}
+      },
+      "id": "a1b2c3d4-0035-4000-8000-000000000035",
+      "name": "Gmail — Create Comment Draft",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2,
+      "position": [ 2000, 580 ],
+      "credentials": { "gmailOAuth2": { "id": "Eck5j1Xj1x6zyc9A", "name": "Gmail account" } },
+      "notes": "Creates draft for new comment on a suggested Reddit post."
+    },
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "markAsRead",
+        "messageId": "={{ $('Extract — Suggested Posts').first().json.messageId }}"
+      },
+      "id": "a1b2c3d4-0036-4000-8000-000000000036",
+      "name": "Gmail — Mark Suggestion Read",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2,
+      "position": [ 2220, 580 ],
+      "credentials": { "gmailOAuth2": { "id": "Eck5j1Xj1x6zyc9A", "name": "Gmail account" } },
+      "notes": "Marks the suggestion email as read after draft is created."
+    },
+
+    {
+      "parameters": {
+        "resource": "message",
+        "operation": "markAsRead",
+        "messageId": "={{ $json.id }}"
+      },
+      "id": "a1b2c3d4-0040-4000-8000-000000000040",
+      "name": "Gmail — Mark Other Read",
+      "type": "n8n-nodes-base.gmail",
+      "typeVersion": 2,
+      "position": [ 900, 650 ],
+      "credentials": { "gmailOAuth2": { "id": "Eck5j1Xj1x6zyc9A", "name": "Gmail account" } },
+      "notes": "Marks non-reply/non-suggestion Reddit emails (noise) as read immediately."
+    },
+    {
+      "parameters": { "options": {} },
       "id": "a1b2c3d4-0008-4000-8000-000000000008",
-      "name": "No Replies Found",
+      "name": "No Emails",
       "type": "n8n-nodes-base.noOp",
       "typeVersion": 1,
-      "position": [
-        900,
-        420
-      ],
-      "notes": "Reached when no unread Reddit reply emails are present. Workflow ends cleanly."
+      "position": [ 900, 780 ],
+      "notes": "No unread Reddit emails found."
     }
   ],
   "connections": {
     "Manual Trigger": {
       "main": [
         [
-          {
-            "node": "Gmail — Fetch Reddit Replies",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Gmail — Fetch Reddit Emails", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Gmail — Fetch Reddit Replies": {
+    "Gmail — Fetch Reddit Emails": {
       "main": [
         [
-          {
-            "node": "Filter — Reddit Reply Emails",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Router — Email Type", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Filter — Reddit Reply Emails": {
+    "Router — Email Type": {
       "main": [
         [
-          {
-            "node": "Extract — Thread Context",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Extract — Reply Context", "type": "main", "index": 0 }
         ],
         [
-          {
-            "node": "No Replies Found",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Extract — Thread Context": {
-      "main": [
-        [
-          {
-            "node": "Filter — Not Ignored",
-            "type": "main",
-            "index": 0
-          }
-        ]
-      ]
-    },
-    "Filter — Not Ignored": {
-      "main": [
-        [
-          {
-            "node": "Claude API — Draft Follow-up",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Extract — Suggested Posts", "type": "main", "index": 0 }
         ],
         [
-          {
-            "node": "Gmail — Mark as Read",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Gmail — Mark Other Read", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Claude API — Draft Follow-up": {
+
+    "Extract — Reply Context": {
       "main": [
         [
-          {
-            "node": "Merge — Context + Draft",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Filter — Reply Not Ignored", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Merge — Context + Draft": {
+    "Filter — Reply Not Ignored": {
       "main": [
         [
-          {
-            "node": "Gmail — Create Draft Reply",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Claude — Draft Reply", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "Gmail — Mark Reply Read", "type": "main", "index": 0 }
         ]
       ]
     },
-    "Gmail — Create Draft Reply": {
+    "Claude — Draft Reply": {
       "main": [
         [
-          {
-            "node": "Gmail — Mark as Read",
-            "type": "main",
-            "index": 0
-          }
+          { "node": "Merge — Reply + Draft", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Merge — Reply + Draft": {
+      "main": [
+        [
+          { "node": "Gmail — Create Reply Draft", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Gmail — Create Reply Draft": {
+      "main": [
+        [
+          { "node": "Gmail — Mark Reply Read", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+
+    "Extract — Suggested Posts": {
+      "main": [
+        [
+          { "node": "Fetch — Reddit Post JSON", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Fetch — Reddit Post JSON": {
+      "main": [
+        [
+          { "node": "Filter — Post Fetched OK", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Filter — Post Fetched OK": {
+      "main": [
+        [
+          { "node": "Claude — Draft Comment", "type": "main", "index": 0 }
+        ],
+        [
+          { "node": "Gmail — Mark Suggestion Read", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Claude — Draft Comment": {
+      "main": [
+        [
+          { "node": "Merge — Post + Draft", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Merge — Post + Draft": {
+      "main": [
+        [
+          { "node": "Gmail — Create Comment Draft", "type": "main", "index": 0 }
+        ]
+      ]
+    },
+    "Gmail — Create Comment Draft": {
+      "main": [
+        [
+          { "node": "Gmail — Mark Suggestion Read", "type": "main", "index": 0 }
         ]
       ]
     }
@@ -364,7 +440,7 @@
   "pinData": null,
   "versionId": "e328a9d2-6ad5-4b8f-b0e6-967479bd8487",
   "activeVersionId": null,
-  "versionCounter": 1,
+  "versionCounter": 2,
   "triggerCount": 0,
   "tags": [
     {


### PR DESCRIPTION
## Summary
- Router splits Reddit emails: replies, suggestions, noise
- New suggestion branch: extract links → filter PREFERRED_SUBREDDITS → fetch Reddit JSON → Claude drafts comment → create Gmail draft
- Noise emails marked as read immediately
- Reddit JSON API (no auth, append .json to URL)
- Claude SKIP response for irrelevant posts

## Test plan
- [ ] Import to n8n, run workflow with unread Reddit suggestion emails

Generated with [Claude Code](https://claude.com/claude-code)