### PR TITLE
fix: JWT secret init blocked by NEXT_RUNTIME guard in standalone mode

### DIFF
--- a/development/ledger/src/instrumentation.ts
+++ b/development/ledger/src/instrumentation.ts
@@ -9,9 +9,17 @@
  */
 
 export async function register(): Promise<void> {
-  // Only runs on the Node.js runtime (not Edge)
-  if (process.env.NEXT_RUNTIME === "nodejs") {
+  // Runs on server startup. Skip only if explicitly Edge runtime.
+  // NEXT_RUNTIME may not be set in standalone mode at register() time,
+  // so we default to running unless we know we're on Edge.
+  if (process.env.NEXT_RUNTIME === "edge") return;
+
+  try {
     const { initJwtSecret } = await import("./lib/auth/kms");
     await initJwtSecret();
+    console.log("[instrumentation] JWT secret initialised");
+  } catch (err) {
+    // Log but don't crash the server — fallback to Google tokens still works
+    console.error("[instrumentation] Failed to init JWT secret:", err instanceof Error ? err.message : err);
   }
 }


### PR DESCRIPTION
## Summary
- `register()` checked `NEXT_RUNTIME === "nodejs"` but standalone mode doesn't set this env var
- Changed to skip only on Edge runtime (`=== "edge"`)
- Added try/catch so server doesn't crash if JWT secret is missing (graceful fallback)
- Added console.log for successful init to confirm in pod logs

## Root cause
Pod logs showed: `mintFenrirSessionResponse: failed — JWT secret not initialised`
The env var `FENRIR_JWT_SECRET` was present in the pod but `initJwtSecret()` never ran.

## Test plan
- [ ] Deploy, check pod logs for `[instrumentation] JWT secret initialised`
- [ ] Login flow mints Fenrir JWT (no more "returning raw Google response" warning)

Generated with [Claude Code](https://claude.com/claude-code)