### PR TITLE
fix: match displayed subreddit names instead of obfuscated URLs

### DIFF
--- a/infrastructure/n8n/workflows/gmail-reddit-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-reddit-monitor.json
@@ -81,7 +81,7 @@
     },
     {
       "parameters": {
-        "jsCode": "// Check if the email contains links to posts in preferred subreddits\nconst PREFERRED = new Set(\n  ($env.PREFERRED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst item = $input.first();\nconst htmlBody = item.json.html || item.json.textAsHtml || item.json.body || '';\n\n// Check if any links match preferred subs\nconst linkRegex = /href=[\"'](https?:\\/\\/(?:www\\.)?reddit\\.com\\/r\\/([^/]+)\\/comments\\/[^\"']*)[\"']/gi;\nlet hasPreferred = false;\nlet match;\nwhile ((match = linkRegex.exec(htmlBody)) !== null) {\n  const sub = 'r/' + match[2];\n  if (PREFERRED.size === 0 || PREFERRED.has(sub.toLowerCase())) {\n    hasPreferred = true;\n    break;\n  }\n}\n\nreturn [{ json: { ...item.json, hasPreferred } }];"
+        "jsCode": "// Check if the email contains displayed subreddit names matching preferred subs.\n// Reddit emails use click.redditmail.com tracking links, so we match the\n// visible text (e.g. >r/churning<) instead of href URLs.\nconst PREFERRED = new Set(\n  ($env.PREFERRED_SUBREDDITS || '').split(',').map(s => s.trim().toLowerCase()).filter(Boolean)\n);\n\nconst item = $input.first();\nconst htmlBody = item.json.html || item.json.textAsHtml || item.json.body || '';\n\n// Match displayed subreddit names like >r/churning< or >r/CreditCards<\nconst subRegex = />r\\/([A-Za-z0-9_]+)</gi;\nlet hasPreferred = false;\nlet match;\nwhile ((match = subRegex.exec(htmlBody)) !== null) {\n  const sub = 'r/' + match[1].toLowerCase();\n  if (PREFERRED.size === 0 || PREFERRED.has(sub)) {\n    hasPreferred = true;\n    break;\n  }\n}\n\nreturn [{ json: { ...item.json, hasPreferred } }];"
       },
       "id": "a1b2c3d4-0021-4000-8000-000000000021",
       "name": "Check \u2014 Has Preferred Sub?",
@@ -91,7 +91,7 @@
         912,
         416
       ],
-      "notes": "For non-reply emails: checks if it's a suggestion email with links to preferred subreddits."
+      "notes": "For non-reply emails: checks displayed subreddit names (not href URLs) against preferred list."
     },
     {
       "parameters": {


### PR DESCRIPTION
## Summary
- Reddit emails use `click.redditmail.com` tracking URLs — href-based regex never matched
- Now scans for visible subreddit text (`>r/churning<`) in HTML body instead
- Verified against real Reddit email — correctly finds r/AmexPlatinum, r/CapitalOne_, r/mtg, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)