### PR TITLE
fix: add FENRIR_JWT_SECRET to deploy workflow secrets sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -433,6 +433,7 @@ jobs:
             --from-literal=NEXT_PUBLIC_APP_VERSION="${{ github.sha }}" \
             --from-literal=GITHUB_TOKEN="${{ secrets.GH_TOKEN_AGENTS }}" \
             --from-literal=ADMIN_EMAILS="${{ secrets.ADMIN_EMAILS }}" \
+            --from-literal=FENRIR_JWT_SECRET="${{ secrets.FENRIR_JWT_SECRET }}" \
             --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Sync agent secrets


### PR DESCRIPTION
## Summary
- Add `FENRIR_JWT_SECRET` to the deploy workflow's "Sync app secrets" kubectl step
- The step replaces the entire K8s secret, so any key not listed gets wiped
- This was causing pod crash loops after the KMS→GSM migration (#2092)

## Test plan
- [ ] Deploy succeeds, pods start without crash loop
- [ ] `kubectl get secret fenrir-app-secrets -n fenrir-app -o json | jq '.data | keys'` includes FENRIR_JWT_SECRET

🤖 Generated with [Claude Code](https://claude.com/claude-code)