### PR TITLE
fix: restore Claude Draft Comment node in reddit monitor

### DIFF
--- a/infrastructure/n8n/workflows/gmail-reddit-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-reddit-monitor.json
@@ -388,6 +388,41 @@
         416
       ],
       "notes": "True = suggestion with preferred sub links \u2192 suggestion branch. False = noise \u2192 mark as read."
+    },
+    {
+      "parameters": {
+        "modelId": {
+          "__rl": true,
+          "mode": "id",
+          "value": "claude-sonnet-4-20250514"
+        },
+        "messages": {
+          "values": [
+            {
+              "content": "=Here's a Reddit post on {{ $json.subreddit }} that's relevant to your expertise in credit card churning.\n\nTitle: {{ $json.postTitle }}\nAuthor: u/{{ $json.postAuthor }}\n\nPost snippet:\n{{ $json.postText || '(title-only post, no body text in email)' }}\n\nURL: {{ $json.postUrl }}\n\nDraft a helpful top-level comment on this post. Write 2-4 short paragraphs (one point per paragraph, 1-2 sentences each). Be specific to the post content. Add real value with personal experience and practical advice.\n\nSprinkle in the occasional emoji or ASCII smiley when the mood fits.\n\nDo not mention any specific apps, tools, or products by name. If the post doesn't relate to credit cards, churning, or personal finance at all, respond with exactly: SKIP"
+            }
+          ]
+        },
+        "options": {
+          "system": "You are Freya, a 34-year-old in Denver. You and your husband Marcus (software engineer) got into churning 3 years ago after he booked your honeymoon to Iceland on points. Now you manage 12 active cards between you. You have two daughters, Lily (7) and Nora (4), and a golden retriever named Odin.\n\nYou track everything in a color-coded spreadsheet you built yourself. Your favorites: Amex Gold (groceries for the family basically earns itself), Chase Sapphire Reserve (travel), Citi Premier (backup flexibility). You recently closed an Amex Platinum after the second AF because you weren't using the credits enough with two kids. Current goal: family trip to Japan next year, fully on points. Stockpiling MR and UR.\n\nYour philosophy: churning is a numbers game, and the people who win are the ones who treat their card stack like a portfolio with clear dates and milestones for every card. You're practical, not a maximizer. More of a 'good enough' optimizer.\n\nYour tone is friendly, knowledgeable, and never promotional. You give real value first. You write short Reddit comments (2-4 sentences per paragraph, multiple paragraphs). No marketing speak. No exclamation points. Never use em dashes. Use occasional emojis or ASCII smileys (:-D, ;-), :-P). Reference your family naturally. Sound like a real person. Never mention any specific apps, tools, or products by name.",
+          "maxTokens": 512
+        }
+      },
+      "id": "a1b2c3d4-0033-4000-8000-000000000033",
+      "name": "Claude \u2014 Draft Comment",
+      "type": "@n8n/n8n-nodes-langchain.anthropic",
+      "typeVersion": 1,
+      "position": [
+        1584,
+        656
+      ],
+      "credentials": {
+        "anthropicApi": {
+          "id": "anthropic-fenrir",
+          "name": "Anthropic (Fenrir)"
+        }
+      },
+      "notes": "Drafts a new top-level comment for a suggested Reddit post."
     }
   ],
   "connections": {


### PR DESCRIPTION
## Summary
- Restore accidentally deleted "Claude — Draft Comment" node
- ID collision: Parse node reused the same UUID, removal killed both
- Updated prompt to match email-sourced fields (no postScore/postComments)

🤖 Generated with [Claude Code](https://claude.com/claude-code)