### PR TITLE
Issue #2125 - fix: swap Households/Users tab order in Odin's Spear

### DIFF
--- a/development/odins-spear/src/app.tsx
+++ b/development/odins-spear/src/app.tsx
@@ -282,13 +282,6 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
     );
   } else if (activeTab === 0) {
     mainContent = (
-      <UsersTab
-        cmdStatus={cmdStatus}
-        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(1); }}
-      />
-    );
-  } else {
-    mainContent = (
       <HouseholdsTab
         cmdStatus={cmdStatus}
         initialHouseholdId={jumpHouseholdId}
@@ -299,6 +292,13 @@ function SpearInner({ initialConnStatus, initialCounts }: SpearInnerProps): Reac
           const cmd = getCommands().find((c) => c.name === "trial-adjust");
           if (cmd) handleTrialInput(cmd);
         }}
+      />
+    );
+  } else {
+    mainContent = (
+      <UsersTab
+        cmdStatus={cmdStatus}
+        onJumpToHousehold={(householdId) => { setJumpHouseholdId(householdId); setActiveTab(0); }}
       />
     );
   }

--- a/development/odins-spear/src/components/TopBar.tsx
+++ b/development/odins-spear/src/components/TopBar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Box, Text } from "ink";
 import { log } from "@fenrir/logger";
 
-const TUI_TABS = ["Users", "Households"];
+const TUI_TABS = ["Households", "Users"];
 const GOLD = "#c9920a";
 const GRAY = "#6b6b80";
 


### PR DESCRIPTION
PR for issue: #2125

Swaps tab order so Households is the default view, Users is secondary.

**Changes:**
- `TopBar.tsx`: Reordered `TUI_TABS` array — Households first, Users second
- `app.tsx`: Swapped rendered components so `activeTab === 0` renders `HouseholdsTab`
- `app.tsx`: Fixed `onJumpToHousehold` callback to target tab 0 (Households) after the swap

**Verification:**
- Open Odin's Spear — should start on Households view
- Press Tab — should switch to Users view
- `onJumpToHousehold` from Users tab correctly navigates to Households (tab 0)