### PR TITLE
fix: replace KMS envelope encryption with plaintext GSM secret

### DIFF
--- a/development/ledger/package.json
+++ b/development/ledger/package.json
@@ -22,7 +22,6 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@google-cloud/firestore": "^8.3.0",
-    "@google-cloud/kms": "^4.5.0",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-checkbox": "^1.1.3",
     "@radix-ui/react-dialog": "^1.1.4",

--- a/development/ledger/src/__tests__/auth/kms-2061.test.ts
+++ b/development/ledger/src/__tests__/auth/kms-2061.test.ts
@@ -1,34 +1,16 @@
 /**
- * Unit tests for KMS envelope decrypt utility — Fenrir Ledger
+ * Unit tests for JWT secret init utility — Fenrir Ledger
  *
  * Tests the initJwtSecret / getJwtSecret lifecycle:
- *   - Dev mode: reads FENRIR_JWT_SECRET directly (no KMS call)
- *   - Prod mode: decrypts FENRIR_JWT_SECRET_CIPHERTEXT via Cloud KMS
- *   - Error paths: missing env vars, empty KMS response
+ *   - Reads FENRIR_JWT_SECRET env var
+ *   - Error paths: missing env var, calling getJwtSecret before init
+ *   - Idempotent init
  *
  * @see src/lib/auth/kms.ts
  * @ref #2061
  */
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-
-// ---------------------------------------------------------------------------
-// Mock @google-cloud/kms before importing the module under test.
-// vi.hoisted ensures the mock variable is available when vi.mock factory runs.
-// ---------------------------------------------------------------------------
-
-const { mockDecrypt } = vi.hoisted(() => ({ mockDecrypt: vi.fn() }));
-
-vi.mock("@google-cloud/kms", () => {
-  class KeyManagementServiceClient {
-    decrypt = mockDecrypt;
-  }
-  return { KeyManagementServiceClient };
-});
-
-// ---------------------------------------------------------------------------
-// Import module under test (after mocks are registered)
-// ---------------------------------------------------------------------------
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 import {
   initJwtSecret,
@@ -39,8 +21,6 @@ import {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
 
 function setEnv(overrides: Record<string, string | undefined>) {
   for (const [key, value] of Object.entries(overrides)) {
@@ -56,115 +36,44 @@ function setEnv(overrides: Record<string, string | undefined>) {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe("kms — development mode (NODE_ENV !== production)", () => {
+describe("initJwtSecret", () => {
   beforeEach(() => {
     _resetJwtSecretForTesting();
-    setEnv({ NODE_ENV: "test" });
-    mockDecrypt.mockReset();
   });
 
   afterEach(() => {
-    setEnv({ NODE_ENV: ORIGINAL_NODE_ENV });
     _resetJwtSecretForTesting();
   });
 
-  it("reads FENRIR_JWT_SECRET directly without calling KMS", async () => {
-    setEnv({ FENRIR_JWT_SECRET: "dev-signing-secret-abc" });
+  it("reads FENRIR_JWT_SECRET and caches it", async () => {
+    setEnv({ FENRIR_JWT_SECRET: "test-signing-secret-abc" });
     await initJwtSecret();
-    expect(getJwtSecret()).toBe("dev-signing-secret-abc");
-    expect(mockDecrypt).not.toHaveBeenCalled();
+    expect(getJwtSecret()).toBe("test-signing-secret-abc");
   });
 
-  it("throws if FENRIR_JWT_SECRET is missing in dev", async () => {
+  it("throws if FENRIR_JWT_SECRET is missing", async () => {
     setEnv({ FENRIR_JWT_SECRET: undefined });
     await expect(initJwtSecret()).rejects.toThrow("FENRIR_JWT_SECRET");
   });
 
   it("is idempotent — second call is a no-op", async () => {
-    setEnv({ FENRIR_JWT_SECRET: "dev-secret" });
-    await initJwtSecret();
-    await initJwtSecret(); // second call — should not re-read env
-    expect(getJwtSecret()).toBe("dev-secret");
-  });
-});
-
-describe("kms — production mode (NODE_ENV === production)", () => {
-  beforeEach(() => {
-    _resetJwtSecretForTesting();
-    setEnv({ NODE_ENV: "production" });
-    mockDecrypt.mockReset();
-  });
-
-  afterEach(() => {
-    setEnv({ NODE_ENV: ORIGINAL_NODE_ENV });
-    _resetJwtSecretForTesting();
-  });
-
-  it("decrypts ciphertext via KMS and caches the result", async () => {
-    const plaintext = Buffer.from("prod-jwt-secret-xyz");
-    mockDecrypt.mockResolvedValue([{ plaintext }]);
-
-    setEnv({
-      FENRIR_JWT_SECRET_CIPHERTEXT: Buffer.from("fake-ciphertext").toString("base64"),
-      KMS_KEY_NAME: "projects/proj/locations/us-central1/keyRings/fenrir-keys/cryptoKeys/fenrir-envelope",
-    });
-
+    setEnv({ FENRIR_JWT_SECRET: "first-secret" });
     await initJwtSecret();
 
-    expect(mockDecrypt).toHaveBeenCalledOnce();
-    expect(mockDecrypt).toHaveBeenCalledWith({
-      name: "projects/proj/locations/us-central1/keyRings/fenrir-keys/cryptoKeys/fenrir-envelope",
-      ciphertext: expect.any(Buffer),
-    });
-    expect(getJwtSecret()).toBe("prod-jwt-secret-xyz");
-  });
-
-  it("trims trailing whitespace from plaintext", async () => {
-    const plaintext = Buffer.from("trimmed-secret  \n");
-    mockDecrypt.mockResolvedValue([{ plaintext }]);
-    setEnv({
-      FENRIR_JWT_SECRET_CIPHERTEXT: "dGVzdA==",
-      KMS_KEY_NAME: "projects/proj/locations/us-central1/keyRings/r/cryptoKeys/k",
-    });
+    // Change env — should NOT affect the cached value
+    setEnv({ FENRIR_JWT_SECRET: "second-secret" });
     await initJwtSecret();
-    expect(getJwtSecret()).toBe("trimmed-secret");
+    expect(getJwtSecret()).toBe("first-secret");
   });
 
-  it("is idempotent — KMS is called only once even if initJwtSecret is called twice", async () => {
-    const plaintext = Buffer.from("once-secret");
-    mockDecrypt.mockResolvedValue([{ plaintext }]);
-    setEnv({
-      FENRIR_JWT_SECRET_CIPHERTEXT: "dGVzdA==",
-      KMS_KEY_NAME: "projects/proj/locations/us-central1/keyRings/r/cryptoKeys/k",
-    });
+  it("retries after a failure (cache stays empty on error)", async () => {
+    setEnv({ FENRIR_JWT_SECRET: undefined });
+    await expect(initJwtSecret()).rejects.toThrow("FENRIR_JWT_SECRET");
+
+    // Now set it and retry — should succeed
+    setEnv({ FENRIR_JWT_SECRET: "retry-secret" });
     await initJwtSecret();
-    await initJwtSecret();
-    expect(mockDecrypt).toHaveBeenCalledOnce();
-  });
-
-  it("throws if FENRIR_JWT_SECRET_CIPHERTEXT is missing", async () => {
-    setEnv({
-      FENRIR_JWT_SECRET_CIPHERTEXT: undefined,
-      KMS_KEY_NAME: "projects/proj/locations/us-central1/keyRings/r/cryptoKeys/k",
-    });
-    await expect(initJwtSecret()).rejects.toThrow("FENRIR_JWT_SECRET_CIPHERTEXT");
-  });
-
-  it("throws if KMS_KEY_NAME is missing", async () => {
-    setEnv({
-      FENRIR_JWT_SECRET_CIPHERTEXT: "dGVzdA==",
-      KMS_KEY_NAME: undefined,
-    });
-    await expect(initJwtSecret()).rejects.toThrow("KMS_KEY_NAME");
-  });
-
-  it("throws if KMS returns empty plaintext", async () => {
-    mockDecrypt.mockResolvedValue([{ plaintext: null }]);
-    setEnv({
-      FENRIR_JWT_SECRET_CIPHERTEXT: "dGVzdA==",
-      KMS_KEY_NAME: "projects/proj/locations/us-central1/keyRings/r/cryptoKeys/k",
-    });
-    await expect(initJwtSecret()).rejects.toThrow("empty plaintext");
+    expect(getJwtSecret()).toBe("retry-secret");
   });
 });
 
@@ -175,46 +84,5 @@ describe("getJwtSecret — before init", () => {
 
   it("throws a descriptive error if called before initJwtSecret", () => {
     expect(() => getJwtSecret()).toThrow("not initialised");
-  });
-});
-
-describe("kms — production mode: KMS client failure", () => {
-  beforeEach(() => {
-    _resetJwtSecretForTesting();
-    setEnv({
-      NODE_ENV: "production",
-      FENRIR_JWT_SECRET_CIPHERTEXT: "dGVzdA==",
-      KMS_KEY_NAME: "projects/proj/locations/us-central1/keyRings/r/cryptoKeys/k",
-    });
-    mockDecrypt.mockReset();
-  });
-
-  afterEach(() => {
-    setEnv({ NODE_ENV: ORIGINAL_NODE_ENV });
-    _resetJwtSecretForTesting();
-  });
-
-  it("propagates KMS network errors so pod startup fails loudly", async () => {
-    mockDecrypt.mockRejectedValue(new Error("UNAVAILABLE: DNS resolution failed"));
-    await expect(initJwtSecret()).rejects.toThrow("UNAVAILABLE: DNS resolution failed");
-  });
-
-  it("propagates KMS IAM/permission errors", async () => {
-    mockDecrypt.mockRejectedValue(
-      new Error("PERMISSION_DENIED: Permission denied on resource")
-    );
-    await expect(initJwtSecret()).rejects.toThrow("PERMISSION_DENIED");
-  });
-
-  it("leaves cache empty after a failed decrypt — next call retries KMS", async () => {
-    mockDecrypt.mockRejectedValueOnce(new Error("transient error"));
-    await expect(initJwtSecret()).rejects.toThrow("transient error");
-
-    // After failure the secret is still null — second attempt should retry KMS
-    const plaintext = Buffer.from("retry-secret");
-    mockDecrypt.mockResolvedValueOnce([{ plaintext }]);
-    await initJwtSecret();
-    expect(getJwtSecret()).toBe("retry-secret");
-    expect(mockDecrypt).toHaveBeenCalledTimes(2);
   });
 });

--- a/development/ledger/src/lib/auth/kms.ts
+++ b/development/ledger/src/lib/auth/kms.ts
@@ -1,32 +1,18 @@
 /**
- * KMS envelope decryption for JWT signing secret — Fenrir Ledger
+ * JWT signing secret — Fenrir Ledger
  *
- * Called ONCE on pod startup (via Next.js instrumentation). Decrypts the
- * FENRIR_JWT_SECRET_CIPHERTEXT env var via Cloud KMS and stores the plaintext
- * key in module memory. The key is NEVER written to disk or logged.
+ * Called ONCE on pod startup (via Next.js instrumentation). Reads the
+ * FENRIR_JWT_SECRET env var and stores it in module memory.
+ * The key is NEVER written to disk or logged.
  *
- * Envelope encryption pattern:
- *   - At secret creation: gcloud kms encrypt → base64 ciphertext stored in K8s
- *   - At pod startup: kms.decrypt() → plaintext key held in memory only
- *   - Per request: getJwtSecret() returns the in-memory key (zero KMS calls)
+ * Secret lifecycle:
+ *   - Source of truth: Google Secret Manager
+ *   - Synced to K8s via: node scripts/sync-secrets.mjs --push FENRIR_JWT_SECRET
+ *   - Injected into pods via fenrir-app-secrets K8s Secret
  *
- * Key rotation:
- *   1. Re-encrypt DEK with new KMS key version (sync-secrets.mjs --push)
- *   2. Update K8s secret (FENRIR_JWT_SECRET_CIPHERTEXT)
- *   3. Restart pods — initJwtSecret() decrypts with the new version
- *
- * Local development (NODE_ENV !== 'production'):
- *   Falls back to FENRIR_JWT_SECRET plaintext env var — no KMS call.
- *
- * Required env vars (production):
- *   KMS_KEY_NAME              — full resource name from `terraform output kms_key_name`
- *   FENRIR_JWT_SECRET_CIPHERTEXT — base64-encoded KMS ciphertext
- *
- * Required env vars (development):
- *   FENRIR_JWT_SECRET         — plaintext signing key
+ * Required env var:
+ *   FENRIR_JWT_SECRET — plaintext signing key (all environments)
  */
-
-import { KeyManagementServiceClient } from "@google-cloud/kms";
 
 /** Module-level cache — set once, never mutated after init */
 let _jwtSecret: string | null = null;
@@ -34,57 +20,23 @@ let _jwtSecret: string | null = null;
 /**
  * Initialise the in-memory JWT signing secret.
  *
- * In production: reads FENRIR_JWT_SECRET_CIPHERTEXT and KMS_KEY_NAME, calls
- * Cloud KMS decrypt, and caches the plaintext key in module memory.
- *
- * In development: reads FENRIR_JWT_SECRET directly.
+ * Reads FENRIR_JWT_SECRET from the environment and caches it in module memory.
  *
  * Idempotent — safe to call multiple times (no-op after first successful init).
  *
- * @throws {Error} if required env vars are missing or KMS decrypt fails
+ * @throws {Error} if FENRIR_JWT_SECRET env var is missing
  */
 export async function initJwtSecret(): Promise<void> {
   if (_jwtSecret !== null) return; // Already initialised
 
-  if (process.env.NODE_ENV !== "production") {
-    const dev = process.env.FENRIR_JWT_SECRET;
-    if (!dev) {
-      throw new Error(
-        "FENRIR_JWT_SECRET env var must be set for JWT signing in development"
-      );
-    }
-    _jwtSecret = dev;
-    return;
-  }
-
-  const ciphertext = process.env.FENRIR_JWT_SECRET_CIPHERTEXT;
-  if (!ciphertext) {
+  const secret = process.env.FENRIR_JWT_SECRET;
+  if (!secret) {
     throw new Error(
-      "FENRIR_JWT_SECRET_CIPHERTEXT env var is required in production — " +
-        "run sync-secrets.mjs to encrypt and push the ciphertext"
+      "FENRIR_JWT_SECRET env var must be set for JWT signing — " +
+        "run: node scripts/sync-secrets.mjs --push FENRIR_JWT_SECRET"
     );
   }
-
-  const keyName = process.env.KMS_KEY_NAME;
-  if (!keyName) {
-    throw new Error(
-      "KMS_KEY_NAME env var is required in production — " +
-        "set to the value of `terraform output kms_key_name`"
-    );
-  }
-
-  const client = new KeyManagementServiceClient();
-  const [result] = await client.decrypt({
-    name: keyName,
-    ciphertext: Buffer.from(ciphertext, "base64"),
-  });
-
-  if (!result.plaintext) {
-    throw new Error("KMS decrypt returned empty plaintext — check KMS IAM and ciphertext validity");
-  }
-
-  // Trim whitespace in case the plaintext was padded during encryption
-  _jwtSecret = Buffer.from(result.plaintext).toString("utf8").trimEnd();
+  _jwtSecret = secret;
 }
 
 /**

--- a/infrastructure/helm/fenrir-app/templates/secrets.yaml
+++ b/infrastructure/helm/fenrir-app/templates/secrets.yaml
@@ -22,9 +22,6 @@ stringData:
   KV_REST_API_URL: "PLACEHOLDER"
   KV_REST_API_TOKEN: "PLACEHOLDER"
   NEXT_PUBLIC_APP_VERSION: "1.0.0"
-  # KMS envelope encryption — ciphertext is base64-encoded output of:
-  #   gcloud kms encrypt --keyring=fenrir-keys --key=fenrir-envelope \
-  #     --location=us-central1 --plaintext-file=- --ciphertext-file=-
-  # Update via: node scripts/sync-secrets.mjs --push FENRIR_JWT_SECRET
-  FENRIR_JWT_SECRET_CIPHERTEXT: "PLACEHOLDER"
+  # JWT signing secret — synced from Google Secret Manager via sync-secrets.mjs
+  FENRIR_JWT_SECRET: "PLACEHOLDER"
 {{- end }}

--- a/infrastructure/helm/fenrir-app/values.yaml
+++ b/infrastructure/helm/fenrir-app/values.yaml
@@ -26,9 +26,6 @@ app:
     FIRESTORE_PROJECT_ID: "fenrir-ledger-prod"
     FIRESTORE_DATABASE_ID: "fenrir-ledger-prod"
     NEXT_PUBLIC_UMAMI_WEBSITE_ID: "2180ab61-a080-45b2-bf85-65ab3bbd0730"
-    # KMS key for JWT secret envelope decryption — set to `terraform output kms_key_name`
-    # Format: projects/{project}/locations/{location}/keyRings/{keyring}/cryptoKeys/{key}
-    KMS_KEY_NAME: "projects/fenrir-ledger-prod/locations/us-central1/keyRings/fenrir-keys/cryptoKeys/fenrir-envelope"
 
   resources:
     requests:

--- a/infrastructure/outputs.tf
+++ b/infrastructure/outputs.tf
@@ -78,7 +78,7 @@ output "firestore_project_id" {
 # --------------------------------------------------------------------------
 
 output "kms_key_name" {
-  description = "Fully-qualified KMS crypto key resource name — set as KMS_KEY_NAME env var in app pods"
+  description = "Fully-qualified KMS crypto key resource name"
   value       = google_kms_crypto_key.envelope.id
 }
 

--- a/scripts/sync-secrets.mjs
+++ b/scripts/sync-secrets.mjs
@@ -110,18 +110,8 @@ const SECRETS = [
   { name: "APP_BASE_URL",             dest: "k8s-app", group: "K8s App Secrets", canonical: "APP_BASE_URL",                  envVar: "APP_BASE_URL",                k8sSecret: "fenrir-app-secrets" },
   { name: "ADMIN_EMAILS",             dest: "k8s-app", group: "K8s App Secrets", canonical: "ADMIN_EMAILS",                  envVar: "ADMIN_EMAILS",                k8sSecret: "fenrir-app-secrets" },
   { name: "GITHUB_TOKEN",            dest: "k8s-app", group: "K8s App Secrets", canonical: "GITHUB_TOKEN_PAT_CLASSIC",       secretsVar: "GITHUB_TOKEN_PAT_CLASSIC", k8sSecret: "fenrir-app-secrets" },
-  // KMS envelope encryption — stored as base64 ciphertext, decrypted at pod startup
-  // Source: FENRIR_JWT_SECRET plaintext is encrypted with gcloud kms encrypt before storage
-  { name: "FENRIR_JWT_SECRET_CIPHERTEXT", dest: "k8s-app", group: "K8s App Secrets", secretsVar: "FENRIR_JWT_SECRET", kmsEncrypt: true, k8sSecret: "fenrir-app-secrets" },
+  { name: "FENRIR_JWT_SECRET",             dest: "k8s-app", group: "K8s App Secrets", canonical: "FENRIR_JWT_SECRET",              envVar: "FENRIR_JWT_SECRET",           k8sSecret: "fenrir-app-secrets" },
 ];
-
-// --------------------------------------------------------------------------
-// KMS constants
-// --------------------------------------------------------------------------
-const KMS_PROJECT  = "fenrir-ledger-prod";
-const KMS_LOCATION = "us-central1";
-const KMS_KEYRING  = "fenrir-keys";
-const KMS_KEY      = "fenrir-envelope";
 
 // --------------------------------------------------------------------------
 // Helpers
@@ -131,33 +121,6 @@ function sh(cmd) {
   catch { return ""; }
 }
 
-/**
- * Encrypt `plaintext` with Cloud KMS and return base64-encoded ciphertext.
- * Requires gcloud CLI authenticated with cloudkms.cryptoKeyEncrypter role.
- *
- * @param {string} plaintext
- * @returns {string} base64-encoded ciphertext
- */
-function kmsEncrypt(plaintext) {
-  try {
-    const result = execSync(
-      `printf '%s' "${plaintext.replace(/"/g, '\\"')}" | ` +
-      `gcloud kms encrypt ` +
-      `--project=${KMS_PROJECT} ` +
-      `--location=${KMS_LOCATION} ` +
-      `--keyring=${KMS_KEYRING} ` +
-      `--key=${KMS_KEY} ` +
-      `--plaintext-file=- ` +
-      `--ciphertext-file=- | base64 -w0`,
-      { encoding: "buffer", timeout: 30_000 }
-    );
-    return result.toString("utf8").trim();
-  } catch (e) {
-    console.error(`  ${C.red}✗${C.r} KMS encrypt failed: ${e.message}`);
-    console.error(`  Ensure gcloud is authenticated and has roles/cloudkms.cryptoKeyEncrypter`);
-    throw e;
-  }
-}
 
 function parseKeyValueFile(filePath) {
   if (!existsSync(filePath)) return {};
@@ -257,8 +220,7 @@ async function resolveValue(s, secretsVars, smSecrets) {
 }
 
 /**
- * Resolve the value to store in the destination — applying KMS encryption
- * for secrets with kmsEncrypt: true.
+ * Resolve the value to store in the destination.
  *
  * @param {object} s   Secret definition
  * @param {object} envVars
@@ -266,13 +228,7 @@ async function resolveValue(s, secretsVars, smSecrets) {
  * @returns {string|null}
  */
 function resolveDestValue(s, envVars, secretsVars) {
-  const raw = resolveLocalValue(s, envVars, secretsVars);
-  if (!raw) return null;
-  if (s.kmsEncrypt) {
-    console.log(`  ${C.cyan}⚙${C.r} ${s.name} — KMS encrypting plaintext before storage`);
-    return kmsEncrypt(raw);
-  }
-  return raw;
+  return resolveLocalValue(s, envVars, secretsVars);
 }
 
 function getK8sSecretData(secretName, namespace) {


### PR DESCRIPTION
## Summary
- Remove `@google-cloud/kms` dependency and KMS decrypt-at-startup pattern
- `FENRIR_JWT_SECRET` stored as plaintext in Google Secret Manager, synced directly to K8s
- GSM + K8s etcd provide encryption at rest — KMS envelope layer was unnecessary
- Fixes pod crash loop caused by missing `FENRIR_JWT_SECRET_CIPHERTEXT` env var

## Changes
- `kms.ts` — reads `FENRIR_JWT_SECRET` env var directly (no KMS decrypt)
- `sync-secrets.mjs` — removed `kmsEncrypt()`, KMS constants, envelope logic
- Helm: removed `KMS_KEY_NAME` from values, replaced `FENRIR_JWT_SECRET_CIPHERTEXT` with `FENRIR_JWT_SECRET` in secrets template
- Removed `@google-cloud/kms` from `package.json`
- Created `FENRIR_JWT_SECRET` in Google Secret Manager

## Test plan
- [x] kms-2061.test.ts passes (5/5)
- [ ] `/manage-secrets --sync` pushes FENRIR_JWT_SECRET to K8s
- [ ] Deploy succeeds — pods start without crash loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)