### PR TITLE
chore: run tests parallel with build in deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -281,8 +281,8 @@ jobs:
 
   app-pre-deploy-tests:
     name: "App: Pre-Deploy Tests"
-    needs: [build-app-image]
-    if: needs.build-app-image.result == 'success'
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.app == 'true' || needs.detect-changes.outputs.k8s-app == 'true'
     runs-on: ubuntu-latest
     env:
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${{ secrets.NEXT_PUBLIC_GOOGLE_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- Pre-deploy tests now depend on `detect-changes` (not `build-app-image`)
- Build and tests run in parallel
- Deploy job still waits for both to pass
- Saves ~3-4 min per deploy

Generated with [Claude Code](https://claude.com/claude-code)