### PR TITLE
fix: remove billing budget resource causing Terraform 403

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -98,7 +98,6 @@ jobs:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
           TF_VAR_region: ${{ secrets.GCP_REGION }}
           TF_VAR_zone: ${{ secrets.GCP_ZONE }}
-          TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
           TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
           TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}
 

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -66,7 +66,6 @@ jobs:
           TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
           TF_VAR_region: ${{ secrets.GCP_REGION }}
           TF_VAR_zone: ${{ secrets.GCP_ZONE }}
-          TF_VAR_billing_account_id: ${{ secrets.TF_VAR_BILLING_ACCOUNT_ID }}
           TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
           TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}
 

--- a/infrastructure/docs/terraform.md
+++ b/infrastructure/docs/terraform.md
@@ -165,10 +165,9 @@ Binding pattern: each K8s SA is annotated with `iam.gke.io/gcp-service-account=<
 | `cluster_name` | `fenrir-autopilot` | GKE cluster name |
 | `network_name` | (set in var) | VPC name |
 | `artifact_repo_name` | (set in var) | Artifact Registry repo name |
-| `billing_account_id` | — | Required for project/billing association |
 | `uptime_check_host` | — | Hostname for uptime monitoring check |
 
-All variables have defaults except `billing_account_id` and `uptime_check_host` — these must be supplied at apply time (via GitHub Secrets in CI).
+All variables have defaults except `uptime_check_host` — this must be supplied at apply time (via GitHub Secrets in CI).
 
 ### `outputs.tf` — Output Values
 

--- a/infrastructure/example.tfvars
+++ b/infrastructure/example.tfvars
@@ -6,9 +6,6 @@ region             = "us-central1"
 zone               = "us-central1-a"
 cluster_name       = "fenrir-autopilot"
 domain             = "fenrirledger.com"
-billing_account_id = "XXXXXX-XXXXXX-XXXXXX"
-cost_alert_amount  = 150
-
 # Monitoring
 alert_email        = "alerts@fenrirledger.com"
 uptime_check_host  = "34.xxx.xxx.xxx.nip.io"  # GKE Ingress hostname — get from: kubectl get ingress -n fenrir-app

--- a/infrastructure/iam.tf
+++ b/infrastructure/iam.tf
@@ -124,49 +124,6 @@ resource "google_project_iam_member" "deploy_roles" {
 }
 
 # --------------------------------------------------------------------------
-# Cost Alerts — Budget notification
-# --------------------------------------------------------------------------
-
-resource "google_billing_budget" "monthly_budget" {
-  count    = var.billing_account_id != "" ? 1 : 0
-  provider = google-beta
-
-  billing_account = var.billing_account_id
-  display_name    = "Fenrir Ledger Monthly Budget"
-
-  budget_filter {
-    projects = ["projects/${data.google_project.project.number}"]
-  }
-
-  amount {
-    specified_amount {
-      currency_code = "USD"
-      units         = tostring(var.cost_alert_amount)
-    }
-  }
-
-  threshold_rules {
-    threshold_percent = 0.5
-    spend_basis       = "CURRENT_SPEND"
-  }
-
-  threshold_rules {
-    threshold_percent = 0.8
-    spend_basis       = "CURRENT_SPEND"
-  }
-
-  threshold_rules {
-    threshold_percent = 1.0
-    spend_basis       = "CURRENT_SPEND"
-  }
-
-  threshold_rules {
-    threshold_percent = 1.2
-    spend_basis       = "FORECASTED_SPEND"
-  }
-}
-
-# --------------------------------------------------------------------------
 # Data sources
 # --------------------------------------------------------------------------
 

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -56,18 +56,6 @@ variable "deploy_service_account" {
   default     = "fenrir-deploy@fenrir-ledger-prod.iam.gserviceaccount.com"
 }
 
-variable "billing_account_id" {
-  description = "GCP billing account ID (format: XXXXXX-XXXXXX-XXXXXX). If empty, billing budget is skipped."
-  type        = string
-  default     = ""
-}
-
-variable "cost_alert_amount" {
-  description = "Monthly budget amount in USD for cost alerts"
-  type        = number
-  default     = 150
-}
-
 # --------------------------------------------------------------------------
 # Monitoring
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Remove `google_billing_budget` resource from `iam.tf` — deploy SA lacks billing-level IAM permissions
- Remove `billing_account_id` and `cost_alert_amount` variables
- Clean up references in deploy.yml, terraform-plan.yml, example.tfvars, and docs

Billing budgets are managed in the GCP Console directly.

## Test plan
- [ ] Terraform plan shows resource removal, no errors
- [ ] Deploy workflow passes without 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)