### PR TITLE
fix: update instrumentation test for standalone mode

### DIFF
--- a/development/ledger/src/__tests__/instrumentation-2061.test.ts
+++ b/development/ledger/src/__tests__/instrumentation-2061.test.ts
@@ -1,8 +1,9 @@
 /**
  * Tests for Next.js instrumentation startup hook — Fenrir Ledger
  *
- * Validates that register() correctly guards the KMS init call behind
- * the Node.js runtime check (NEXT_RUNTIME === 'nodejs').
+ * Validates that register() calls initJwtSecret() on all runtimes
+ * except Edge. In standalone mode, NEXT_RUNTIME may not be set,
+ * so register() defaults to running.
  *
  * @see src/instrumentation.ts
  * @ref #2061
@@ -55,10 +56,10 @@ describe("instrumentation register() — runtime guard", () => {
     expect(mockInitJwtSecret).not.toHaveBeenCalled();
   });
 
-  it("does NOT call initJwtSecret when NEXT_RUNTIME is undefined", async () => {
+  it("calls initJwtSecret when NEXT_RUNTIME is undefined (standalone mode)", async () => {
     delete process.env.NEXT_RUNTIME;
     const { register } = await import("../instrumentation");
     await register();
-    expect(mockInitJwtSecret).not.toHaveBeenCalled();
+    expect(mockInitJwtSecret).toHaveBeenCalledOnce();
   });
 });


### PR DESCRIPTION
## Summary
- Test asserted old behavior (skip when NEXT_RUNTIME undefined)
- Updated to match #2107 fix (call initJwtSecret when NEXT_RUNTIME undefined)
- This was blocking all deploys

Generated with [Claude Code](https://claude.com/claude-code)