### PR TITLE
fix: remove spurious Extract -> Mark Read connection

### DIFF
--- a/infrastructure/n8n/workflows/gmail-reddit-monitor.json
+++ b/infrastructure/n8n/workflows/gmail-reddit-monitor.json
@@ -546,11 +546,6 @@
             "node": "Claude \u2014 Draft Comment",
             "type": "main",
             "index": 0
-          },
-          {
-            "node": "Gmail \u2014 Mark Suggestion Read",
-            "type": "main",
-            "index": 0
           }
         ]
       ]


### PR DESCRIPTION
## Summary
- Remove direct Extract — Suggested Posts -> Gmail — Mark Suggestion Read connection
- Mark Read already happens correctly at end of pipeline: Claude -> Merge -> Create Draft -> Mark Read

🤖 Generated with [Claude Code](https://claude.com/claude-code)