### PR TITLE
Issue #2137 - feat: add namespace selector for multi-project agent monitoring

### DIFF
--- a/development/odins-throne/src/index.ts
+++ b/development/odins-throne/src/index.ts
@@ -7,8 +7,43 @@ import { attachWebSocketServer } from "./ws.js";
 const app = new Hono();
 
 const PORT = parseInt(process.env.PORT ?? "3001", 10);
-const NAMESPACE = process.env.K8S_NAMESPACE ?? "fenrir-agents";
+const DEFAULT_NAMESPACE = process.env.K8S_NAMESPACE ?? "fenrir-agents";
 const JOB_LABEL = process.env.JOB_LABEL_SELECTOR ?? "app.kubernetes.io/component=agent-sandbox";
+
+// ── Namespace configuration ──────────────────────────────────────────────────
+
+export interface NamespaceConfig {
+  id: string;
+  label: string;
+}
+
+const DEFAULT_NAMESPACES: NamespaceConfig[] = [
+  { id: "fenrir-agents", label: "Fenrir Ledger Agents" },
+  { id: "say-so-agents", label: "SaySo Agents" },
+];
+
+function loadNamespaces(): NamespaceConfig[] {
+  // Prefer NAMESPACES_JSON env var (injected from ConfigMap)
+  const raw = process.env.NAMESPACES_JSON;
+  if (raw) {
+    try {
+      const parsed = JSON.parse(raw) as NamespaceConfig[];
+      if (Array.isArray(parsed) && parsed.length > 0) return parsed;
+    } catch {
+      console.warn("[config] Failed to parse NAMESPACES_JSON, using defaults");
+    }
+  }
+  return DEFAULT_NAMESPACES;
+}
+
+const NAMESPACES = loadNamespaces();
+
+/** Validate that a namespace param is in the allowed list. */
+function resolveNamespace(param: string | undefined): string {
+  if (!param) return DEFAULT_NAMESPACE;
+  const allowed = NAMESPACES.map((n) => n.id);
+  return allowed.includes(param) ? param : DEFAULT_NAMESPACE;
+}
 
 // ── Health check (public) ────────────────────────────────────────────────────
 app.get("/healthz", (c) => {
@@ -17,10 +52,16 @@ app.get("/healthz", (c) => {
 
 // ── Protected routes (auth enforced by oauth2-proxy sidecar) ─────────────────
 
+// Return available namespaces — read from NAMESPACES_JSON env var (sourced from ConfigMap)
+app.get("/api/namespaces", (c) => {
+  return c.json({ namespaces: NAMESPACES });
+});
+
 // List agent jobs — kept for curl debugging; UI uses WebSocket push
 app.get("/api/jobs", async (c) => {
+  const namespace = resolveNamespace(c.req.query("namespace"));
   try {
-    const jobs = await listAgentJobs(NAMESPACE, JOB_LABEL);
+    const jobs = await listAgentJobs(namespace, JOB_LABEL);
     return c.json({ jobs, count: jobs.length });
   } catch (err) {
     const message = err instanceof Error ? err.message : "Unknown error";
@@ -32,8 +73,9 @@ app.get("/api/jobs", async (c) => {
 // Download full agent session log from K8s pod
 app.get("/api/logs/:sessionId", async (c) => {
   const sessionId = c.req.param("sessionId");
+  const namespace = resolveNamespace(c.req.query("namespace"));
   try {
-    const podName = await findPodForSession(sessionId, NAMESPACE);
+    const podName = await findPodForSession(sessionId, namespace);
     if (!podName) {
       return c.json({ error: "Pod not found for session" }, 404);
     }
@@ -41,7 +83,7 @@ app.get("/api/logs/:sessionId", async (c) => {
     await new Promise<void>((resolve, reject) => {
       streamPodLogs(
         podName,
-        NAMESPACE,
+        namespace,
         (line) => lines.push(line),
         () => resolve(),
         (err) => reject(err),
@@ -65,8 +107,9 @@ app.get("/api/logs/:sessionId", async (c) => {
 // Cancel / delete a running agent job — invoked by Ragnarök dialog confirm
 app.delete("/api/jobs/:sessionId", async (c) => {
   const sessionId = c.req.param("sessionId");
+  const namespace = resolveNamespace(c.req.query("namespace"));
   try {
-    await deleteAgentJob(sessionId, NAMESPACE);
+    await deleteAgentJob(sessionId, namespace);
     console.log(`[k8s] Job deleted for session ${sessionId}`);
     return c.json({ ok: true, sessionId });
   } catch (err) {
@@ -89,6 +132,6 @@ const server = serve({ fetch: app.fetch, port: PORT }, (info) => {
   console.log(`[odin-throne] Listening on http://localhost:${info.port}`);
 });
 
-attachWebSocketServer(server, NAMESPACE, JOB_LABEL);
+attachWebSocketServer(server, JOB_LABEL, NAMESPACES.map((n) => n.id), DEFAULT_NAMESPACE);
 
 export { app };

--- a/development/odins-throne/src/ws.ts
+++ b/development/odins-throne/src/ws.ts
@@ -438,43 +438,82 @@ function startLogStream(
 export const HEARTBEAT_INTERVAL_MS = 20_000;
 
 // ---------------------------------------------------------------------------
+// Per-namespace watcher context — shared across all connections for that ns
+// ---------------------------------------------------------------------------
+
+interface NamespaceContext {
+  cachedJobs: Job[];
+  clients: Set<WebSocket>;
+  cancelWatch: () => void;
+}
+
+// ---------------------------------------------------------------------------
 // WebSocket server — single multiplexed /ws endpoint
 // ---------------------------------------------------------------------------
 
 export function attachWebSocketServer(
   server: ServerType,
-  namespace = "fenrir-app",
-  labelSelector = "app=odin-agent"
+  labelSelector = "app.kubernetes.io/component=agent-sandbox",
+  allowedNamespaces: string[] = ["fenrir-agents"],
+  defaultNamespace = "fenrir-agents"
 ): WebSocketServer {
-  // Per-server-instance state — no module-level singletons
-  const connectedClients = new Set<WebSocket>();
-  let cachedJobs: Job[] = [];
+  // Per-namespace watcher contexts — lazy initialised on first connection
+  const nsContexts = new Map<string, NamespaceContext>();
 
-  // Start K8s job watch, push updates to all connected clients
-  watchAgentJobs(
-    namespace,
-    labelSelector,
-    (jobs) => {
-      cachedJobs = jobs;
-      broadcast(connectedClients, {
-        type: "jobs-updated",
-        ts: Date.now(),
-        jobs: mergeWithFixtures(jobs),
-      });
-    },
-    (err) => {
-      console.error("[ws] K8s watch error:", err.message);
-      // watchAgentJobs auto-reconnects internally
+  function getOrCreateContext(namespace: string): NamespaceContext {
+    const existing = nsContexts.get(namespace);
+    if (existing) return existing;
+
+    const ctx: NamespaceContext = {
+      cachedJobs: [],
+      clients: new Set(),
+      cancelWatch: watchAgentJobs(
+        namespace,
+        labelSelector,
+        (jobs) => {
+          ctx.cachedJobs = jobs;
+          broadcast(ctx.clients, {
+            type: "jobs-updated",
+            ts: Date.now(),
+            jobs: mergeWithFixtures(jobs),
+          });
+        },
+        (err) => {
+          console.error(`[ws] K8s watch error (ns=${namespace}):`, err.message);
+          // watchAgentJobs auto-reconnects internally
+        }
+      ),
+    };
+    nsContexts.set(namespace, ctx);
+    return ctx;
+  }
+
+  function releaseContext(namespace: string, ws: WebSocket): void {
+    const ctx = nsContexts.get(namespace);
+    if (!ctx) return;
+    ctx.clients.delete(ws);
+    if (ctx.clients.size === 0) {
+      ctx.cancelWatch();
+      nsContexts.delete(namespace);
     }
-  );
+  }
 
   const wss = new WebSocketServer({ server: server as Server, path: "/ws" });
 
   // Auth is handled by oauth2-proxy sidecar — no in-app session check needed.
 
-  wss.on("connection", async (ws: WebSocket, _req: IncomingMessage) => {
-    // Register this client for jobs-updated broadcasts
-    connectedClients.add(ws);
+  wss.on("connection", async (ws: WebSocket, req: IncomingMessage) => {
+    // Extract namespace from query param (e.g. /ws?namespace=say-so-agents)
+    const rawUrl = req.url ?? "";
+    const qIdx = rawUrl.indexOf("?");
+    const nsParam = qIdx >= 0
+      ? new URLSearchParams(rawUrl.slice(qIdx + 1)).get("namespace") ?? ""
+      : "";
+    const namespace = allowedNamespaces.includes(nsParam) ? nsParam : defaultNamespace;
+
+    // Get or start the watcher for this namespace, register this client
+    const ctx = getOrCreateContext(namespace);
+    ctx.clients.add(ws);
 
     // ── Per-connection heartbeat ───────────────────────────────────────────
     // Ping every 20 s so GKE's 30 s idle timeout never fires.
@@ -496,12 +535,12 @@ export function attachWebSocketServer(
     }, HEARTBEAT_INTERVAL_MS);
 
     // Seed cache from listAgentJobs if watch hasn't populated it yet
-    let jobs = cachedJobs;
+    let jobs = ctx.cachedJobs;
     if (jobs.length === 0) {
       try {
         const agentJobs = await listAgentJobs(namespace, labelSelector);
         jobs = agentJobs.map(mapAgentJobToJob);
-        cachedJobs = jobs;
+        ctx.cachedJobs = jobs;
       } catch {
         // proceed with empty list
       }
@@ -528,7 +567,7 @@ export function attachWebSocketServer(
         // startLogStream returns a cancel function immediately — async work runs
         // in the background. Setting subscriptions synchronously prevents duplicate
         // subscribe messages from spawning parallel streams for the same session.
-        const cancel = startLogStream(ws, sessionId, namespace, () => cachedJobs);
+        const cancel = startLogStream(ws, sessionId, namespace, () => ctx.cachedJobs);
         subscriptions.set(sessionId, cancel);
       } else if (msg.type === "unsubscribe") {
         const { sessionId } = msg;
@@ -548,7 +587,7 @@ export function attachWebSocketServer(
 
     const cleanup = () => {
       clearInterval(heartbeat);
-      connectedClients.delete(ws);
+      releaseContext(namespace, ws);
       for (const [, cancel] of subscriptions) {
         cancel();
       }

--- a/development/odins-throne/ui/App.tsx
+++ b/development/odins-throne/ui/App.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ServerMessage } from "./lib/types";
 import { randomQuote } from "./lib/constants";
 import { useWebSocket } from "./hooks/useWebSocket";
+import { useNamespace } from "./hooks/useNamespace";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { useJobs } from "./hooks/useJobs";
 import { useLogStream } from "./hooks/useLogStream";
@@ -26,6 +27,7 @@ import type { CachedSessionMeta } from "./lib/localStorageLogs";
 export function App() {
   const quote = useMemo(() => randomQuote(), []);
   const { theme } = useTheme();
+  const { namespace, namespaces, setNamespace } = useNamespace();
   const [profileAgent, setProfileAgent] = useState<string | null>(null);
   const [cancelTarget, setCancelTarget] = useState<{ sessionId: string; jobTitle: string } | null>(null);
   const { jobs, handleMessage: handleJobsMessage, refreshCached } = useJobs();
@@ -59,6 +61,21 @@ export function App() {
     migrateRemoveDuplicateLogs();
     evictExpiredLogs();
   }, []);
+
+  // When namespace changes: clear active session, entries, and subscriptions.
+  // The WebSocket hook reconnects automatically to the new namespace.
+  const prevNamespaceRef = useRef(namespace);
+  useEffect(() => {
+    if (prevNamespaceRef.current === namespace) return;
+    prevNamespaceRef.current = namespace;
+    // Clean up existing subscriptions
+    if (subscribedSessionRef.current) {
+      subscribedSessionRef.current = null;
+    }
+    backgroundSubsRef.current.clear();
+    setActiveSessionId(null);
+    clearEntries();
+  }, [namespace, setActiveSessionId, clearEntries]);
 
   const [isFixture, setIsFixture] = useState(false);
   const [pinnedSessionId, setPinnedSessionId] = useState<string | null>(null);
@@ -113,7 +130,7 @@ export function App() {
     [handleJobsMessage, handleLogMessage, activeSessionId]
   );
 
-  const { state: wsState, error: wsError, send } = useWebSocket(onMessage);
+  const { state: wsState, error: wsError, send } = useWebSocket(onMessage, namespace);
 
   const handleSelectSession = useCallback(
     (sessionId: string) => {
@@ -337,6 +354,9 @@ export function App() {
           pinnedSessionIds={pinnedSessionIds}
           onCancelJob={handleOpenCancelDialog}
           terminatingSessionIds={terminatingSessionIds}
+          namespace={namespace}
+          namespaces={namespaces}
+          onNamespaceChange={setNamespace}
         />
         <ErrorBoundary>
           <LogViewer

--- a/development/odins-throne/ui/components/NamespaceSelector.tsx
+++ b/development/odins-throne/ui/components/NamespaceSelector.tsx
@@ -1,0 +1,42 @@
+import type { NamespaceOption } from "../hooks/useNamespace";
+
+interface Props {
+  namespace: string;
+  namespaces: NamespaceOption[];
+  onNamespaceChange: (ns: string) => void;
+  isCompact: boolean;
+}
+
+export function NamespaceSelector({ namespace, namespaces, onNamespaceChange, isCompact }: Props) {
+  if (isCompact) {
+    // In compact mode, show a minimal indicator button
+    const active = namespaces.find((n) => n.id === namespace);
+    const initials = active?.label.split(" ").map((w) => w[0]).join("").slice(0, 2) ?? "NS";
+    return (
+      <div className="namespace-selector namespace-selector--compact" title={active?.label ?? namespace}>
+        <span className="namespace-selector__initials">{initials}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="namespace-selector" role="group" aria-label="Select namespace">
+      <label className="namespace-selector__label" htmlFor="namespace-select">
+        Namespace
+      </label>
+      <select
+        id="namespace-select"
+        className="namespace-selector__select"
+        value={namespace}
+        onChange={(e) => onNamespaceChange(e.target.value)}
+        aria-label="Select agent namespace"
+      >
+        {namespaces.map((ns) => (
+          <option key={ns.id} value={ns.id}>
+            {ns.label}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/development/odins-throne/ui/components/Sidebar.tsx
+++ b/development/odins-throne/ui/components/Sidebar.tsx
@@ -1,9 +1,11 @@
 import { useState, useCallback, useRef, useEffect } from "react";
 import type { DisplayJob } from "../lib/types";
 import { useTheme } from "../hooks/useTheme";
+import type { NamespaceOption } from "../hooks/useNamespace";
 import { JobCard } from "./JobCard";
 import { ThemeSwitcher } from "./ThemeSwitcher";
 import { StatusBadge } from "./StatusBadge";
+import { NamespaceSelector } from "./NamespaceSelector";
 
 const WIDTH_KEY = "hlidskjalf:sidebar-width";
 const DEFAULT_WIDTH = 300;
@@ -51,9 +53,12 @@ interface Props {
   pinnedSessionIds?: Set<string>;
   onCancelJob?: (sessionId: string) => void;
   terminatingSessionIds?: Set<string>;
+  namespace: string;
+  namespaces: NamespaceOption[];
+  onNamespaceChange: (ns: string) => void;
 }
 
-export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession, onAvatarClick, onOdinClick, onTogglePinSession, pinnedSessionIds, onCancelJob, terminatingSessionIds }: Props) {
+export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession, onAvatarClick, onOdinClick, onTogglePinSession, pinnedSessionIds, onCancelJob, terminatingSessionIds, namespace, namespaces, onNamespaceChange }: Props) {
   const { theme, setTheme } = useTheme();
   const [width, setWidth] = useState<number>(loadWidth);
   const isDraggingRef = useRef(false);
@@ -138,6 +143,12 @@ export function Sidebar({ jobs, activeSessionId, quote, wsState, onSelectSession
             </div>
           </>
         )}
+        <NamespaceSelector
+          namespace={namespace}
+          namespaces={namespaces}
+          onNamespaceChange={onNamespaceChange}
+          isCompact={isCompact}
+        />
       </div>
       <div className="card-list" role="list" aria-label="Job sessions">
         {jobs.length === 0 ? (

--- a/development/odins-throne/ui/hooks/useNamespace.ts
+++ b/development/odins-throne/ui/hooks/useNamespace.ts
@@ -1,0 +1,66 @@
+import { useState, useCallback, useEffect } from "react";
+
+export interface NamespaceOption {
+  id: string;
+  label: string;
+}
+
+const STORAGE_KEY = "hlidskjalf:namespace";
+const DEFAULT_NAMESPACE = "fenrir-agents";
+
+function loadNamespace(): string {
+  try {
+    const v = localStorage.getItem(STORAGE_KEY);
+    if (v) return v;
+  } catch {
+    // private browsing — ignore
+  }
+  return DEFAULT_NAMESPACE;
+}
+
+function saveNamespace(ns: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, ns);
+  } catch {
+    // private browsing — ignore
+  }
+}
+
+export function useNamespace() {
+  const [namespace, setNamespaceState] = useState<string>(loadNamespace);
+  const [namespaces, setNamespaces] = useState<NamespaceOption[]>([
+    { id: "fenrir-agents", label: "Fenrir Ledger Agents" },
+    { id: "say-so-agents", label: "SaySo Agents" },
+  ]);
+
+  // Fetch available namespaces from API at startup
+  useEffect(() => {
+    fetch("/api/namespaces")
+      .then((res) => res.json())
+      .then((data: { namespaces?: NamespaceOption[] }) => {
+        if (Array.isArray(data.namespaces) && data.namespaces.length > 0) {
+          setNamespaces(data.namespaces);
+          // If saved namespace is no longer in the list, reset to first
+          const ids = data.namespaces.map((n) => n.id);
+          setNamespaceState((prev) => {
+            if (!ids.includes(prev)) {
+              const fallback = data.namespaces![0]!.id;
+              saveNamespace(fallback);
+              return fallback;
+            }
+            return prev;
+          });
+        }
+      })
+      .catch(() => {
+        // Non-fatal — default namespace list remains
+      });
+  }, []);
+
+  const setNamespace = useCallback((ns: string) => {
+    saveNamespace(ns);
+    setNamespaceState(ns);
+  }, []);
+
+  return { namespace, namespaces, setNamespace };
+}

--- a/development/odins-throne/ui/hooks/useWebSocket.ts
+++ b/development/odins-throne/ui/hooks/useWebSocket.ts
@@ -6,23 +6,38 @@ type WsState = "connecting" | "open" | "closed" | "error";
 const MAX_RECONNECT = 10;
 const BASE_DELAY_MS = 1000;
 
-export function useWebSocket(onMessage: (msg: ServerMessage) => void) {
+export function useWebSocket(onMessage: (msg: ServerMessage) => void, namespace = "fenrir-agents") {
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectCount = useRef(0);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
+  // Track the namespace the current WS connection was opened with
+  const connectedNamespaceRef = useRef<string | null>(null);
 
   const [state, setState] = useState<WsState>("connecting");
   const [error, setError] = useState<string | null>(null);
 
-  const connect = useCallback(() => {
-    if (wsRef.current?.readyState === WebSocket.OPEN ||
-        wsRef.current?.readyState === WebSocket.CONNECTING) return;
+  const connect = useCallback((ns: string) => {
+    // If already connected to the right namespace, skip
+    if (
+      connectedNamespaceRef.current === ns &&
+      (wsRef.current?.readyState === WebSocket.OPEN ||
+        wsRef.current?.readyState === WebSocket.CONNECTING)
+    ) return;
+
+    // Close existing connection when switching namespaces
+    if (wsRef.current) {
+      wsRef.current.onclose = null; // prevent scheduleReconnect
+      wsRef.current.close();
+      wsRef.current = null;
+      connectedNamespaceRef.current = null;
+    }
 
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    const ws = new WebSocket(`${proto}//${location.host}/ws`);
+    const ws = new WebSocket(`${proto}//${location.host}/ws?namespace=${encodeURIComponent(ns)}`);
     wsRef.current = ws;
+    connectedNamespaceRef.current = ns;
     setState("connecting");
 
     ws.addEventListener("open", () => {
@@ -39,7 +54,10 @@ export function useWebSocket(onMessage: (msg: ServerMessage) => void) {
     });
 
     ws.addEventListener("close", () => {
-      wsRef.current = null;
+      if (wsRef.current === ws) {
+        wsRef.current = null;
+        connectedNamespaceRef.current = null;
+      }
       setState("closed");
       scheduleReconnect();
     });
@@ -50,6 +68,10 @@ export function useWebSocket(onMessage: (msg: ServerMessage) => void) {
     });
   }, []);
 
+  // Keep a stable ref to the current namespace so scheduleReconnect can use it
+  const namespaceRef = useRef(namespace);
+  namespaceRef.current = namespace;
+
   const scheduleReconnect = useCallback(() => {
     if (reconnectCount.current >= MAX_RECONNECT) {
       setError(`WebSocket failed after ${MAX_RECONNECT} attempts. Reload to retry.`);
@@ -59,7 +81,7 @@ export function useWebSocket(onMessage: (msg: ServerMessage) => void) {
     reconnectCount.current++;
     reconnectTimer.current = setTimeout(() => {
       reconnectTimer.current = null;
-      connect();
+      connect(namespaceRef.current);
     }, delay);
   }, [connect]);
 
@@ -69,13 +91,20 @@ export function useWebSocket(onMessage: (msg: ServerMessage) => void) {
     }
   }, []);
 
+  // Connect on mount and reconnect when namespace changes
   useEffect(() => {
-    connect();
+    reconnectCount.current = 0;
+    connect(namespace);
     return () => {
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
-      wsRef.current?.close();
+      if (wsRef.current) {
+        wsRef.current.onclose = null;
+        wsRef.current.close();
+        wsRef.current = null;
+        connectedNamespaceRef.current = null;
+      }
     };
-  }, [connect]);
+  }, [connect, namespace]);
 
   return { state, error, send };
 }

--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -312,6 +312,54 @@ body {
 @media (prefers-reduced-motion: reduce) {
   .theme-btn { transition: none; }
 }
+/* ── Namespace selector ─────────────────────────── */
+.namespace-selector {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+.namespace-selector__label {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.65rem;
+  color: var(--text-void);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  flex-shrink: 0;
+}
+.namespace-selector__select {
+  flex: 1;
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.7rem;
+  background: var(--chain);
+  color: var(--text-rune);
+  border: 1px solid var(--rune-border);
+  border-radius: 3px;
+  padding: 0.2rem 0.3rem;
+  cursor: pointer;
+  outline: none;
+  min-width: 0;
+}
+.namespace-selector__select:hover,
+.namespace-selector__select:focus {
+  border-color: var(--gold);
+  color: var(--text-saga);
+}
+.namespace-selector--compact {
+  justify-content: center;
+  margin-top: 0.4rem;
+}
+.namespace-selector__initials {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 0.6rem;
+  color: var(--gold);
+  background: var(--chain);
+  border: 1px solid var(--rune-border);
+  border-radius: 3px;
+  padding: 0.1rem 0.25rem;
+  letter-spacing: 0.04em;
+}
+
 .card-list { flex: 1; overflow-y: auto; padding: 0.5rem; }
 
 /* ── Sidebar resize handle ─────────────────────── */

--- a/infrastructure/helm/odin-throne/templates/configmap.yaml
+++ b/infrastructure/helm/odin-throne/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.namespaces.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: odins-throne-config
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "odin-throne.labels" (dict "component" "odins-throne") | nindent 4 }}
+data:
+  namespaces.json: |
+    {{ .Values.namespaces.list | toJson | nindent 4 }}
+{{- end }}

--- a/infrastructure/helm/odin-throne/templates/deployment.yaml
+++ b/infrastructure/helm/odin-throne/templates/deployment.yaml
@@ -48,6 +48,13 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
+            {{- if .Values.namespaces.enabled }}
+            - name: NAMESPACES_JSON
+              valueFrom:
+                configMapKeyRef:
+                  name: odins-throne-config
+                  key: namespaces.json
+            {{- end }}
             {{- if .Values.app.secretRef }}
           envFrom:
             - secretRef:

--- a/infrastructure/helm/odin-throne/templates/rbac.yaml
+++ b/infrastructure/helm/odin-throne/templates/rbac.yaml
@@ -9,7 +9,7 @@ metadata:
     {{- include "odin-throne.labels" (dict "component" "odins-throne") | nindent 4 }}
 
 ---
-# Role that grants read+delete access to jobs, pods, and pod logs in the agents namespace
+# Role that grants read+delete access to jobs, pods, and pod logs in the primary agents namespace
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -26,7 +26,7 @@ rules:
     verbs: ["get", "list", "watch"]
 
 ---
-# Bind the ServiceAccount (in fenrir-monitor) to the Role (in fenrir-agents)
+# Bind the ServiceAccount (in fenrir-monitor) to the Role (in primary agents namespace)
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -42,4 +42,41 @@ subjects:
   - kind: ServiceAccount
     name: {{ .Values.app.serviceAccountName }}
     namespace: {{ .Values.namespace }}
+
+{{- range .Values.rbac.additionalNamespaces }}
+---
+# Role for cross-namespace monitoring of {{ . }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: odin-throne-agent-reader
+  namespace: {{ . }}
+  labels:
+    {{- include "odin-throne.labels" (dict "component" "odins-throne") | nindent 4 }}
+rules:
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "watch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods", "pods/log"]
+    verbs: ["get", "list", "watch"]
+
+---
+# Bind the ServiceAccount (in fenrir-monitor) to the Role (in {{ . }})
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: odin-throne-agent-reader
+  namespace: {{ . }}
+  labels:
+    {{- include "odin-throne.labels" (dict "component" "odins-throne") | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: odin-throne-agent-reader
+subjects:
+  - kind: ServiceAccount
+    name: {{ $.Values.app.serviceAccountName }}
+    namespace: {{ $.Values.namespace }}
+{{- end }}
 {{- end }}

--- a/infrastructure/helm/odin-throne/values.yaml
+++ b/infrastructure/helm/odin-throne/values.yaml
@@ -25,6 +25,8 @@ app:
     PORT: "3001"
     K8S_NAMESPACE: "fenrir-agents"
     JOB_LABEL_SELECTOR: "app.kubernetes.io/component=agent-sandbox"
+    # NAMESPACES_JSON injected separately from odins-throne-config ConfigMap
+    # via deployment.yaml valueFrom configMapKeyRef when namespaces.enabled=true.
 
   # K8s secret containing GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET — injected via envFrom.
   # SESSION_SECRET and ALLOWED_EMAIL are no longer used (handled by oauth2-proxy).
@@ -133,11 +135,26 @@ ingress:
       - odins-throne.fenrirledger.com
 
 # -- RBAC ------------------------------------------------------------------
-# ServiceAccount with cross-namespace read access to jobs/pods/logs
-# in fenrir-agents so the monitor can display agent activity.
+# ServiceAccount with cross-namespace read access to jobs/pods/logs.
+# agentsNamespaces lists every namespace the monitor needs read access to.
 rbac:
   enabled: true
   agentsNamespace: fenrir-agents
+  # Additional namespaces for cross-project monitoring.
+  # Each entry gets its own RoleBinding in that namespace.
+  additionalNamespaces:
+    - say-so-agents
+
+# -- Namespaces ConfigMap --------------------------------------------------
+# Defines which namespaces are available in the UI selector.
+# The list is serialised as NAMESPACES_JSON and injected into the pod env.
+namespaces:
+  enabled: true
+  list:
+    - id: fenrir-agents
+      label: "Fenrir Ledger Agents"
+    - id: say-so-agents
+      label: "SaySo Agents"
 
 # -- Secrets ---------------------------------------------------------------
 secrets:


### PR DESCRIPTION
PR for issue: #2137

Adds a namespace selector dropdown to Odin's Throne header for switching between `fenrir-agents` and `say-so-agents` namespaces. Namespace list is sourced from a ConfigMap, selection persisted in localStorage.

**Changes:**

- `src/index.ts`: `/api/namespaces` endpoint reads from `NAMESPACES_JSON` env var (injected from ConfigMap); all K8s API routes accept `?namespace=` query param with allowlist validation
- `src/ws.ts`: Per-connection namespace via `?namespace=` WebSocket URL query param; per-namespace job watcher contexts (lazy-initialized, shared across connections, auto-released when last client disconnects)
- `ui/hooks/useNamespace.ts`: New hook — fetches namespace list from `/api/namespaces`, persists selection in `localStorage` (`hlidskjalf:namespace`), defaults to `fenrir-agents`
- `ui/hooks/useWebSocket.ts`: Accepts `namespace` param, reconnects with new namespace in URL on change
- `ui/components/NamespaceSelector.tsx`: Dropdown selector in sidebar header with compact mode initials fallback
- `ui/components/Sidebar.tsx`: Renders `NamespaceSelector` above the session list
- `ui/App.tsx`: Wires `useNamespace` through WS hook and Sidebar; clears active session on namespace switch
- `ui/styles/index.css`: Namespace selector styles (monospace, JetBrains Mono, matches existing design system)
- `infrastructure/helm/odin-throne/templates/configmap.yaml`: `odins-throne-config` ConfigMap with `namespaces.json`
- `infrastructure/helm/odin-throne/templates/rbac.yaml`: `Role` + `RoleBinding` for each `rbac.additionalNamespaces` entry (say-so-agents)
- `infrastructure/helm/odin-throne/values.yaml`: `namespaces.list` + `rbac.additionalNamespaces`
- `infrastructure/helm/odin-throne/templates/deployment.yaml`: Injects `NAMESPACES_JSON` from ConfigMap via `valueFrom.configMapKeyRef`

**Verification:**
- Select different namespaces and verify session list refreshes
- Reload page and verify selection persists
- Verify default is `fenrir-agents` when no saved selection
- Verify all K8s queries use selected namespace