### PR TITLE
feat: configure database backups for Firestore, PostgreSQL, and n8n (#2090)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -738,6 +738,45 @@ jobs:
             echo "PVC postgresql-data-postgresql-0 not found yet — skipping PV patch"
           fi
 
+      - name: Setup Terraform (snapshot activation)
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~> 1.9"
+
+      - name: Activate PostgreSQL snapshot policy
+        # Discovers the GCE disk name from the PV's CSI volumeHandle and runs
+        # a targeted terraform apply to attach the pre-defined snapshot policy.
+        # The snapshot policy resource is created by the main terraform job;
+        # this step wires it to the physical disk after Helm provisions the PVC.
+        # Idempotent — safe to run on every deploy. Issue #2090.
+        run: |
+          PV_NAME=$(kubectl get pvc postgresql-data-postgresql-0 \
+            -n fenrir-analytics \
+            -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)
+          if [ -z "$PV_NAME" ]; then
+            echo "PVC not found — skipping snapshot policy activation"
+            exit 0
+          fi
+          DISK_HANDLE=$(kubectl get pv "$PV_NAME" \
+            -o jsonpath='{.spec.csi.volumeHandle}' 2>/dev/null || true)
+          if [ -z "$DISK_HANDLE" ]; then
+            echo "Could not read volumeHandle for PV $PV_NAME — skipping"
+            exit 0
+          fi
+          DISK_NAME="${DISK_HANDLE##*/}"
+          echo "Activating snapshot policy for PostgreSQL disk: $DISK_NAME"
+          cd infrastructure
+          terraform init -input=false -reconfigure
+          export TF_VAR_postgresql_disk_name="$DISK_NAME"
+          terraform apply -input=false -auto-approve \
+            -target=google_compute_disk_resource_policy_attachment.postgresql_snapshot_attachment
+        env:
+          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_region: ${{ secrets.GCP_REGION }}
+          TF_VAR_zone: ${{ secrets.GCP_ZONE }}
+          TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
+          TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}
+
       - name: Verify rollout
         run: |
           echo "### Analytics Deploy" >> $GITHUB_STEP_SUMMARY
@@ -859,6 +898,44 @@ jobs:
           else
             echo "No PVC found in fenrir-marketing yet — skipping PV patch"
           fi
+
+      - name: Setup Terraform (snapshot activation)
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_version: "~> 1.9"
+
+      - name: Activate n8n snapshot policy
+        # Discovers the GCE disk name from the PV's CSI volumeHandle and runs
+        # a targeted terraform apply to attach the pre-defined snapshot policy.
+        # The snapshot policy resource is created by the main terraform job;
+        # this step wires it to the physical disk after Helm provisions the PVC.
+        # Idempotent — safe to run on every deploy. Issue #2090.
+        run: |
+          PV_NAME=$(kubectl get pvc -n fenrir-marketing \
+            -o jsonpath='{.items[0].spec.volumeName}' 2>/dev/null || true)
+          if [ -z "$PV_NAME" ]; then
+            echo "PVC not found — skipping snapshot policy activation"
+            exit 0
+          fi
+          DISK_HANDLE=$(kubectl get pv "$PV_NAME" \
+            -o jsonpath='{.spec.csi.volumeHandle}' 2>/dev/null || true)
+          if [ -z "$DISK_HANDLE" ]; then
+            echo "Could not read volumeHandle for PV $PV_NAME — skipping"
+            exit 0
+          fi
+          DISK_NAME="${DISK_HANDLE##*/}"
+          echo "Activating snapshot policy for n8n disk: $DISK_NAME"
+          cd infrastructure
+          terraform init -input=false -reconfigure
+          export TF_VAR_n8n_disk_name="$DISK_NAME"
+          terraform apply -input=false -auto-approve \
+            -target=google_compute_disk_resource_policy_attachment.n8n_snapshot_attachment
+        env:
+          TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+          TF_VAR_region: ${{ secrets.GCP_REGION }}
+          TF_VAR_zone: ${{ secrets.GCP_ZONE }}
+          TF_VAR_uptime_check_host: ${{ secrets.TF_VAR_UPTIME_CHECK_HOST }}
+          TF_VAR_stripe_api_key: ${{ secrets.STRIPE_SECRET_KEY }}
 
       - name: Verify rollout
         run: |

--- a/infrastructure/docs/database-restore.md
+++ b/infrastructure/docs/database-restore.md
@@ -1,0 +1,280 @@
+# Database Restore Procedures
+
+Fenrir Ledger runs three databases in production. This document describes how to
+restore each one from backup.
+
+---
+
+## 1. Firestore (Primary App Database)
+
+**Collections:** users, households, cards, trials, processedEvents, entitlements
+
+### Backup Configuration
+
+| Setting | Value |
+|---------|-------|
+| Type | Firestore managed backup schedule |
+| Schedule | Daily |
+| Retention | 30 days |
+| PITR window | 35 days |
+| Terraform resource | `google_firestore_backup_schedule.daily` |
+| Database | `fenrir-ledger-prod` |
+
+### List Available Backups
+
+```bash
+gcloud firestore backups list \
+  --location=us-central1 \
+  --project=fenrir-ledger-prod
+```
+
+### Restore to a New Database
+
+Firestore restore creates a **new** database. You cannot restore directly into an
+existing database. After restore, update the app's `FIRESTORE_DB` config to point
+at the restored database and verify before decommissioning the broken one.
+
+```bash
+# 1. Pick a backup from the list above
+BACKUP_NAME="projects/fenrir-ledger-prod/locations/us-central1/backups/<BACKUP_ID>"
+
+# 2. Restore into a new database (takes 5–30 min depending on data size)
+gcloud firestore databases restore \
+  --source-backup="$BACKUP_NAME" \
+  --destination-database="fenrir-ledger-restore-$(date +%Y%m%d)" \
+  --project=fenrir-ledger-prod
+
+# 3. Monitor restore progress
+gcloud firestore operations list \
+  --project=fenrir-ledger-prod
+
+# 4. After verification, update FIRESTORE_DB in the K8s ConfigMap
+kubectl edit configmap fenrir-app-config -n fenrir-app
+# Change FIRESTORE_DB to the restored database name
+
+# 5. Restart the app
+kubectl rollout restart deployment/fenrir-app -n fenrir-app
+```
+
+### Point-in-Time Recovery (PITR)
+
+PITR allows restoring the database to any second within the last **35 days**.
+
+```bash
+# Restore to a specific timestamp (ISO 8601)
+gcloud firestore databases restore \
+  --source-database="fenrir-ledger-prod" \
+  --restore-time="2026-04-01T03:00:00Z" \
+  --destination-database="fenrir-ledger-pitr-$(date +%Y%m%d)" \
+  --project=fenrir-ledger-prod
+```
+
+---
+
+## 2. PostgreSQL for Umami Analytics
+
+**Namespace:** `fenrir-analytics`
+**PVC:** `postgresql-data-postgresql-0`
+**Schedule:** Daily GCE disk snapshot at 03:00 UTC, 7-day retention
+**Terraform resource:** `google_compute_disk_resource_policy_attachment.postgresql_snapshot_attachment`
+
+### List Available Snapshots
+
+```bash
+# Get the disk name
+PV_NAME=$(kubectl get pvc postgresql-data-postgresql-0 \
+  -n fenrir-analytics \
+  -o jsonpath='{.spec.volumeName}')
+DISK_HANDLE=$(kubectl get pv "$PV_NAME" -o jsonpath='{.spec.csi.volumeHandle}')
+DISK_NAME="${DISK_HANDLE##*/}"
+echo "Disk: $DISK_NAME"
+
+# List snapshots for this disk
+gcloud compute snapshots list \
+  --filter="sourceDisk~${DISK_NAME}" \
+  --project=fenrir-ledger-prod \
+  --sort-by=~creationTimestamp \
+  --limit=10
+```
+
+### Restore Procedure
+
+GCE disk snapshots restore by creating a **new disk** from the snapshot, then
+re-binding the PVC to that disk.
+
+```bash
+# 1. Pick a snapshot name from the list above
+SNAPSHOT_NAME="<snapshot-name>"
+ZONE="us-central1-a"
+
+# 2. Create a new disk from the snapshot
+gcloud compute disks create "postgresql-restore-$(date +%Y%m%d)" \
+  --source-snapshot="$SNAPSHOT_NAME" \
+  --zone="$ZONE" \
+  --project=fenrir-ledger-prod
+
+# 3. Scale down PostgreSQL StatefulSet to release the PVC
+kubectl scale statefulset postgresql \
+  -n fenrir-analytics --replicas=0
+
+# 4. Delete the existing PVC (reclaimPolicy=Retain keeps the underlying disk)
+kubectl delete pvc postgresql-data-postgresql-0 -n fenrir-analytics
+
+# 5. Delete the old PV (the GCE disk is retained)
+kubectl delete pv "$PV_NAME"
+
+# 6. Create a new PV pointing at the restored disk
+#    Replace RESTORED_DISK with the disk name from step 2
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: postgresql-restore-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard-rwo-retain
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/fenrir-ledger-prod/zones/${ZONE}/disks/postgresql-restore-$(date +%Y%m%d)
+    fsType: ext4
+  claimRef:
+    namespace: fenrir-analytics
+    name: postgresql-data-postgresql-0
+EOF
+
+# 7. Scale PostgreSQL back up
+kubectl scale statefulset postgresql \
+  -n fenrir-analytics --replicas=1
+
+# 8. Verify
+kubectl rollout status statefulset/postgresql -n fenrir-analytics --timeout=120s
+kubectl get pods -n fenrir-analytics
+```
+
+---
+
+## 3. n8n SQLite (Marketing Automation)
+
+**Namespace:** `fenrir-marketing`
+**PVC:** First PVC in namespace (n8n data volume)
+**Mount:** `/home/node/.n8n` inside the n8n pod
+**Schedule:** Daily GCE disk snapshot at 04:00 UTC, 7-day retention
+**Terraform resource:** `google_compute_disk_resource_policy_attachment.n8n_snapshot_attachment`
+
+### List Available Snapshots
+
+```bash
+# Get the disk name
+PV_NAME=$(kubectl get pvc -n fenrir-marketing \
+  -o jsonpath='{.items[0].spec.volumeName}')
+DISK_HANDLE=$(kubectl get pv "$PV_NAME" -o jsonpath='{.spec.csi.volumeHandle}')
+DISK_NAME="${DISK_HANDLE##*/}"
+echo "Disk: $DISK_NAME"
+
+# List snapshots
+gcloud compute snapshots list \
+  --filter="sourceDisk~${DISK_NAME}" \
+  --project=fenrir-ledger-prod \
+  --sort-by=~creationTimestamp \
+  --limit=10
+```
+
+### Restore Procedure
+
+```bash
+# 1. Pick a snapshot name from the list above
+SNAPSHOT_NAME="<snapshot-name>"
+ZONE="us-central1-a"
+
+# 2. Create a new disk from the snapshot
+gcloud compute disks create "n8n-restore-$(date +%Y%m%d)" \
+  --source-snapshot="$SNAPSHOT_NAME" \
+  --zone="$ZONE" \
+  --project=fenrir-ledger-prod
+
+# 3. Scale down n8n to release the PVC
+kubectl scale deployment n8n -n fenrir-marketing --replicas=0
+
+# 4. Delete PVC (reclaimPolicy=Retain keeps the underlying disk)
+kubectl delete pvc -n fenrir-marketing \
+  $(kubectl get pvc -n fenrir-marketing -o jsonpath='{.items[0].metadata.name}')
+
+# 5. Delete the old PV
+kubectl delete pv "$PV_NAME"
+
+# 6. Create a new PV pointing at the restored disk
+cat <<EOF | kubectl apply -f -
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: n8n-restore-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes: [ReadWriteOnce]
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: standard-rwo-retain
+  csi:
+    driver: pd.csi.storage.gke.io
+    volumeHandle: projects/fenrir-ledger-prod/zones/${ZONE}/disks/n8n-restore-$(date +%Y%m%d)
+    fsType: ext4
+  claimRef:
+    namespace: fenrir-marketing
+    name: n8n-data
+EOF
+
+# 7. Scale n8n back up
+kubectl scale deployment n8n -n fenrir-marketing --replicas=1
+
+# 8. Verify
+kubectl rollout status deployment/n8n -n fenrir-marketing --timeout=120s
+kubectl get pods -n fenrir-marketing
+```
+
+---
+
+## Verifying Backups Are Running
+
+### Firestore
+
+```bash
+# List recent backups — should show backups from the last 30 days
+gcloud firestore backups list \
+  --location=us-central1 \
+  --project=fenrir-ledger-prod
+```
+
+### PostgreSQL & n8n Disk Snapshots
+
+```bash
+# List all auto-snapshots created by the scheduled policies
+gcloud compute snapshots list \
+  --filter="labels.managed-by=terraform" \
+  --project=fenrir-ledger-prod \
+  --sort-by=~creationTimestamp
+```
+
+### Terraform State
+
+```bash
+cd infrastructure
+terraform show | grep -A5 "snapshot_attachment\|backup_schedule"
+```
+
+---
+
+## Snapshot Retention
+
+| Database | Schedule | Retention | Policy resource |
+|----------|----------|-----------|-----------------|
+| Firestore | Daily | 30 days | `google_firestore_backup_schedule.daily` |
+| PostgreSQL | 03:00 UTC daily | 7 days | `google_compute_resource_policy.postgresql_daily_snapshot` |
+| n8n | 04:00 UTC daily | 7 days | `google_compute_resource_policy.n8n_daily_snapshot` |
+
+> **Note:** The issue (#2090) notes that 7-day retention for disk snapshots may be
+> increased to 30 days for production. To increase, update `max_retention_days` in
+> `infrastructure/postgresql-backup.tf` and `infrastructure/n8n-backup.tf` and run
+> `terraform apply`.

--- a/infrastructure/firestore.tf
+++ b/infrastructure/firestore.tf
@@ -18,7 +18,33 @@ resource "google_firestore_database" "main" {
   # Prevent accidental deletion of production data
   deletion_policy = "DELETE"
 
+  # Enable 35-day point-in-time recovery — issue #2090
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+
   depends_on = [google_project_service.apis]
+}
+
+# --------------------------------------------------------------------------
+# Firestore Backup Schedule — daily exports, 30-day retention
+#
+# Firestore managed backups stored in Firestore's backup storage system.
+# Backups can be listed via: gcloud firestore backups list --location=REGION
+# Restore: gcloud firestore databases restore --source-backup=BACKUP_NAME
+#          --destination-database=RESTORE_DB_NAME
+#
+# See infrastructure/docs/database-restore.md for full restore procedures.
+# --------------------------------------------------------------------------
+
+resource "google_firestore_backup_schedule" "daily" {
+  project  = var.project_id
+  database = google_firestore_database.main.name
+
+  # 30 days = 30 * 24 * 60 * 60 = 2,592,000 seconds
+  retention = "2592000s"
+
+  daily_recurrence {}
+
+  depends_on = [google_firestore_database.main]
 }
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Firestore:** Enables 35-day PITR and adds a daily managed backup schedule with 30-day retention via `google_firestore_backup_schedule.daily` and `point_in_time_recovery_enablement` on `google_firestore_database.main`
- **PostgreSQL (Umami):** Snapshot policy was already defined in `postgresql-backup.tf` but never wired to a physical disk. New post-deploy step in the analytics CI job discovers the GCE disk name from the PV's CSI `volumeHandle` and runs a targeted `terraform apply` to activate the attachment
- **n8n (SQLite):** Same pattern — targeted `terraform apply` in the marketing-engine CI job activates the pre-existing `n8n-backup.tf` snapshot policy after Helm provisions the PVC
- **Docs:** `infrastructure/docs/database-restore.md` covering restore procedures for all three databases

## Why post-deploy targeted apply?

The snapshot policy attachment resources use `count = var.xxx_disk_name != "" ? 1 : 0`. The disk name is only known after Helm creates the PVC/PV. The main Terraform job runs before Helm deploys, so the attachment was always skipped. The new steps run after each Helm deploy, discover the disk name, and wire the attachment on every run (idempotent).

## Changed files

| File | Change |
|------|--------|
| `infrastructure/firestore.tf` | Add PITR + `google_firestore_backup_schedule.daily` |
| `.github/workflows/deploy.yml` | Add "Activate PostgreSQL snapshot policy" and "Activate n8n snapshot policy" steps |
| `infrastructure/docs/database-restore.md` | New — restore procedures for all 3 databases |

## Test plan

- [ ] Merge triggers Terraform plan CI — review plan shows `google_firestore_backup_schedule.daily` and PITR attribute change
- [ ] After merge, analytics deploy run shows "Activating snapshot policy for PostgreSQL disk: ..." in logs
- [ ] After merge, marketing-engine deploy run shows "Activating snapshot policy for n8n disk: ..." in logs
- [ ] `gcloud firestore backups list --location=us-central1 --project=fenrir-ledger-prod` returns backups after 24h
- [ ] `gcloud compute snapshots list --filter="labels.managed-by=terraform" --project=fenrir-ledger-prod` shows scheduled snapshots

Closes #2090

🤖 Generated with [Claude Code](https://claude.com/claude-code)