### PR TITLE
Issue #2139 - fix: show issue title in session sidebar

### DIFF
--- a/development/odins-throne/ui/components/JobCard.tsx
+++ b/development/odins-throne/ui/components/JobCard.tsx
@@ -45,10 +45,12 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
   const sColor = statusColorMap[job.status] || (theme === "light" ? "#57534e" : "#606070");
   const sLabel = STATUS_LABELS[job.status] || job.status;
   const pulse = job.status === "running" ? " pulse" : "";
+  // Primary title: bare issueTitle when available, else "Issue #N – Step N" fallback
   const displayTitle = resolveSessionTitle(job);
-  const cardTitle = job.issueTitle
-    ? `#${job.issue} \u2013 ${job.issueTitle}`
-    : displayTitle;
+  // Secondary meta line: "Issue #N · Agent · Step N" when title is shown; otherwise "Agent · Step N"
+  const secondaryMeta = job.issueTitle
+    ? `Issue #${job.issue} \u00b7 ${job.agentName} \u00b7 Step ${job.step}`
+    : null;
 
   if (displayMode === "compact") {
     return (
@@ -91,7 +93,7 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
     <div
       className={`card${isActive ? " active" : ""}${isTerminating ? " card--terminating" : ""}`}
       role="listitem"
-      aria-label={`Job: Issue ${job.issue} – ${displayTitle} – Step ${job.step} – ${job.agentName} – ${sLabel}`}
+      aria-label={`Job: ${displayTitle} – Issue ${job.issue} – ${job.agentName} – Step ${job.step} – ${sLabel}`}
       onClick={onClick}
     >
       <div className="card-top">
@@ -113,15 +115,27 @@ export function JobCard({ job, isActive, onClick, onAvatarClick, isPinned = fals
             #{job.issue}
           </span>
         )}
-        <span className="card-issue-title" title={isExtended ? (job.issueTitle ?? displayTitle) : cardTitle}>
-          {isExtended ? (job.issueTitle ?? displayTitle) : cardTitle}
+        <span className="card-issue-title" title={displayTitle}>
+          {displayTitle}
         </span>
       </div>
       <div className="card-meta-new">
-        <span className="card-agent-badge" style={{ color: agentColor }}>
-          {job.agentName}
-        </span>
-        <span>Step {job.step}</span>
+        {secondaryMeta ? (
+          <span className="card-secondary-meta" aria-label={secondaryMeta}>
+            <span className="card-secondary-issue">Issue #{job.issue}</span>
+            <span className="card-meta-sep" aria-hidden="true"> · </span>
+            <span className="card-agent-badge" style={{ color: agentColor }}>{job.agentName}</span>
+            <span className="card-meta-sep" aria-hidden="true"> · </span>
+            <span>Step {job.step}</span>
+          </span>
+        ) : (
+          <>
+            <span className="card-agent-badge" style={{ color: agentColor }}>
+              {job.agentName}
+            </span>
+            <span>Step {job.step}</span>
+          </>
+        )}
         {job.fixture && <span className="card-fixture-badge" title="Fixture (replayed log)">ᚠ</span>}
         {isExtended ? (
           <>

--- a/development/odins-throne/ui/lib/resolveSessionTitle.ts
+++ b/development/odins-throne/ui/lib/resolveSessionTitle.ts
@@ -46,10 +46,14 @@ export function parseSessionIdTitle(sessionId: string): string | null {
  *   2. branchName parse (only if branch contains an issue pattern)
  *   3. sessionId parse (issue-<N>-step<S>-<agent>-<uuid> pattern)
  *   4. Raw branchName or sessionId (graceful degradation)
+ *
+ * When issueTitle is available it is returned as-is (no prefix).
+ * The caller (JobCard) is responsible for rendering "Issue #N · Agent · Step N"
+ * as the secondary line below the title.
  */
 export function resolveSessionTitle(job: DisplayJob): string {
   if (job.issueTitle) {
-    return `Issue #${job.issue} – ${job.issueTitle} – Step ${job.step}`;
+    return job.issueTitle;
   }
   if (job.branchName) {
     const fromBranch = parseBranchTitle(job.branchName, job.step);

--- a/development/odins-throne/ui/styles/index.css
+++ b/development/odins-throne/ui/styles/index.css
@@ -511,6 +511,16 @@ body {
   padding: 1px 5px; border: 1px solid var(--rune-border);
   white-space: nowrap;
 }
+.card-secondary-meta {
+  display: flex; align-items: center; flex-wrap: nowrap;
+  overflow: hidden; min-width: 0;
+}
+.card-secondary-issue {
+  color: var(--text-void); white-space: nowrap; flex-shrink: 0;
+}
+.card-meta-sep {
+  color: var(--text-void); flex-shrink: 0;
+}
 .card-fixture-badge {
   font-size: 0.55rem;
   color: var(--gold);


### PR DESCRIPTION
PR for issue: #2139

Fixes #2139

Shows issue title from K8s Job annotation (fenrir/issue-title or fenrir/pr-title) as the primary label in the session sidebar instead of generic 'Issue #N – Step N'. Falls back gracefully when annotation is blank.

**Changes:**
- resolveSessionTitle.ts: bare issueTitle when available; falls back to Issue #N – Step N
- JobCard.tsx: issue title as primary label; secondary row shows Issue #N · AgentName · Step N
- index.css: CSS for .card-secondary-meta, .card-secondary-issue, .card-meta-sep

**QA:** tsc + build PASS. No Vitest infra in odins-throne package.